### PR TITLE
feature: remove font preload since it would be unused if another font…

### DIFF
--- a/build/src/parts/BuildServer/BuildServer.js
+++ b/build/src/parts/BuildServer/BuildServer.js
@@ -80,11 +80,6 @@ const copyStaticFiles = async ({ commitHash }) => {
     occurrence: '/css',
     replacement: `/${commitHash}/css`,
   })
-  await Replace.replace({
-    path: `build/.tmp/server/server/static/index.html`,
-    occurrence: '/fonts',
-    replacement: `/${commitHash}/fonts`,
-  })
   await BundleCss.bundleCss({
     outDir: `build/.tmp/server/server/static/${commitHash}/css`,
     assetDir: `/${commitHash}`,

--- a/build/src/parts/Static/Static.js
+++ b/build/src/parts/Static/Static.js
@@ -303,11 +303,6 @@ const copyStaticFiles = async ({ pathPrefix, ignoreIconTheme, commitHash }) => {
     from: 'static/index.html',
     to: `build/.tmp/dist/index.html`,
   })
-  await Replace.replace({
-    path: `build/.tmp/dist/index.html`,
-    occurrence: '/fonts/',
-    replacement: `${pathPrefix}/${commitHash}/fonts/`,
-  })
   if (pathPrefix) {
     await Replace.replace({
       path: `build/.tmp/dist/index.html`,

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Online Code Editor" />
     <title>Code Editor</title>
     <link rel="stylesheet" href="/css/App.css" />
-    <link rel="preload" href="/fonts/FiraCode-VariableFont.ttf" as="font" type="font/ttf" crossorigin />
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <script type="module" src="/packages/renderer-process/src/rendererProcessMain.js"></script>
     <link rel="apple-touch-icon" href="/icons/pwa-icon-192.png" />


### PR DESCRIPTION
… is configured in settings and it doesn't apply to webworker and is unused if the no editor is opened initially