### PR TITLE
refactor: directly import createPidMap dependencies instead of passin…

### DIFF
--- a/packages/main-process/src/parts/CreatePidMap/CreatePidMap.js
+++ b/packages/main-process/src/parts/CreatePidMap/CreatePidMap.js
@@ -1,8 +1,11 @@
-/**
- *
- * @param {import('electron').BrowserWindow[]} browserWindows
- */
-exports.createPidMap = (browserWindows, browserViews, utilityProcesses) => {
+const { BrowserWindow } = require('electron')
+const ElectronBrowserViewState = require('../ElectronBrowserViewState/ElectronBrowserViewState.js')
+const UtilityProcessState = require('../UtilityProcessState/UtilityProcessState.js')
+
+exports.createPidMap = () => {
+  const browserWindows = BrowserWindow.getAllWindows()
+  const browserViews = ElectronBrowserViewState.getAll()
+  const utilityProcesses = UtilityProcessState.getAll()
   const pidWindowMap = Object.create(null)
   for (const browserWindow of browserWindows) {
     const { webContents } = browserWindow

--- a/packages/main-process/src/parts/ListProcessGetName/ListProcessGetName.js
+++ b/packages/main-process/src/parts/ListProcessGetName/ListProcessGetName.js
@@ -1,16 +1,10 @@
-const { BrowserWindow } = require('electron')
 const Assert = require('../Assert/Assert.js')
 const CreatePidMap = require('../CreatePidMap/CreatePidMap.js')
-const ElectronBrowserViewState = require('../ElectronBrowserViewState/ElectronBrowserViewState.js')
-const UtilityProcessState = require('../UtilityProcessState/UtilityProcessState.js')
 
 exports.getName = (pid, cmd, rootPid) => {
   Assert.object(process)
   Assert.number(rootPid)
-  const browserWindows = BrowserWindow.getAllWindows()
-  const browserViews = ElectronBrowserViewState.getAll()
-  const utilityProcesses = UtilityProcessState.getAll()
-  const pidMap = CreatePidMap.createPidMap(browserWindows, browserViews, utilityProcesses)
+  const pidMap = CreatePidMap.createPidMap()
   if (pid === rootPid) {
     return 'main'
   }

--- a/packages/shared-process/src/parts/ParsePsOutput/ParsePsOutput.js
+++ b/packages/shared-process/src/parts/ParsePsOutput/ParsePsOutput.js
@@ -42,7 +42,7 @@ export const parsePsOutput = (stdout, rootPid, pidMap) => {
     result.push({
       ...parsedLine,
       depth,
-      name: ListProcessGetName.getName(pid, cmd, rootPid),
+      name: ListProcessGetName.getName(pid, cmd, rootPid, pidMap),
     })
     depthMap[pid] = depth + 1
   }


### PR DESCRIPTION
…g them as arguments to allow calling that function from shared process