### PR TITLE
fix: don't show html window control buttons when windowControlsOverla…

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBar.js
+++ b/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBar.js
@@ -29,7 +29,10 @@ const getTitleBarButtonsRemote = () => {
 }
 
 const getTitleBarButtonsElectron = () => {
-  if (Preferences.get('window.titleBarStyle') === 'custom') {
+  if (
+    Preferences.get('window.titleBarStyle') === 'custom' &&
+    !Preferences.get('window.controlsOverlay.enabled')
+  ) {
     return [
       { label: 'Minimize', icon: 'Minimize', id: 'Minimize' },
       { label: 'Maximize', icon: 'Maximize', id: 'ToggleMaximize' },


### PR DESCRIPTION
…y is enabled