### PR TITLE
refactor: use ripgrep as deb dependency instead of including it with …

### DIFF
--- a/build/src/parts/Deb/Deb.js
+++ b/build/src/parts/Deb/Deb.js
@@ -11,6 +11,7 @@ import * as Path from '../Path/Path.js'
 import * as Product from '../Product/Product.js'
 import * as Remove from '../Remove/Remove.js'
 import * as Rename from '../Rename/Rename.js'
+import * as Replace from '../Replace/Replace.js'
 import * as Stat from '../Stat/Stat.js'
 import * as Tag from '../Tag/Tag.js'
 import * as Template from '../Template/Template.js'
@@ -47,6 +48,11 @@ const copyElectronResult = async () => {
   await Remove.remove(
     `build/.tmp/linux/deb/${debArch}/app/usr/lib/${Product.applicationName}/resources/app/packages/shared-process/node_modules/vscode-ripgrep-with-github-api-error-fix`
   )
+  await Replace.replace({
+    path: `build/.tmp/linux/deb/${debArch}/app/usr/lib/${Product.applicationName}/resources/app/packages/shared-process/src/parts/RgPath/RgPath.js`,
+    occurrence: `export { rgPath } from 'vscode-ripgrep-with-github-api-error-fix'`,
+    replacement: `export const rgPath = 'rg'`,
+  })
 }
 
 const copyMetaFiles = async () => {

--- a/build/src/parts/Deb/Deb.js
+++ b/build/src/parts/Deb/Deb.js
@@ -97,6 +97,7 @@ const copyMetaFiles = async () => {
     'libxss1',
     'libgbm1',
   ]
+  // TODO add options to process.argv whether or not ripgrep should be bundled or a dependency
   const additionalDepends = ['ripgrep']
   const depends = [...defaultDepends, ...additionalDepends].join(', ')
   await Template.write(

--- a/build/src/parts/Template/template_debian_control.txt
+++ b/build/src/parts/Template/template_debian_control.txt
@@ -1,7 +1,7 @@
 Package: @@NAME@@
 Version: @@VERSION@@
 Section: devel
-Depends: libnss3 (>= 2:3.26), gnupg, apt, libxkbfile1, libsecret-1-0, libgtk-3-0 (>= 3.10.0), libxss1, libgbm1
+Depends: @@DEPENDS@@
 Priority: optional
 Architecture: @@ARCHITECTURE@@
 Maintainer: @@MAINTAINER@@


### PR DESCRIPTION
…application to reduce package size