### PR TITLE
refactor: use classnames instead of ids for quickpick styles for simp…

### DIFF
--- a/packages/renderer-process/src/parts/ViewletQuickPick/ViewletQuickPick.js
+++ b/packages/renderer-process/src/parts/ViewletQuickPick/ViewletQuickPick.js
@@ -240,11 +240,12 @@ export const create = () => {
   $QuickPickInput.ariaExpanded = AriaBoolean.True
 
   const $QuickPickHeader = document.createElement('div')
-  $QuickPickHeader.id = Ids.QuickPickHeader
+  $QuickPickHeader.className = 'QuickPickHeader'
   $QuickPickHeader.append($QuickPickInput)
 
   const $QuickPickItems = document.createElement('div')
   $QuickPickItems.id = Ids.QuickPickItems
+  $QuickPickItems.className = 'QuickPickItems'
   $QuickPickItems.role = Roles.ListBox
   $QuickPickItems.onpointerdown = ViewletQuickPickEvents.handlePointerDown
   $QuickPickItems.addEventListener(DomEventType.Wheel, ViewletQuickPickEvents.handleWheel, DomEventOptions.Passive)
@@ -255,6 +256,7 @@ export const create = () => {
 
   const $QuickPick = document.createElement('div')
   $QuickPick.id = Ids.QuickPick
+  $QuickPick.className = 'Viewlet QuickPick'
   // $QuickPick.role= 'dialog'
   $QuickPick.append($QuickPickHeader, $QuickPickItems)
   // $QuickPick.setAttribute('aria-modal', 'false') // TODO why is this

--- a/static/css/parts/ViewletQuickPick.css
+++ b/static/css/parts/ViewletQuickPick.css
@@ -2,7 +2,7 @@
    for quickpick to open (3.3ms recalculcate style vs 4.2ms now)  */
 
 /* TODO recalculate style is really slow in chrome for unknown reasons */
-#QuickPick {
+.QuickPick {
   position: absolute;
   width: 600px;
   top: 50px;
@@ -25,7 +25,7 @@
   box-shadow: rgb(0 0 0 / 15%) 0px 0px 8px 2px;
 }
 
-#QuickPickHeader {
+.QuickPickHeader {
   /* width: 100%; */
   display: flex;
   /* margin: 6px 6px 0; */
@@ -36,7 +36,7 @@
   /* margin-bottom: -2px; */
 }
 
-#QuickPickItems {
+.QuickPickItems {
   outline: 0;
   margin: 0;
   padding: 0;
@@ -89,7 +89,7 @@
 }
 
 /* TODO use aria annouce for this */
-#QuickPickCount {
+.QuickPickCount {
   /* Screen Reader Only */
   position: absolute;
   left: -10000px;


### PR DESCRIPTION
…lify css