### PR TITLE
add Editor.goToDefinition and Editor.goToTypeDefinition e2e test apis…

### DIFF
--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-error-failed-to-activate-extension.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-error-failed-to-activate-extension.js
@@ -13,7 +13,6 @@ test('sample.type-definition-provider-error-failed-to-activate-extension', async
 add(1, 2)
     `
   )
-  // act
   await Workspace.setPath(tmpDir)
   await Extension.addWebExtension(
     new URL(`../fixtures/${name}`, import.meta.url).toString()
@@ -22,11 +21,11 @@ add(1, 2)
   await Main.openUri(`${tmpDir}/test.xyz`)
   // TODO editor object should have setCursor function
   await Editor.setCursor(0, 0)
-  // TODO editor object should have openContextMenu function
-  await Editor.openEditorContextMenu()
-  // TODO contextMenu should have selectItem function
-  await ContextMenu.selectItem('Go To Type Definition')
 
+  // act
+  await Editor.goToTypeDefinition()
+
+  // assert
   const overlayMessage = Locator('.EditorOverlayMessage')
   await expect(overlayMessage).toBeVisible()
   // TODO error message is too long
@@ -35,3 +34,5 @@ add(1, 2)
     'Error: Failed to activate extension sample.type-definition-provider-error-failed-to-activate-extension: TypeError: x is not a function'
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-error.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-error.js
@@ -12,17 +12,15 @@ test('sample.type-definition-provider-error', async () => {
 add(1, 2)
     `
   )
-  // act
   await Workspace.setPath(tmpDir)
   await Extension.addWebExtension(
     new URL(`../fixtures/${name}`, import.meta.url).toString()
   )
-
-  // act
   await Main.openUri(`${tmpDir}/test.xyz`)
   await Editor.setCursor(0, 0)
-  await Editor.openEditorContextMenu()
-  await ContextMenu.selectItem('Go To Type Definition')
+
+  // act
+  await Editor.goToTypeDefinition()
 
   // assert
   const overlayMessage = Locator('.EditorOverlayMessage')
@@ -31,3 +29,5 @@ add(1, 2)
     'Error: Failed to execute type definition provider: oops'
   )
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-no-result.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-no-result.js
@@ -12,20 +12,20 @@ test.skip('sample.type-definition-provider-no-result', async () => {
 add(1, 2)
     `
   )
-  // act
   await Workspace.setPath(tmpDir)
   await Extension.addWebExtension(
     new URL(`../fixtures/${name}`, import.meta.url).toString()
   )
-
-  // act
   await Main.openUri(`${tmpDir}/test.xyz`)
   await Editor.setCursor(0, 0)
-  await Editor.openEditorContextMenu()
-  await ContextMenu.selectItem('Go To Type Definition')
+
+  // act
+  await Editor.goToTypeDefinition()
 
   // assert
   const overlayMessage = Locator('.EditorOverlayMessage')
   await expect(overlayMessage).toBeVisible()
   await expect(overlayMessage).toHaveText('No type definition found')
 })
+
+export {}

--- a/packages/extension-host-worker-tests/src/sample.type-definition-provider-not-registered.js
+++ b/packages/extension-host-worker-tests/src/sample.type-definition-provider-not-registered.js
@@ -1,5 +1,3 @@
-const name = 'sample.type-definition-provider-not-registered'
-
 test('sample.type-definition-provider-not-registered', async () => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -12,14 +10,12 @@ test('sample.type-definition-provider-not-registered', async () => {
 add(1, 2)
     `
   )
-  // act
   await Workspace.setPath(tmpDir)
-
-  // act
   await Main.openUri(`${tmpDir}/test.xyz`)
   await Editor.setCursor(0, 0)
-  await Editor.openEditorContextMenu()
-  await ContextMenu.selectItem('Go To Type Definition')
+
+  // act
+  await Editor.goToTypeDefinition()
 
   // assert
   const overlayMessage = Locator('.EditorOverlayMessage')
@@ -27,3 +23,5 @@ add(1, 2)
   // TODO should say "no type definition provider found"
   await expect(overlayMessage).toHaveText('No type definition found')
 })
+
+export {}

--- a/packages/extension-host-worker-tests/typings/types.d.ts
+++ b/packages/extension-host-worker-tests/typings/types.d.ts
@@ -15,6 +15,8 @@ declare const Editor: {
   readonly cursorCharacterRight: () => Promise<void>
   readonly cursorCharacterLeft: () => Promise<void>
   readonly copyLineDown: () => Promise<void>
+  readonly goToDefinition: () => Promise<void>
+  readonly goToTypeDefinition: () => Promise<void>
 }
 
 declare const Explorer: {

--- a/packages/renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponentEditor.js
+++ b/packages/renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponentEditor.js
@@ -47,3 +47,12 @@ export const cursorWordLeft = async () => {
 export const cursorWordRight = async () => {
   await Command.execute('Editor.cursorWordRight')
 }
+
+export const goToDefinition = async () => {
+  await Command.execute('Editor.goToDefinition')
+}
+}
+
+export const goToTypeDefinition = async () => {
+  await Command.execute('Editor.goToTypeDefinition')
+}

--- a/packages/renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponentEditor.js
+++ b/packages/renderer-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponentEditor.js
@@ -51,7 +51,6 @@ export const cursorWordRight = async () => {
 export const goToDefinition = async () => {
   await Command.execute('Editor.goToDefinition')
 }
-}
 
 export const goToTypeDefinition = async () => {
   await Command.execute('Editor.goToTypeDefinition')


### PR DESCRIPTION
… to simplify e2e tests, not necessary anymore to open context menu to execute those actions