### PR TITLE
fix: cache electron builder dependencies to avoid always downloading …

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Build Electron App (deb)
         if: matrix.os == 'ubuntu-22.04'
         run: node build/bin/build.js --target=electron-deb --force # --force workaround for issue with node-pty
+      - name: Cache Electron Builder Dependencies (Windows)
+        uses: actions/cache@v3
+        id: electron-builder-cache-windows
+        if: matrix.os == 'windows-2022'
+        with:
+          path: '~\AppData\Local\electron-builder'
       - name: Build Electron App (exe)
         if: matrix.os == 'windows-2022'
         run: node build/bin/build.js --target=electron-builder-windows-exe --force # --force workaround for issue with node-pty

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,6 +74,7 @@ jobs:
         if: matrix.os == 'windows-2022'
         with:
           path: '~\AppData\Local\electron-builder'
+          key: ${{ runner.os }}-electron-builder-${{ hashFiles('build/package-lock.json') }}
       - name: Build Electron App (exe)
         if: matrix.os == 'windows-2022'
         run: node build/bin/build.js --target=electron-builder-windows-exe --force # --force workaround for issue with node-pty


### PR DESCRIPTION
…files from github releases which can be flaky sometimes