### PR TITLE
refactor: pass port as parameter instead of using event.ports[0] to a…

### DIFF
--- a/packages/main-process/src/parts/HandleMessagePort/HandleMessagePort.js
+++ b/packages/main-process/src/parts/HandleMessagePort/HandleMessagePort.js
@@ -29,5 +29,6 @@ exports.handlePort = async (event, data) => {
     Logger.error(`[main-process] unexpected port type ${data}`)
     return
   }
-  await module.handlePort(event, data)
+  const port = event.ports[0]
+  await module.handlePort(event, port, data)
 }

--- a/packages/main-process/src/parts/HandleMessagePortForCustom/HandleMessagePortForCustom.js
+++ b/packages/main-process/src/parts/HandleMessagePortForCustom/HandleMessagePortForCustom.js
@@ -12,8 +12,7 @@ const getPath = (data) => {
  * @param {import('electron').IpcMainEvent} event
  * @returns
  */
-exports.handlePort = async (event, data) => {
-  const browserWindowPort = event.ports[0]
+exports.handlePort = async (event, browserWindowPort, data) => {
   if (!browserWindowPort) {
     throw new Error(`browserWindowPort must be passed`)
   }

--- a/packages/main-process/src/parts/HandleMessagePortForExtensionHost/HandleMessagePortForExtensionHost.js
+++ b/packages/main-process/src/parts/HandleMessagePortForExtensionHost/HandleMessagePortForExtensionHost.js
@@ -2,7 +2,7 @@ const { fork } = require('node:child_process')
 const Platform = require('../Platform/Platform.js')
 const Logger = require('../Logger/Logger.js')
 
-exports.handlePort = async (event) => {
+exports.handlePort = async (event, browserWindowPort) => {
   const extensionHostPath = Platform.getExtensionHostPath()
   const start = Date.now()
   const extensionHost = fork(extensionHostPath, ['--ipc-type=parent'], {
@@ -16,7 +16,6 @@ exports.handlePort = async (event) => {
   const { pid } = extensionHost
   const forkTime = end - start
   Logger.info(`[main-process] Starting extension host with pid ${pid} (fork took ${forkTime} ms).`)
-  const browserWindowPort = event.ports[0]
 
   await new Promise((resolve, reject) => {
     const handleFirstMessage = (event) => {

--- a/packages/main-process/src/parts/HandleMessagePortForExtensionHostHelperProcess/HandleMessagePortForExtensionHostHelperProcess.js
+++ b/packages/main-process/src/parts/HandleMessagePortForExtensionHostHelperProcess/HandleMessagePortForExtensionHostHelperProcess.js
@@ -2,7 +2,7 @@ const { fork } = require('node:child_process')
 const Platform = require('../Platform/Platform.js')
 const Logger = require('../Logger/Logger.js')
 
-exports.handlePort = async (event) => {
+exports.handlePort = async (event, browserWindowPort) => {
   const extensionHostPath = Platform.getExtensionHostHelperProcessPath()
   const start = Date.now()
   const extensionHost = fork(extensionHostPath, ['--ipc-type=parent'], {
@@ -16,7 +16,6 @@ exports.handlePort = async (event) => {
   const { pid } = extensionHost
   const forkTime = end - start
   Logger.info(`[main-process] Starting extension host helper with pid ${pid} (fork took ${forkTime} ms).`)
-  const browserWindowPort = event.ports[0]
 
   await new Promise((resolve, reject) => {
     const handleFirstMessage = (event) => {

--- a/packages/main-process/src/parts/HandleMessagePortForMainProcess/HandleMessagePortForMainProcess.js
+++ b/packages/main-process/src/parts/HandleMessagePortForMainProcess/HandleMessagePortForMainProcess.js
@@ -5,8 +5,7 @@ const GetResponse = require('../GetResponse/GetResponse.js')
  *
  * @param {import('electron').IpcMainEvent} event
  */
-exports.handlePort = (event) => {
-  const browserWindowPort = event.ports[0]
+exports.handlePort = (event, browserWindowPort) => {
   const { id } = event.sender
   const state = AppWindowStates.findById(id)
   state.port = browserWindowPort

--- a/packages/main-process/src/parts/HandleMessagePortForQuickPick/HandleMessagePortForQuickPick.js
+++ b/packages/main-process/src/parts/HandleMessagePortForQuickPick/HandleMessagePortForQuickPick.js
@@ -17,8 +17,7 @@ const getQuickPickViewFromArray = (views) => {
   return undefined
 }
 
-exports.handlePort = (event) => {
-  const browserWindowPort = event.ports[0]
+exports.handlePort = (event, browserWindowPort) => {
   const browserWindow = Electron.BrowserWindow.getFocusedWindow()
   if (!browserWindow) {
     return

--- a/packages/main-process/src/parts/HandleMessagePortForSharedProcess/HandleMessagePortForSharedProcess.js
+++ b/packages/main-process/src/parts/HandleMessagePortForSharedProcess/HandleMessagePortForSharedProcess.js
@@ -25,13 +25,12 @@ const getFolder = (args) => {
  * @param {import('electron').IpcMainEvent} event
  * @returns
  */
-exports.handlePort = async (event) => {
+exports.handlePort = async (event, browserWindowPort) => {
   const config = AppWindow.findById(event.sender.id)
   if (!config) {
     Logger.warn('port event - config expected')
     return
   }
-  const browserWindowPort = event.ports[0]
   const folder = getFolder(config.parsedArgs)
   Performance.mark(PerformanceMarkerType.WillStartSharedProcess)
   const sharedProcess = await SharedProcess.hydrate({


### PR DESCRIPTION
…void duplicate code and make it easier to switch implementation