### PR TITLE
[codex] add renderer extension keybinding context support

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -146,6 +146,7 @@ export const commandMap = {
   'ExtensionManagement.getExtensions': lazy('ExtensionManagement.getExtensions'),
   'ExtensionManagement.getExtensionsEtag': lazy('ExtensionManagement.getExtensionsEtag'),
   'ExtensionManagement.handleExtensionStatusUpdate': lazy('ExtensionManagement.handleExtensionStatusUpdate'),
+  'ExtensionManagement.handleViewContextChange': lazy('ExtensionManagement.handleViewContextChange'),
   'ExtensionManagement.invalidateExtensionsCache': lazy('ExtensionManagement.invalidateExtensionsCache'),
   'ExtensionManagement.uninstall': lazy('ExtensionManagement.uninstall'),
   'ExtensionMeta.addNodeExtension': lazy('ExtensionMeta.addNodeExtension'),

--- a/packages/renderer-worker/src/parts/ExtensionKeyBindings/ExtensionKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ExtensionKeyBindings/ExtensionKeyBindings.js
@@ -1,0 +1,28 @@
+import { assetDir } from '../AssetDir/AssetDir.js'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as KeyCode from '../KeyCode/KeyCode.js'
+import * as Logger from '../Logger/Logger.js'
+import { getPlatform } from '../Platform/Platform.js'
+import * as ParseKeyBindingString from '../ParseKeyBindingString/ParseKeyBindingString.js'
+
+const toKeyBinding = (contribution) => {
+  const key = ParseKeyBindingString.parseKeyBindingString(contribution.key)
+  if (key === KeyCode.Unknown) {
+    Logger.warn(`ignoring extension keybinding with invalid key: ${contribution.key}`)
+    return undefined
+  }
+  return {
+    key,
+    command: 'ExtensionHost.executeCommand',
+    args: [contribution.command, ...(contribution.args || [])],
+    ...(contribution.when && { when: contribution.when }),
+  }
+}
+
+export const getKeyBindings = async () => {
+  const contributions = await ExtensionManagementWorker.invoke('Extensions.getKeyBindings', assetDir, getPlatform())
+  if (!Array.isArray(contributions)) {
+    return []
+  }
+  return contributions.map(toKeyBinding).filter(Boolean)
+}

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
@@ -10,6 +10,7 @@ export const Commands = {
   getExtensions: ExtensionManagement.getAllExtensions,
   getExtensionsEtag: ExtensionManagement.getExtensionsEtag,
   handleExtensionStatusUpdate: ExtensionManagement.handleExtensionStatusUpdate,
+  handleViewContextChange: ExtensionManagement.handleViewContextChange,
   uninstall: ExtensionManagement.uninstall,
   invalidateExtensionsCache: ExtensionManagement.invalidateExtensionsCache,
 }

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -2,6 +2,7 @@ import * as Command from '../Command/Command.js'
 import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as ExtensionManifestStatus from '../ExtensionManifestStatus/ExtensionManifestStatus.js'
+import * as ExtensionViewContext from '../ExtensionViewContext/ExtensionViewContext.js'
 import * as InstallExtension from '../InstallExtension/InstallExtension.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
@@ -15,10 +16,15 @@ export const handleExtensionStatusUpdate = async () => {
 export const invalidateExtensionsCache = async () => {
   try {
     await ExtensionManagementWorker.invoke('Extensions.invalidateExtensionsCache')
+    await Command.execute('KeyBindings.hydrate')
     await Command.execute('Layout.handleExtensionsChanged')
   } catch {
     // ignore
   }
+}
+
+export const handleViewContextChange = (uid, viewId, context) => {
+  ExtensionViewContext.handleViewContextChange(uid, viewId, context)
 }
 
 export const install = async (id) => {

--- a/packages/renderer-worker/src/parts/ExtensionViewContext/ExtensionViewContext.js
+++ b/packages/renderer-worker/src/parts/ExtensionViewContext/ExtensionViewContext.js
@@ -1,0 +1,42 @@
+import * as Context from '../Context/Context.js'
+import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
+
+const contexts = Object.create(null)
+
+const getAllKeys = () => {
+  const keys = new Set()
+  for (const context of Object.values(contexts)) {
+    for (const key of Object.keys(context)) {
+      keys.add(key)
+    }
+  }
+  return keys
+}
+
+const removeKeys = (keys) => {
+  for (const key of keys) {
+    Context.remove(key)
+  }
+}
+
+const addAllContexts = () => {
+  for (const context of Object.values(contexts)) {
+    for (const [key, value] of Object.entries(context)) {
+      if (value === true) {
+        Context.set(key, true)
+      }
+    }
+  }
+}
+
+export const handleViewContextChange = (uid, viewId, context) => {
+  const oldKeys = getAllKeys()
+  removeKeys(oldKeys)
+  if (!context || Object.keys(context).length === 0) {
+    delete contexts[uid]
+  } else {
+    contexts[uid] = context
+  }
+  addAllContexts()
+  KeyBindingsState.update()
+}

--- a/packages/renderer-worker/src/parts/KeyBindings/KeyBindings.js
+++ b/packages/renderer-worker/src/parts/KeyBindings/KeyBindings.js
@@ -1,5 +1,6 @@
 import * as Command from '../Command/Command.js'
 import * as Assert from '../Assert/Assert.ts'
+import * as ExtensionKeyBindings from '../ExtensionKeyBindings/ExtensionKeyBindings.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 
 // TODO where to store keybindings? need them here and in renderer process
@@ -33,4 +34,9 @@ export const handleKeyBinding = async (identifier) => {
   //     ...(keyBinding.args || [])
   //   )
   // }
+}
+
+export const hydrate = async () => {
+  const keyBindings = await ExtensionKeyBindings.getKeyBindings()
+  KeyBindingsState.setKeyBindings('extensions', keyBindings)
 }

--- a/packages/renderer-worker/src/parts/KeyBindingsInitial/KeyBindingsInitial.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsInitial/KeyBindingsInitial.js
@@ -1,7 +1,6 @@
+import * as ExtensionKeyBindings from '../ExtensionKeyBindings/ExtensionKeyBindings.js'
 import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
-
-// TODO extension key bindings
 
 const getViewletKeyBindings = (module) => {
   if (module.getKeyBindings) {
@@ -21,7 +20,6 @@ const maybeLoad = async (id) => {
 export const getKeyBindings = async () => {
   const ids = Object.keys(ViewletModuleId)
   const modules = await Promise.all(ids.map(maybeLoad))
-  const keyBindingsPromises = await Promise.all(modules.map(getViewletKeyBindings))
-  const keybindings = keyBindingsPromises.flat(1)
-  return keybindings
+  const keyBindingsPromises = await Promise.all([...modules.map(getViewletKeyBindings), ExtensionKeyBindings.getKeyBindings()])
+  return keyBindingsPromises.flat(1)
 }

--- a/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
@@ -63,6 +63,13 @@ export const addKeyBindings = (id, keyBindings) => {
   update()
 }
 
+export const setKeyBindings = (id, keyBindings) => {
+  Assert.string(id)
+  Assert.array(keyBindings)
+  state.keyBindingSets[id] = keyBindings
+  update()
+}
+
 export const removeKeyBindings = (id) => {
   const { keyBindingSets } = state
   if (!(id in keyBindingSets)) {

--- a/packages/renderer-worker/src/parts/ParseKeyBindingString/ParseKeyBindingString.js
+++ b/packages/renderer-worker/src/parts/ParseKeyBindingString/ParseKeyBindingString.js
@@ -1,0 +1,98 @@
+import * as KeyCode from '../KeyCode/KeyCode.js'
+import * as KeyModifier from '../KeyModifier/KeyModifier.js'
+
+const keyAliases = {
+  '`': KeyCode.Backquote,
+  ',': KeyCode.Comma,
+  '-': KeyCode.Minus,
+  '=': KeyCode.Equal,
+  '+': KeyCode.Plus,
+  '*': KeyCode.Star,
+  '\\': KeyCode.Backslash,
+  backquote: KeyCode.Backquote,
+  backslash: KeyCode.Backslash,
+  comma: KeyCode.Comma,
+  delete: KeyCode.Delete,
+  down: KeyCode.DownArrow,
+  downarrow: KeyCode.DownArrow,
+  end: KeyCode.End,
+  enter: KeyCode.Enter,
+  escape: KeyCode.Escape,
+  f1: KeyCode.F1,
+  f2: KeyCode.F2,
+  f3: KeyCode.F3,
+  f4: KeyCode.F4,
+  f5: KeyCode.F5,
+  f6: KeyCode.F6,
+  f7: KeyCode.F7,
+  f8: KeyCode.F8,
+  f9: KeyCode.F9,
+  f10: KeyCode.F10,
+  f11: KeyCode.F11,
+  f12: KeyCode.F12,
+  home: KeyCode.Home,
+  insert: KeyCode.Insert,
+  left: KeyCode.LeftArrow,
+  leftarrow: KeyCode.LeftArrow,
+  minus: KeyCode.Minus,
+  pagedown: KeyCode.PageDown,
+  pageup: KeyCode.PageUp,
+  plus: KeyCode.Plus,
+  right: KeyCode.RightArrow,
+  rightarrow: KeyCode.RightArrow,
+  space: KeyCode.Space,
+  tab: KeyCode.Tab,
+  up: KeyCode.UpArrow,
+  uparrow: KeyCode.UpArrow,
+}
+
+const getKeyCode = (part) => {
+  const normalized = part.toLowerCase()
+  if (normalized.length === 1 && normalized >= 'a' && normalized <= 'z') {
+    return KeyCode[`Key${normalized.toUpperCase()}`]
+  }
+  if (normalized.length === 1 && normalized >= '0' && normalized <= '9') {
+    return KeyCode[`Digit${normalized}`]
+  }
+  return keyAliases[normalized] || KeyCode.Unknown
+}
+
+export const parseKeyBindingString = (keybinding) => {
+  if (typeof keybinding !== 'string') {
+    return KeyCode.Unknown
+  }
+  const parts = keybinding
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length === 0) {
+    return KeyCode.Unknown
+  }
+  let key = KeyCode.Unknown
+  let modifiers = 0
+  for (const part of parts) {
+    const normalized = part.toLowerCase()
+    switch (normalized) {
+      case 'alt':
+        modifiers |= KeyModifier.Alt
+        break
+      case 'cmd':
+      case 'command':
+      case 'ctrl':
+      case 'ctrlcmd':
+      case 'meta':
+        modifiers |= KeyModifier.CtrlCmd
+        break
+      case 'shift':
+        modifiers |= KeyModifier.Shift
+        break
+      default:
+        key = getKeyCode(part)
+        break
+    }
+  }
+  if (key === KeyCode.Unknown) {
+    return KeyCode.Unknown
+  }
+  return modifiers | key
+}

--- a/packages/renderer-worker/test/ParseKeyBindingString.test.js
+++ b/packages/renderer-worker/test/ParseKeyBindingString.test.js
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
+import * as KeyModifier from '../src/parts/KeyModifier/KeyModifier.js'
+import * as ParseKeyBindingString from '../src/parts/ParseKeyBindingString/ParseKeyBindingString.js'
+
+test('parseKeyBindingString parses modifiers and named keys', () => {
+  expect(ParseKeyBindingString.parseKeyBindingString('Ctrl+Enter')).toBe(KeyModifier.CtrlCmd | KeyCode.Enter)
+  expect(ParseKeyBindingString.parseKeyBindingString('Alt+Left')).toBe(KeyModifier.Alt | KeyCode.LeftArrow)
+  expect(ParseKeyBindingString.parseKeyBindingString('CtrlCmd+Shift+R')).toBe(
+    KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyR,
+  )
+})
+
+test('parseKeyBindingString returns unknown for invalid keys', () => {
+  expect(ParseKeyBindingString.parseKeyBindingString('Ctrl+Nope')).toBe(KeyCode.Unknown)
+})


### PR DESCRIPTION
## Summary
- load extension-contributed keybindings into renderer-worker
- parse human-readable keybinding strings into existing key identifiers
- track extension view contexts and refresh active keybindings when context changes

## Validation
- npm run type-check
- npm test -- --runInBand ParseKeyBindingString.test.js
- git diff --check

Note: an unrelated pre-existing change remains in packages/shared-process/src/parts/ProcessExplorerPath/ProcessExplorerPath.js and is not included in this PR.