### PR TITLE
feature: extension view event listeners

### DIFF
--- a/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
+++ b/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
@@ -10,8 +10,18 @@ export interface ExtensionViewIframe {
   readonly src: string
 }
 
+export interface DomEventListener {
+  readonly capture?: boolean
+  readonly name: string | number
+  readonly params: readonly string[]
+  readonly passive?: boolean
+  readonly preventDefault?: boolean
+  readonly stopPropagation?: boolean
+}
+
 export interface ExtensionView {
   readonly css?: string
+  readonly eventListeners?: readonly DomEventListener[]
   readonly extensionId: string
   readonly icon: string
   readonly id: string

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -76,6 +76,7 @@ export const create = (id: number, uri: string, x: number, y: number, width: num
     csp: '',
     credentialless: true,
     dom: [],
+    eventListeners: [],
     height,
     iframeSandbox: [],
     iframeSrc: '',
@@ -97,6 +98,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
   }
   const css = await loadCss(view)
   const cssId = css ? getCssId(view) : ''
+  const eventListeners = view.eventListeners || []
   if (view.kind === 'virtualDom') {
     const result = await ExtensionManagementWorker.invoke(
       'Extensions.createViewInstance',
@@ -114,6 +116,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
         css,
         cssId,
         error: createResult.error,
+        eventListeners,
         kind: view.kind,
         patches: [],
         title: view.title,
@@ -124,6 +127,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
       ...renderVirtualDomResult(state, renderResult),
       css,
       cssId,
+      eventListeners,
       kind: view.kind,
       title: view.title,
     }
@@ -137,6 +141,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
     cssId,
     csp: view.iframe.csp,
     credentialless: view.iframe.credentialless,
+    eventListeners,
     iframeSandbox: view.iframe.sandbox,
     iframeSrc: view.iframe.src,
     kind: 'iframe',
@@ -161,40 +166,37 @@ const dispatchEvent = async (state: ViewletExtensionViewState, event: unknown): 
   return renderVirtualDomResult(state, result as ViewRenderResult | undefined)
 }
 
-export const handleInput = (state: ViewletExtensionViewState, name: string, value: string): Promise<ViewletExtensionViewState> => {
+export const handleViewEvent = (
+  state: ViewletExtensionViewState,
+  type: string,
+  name: string,
+  value?: unknown,
+): Promise<ViewletExtensionViewState> => {
   return dispatchEvent(state, {
     name,
-    type: 'input',
-    value,
+    type,
+    ...(value !== undefined && { value }),
   })
+}
+
+export const handleInput = (state: ViewletExtensionViewState, name: string, value: string): Promise<ViewletExtensionViewState> => {
+  return handleViewEvent(state, 'input', name, value)
 }
 
 export const handleClick = (state: ViewletExtensionViewState, name: string): Promise<ViewletExtensionViewState> => {
-  return dispatchEvent(state, {
-    name,
-    type: 'click',
-  })
+  return handleViewEvent(state, 'click', name)
 }
 
 export const handleSubmit = (state: ViewletExtensionViewState, name: string): Promise<ViewletExtensionViewState> => {
-  return dispatchEvent(state, {
-    name,
-    type: 'submit',
-  })
+  return handleViewEvent(state, 'submit', name)
 }
 
 export const handleFocus = (state: ViewletExtensionViewState, name: string): Promise<ViewletExtensionViewState> => {
-  return dispatchEvent(state, {
-    name,
-    type: 'focus',
-  })
+  return handleViewEvent(state, 'focus', name)
 }
 
 export const handleBlur = (state: ViewletExtensionViewState, name: string): Promise<ViewletExtensionViewState> => {
-  return dispatchEvent(state, {
-    name,
-    type: 'blur',
-  })
+  return handleViewEvent(state, 'blur', name)
 }
 
 export const Commands = {
@@ -203,6 +205,7 @@ export const Commands = {
   handleFocus,
   handleInput,
   handleSubmit,
+  handleViewEvent,
 }
 
 export const dispose = async (state: ViewletExtensionViewState): Promise<void> => {

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
@@ -60,28 +60,33 @@ const renderCommands = {
 
 export const render = [renderIframe, renderDom, renderPatches, renderCss, renderCommands]
 
-export const renderEventListeners = (): readonly any[] => {
+const defaultEventListeners = [
+  {
+    name: 'handleInput',
+    params: ['handleInput', 'event.target.name', 'event.target.value'],
+  },
+  {
+    name: 'handleClick',
+    params: ['handleClick', 'event.target.name'],
+  },
+  {
+    name: 'handleSubmit',
+    params: ['handleSubmit', 'event.target.name'],
+    preventDefault: true,
+  },
+  {
+    name: 'handleFocus',
+    params: ['handleFocus', 'event.target.name'],
+  },
+  {
+    name: 'handleBlur',
+    params: ['handleBlur', 'event.target.name'],
+  },
+]
+
+export const renderEventListeners = (state?: ViewletExtensionViewState): readonly any[] => {
   return [
-    {
-      name: 'handleInput',
-      params: ['handleInput', 'event.target.name', 'event.target.value'],
-    },
-    {
-      name: 'handleClick',
-      params: ['handleClick', 'event.target.name'],
-    },
-    {
-      name: 'handleSubmit',
-      params: ['handleSubmit', 'event.target.name'],
-      preventDefault: true,
-    },
-    {
-      name: 'handleFocus',
-      params: ['handleFocus', 'event.target.name'],
-    },
-    {
-      name: 'handleBlur',
-      params: ['handleBlur', 'event.target.name'],
-    },
+    ...defaultEventListeners,
+    ...(state?.eventListeners || []),
   ]
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -6,6 +6,7 @@ export interface ViewletExtensionViewState {
   readonly credentialless: boolean
   readonly dom: readonly unknown[]
   readonly error?: unknown
+  readonly eventListeners: readonly unknown[]
   readonly height: number
   readonly iframeSandbox: readonly string[]
   readonly iframeSrc: string

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -530,7 +530,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
 
     if (module.renderEventListeners) {
       // TODO reuse event listeners between components
-      const eventListeners = await module.renderEventListeners()
+      const eventListeners = await module.renderEventListeners(newState)
       if (shouldRenderEvents === false) {
         commands.push(['Viewlet.registerEventListeners', viewletUid, eventListeners])
       } else {

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -3,6 +3,12 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 const extensionViews = {
   view: {
     css: '/extensions/sample/view.css',
+    eventListeners: [
+      {
+        name: 'handleDragStart',
+        params: ['handleViewEvent', 'dragstart', 'event.target.name'],
+      },
+    ],
     extensionId: 'sample.extension',
     icon: '',
     id: 'sample.views.testing',
@@ -51,6 +57,7 @@ test('render supports functional events', () => {
 test('exports virtual dom event commands', () => {
   expect(ViewletExtensionView.Commands.handleInput).toBe(ViewletExtensionView.handleInput)
   expect(ViewletExtensionView.Commands.handleClick).toBe(ViewletExtensionView.handleClick)
+  expect(ViewletExtensionView.Commands.handleViewEvent).toBe(ViewletExtensionView.handleViewEvent)
 })
 
 test('loadContent loads css from extension view metadata', async () => {
@@ -76,7 +83,20 @@ test('loadContent stores virtual dom without duplicate commands', async () => {
 
   expect(newState.commands).toEqual([])
   expect(newState.dom).toBe(dom)
+  expect(newState.eventListeners).toBe(extensionViews.view.eventListeners)
   expect(newState.patches).toEqual([])
+})
+
+test('renderEventListeners includes extension view listeners', () => {
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    eventListeners: extensionViews.view.eventListeners,
+  }
+
+  expect(ViewletExtensionViewRender.renderEventListeners(state)).toEqual([
+    ...ViewletExtensionViewRender.renderEventListeners(),
+    ...extensionViews.view.eventListeners,
+  ])
 })
 
 test('handleClick stores patches without duplicate commands', async () => {


### PR DESCRIPTION
## Summary
- Carry extension view event listener metadata through renderer-worker state.
- Register default plus contributed extension view listeners with the renderer process.
- Add a generic `handleViewEvent` command for extension virtual DOM events.

## Validation
- `npm test -- --runTestsByPath test/ViewletExtensionViewCss.test.js`
- `npm run type-check`