### PR TITLE
fix: log info message when dialog cannot be shown because there is no…

### DIFF
--- a/packages/main-process/src/parts/ElectronDialog/ElectronDialog.js
+++ b/packages/main-process/src/parts/ElectronDialog/ElectronDialog.js
@@ -1,6 +1,7 @@
 const Assert = require('../Assert/Assert.js')
 const Electron = require('electron')
 const ElectronMessageBoxType = require('../ElectronMessageBoxType/ElectronMessageBoxType.js')
+const Logger = require('../Logger/Logger.js')
 const Platform = require('../Platform/Platform.js')
 const Window = require('../ElectronWindow/ElectronWindow.js')
 
@@ -34,6 +35,7 @@ exports.showMessageBox = async (message, buttons, type = ElectronMessageBoxType.
   Assert.array(buttons)
   const focusedWindow = Window.getFocusedWindow()
   if (!focusedWindow) {
+    Logger.info(`[main-process] cannot show dialog message because there is no focused window`)
     return
   }
   if (message.message) {


### PR DESCRIPTION
… focused window