### PR TITLE
feature: fix extension view rerender

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -179,6 +179,14 @@ export const handleViewEvent = (
   })
 }
 
+export const rerender = async (state: ViewletExtensionViewState): Promise<ViewletExtensionViewState> => {
+  if (state.kind !== 'virtualDom') {
+    return state
+  }
+  const result = await ExtensionManagementWorker.invoke('Extensions.renderViewInstance', state.uri, state.uid, assetDir, getPlatform())
+  return renderVirtualDomResult(state, result as ViewRenderResult)
+}
+
 export const handleInput = (state: ViewletExtensionViewState, name: string, value: string): Promise<ViewletExtensionViewState> => {
   return handleViewEvent(state, 'input', name, value)
 }
@@ -206,6 +214,7 @@ export const Commands = {
   handleInput,
   handleSubmit,
   handleViewEvent,
+  rerender,
 }
 
 export const dispose = async (state: ViewletExtensionViewState): Promise<void> => {

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -58,6 +58,7 @@ test('exports virtual dom event commands', () => {
   expect(ViewletExtensionView.Commands.handleInput).toBe(ViewletExtensionView.handleInput)
   expect(ViewletExtensionView.Commands.handleClick).toBe(ViewletExtensionView.handleClick)
   expect(ViewletExtensionView.Commands.handleViewEvent).toBe(ViewletExtensionView.handleViewEvent)
+  expect(ViewletExtensionView.Commands.rerender).toBe(ViewletExtensionView.rerender)
 })
 
 test('loadContent loads css from extension view metadata', async () => {
@@ -115,6 +116,38 @@ test('handleClick stores patches without duplicate commands', async () => {
 
   expect(newState.commands).toEqual([])
   expect(newState.patches).toBe(patches)
+})
+
+test('rerender stores patches without duplicate commands', async () => {
+  const patches = [{ type: 1 }]
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    patches,
+    type: 'setPatches',
+  })
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    commands: [['stale']],
+    kind: 'virtualDom',
+  }
+
+  const newState = await ViewletExtensionView.rerender(state)
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.renderViewInstance', 'sample.views.testing', 1, '', 4)
+  expect(newState.commands).toEqual([])
+  expect(newState.patches).toBe(patches)
+})
+
+test('rerender ignores iframe views', async () => {
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    kind: 'iframe',
+  }
+
+  const newState = await ViewletExtensionView.rerender(state)
+
+  expect(newState).toBe(state)
+  expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
 })
 
 test('loadContent ignores css load errors', async () => {


### PR DESCRIPTION
## Summary
- add a renderer-worker rerender command for virtual-dom extension views
- route rerender through Extensions.renderViewInstance so async extension updates can apply patches
- cover command registration, patch handling, and iframe no-op behavior

## Validation
- npm test -- ViewletExtensionViewCss.test.js
- npm run type-check
- npm test -- TrelloView.test.ts
- npm test -- ExtensionView.test.ts --coverage=false