### PR TITLE
fix: don't throw error when no language configuration is found, retur…

### DIFF
--- a/packages/shared-process/src/parts/ExtensionManagement/ExtensionManagementLanguages.js
+++ b/packages/shared-process/src/parts/ExtensionManagement/ExtensionManagementLanguages.js
@@ -1,6 +1,7 @@
+// TODO rename file to languageConfiguration.js
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import * as ReadJson from '../JsonFile/JsonFile.js'
+import * as JsonFile from '../JsonFile/JsonFile.js'
 import { VError } from '../VError/VError.js'
 import * as ExtensionManagement from './ExtensionManagement.js'
 
@@ -70,7 +71,10 @@ export const getLanguageConfiguration = async (languageId) => {
   try {
     const extensions = await ExtensionManagement.getExtensions()
     const languageConfigurationPath = getLanguageConfigurationPathFromExtensions(extensions, languageId)
-    return await ReadJson.readJson(languageConfigurationPath)
+    if (!languageConfigurationPath) {
+      return {}
+    }
+    return await JsonFile.readJson(languageConfigurationPath)
   } catch (error) {
     throw new VError(error, `Failed to load language configuration for ${languageId}`)
   }

--- a/packages/shared-process/test/ExtensionHostLanguages.test.js
+++ b/packages/shared-process/test/ExtensionHostLanguages.test.js
@@ -173,7 +173,8 @@ test('getLanguageConfiguration', async () => {
     },
   })
 })
-test('getLanguageConfiguration - error - language configuration not found', async () => {
+
+test('getLanguageConfiguration - error - language configuration file not found', async () => {
   const tmpDir = await getTmpDir()
   // @ts-ignore
   ExtensionManagement.getExtensions.mockImplementation(() => {
@@ -223,5 +224,39 @@ test('getLanguageConfiguration - error - language configuration has invalid json
   // TODO should display path as well
   await expect(ExtensionHostLanguages.getLanguageConfiguration('javascript')).rejects.toThrowError(
     new Error('Failed to load language configuration for javascript: JsonParsingError: Json Parsing Error')
+  )
+})
+
+test('getLanguageConfiguration - error - no language configuration', async () => {
+  const tmpDir = await getTmpDir()
+  // @ts-ignore
+  ExtensionManagement.getExtensions.mockImplementation(() => {
+    return [
+      {
+        status: ExtensionManifestStatus.Resolved,
+        id: 'builtin.test',
+        languages: [],
+        path: tmpDir,
+      },
+    ]
+  })
+  expect(await ExtensionHostLanguages.getLanguageConfiguration('test')).toEqual({})
+})
+
+test('getLanguageConfiguration - error - language is null', async () => {
+  const tmpDir = await getTmpDir()
+  // @ts-ignore
+  ExtensionManagement.getExtensions.mockImplementation(() => {
+    return [
+      {
+        status: ExtensionManifestStatus.Resolved,
+        id: 'builtin.javascript',
+        languages: [null],
+        path: tmpDir,
+      },
+    ]
+  })
+  await expect(ExtensionHostLanguages.getLanguageConfiguration('test')).rejects.toThrowError(
+    new Error("Failed to load language configuration for test: TypeError: Cannot read properties of null (reading 'id')")
   )
 })


### PR DESCRIPTION
…n empty object instead