### PR TITLE
refactor e2e tests to use globals which is not great but it makes the…

### DIFF
--- a/packages/extension-host-worker-tests/package.json
+++ b/packages/extension-host-worker-tests/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "e2e": "node src/_all.js",
-    "e2e:headless": "node src/_all.js --headless"
+    "e2e:headless": "node src/_all.js --headless",
+    "type-check": "tsc"
   },
   "keywords": [],
   "author": "",

--- a/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error-spelling.js
+++ b/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error-spelling.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.brace-completion-provider-error-spelling'
 
@@ -38,3 +27,5 @@ test.skip('sample.brace-completion-provider-error-spelling', async () => {
     'Error: Failed to activate extension sample.brace-completion-provider-error-spelling: TypeError: vscode.registerBraceCompletionProcider is not a function'
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error-spelling.js
+++ b/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error-spelling.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.brace-completion-provider-error-spelling'
 
 test.skip('sample.brace-completion-provider-error-spelling', async () => {

--- a/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.brace-completion-provider-error'
 
 test.skip('sample.brace-completion-provider-error', async () => {

--- a/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.brace-completion-provider-error.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.brace-completion-provider-error'
 
@@ -35,3 +24,5 @@ test.skip('sample.brace-completion-provider-error', async () => {
     'Error: Failed to execute brace completion provider: oops'
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.brace-completion-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.brace-completion-provider.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.brace-completion-provider'
 
@@ -32,3 +21,5 @@ test.skip('sample.brace-completion-provider', async () => {
   const editor = Locator('.Viewlet.Editor')
   await expect(editor).toHaveText(`{}`)
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.brace-completion-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.brace-completion-provider.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.brace-completion-provider'
 
 test.skip('sample.brace-completion-provider', async () => {

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-array-with-undefined-items.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-array-with-undefined-items.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('sample.completion-provider-error-invalid-return-value-array-with-undefined-items', async () => {
   const tmpDir = await FileSystem.getTmpDir()
@@ -37,3 +26,5 @@ test('sample.completion-provider-error-invalid-return-value-array-with-undefined
     `Failed to execute completion provider: VError: invalid completion result: expected completion item to be of type object but was of type undefined`
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-array-with-undefined-items.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-array-with-undefined-items.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('sample.completion-provider-error-invalid-return-value-array-with-undefined-items', async () => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-number.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-number.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('sample.completion-provider-error-invalid-return-value-number', async () => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-number.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-number.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('sample.completion-provider-error-invalid-return-value-number', async () => {
   const tmpDir = await FileSystem.getTmpDir()
@@ -38,3 +27,5 @@ test('sample.completion-provider-error-invalid-return-value-number', async () =>
     `Failed to execute completion provider: VError: invalid completion result: completion must be of type array but is 42`
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-undefined.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-undefined.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('sample.completion-provider-error-invalid-return-value-undefined', async () => {
   const tmpDir = await FileSystem.getTmpDir()
@@ -39,3 +28,5 @@ test('sample.completion-provider-error-invalid-return-value-undefined', async ()
     `Failed to execute completion provider: VError: invalid completion result: completion must be of type array but is undefined`
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-undefined.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error-invalid-return-value-undefined.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('sample.completion-provider-error-invalid-return-value-undefined', async () => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('sample.completion-provider-error', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/sample.completion-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider-error.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('sample.completion-provider-error', async () => {
   // arrange
@@ -40,3 +29,5 @@ test('sample.completion-provider-error', async () => {
     'Failed to execute completion provider: oops'
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.completion-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('sample.completion-provider', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/sample.completion-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.completion-provider.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('sample.completion-provider', async () => {
   // arrange
@@ -95,3 +84,5 @@ test('sample.completion-provider', async () => {
   // await page.keyboard.press('ArrowRight')
   // await expect(completions).toBeHidden()
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-error-main-not-found.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-error-main-not-found.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-  ContextMenu,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.reference-provider-error-main-not-found'
 
@@ -49,3 +37,5 @@ test('sample.reference-provider-error-main-not-found', async () => {
     `Error: Failed to activate extension sample.reference-provider-error-main-not-found: TypeError: Failed to fetch dynamically imported module: ${mainUrl}`
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-error-main-not-found.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-error-main-not-found.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.reference-provider-error-main-not-found'
 
 test('sample.reference-provider-error-main-not-found', async () => {

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-error-manifest-not-found.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-error-manifest-not-found.js
@@ -44,3 +44,5 @@ test('sample.reference-provider-error-manifest-not-found', async () => {
 
   // TODO should show dialog with json stack trace
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-error-manifest-not-found.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-error-manifest-not-found.js
@@ -1,17 +1,3 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-  ContextMenu,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
-
 const name = 'sample.reference-provider-error-main-not-found'
 
 test('sample.reference-provider-error-manifest-not-found', async () => {

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-error.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.reference-provider-error'
 
 test('sample.reference-provider-error', async () => {

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-error.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  test,
-  Locator,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.reference-provider-error'
 

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-no-results.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-no-results.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.reference-provider-no-results'
 
 test('sample.reference-provider-no-results', async () => {

--- a/packages/extension-host-worker-tests/src/sample.reference-provider-no-results.js
+++ b/packages/extension-host-worker-tests/src/sample.reference-provider-no-results.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  test,
-  Locator,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.reference-provider-no-results'
 

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error-invalid-return-value-number.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error-invalid-return-value-number.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.tab-completion-provider-error-invalid-return-value-number'
 

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error-invalid-return-value-number.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error-invalid-return-value-number.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.tab-completion-provider-error-invalid-return-value-number'
 
 test('sample.tab-completion-provider-error-invalid-return-value-number', async () => {

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.tab-completion-provider-error'
 

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider-error.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.tab-completion-provider-error'
 
 test('sample.tab-completion-provider-error', async () => {

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider-no-result.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider-no-result.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.tab-completion-provider-no-result'
 
 test('sample.tab-completion-provider-no-result', async () => {

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider-no-result.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider-no-result.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.tab-completion-provider-no-result'
 

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.tab-completion-provider'
 

--- a/packages/extension-host-worker-tests/src/sample.tab-completion-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.tab-completion-provider.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.tab-completion-provider'
 
 // TODO test is flaky https://github.com/lvce-editor/lvce-editor/runs/7821552259?check_suite_focus=true

--- a/packages/extension-host-worker-tests/src/sample.text-search-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.text-search-provider-error.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.text-search-provider-error'
 
 test('sample.text-search-provider-error', async () => {

--- a/packages/extension-host-worker-tests/src/sample.text-search-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.text-search-provider-error.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Extension,
-  FileSystem,
-  Search,
-  SideBar,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.text-search-provider-error'
 

--- a/packages/extension-host-worker-tests/src/sample.text-search-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.text-search-provider.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Extension,
-  FileSystem,
-  Search,
-  SideBar,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.text-search-provider'
 

--- a/packages/extension-host-worker-tests/src/sample.text-search-provider.js
+++ b/packages/extension-host-worker-tests/src/sample.text-search-provider.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.text-search-provider'
 
 test('sample.text-search-provider', async () => {

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-error-failed-to-activate-extension.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-error-failed-to-activate-extension.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name =
   'sample.type-definition-provider-error-failed-to-activate-extension'
 

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-error-failed-to-activate-extension.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-error-failed-to-activate-extension.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  test,
-  Locator,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name =
   'sample.type-definition-provider-error-failed-to-activate-extension'

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-error.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  test,
-  Locator,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.type-definition-provider-error'
 

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-error.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.type-definition-provider-error'
 
 test('sample.type-definition-provider-error', async () => {

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-no-result.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-no-result.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  test,
-  Locator,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.type-definition-provider-no-result'
 

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-no-result.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-no-result.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.type-definition-provider-no-result'
 
 test.skip('sample.type-definition-provider-no-result', async () => {

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-not-registered.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-not-registered.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 const name = 'sample.type-definition-provider-not-registered'
 
 test('sample.type-definition-provider-not-registered', async () => {

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-not-registered.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-not-registered.js
@@ -1,16 +1,4 @@
-import {
-  expect,
-  test,
-  Locator,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Editor,
-  Extension,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 const name = 'sample.type-definition-provider-not-registered'
 

--- a/packages/extension-host-worker-tests/src/viewlet.editor-copy-line-down.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-copy-line-down.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.editor-copy-line-down', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.editor-copy-line-down.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-copy-line-down.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.editor-copy-line-down', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-left.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-left.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.editor-cursor-character-left', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-left.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-left.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.editor-cursor-character-left', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-right.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-right.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.editor-cursor-character-right', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-right.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-character-right.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.editor-cursor-character-right', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-down.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-down.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.editor-cursor-down', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-down.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-down.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.editor-cursor-down', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-up.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-up.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.editor-cursor-up', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-up.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-up.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.editor-cursor-up', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-left.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-left.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // TODO test is broken in ci, not sure why https://github.com/lvce-editor/lvce-editor/runs/7691685045?check_suite_focus=true
 test.skip('viewlet.editor-cursor-word-left', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-left.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-left.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // TODO test is broken in ci, not sure why https://github.com/lvce-editor/lvce-editor/runs/7691685045?check_suite_focus=true
 test.skip('viewlet.editor-cursor-word-left', async () => {

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-right.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-right.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // TODO test is broken in ci, not sure why https://github.com/lvce-editor/lvce-editor/runs/7692111020?check_suite_focus=true
 test.skip('viewlet.editor-cursor-word-right', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-right.js
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-cursor-word-right.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Editor,
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // TODO test is broken in ci, not sure why https://github.com/lvce-editor/lvce-editor/runs/7692111020?check_suite_focus=true
 test.skip('viewlet.editor-cursor-word-right', async () => {

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-accessibility.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-accessibility.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // manual accessibility tests
 
 // explorer

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-accessibility.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-accessibility.js
@@ -1,13 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  FileSystem,
-  Main,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // manual accessibility tests
 

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-create-file-error-no-name-provided.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-create-file-error-no-name-provided.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Explorer,
-  FileSystem,
-  KeyBoard,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // TODO test is flaky https://github.com/lvce-editor/lvce-editor/runs/7883530122?check_suite_focus=true
 test.skip('viewlet.explorer-create-file-error-no-name-provided', async () => {

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-create-file-error-no-name-provided.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-create-file-error-no-name-provided.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // TODO test is flaky https://github.com/lvce-editor/lvce-editor/runs/7883530122?check_suite_focus=true
 test.skip('viewlet.explorer-create-file-error-no-name-provided', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-create-file.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-create-file.js
@@ -1,15 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Explorer,
-  FileSystem,
-  KeyBoard,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // TODO test might be flaky https://github.com/lvce-editor/lvce-editor/runs/7490211933?check_suite_focus=true
 test('viewlet.explorer-create-file', async () => {

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-create-file.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-create-file.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // TODO test might be flaky https://github.com/lvce-editor/lvce-editor/runs/7490211933?check_suite_focus=true
 test('viewlet.explorer-create-file', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-delete-file.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-delete-file.js
@@ -1,14 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  ContextMenu,
-  Explorer,
-  FileSystem,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.explorer-delete-file', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-delete-file.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-delete-file.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.explorer-delete-file', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-delete-multiple-files.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-delete-multiple-files.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test.skip('viewlet.explorer-delete-multiple-files', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-delete-multiple-files.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-delete-multiple-files.js
@@ -1,13 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  FileSystem,
-  KeyBoard,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test.skip('viewlet.explorer-delete-multiple-files', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-keyboard-navigation.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-keyboard-navigation.js
@@ -1,13 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  Explorer,
-  FileSystem,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 test('viewlet.explorer-keyboard-navigation', async () => {
   // arrange

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-keyboard-navigation.js
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-keyboard-navigation.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 test('viewlet.explorer-keyboard-navigation', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/extension-host-worker-tests/src/viewlet.quick-pick-accessibility.js
+++ b/packages/extension-host-worker-tests/src/viewlet.quick-pick-accessibility.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // manual accessibility tests
 
 // open quick pick

--- a/packages/extension-host-worker-tests/src/viewlet.quick-pick-accessibility.js
+++ b/packages/extension-host-worker-tests/src/viewlet.quick-pick-accessibility.js
@@ -1,9 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import { QuickPick } from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // manual accessibility tests
 

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-accessibility.js
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-accessibility.js
@@ -1,5 +1,3 @@
-/// <reference path="../typings/types.d.ts" />
-
 // manual accessibility tests
 
 // title bar

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-accessibility.js
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-accessibility.js
@@ -1,12 +1,4 @@
-import {
-  expect,
-  Locator,
-  test,
-} from '../../renderer-worker/src/parts/TestFrameWork/TestFrameWork.js'
-import {
-  FileSystem,
-  Workspace,
-} from '../../renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.js'
+/// <reference path="../typings/types.d.ts" />
 
 // manual accessibility tests
 

--- a/packages/extension-host-worker-tests/tsconfig.json
+++ b/packages/extension-host-worker-tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "WebWorker", "DOM"],
+    "lib": ["esnext"],
     "checkJs": true,
     "module": "esnext",
     "target": "esnext",
@@ -14,5 +14,5 @@
     "strict": true,
     "noImplicitAny": false
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "typings/types.d.ts"]
 }

--- a/packages/extension-host-worker-tests/tsconfig.json
+++ b/packages/extension-host-worker-tests/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": ".",
     "lib": ["esnext"],
     "checkJs": true,
     "module": "esnext",

--- a/packages/extension-host-worker-tests/typings/types.d.ts
+++ b/packages/extension-host-worker-tests/typings/types.d.ts
@@ -1,0 +1,44 @@
+declare const ContextMenu: {
+  readonly selectItem: (name: string) => Promise<void>
+}
+
+declare const Editor: {
+  readonly setCursor: (rowIndex: number, columnIndex: number) => Promise<void>
+  readonly openCompletion: () => Promise<void>
+  readonly executeTabCompletion: () => Promise<void>
+  readonly openEditorContextMenu: () => Promise<void>
+  readonly executeBraceCompletion: () => Promise<void>
+}
+
+declare const Extension: {
+  readonly addWebExtension: (uri: string) => Promise<void>
+}
+
+declare const FileSystem: {
+  readonly getTmpDir: () => Promise<string>
+  readonly writeFile: (uri: string, content: string) => Promise<void>
+}
+
+declare const Workspace: {
+  readonly setPath: (uri: string) => Promise<void>
+}
+
+declare const Main: {
+  readonly openUri: (uri: string) => Promise<void>
+}
+
+declare const expect: (locator: any) => {
+  readonly toBeVisible: () => Promise<void>
+  readonly toHaveCount: (count: number) => Promise<void>
+  readonly toHaveText: (text: string) => Promise<void>
+  readonly toHaveAttribute: (key: string, value: string) => Promise<void>
+  readonly toHaveClass: (className: string) => Promise<void>
+  readonly toBeFocused: () => Promise<void>
+}
+
+declare const Locator: (selector: string) => any
+
+declare const test: {
+   (name: string, fn: () => Promise<void>) => void
+  readonly skip: (name: string, fn: () => Promise<void>) => {}
+}

--- a/packages/extension-host-worker-tests/typings/types.d.ts
+++ b/packages/extension-host-worker-tests/typings/types.d.ts
@@ -7,7 +7,26 @@ declare const Editor: {
   readonly openCompletion: () => Promise<void>
   readonly executeTabCompletion: () => Promise<void>
   readonly openEditorContextMenu: () => Promise<void>
-  readonly executeBraceCompletion: () => Promise<void>
+  readonly executeBraceCompletion: (brace: string) => Promise<void>
+  readonly cursorUp: () => Promise<void>
+  readonly cursorDown: () => Promise<void>
+  readonly cursorWordLeft: () => Promise<void>
+  readonly cursorWordRight: () => Promise<void>
+  readonly cursorCharacterRight: () => Promise<void>
+  readonly cursorCharacterLeft: () => Promise<void>
+  readonly copyLineDown: () => Promise<void>
+}
+
+declare const Explorer: {
+  readonly openContextMenu: (index: number) => Promise<void>
+  readonly removeDirent: () => Promise<void>
+  readonly focusFirst: () => Promise<void>
+  readonly focusLast: () => Promise<void>
+  readonly focusNext: () => Promise<void>
+  readonly clickCurrent: () => Promise<void>
+
+  // TODO maybe rename this to collapse
+  readonly handleArrowLeft: () => Promise<void>
 }
 
 declare const Extension: {
@@ -17,6 +36,30 @@ declare const Extension: {
 declare const FileSystem: {
   readonly getTmpDir: () => Promise<string>
   readonly writeFile: (uri: string, content: string) => Promise<void>
+  readonly mkdir: (uri: string) => Promise<void>
+}
+
+declare const KeyBoard: {
+  /**
+   * @deprecated this can lead to flaky tests, it might
+   * be better execute the corresponding command instead
+   *
+   */
+  readonly press: (key: string) => Promise<void>
+}
+
+declare const QuickPick: {
+  readonly focusNext: () => Promise<void>
+  readonly open: () => Promise<void>
+  readonly setValue: (value: string) => Promise<void>
+}
+
+declare const SideBar: {
+  readonly open: (id: string) => Promise<void>
+}
+
+declare const Search: {
+  readonly setValue: (value: string) => Promise<void>
 }
 
 declare const Workspace: {
@@ -31,14 +74,16 @@ declare const expect: (locator: any) => {
   readonly toBeVisible: () => Promise<void>
   readonly toHaveCount: (count: number) => Promise<void>
   readonly toHaveText: (text: string) => Promise<void>
-  readonly toHaveAttribute: (key: string, value: string) => Promise<void>
+  readonly toHaveAttribute: (key: string, value: string | null) => Promise<void>
   readonly toHaveClass: (className: string) => Promise<void>
   readonly toBeFocused: () => Promise<void>
+  readonly toHaveCSS: (key: string, value: string) => Promise<void>
+  readonly toBeHidden: () => Promise<void>
 }
 
 declare const Locator: (selector: string) => any
 
 declare const test: {
-   (name: string, fn: () => Promise<void>) => void
+  (name: string, fn: () => Promise<void>): void
   readonly skip: (name: string, fn: () => Promise<void>) => {}
 }

--- a/packages/renderer-worker/src/parts/Test/Test.js
+++ b/packages/renderer-worker/src/parts/Test/Test.js
@@ -1,4 +1,6 @@
 import { VError } from '../VError/VError.js'
+import * as TestFrameWorkComponent from '../TestFrameWorkComponent/TestFrameWorkComponent.js'
+import * as TestFrameWork from '../TestFrameWork/TestFrameWork.js'
 
 export const state = {
   tests: [],
@@ -12,7 +14,15 @@ const importScript = async (url) => {
   }
 }
 
+const exposeGlobals = (global, object) => {
+  for (const [key, value] of Object.entries(object)) {
+    global[key] = value
+  }
+}
+
 export const execute = async (href) => {
+  exposeGlobals(globalThis, TestFrameWorkComponent)
+  exposeGlobals(globalThis, TestFrameWork)
   // TODO
   // 0. wait for page to be ready
   // 1. get script to import from renderer process (url or from html)


### PR DESCRIPTION
… test framework usable by extensions because importmaps are not supported in webworkers