### PR TITLE
fix: don't throw an error when trying to move a folder to trash that …

### DIFF
--- a/packages/shared-process/src/parts/TrashElectron/TrashElectron.js
+++ b/packages/shared-process/src/parts/TrashElectron/TrashElectron.js
@@ -1,5 +1,9 @@
+import { existsSync } from 'node:fs'
 import * as ParentIpc from '../ParentIpc/ParentIpc.js'
 
 export const trash = async (path) => {
+  if (!existsSync(path)) {
+    return
+  }
   await ParentIpc.invoke('Trash.trash', path)
 }

--- a/packages/shared-process/test/TrashElectron.test.js
+++ b/packages/shared-process/test/TrashElectron.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('node:fs', () => ({
+  existsSync: jest.fn(() => {}),
+}))
+
+jest.unstable_mockModule('../src/parts/ParentIpc/ParentIpc.js', () => ({
+  invoke: jest.fn(() => {}),
+}))
+
+const fs = await import('node:fs')
+const TrashElectron = await import('../src/parts/TrashElectron/TrashElectron.js')
+const ParentIpc = await import('../src/parts/ParentIpc/ParentIpc.js')
+
+test("trash - folder doesn't exist", async () => {
+  // @ts-ignore
+  fs.existsSync.mockImplementation(() => {
+    return false
+  })
+  await TrashElectron.trash('/test/file.txt')
+})
+
+test('trash', async () => {
+  // @ts-ignore
+  fs.existsSync.mockImplementation(() => {
+    return true
+  })
+  await TrashElectron.trash('/test/file.txt')
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('Trash.trash', '/test/file.txt')
+})


### PR DESCRIPTION
…doesn't exist