### PR TITLE
refactor: omit sourcesContent from sourcemaps, sources are already av…

### DIFF
--- a/build/src/parts/BundleJsRollup/BundleJsRollup.js
+++ b/build/src/parts/BundleJsRollup/BundleJsRollup.js
@@ -44,6 +44,7 @@ export const bundleJs = async ({
     file: codeSplitting ? undefined : join(cwd, 'dist', basename(from)),
     entryFileNames: 'renderer-process.modern.js',
     exports: 'auto',
+    sourcemapExcludeSources: true,
     chunkFileNames(x) {
       return `${x.name}.js`
     },


### PR DESCRIPTION
…ailable as files


decreases size of dist folders: 
- renderer-process: 1.6MB -> 1.2MB (25% less)
- renderer-worker: 5.1MB -> 4.3 MB (15.6% less)