### PR TITLE
refactor: model editor groups so that each one group always exists to…

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMain.js
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMain.js
@@ -173,20 +173,69 @@ const getSavedActiveIndex = (savedState, restoredGroups) => {
 }
 
 const getRestoredGroups = (savedState, state) => {
+  const { x, y, width, height } = state
   if (Workspace.isTest()) {
-    return { groups: [], activeGroupIndex: -1 }
+    return {
+      groups: [
+        {
+          x,
+          y: 0,
+          width,
+          height,
+          editors: [],
+          tabsUid: 0,
+          uid: Id.create(),
+        },
+      ],
+      activeGroupIndex: 0,
+    }
   }
   const restoredGroups = getMainGroups(savedState, state)
   if (restoredGroups.length === 0) {
-    return { groups: [], activeGroupIndex: -1 }
+    return {
+      groups: [
+        {
+          x,
+          y: 0,
+          width,
+          height,
+          editors: [],
+          tabsUid: 0,
+          uid: Id.create(),
+        },
+      ],
+      activeGroupIndex: 0,
+    }
   }
   const savedActiveIndex = getSavedActiveIndex(savedState, restoredGroups)
   if (savedActiveIndex === -1) {
-    return { groups: [], activeGroupIndex: -1 }
+    return {
+      groups: [
+        {
+          x,
+          y: 0,
+          width,
+          height,
+          editors: [],
+          tabsUid: 0,
+          uid: Id.create(),
+        },
+      ],
+      activeGroupIndex: 0,
+    }
   }
   // TODO support restoring multiple groups
+  const group = restoredGroups[0]
+  const newGroup = {
+    ...group,
+    x,
+    y: 0,
+    width,
+    height,
+    uid: Id.create(),
+  }
   return {
-    groups: [restoredGroups[0]],
+    groups: [newGroup],
     activeGroupIndex: 0,
   }
 }
@@ -317,6 +366,9 @@ export const contentLoaded = async (state) => {
   }
   const commands = []
   for (const group of state.groups) {
+    if (group.editors.length === 0) {
+      continue
+    }
     const editor = Arrays.last(group.editors)
     const x = state.x
     const y = state.y + state.tabHeight

--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMainRender.js
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMainRender.js
@@ -1,6 +1,5 @@
-import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
-import * as ScrollBarFunctions from '../ScrollBarFunctions/ScrollBarFunctions.js'
 import * as GetTabsVirtualDom from '../GetTabsVirtualDom/GetTabsVirtualDom.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
 export const hasFunctionalRender = true
 
@@ -47,7 +46,9 @@ const renderGroupTabs = {
     const oldUids = []
     const newUids = []
     for (const oldGroup of oldGroups) {
-      oldUids.push(oldGroup.uid)
+      if (oldGroup.editors.length > 0) {
+        oldUids.push(oldGroup.uid)
+      }
     }
     for (const newGroup of newGroups) {
       newUids.push(newGroup.uid)
@@ -75,13 +76,14 @@ const renderGroupTabs = {
     }
     for (const insertedGroup of insertedGroups) {
       const { tabsUid, editors, x, y, width, height, activeIndex, tabsDeltaX } = insertedGroup
-      commands.push(['Viewlet.create', ViewletModuleId.MainTabs, tabsUid])
-      commands.push(['Viewlet.setBounds', tabsUid, x, y, width, newState.tabHeight])
-      const tabsDom = GetTabsVirtualDom.getTabsDom(editors, newState.width, activeIndex, newState.tabsDeltax)
-      commands.push(['Viewlet.send', tabsUid, 'setTabsDom', tabsDom])
-      commands.push(['Viewlet.send', tabsUid, 'setScrollLeft', tabsDeltaX])
-      // commands.push(['Viewlet.send', tabsUid, 'setFocusedIndex', -1, activeIndex])
-      commands.push(['Viewlet.append', newState.uid, tabsUid])
+      if (editors.length > 0) {
+        commands.push(['Viewlet.create', ViewletModuleId.MainTabs, tabsUid])
+        commands.push(['Viewlet.setBounds', tabsUid, x, y, width, newState.tabHeight])
+        const tabsDom = GetTabsVirtualDom.getTabsDom(editors, newState.width, activeIndex, newState.tabsDeltax)
+        commands.push(['Viewlet.send', tabsUid, 'setTabsDom', tabsDom])
+        commands.push(['Viewlet.send', tabsUid, 'setScrollLeft', tabsDeltaX])
+        commands.push(['Viewlet.append', newState.uid, tabsUid])
+      }
     }
     for (const group of deletedGroups) {
       commands.push(['Viewlet.dispose', group.tabsUid])

--- a/packages/renderer-worker/test/ViewletMain.test.js
+++ b/packages/renderer-worker/test/ViewletMain.test.js
@@ -63,8 +63,18 @@ test('create', () => {
 test('loadContent - no restored editors', async () => {
   const state = ViewletMain.create(1)
   expect(await ViewletMain.loadContent(state, {})).toMatchObject({
-    activeGroupIndex: -1,
-    groups: [],
+    activeGroupIndex: 0,
+    groups: [
+      {
+        editors: [],
+        height: undefined,
+        tabsUid: 0,
+        uid: 1,
+        width: undefined,
+        x: undefined,
+        y: 0,
+      },
+    ],
   })
 })
 
@@ -92,7 +102,7 @@ test('loadContent - one restored editor', async () => {
         editors: [
           {
             uri: '/test/some-file.txt',
-            uid: 1,
+            uid: 2,
           },
         ],
       },


### PR DESCRIPTION
… make it easier to render empty editor groups