### PR TITLE
Fix virtual DOM extension view CSS rendering

### DIFF
--- a/packages/renderer-worker/src/parts/TestFrameWork/TestFrameWork.js
+++ b/packages/renderer-worker/src/parts/TestFrameWork/TestFrameWork.js
@@ -1,11 +1,32 @@
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
+const defaultTimeout = 1000
+const interval = 50
+
+const delay = (ms) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+const checkCondition = async (method, locator, fnName, options) => {
+  const timeout = options?.timeout ?? defaultTimeout
+  const deadline = Date.now() + timeout
+  while (true) {
+    const result = await RendererProcess.invoke(method, locator, fnName, options)
+    if (!result?.error || Date.now() >= deadline) {
+      return result
+    }
+    await delay(interval)
+  }
+}
+
 export const checkSingleElementCondition = (locator, fnName, options) => {
-  return RendererProcess.invoke('TestFrameWork.checkSingleElementCondition', locator, fnName, options)
+  return checkCondition('TestFrameWork.checkSingleElementCondition', locator, fnName, options)
 }
 
 export const checkMultiElementCondition = (locator, fnName, options) => {
-  return RendererProcess.invoke('TestFrameWork.checkMultiElementCondition', locator, fnName, options)
+  return checkCondition('TestFrameWork.checkMultiElementCondition', locator, fnName, options)
 }
 
 export const showOverlay = (...args) => {

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -11,16 +11,6 @@ interface ViewRenderResult {
   readonly type: string
 }
 
-const toCommands = (result: ViewRenderResult): readonly (readonly unknown[])[] => {
-  if (result.type === 'setDom') {
-    return [['Viewlet.setDom2', result.dom || []]]
-  }
-  if (result.type === 'setPatches') {
-    return [['Viewlet.setPatches', result.patches || []]]
-  }
-  return []
-}
-
 const getCssId = (view: ExtensionView): string => {
   return `ExtensionView:${view.id}`
 }
@@ -52,7 +42,7 @@ const createContext = (state: ViewletExtensionViewState, savedState: unknown): u
 const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRenderResult): ViewletExtensionViewState => {
   return {
     ...state,
-    commands: toCommands(result),
+    commands: [],
     dom: result.type === 'setDom' ? result.dom || [] : state.dom,
     patches: result.type === 'setPatches' ? result.patches || [] : [],
   }
@@ -171,6 +161,14 @@ export const handleBlur = (state: ViewletExtensionViewState, name: string): Prom
     name,
     type: 'blur',
   })
+}
+
+export const Commands = {
+  handleBlur,
+  handleClick,
+  handleFocus,
+  handleInput,
+  handleSubmit,
 }
 
 export const dispose = async (state: ViewletExtensionViewState): Promise<void> => {

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
@@ -4,6 +4,8 @@ export const hasFunctionalRender = true
 
 export const hasFunctionalRootRender = true
 
+export const hasFunctionalEvents = true
+
 const renderIframe = {
   isEqual(oldState: ViewletExtensionViewState, newState: ViewletExtensionViewState): boolean {
     return (

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -268,6 +268,8 @@ const getRenderCommands = (module, oldState, newState, uid = newState.uid || mod
           command.splice(1, 0, uid)
         } else if (command[0] === 'Viewlet.setDom') {
           command.splice(1, 0, uid)
+        } else if (command[0] === 'Viewlet.setPatches') {
+          command.splice(1, 0, uid)
         } else if (command[0] !== 'Viewlet.send' && command[0] !== 'Viewlet.ariaAnnounce' && command[0] !== 'Viewlet.createFunctionalRoot') {
           command.unshift('Viewlet.send', uid)
         }

--- a/packages/renderer-worker/test/TestFrameWork.test.js
+++ b/packages/renderer-worker/test/TestFrameWork.test.js
@@ -1,0 +1,32 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const TestFrameWork = await import('../src/parts/TestFrameWork/TestFrameWork.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('checkSingleElementCondition retries until condition passes', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValueOnce({ error: true })
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValueOnce({ error: false })
+
+  await expect(TestFrameWork.checkSingleElementCondition({ selector: '.Test' }, 'toBeVisible', { timeout: 100 })).resolves.toEqual({ error: false })
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
+})
+
+test('checkSingleElementCondition returns last failed result after timeout', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue({ error: true })
+
+  await expect(TestFrameWork.checkSingleElementCondition({ selector: '.Test' }, 'toBeVisible', { timeout: 0 })).resolves.toEqual({ error: true })
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -42,6 +42,16 @@ jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManage
 
 const ViewletExtensionView = await import('../src/parts/ViewletExtensionView/ViewletExtensionView.ts')
 const ViewletExtensionViewRender = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts')
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+
+test('render supports functional events', () => {
+  expect(ViewletExtensionViewRender.hasFunctionalEvents).toBe(true)
+})
+
+test('exports virtual dom event commands', () => {
+  expect(ViewletExtensionView.Commands.handleInput).toBe(ViewletExtensionView.handleInput)
+  expect(ViewletExtensionView.Commands.handleClick).toBe(ViewletExtensionView.handleClick)
+})
 
 test('loadContent loads css from extension view metadata', async () => {
   const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
@@ -51,6 +61,40 @@ test('loadContent loads css from extension view metadata', async () => {
   expect(fetch).toHaveBeenCalledWith('/extensions/sample/view.css')
   expect(newState.css).toBe('.Testing { color: red; }')
   expect(newState.cssId).toBe('ExtensionView:sample.views.testing')
+})
+
+test('loadContent stores virtual dom without duplicate commands', async () => {
+  const dom = [{ type: 4 }]
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    dom,
+    type: 'setDom',
+  })
+  const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
+
+  const newState = await ViewletExtensionView.loadContent(state, undefined)
+
+  expect(newState.commands).toEqual([])
+  expect(newState.dom).toBe(dom)
+  expect(newState.patches).toEqual([])
+})
+
+test('handleClick stores patches without duplicate commands', async () => {
+  const patches = [{ type: 1 }]
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    patches,
+    type: 'setPatches',
+  })
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    kind: 'virtualDom',
+  }
+
+  const newState = await ViewletExtensionView.handleClick(state, 'connect')
+
+  expect(newState.commands).toEqual([])
+  expect(newState.patches).toBe(patches)
 })
 
 test('loadContent ignores css load errors', async () => {

--- a/packages/renderer-worker/test/ViewletManager.test.js
+++ b/packages/renderer-worker/test/ViewletManager.test.js
@@ -33,6 +33,26 @@ const RendererProcess = await import('../src/parts/RendererProcess/RendererProce
 
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 
+test('render adds uid to setPatches command', () => {
+  const patches = [{ type: 1 }]
+  const mockModule = {
+    render: [
+      {
+        apply() {
+          return ['Viewlet.setPatches', patches]
+        },
+        isEqual() {
+          return false
+        },
+      },
+    ],
+  }
+
+  const commands = ViewletManager.render(mockModule, {}, {}, 42)
+
+  expect(commands).toEqual([['Viewlet.setPatches', 42, patches]])
+})
+
 test.skip('load', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockImplementation(() => {})


### PR DESCRIPTION
## Summary
- Route `Viewlet.setPatches` render commands through the active viewlet uid.
- Enable functional events for extension virtual DOM views and expose event handlers through the command map.
- Avoid duplicate raw DOM/patch commands from extension view state; let render state drive `setDom`/`setPatches`.
- Retry renderer-worker test framework element checks briefly so UI assertions can observe async rerenders.

## Verification
- `cd packages/renderer-worker && npm test -- ViewletExtensionViewCss.test.js`
- `cd packages/renderer-worker && npm test -- ViewletManager.test.js`
- `cd packages/renderer-worker && npm test -- TestFrameWork.test.js`
- Browser check: `http://localhost:3000/tests/trello.virtual-dom-view.boards.html` reaches `test passed` and shows `Roadmap`.