### PR TITLE
feature: extension view listener fallback

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
@@ -82,6 +82,33 @@ const defaultEventListeners = [
     name: 'handleBlur',
     params: ['handleBlur', 'event.target.name'],
   },
+  {
+    name: 'handleContextMenu',
+    params: ['handleViewEvent', 'contextmenu', 'event.target.name'],
+    preventDefault: true,
+  },
+  {
+    name: 'handleDragStart',
+    params: ['handleViewEvent', 'dragstart', 'event.target.name'],
+  },
+  {
+    name: 'handleDragEnd',
+    params: ['handleViewEvent', 'dragend', 'event.target.name'],
+  },
+  {
+    name: 'handleDragOver',
+    params: ['handleViewEvent', 'dragover', 'event.target.name'],
+    preventDefault: true,
+  },
+  {
+    name: 'handleDragLeave',
+    params: ['handleViewEvent', 'dragleave', 'event.target.name'],
+  },
+  {
+    name: 'handleDrop',
+    params: ['handleViewEvent', 'drop', 'event.target.name'],
+    preventDefault: true,
+  },
 ]
 
 export const renderEventListeners = (state?: ViewletExtensionViewState): readonly any[] => {


### PR DESCRIPTION
## Summary
- add default extension-view listener registrations for drag/drop and contextmenu compatibility
- prevents existing Trello virtual DOM listener names from warning when installed @lvce-editor/api drops static metadata

## Verification
- npm test -- --runTestsByPath test/ViewletExtensionViewCss.test.js
- npm run type-check
- Playwright check against http://localhost:3000/ opened Trello, dispatched drag events, and observed 0 listener-not-found warnings