### PR TITLE
feature: process explorer rpc ref counting

### DIFF
--- a/packages/shared-process/src/parts/HandleIncomingIpc/HandleIncomingIpc.js
+++ b/packages/shared-process/src/parts/HandleIncomingIpc/HandleIncomingIpc.js
@@ -3,8 +3,10 @@ import * as Assert from '../Assert/Assert.js'
 import * as HandleIncomingIpcMessagePort from '../HandleIncomingIpcMessagePort/HandleIncomingIpcMessagePort.js'
 import * as HandleIncomingIpcWebSocket from '../HandleIncomingIpcWebSocket/HandleIncomingIpcWebSocket.js'
 import * as HandleIpcModule from '../HandleIpcModule/HandleIpcModule.js'
+import * as IpcId from '../IpcId/IpcId.js'
 import * as IsMessagePortMain from '../IsMessagePortMain/IsMessagePortMain.js'
 import * as IsSocket from '../IsSocket/IsSocket.js'
+import * as ProcessExplorer from '../ProcessExplorer/ProcessExplorer.js'
 
 const strinfyHandle = (handle) => {
   if (!handle) {
@@ -31,5 +33,12 @@ export const handleIncomingIpc = async (ipcId, handle, message) => {
   Assert.number(ipcId)
   const module = HandleIpcModule.getModule(ipcId)
   const { target, response } = await getIpcAndResponse(module, handle, message)
-  await ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, response, ipcId)
+  try {
+    await ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, response, ipcId)
+  } catch (error) {
+    if (ipcId === IpcId.ProcessExplorer) {
+      ProcessExplorer.decreaseRefCount()
+    }
+    throw error
+  }
 }

--- a/packages/shared-process/src/parts/HandleIncomingIpcMessagePort/HandleIncomingIpcMessagePort.js
+++ b/packages/shared-process/src/parts/HandleIncomingIpcMessagePort/HandleIncomingIpcMessagePort.js
@@ -1,6 +1,6 @@
 export const handleIncomingIpcMessagePort = async (module, handle, message) => {
-  const target = await module.targetMessagePort(handle, message)
   const response = module.upgradeMessagePort(handle, message)
+  const target = await module.targetMessagePort(handle, message)
   return {
     target,
     response,

--- a/packages/shared-process/src/parts/HandleIncomingIpcWebSocket/HandleIncomingIpcWebSocket.js
+++ b/packages/shared-process/src/parts/HandleIncomingIpcWebSocket/HandleIncomingIpcWebSocket.js
@@ -1,6 +1,6 @@
 export const handleIncomingIpcWebSocket = async (module, handle, message) => {
-  const target = await module.targetWebSocket(handle, message)
   const response = module.upgradeWebSocket(handle, message)
+  const target = await module.targetWebSocket(handle, message)
   return {
     target,
     response,

--- a/packages/shared-process/src/parts/HandleIpcProcessExplorer/HandleIpcProcessExplorer.js
+++ b/packages/shared-process/src/parts/HandleIpcProcessExplorer/HandleIpcProcessExplorer.js
@@ -2,11 +2,11 @@ import * as ProcessExplorer from '../ProcessExplorer/ProcessExplorer.js'
 import * as Assert from '../Assert/Assert.js'
 
 export const targetMessagePort = () => {
-  return ProcessExplorer.getOrCreate()
+  return ProcessExplorer.acquire()
 }
 
 export const targetWebSocket = () => {
-  return ProcessExplorer.getOrCreate()
+  return ProcessExplorer.acquire()
 }
 
 export const upgradeMessagePort = (port) => {

--- a/packages/shared-process/src/parts/Module/Module.js
+++ b/packages/shared-process/src/parts/Module/Module.js
@@ -96,6 +96,8 @@ export const load = (moduleId) => {
       return import('../Preferences/Preferences.ipc.js')
     case ModuleId.Process:
       return import('../Process/Process.ipc.js')
+    case ModuleId.ProcessExplorer:
+      return import('../ProcessExplorer/ProcessExplorer.ipc.js')
     case ModuleId.ProcessId:
       return import('../ProcessId/ProcessId.ipc.js')
     case ModuleId.RebuildNodePty:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.js
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.js
@@ -10,6 +10,7 @@ export const Preferences = 9
 export const RecentlyOpened = 10
 export const GetWindowId = 377
 export const ElectronWindowProcessExplorer = 12
+export const ProcessExplorer = 13
 export const Terminal = 14
 export const TextDocument = 15
 export const Workspace = 17

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.js
@@ -235,6 +235,8 @@ export const getModuleId = (commandId) => {
     case 'ProcessId.getMainProcessId':
     case 'ProcessId.getSharedProcessId':
       return ModuleId.ProcessId
+    case 'ProcessExplorer.decreaseRefCount':
+      return ModuleId.ProcessExplorer
     case 'RebuildNodePty.rebuildNodePty':
       return ModuleId.RebuildNodePty
     case 'RecentlyOpened.addPath':

--- a/packages/shared-process/src/parts/ProcessExplorer/ProcessExplorer.ipc.js
+++ b/packages/shared-process/src/parts/ProcessExplorer/ProcessExplorer.ipc.js
@@ -1,0 +1,7 @@
+import * as ProcessExplorer from './ProcessExplorer.js'
+
+export const name = 'ProcessExplorer'
+
+export const Commands = {
+  decreaseRefCount: ProcessExplorer.decreaseRefCount,
+}

--- a/packages/shared-process/src/parts/ProcessExplorer/ProcessExplorer.js
+++ b/packages/shared-process/src/parts/ProcessExplorer/ProcessExplorer.js
@@ -5,6 +5,7 @@ export const state = {
    * @type {any}
    */
   ipc: undefined,
+  refCount: 0,
 }
 
 export const getOrCreate = async () => {
@@ -12,4 +13,39 @@ export const getOrCreate = async () => {
     state.ipc = LaunchProcessExplorer.launchProcessExplorer()
   }
   return state.ipc
+}
+
+export const acquire = async () => {
+  state.refCount++
+  try {
+    return await getOrCreate()
+  } catch (error) {
+    decreaseRefCount()
+    throw error
+  }
+}
+
+const disposeLater = (ipcPromise) => {
+  setTimeout(async () => {
+    try {
+      const ipc = await ipcPromise
+      await ipc.dispose()
+    } catch {
+      // ignore disposal errors
+    }
+  }, 0)
+}
+
+export const decreaseRefCount = () => {
+  if (state.refCount > 0) {
+    state.refCount--
+  }
+  if (state.refCount === 0) {
+    const { ipc } = state
+    state.ipc = undefined
+    if (ipc) {
+      disposeLater(ipc)
+    }
+  }
+  return state.refCount
 }

--- a/packages/shared-process/test/HandleIncomingIpcProcessExplorer.test.ts
+++ b/packages/shared-process/test/HandleIncomingIpcProcessExplorer.test.ts
@@ -1,0 +1,58 @@
+import { expect, jest, test } from '@jest/globals'
+import * as IpcId from '../src/parts/IpcId/IpcId.js'
+
+const applyIncomingIpcResponse = jest.fn(async () => {
+  throw new Error('Transfer failed')
+})
+const decreaseRefCount = jest.fn()
+const getModule = jest.fn(() => ({}))
+const handleIncomingIpcWebSocket = jest.fn(async () => ({
+  response: {
+    method: 'HandleWebSocket.handleWebSocket',
+    params: [],
+    type: 'send',
+  },
+  target: {},
+}))
+
+jest.unstable_mockModule(
+  '../src/parts/ApplyIncomingIpcResponse/ApplyIncomingIpcResponse.js',
+  () => ({
+    applyIncomingIpcResponse,
+  }),
+)
+
+jest.unstable_mockModule('../src/parts/HandleIpcModule/HandleIpcModule.js', () => ({
+  getModule,
+}))
+
+jest.unstable_mockModule(
+  '../src/parts/HandleIncomingIpcWebSocket/HandleIncomingIpcWebSocket.js',
+  () => ({
+    handleIncomingIpcWebSocket,
+  }),
+)
+
+jest.unstable_mockModule('../src/parts/IsMessagePortMain/IsMessagePortMain.js', () => ({
+  isMessagePortMain: () => false,
+}))
+
+jest.unstable_mockModule('../src/parts/IsSocket/IsSocket.js', () => ({
+  isSocket: () => true,
+}))
+
+jest.unstable_mockModule('../src/parts/ProcessExplorer/ProcessExplorer.js', () => ({
+  decreaseRefCount,
+}))
+
+const HandleIncomingIpc = await import(
+  '../src/parts/HandleIncomingIpc/HandleIncomingIpc.js'
+)
+
+test('handleIncomingIpc - decrements process explorer ref count when forwarding fails', async () => {
+  await expect(
+    HandleIncomingIpc.handleIncomingIpc(IpcId.ProcessExplorer, {}, {}),
+  ).rejects.toThrow('Transfer failed')
+
+  expect(decreaseRefCount).toHaveBeenCalledTimes(1)
+})

--- a/packages/shared-process/test/ProcessExplorer.test.ts
+++ b/packages/shared-process/test/ProcessExplorer.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const ipc = {
+  dispose: jest.fn(async () => {}),
+}
+const launchProcessExplorer = jest.fn(async () => ipc)
+
+jest.unstable_mockModule(
+  '../src/parts/LaunchProcessExplorer/LaunchProcessExplorer.js',
+  () => ({
+    launchProcessExplorer,
+  }),
+)
+
+const ProcessExplorer = await import(
+  '../src/parts/ProcessExplorer/ProcessExplorer.js'
+)
+
+beforeEach(() => {
+  ProcessExplorer.state.ipc = undefined
+  ProcessExplorer.state.refCount = 0
+  ipc.dispose.mockClear()
+  launchProcessExplorer.mockClear()
+  jest.useRealTimers()
+})
+
+test('acquire - increments ref count and launches once', async () => {
+  const result1 = await ProcessExplorer.acquire()
+  const result2 = await ProcessExplorer.acquire()
+
+  expect(result1).toBe(ipc)
+  expect(result2).toBe(ipc)
+  expect(ProcessExplorer.state.refCount).toBe(2)
+  expect(launchProcessExplorer).toHaveBeenCalledTimes(1)
+})
+
+test('decreaseRefCount - disposes process explorer when count reaches zero', async () => {
+  jest.useFakeTimers()
+  await ProcessExplorer.acquire()
+  await ProcessExplorer.acquire()
+
+  expect(ProcessExplorer.decreaseRefCount()).toBe(1)
+  expect(ProcessExplorer.state.ipc).toBeDefined()
+  expect(ipc.dispose).not.toHaveBeenCalled()
+
+  expect(ProcessExplorer.decreaseRefCount()).toBe(0)
+  expect(ProcessExplorer.state.ipc).toBeUndefined()
+  await jest.runOnlyPendingTimersAsync()
+
+  expect(ipc.dispose).toHaveBeenCalledTimes(1)
+})
+
+test('decreaseRefCount - clamps at zero', () => {
+  expect(ProcessExplorer.decreaseRefCount()).toBe(0)
+  expect(ProcessExplorer.state.refCount).toBe(0)
+})
+
+test('acquire - rolls back ref count when launch fails', async () => {
+  jest.useFakeTimers()
+  const error = new Error('Launch failed')
+  launchProcessExplorer.mockRejectedValueOnce(error)
+
+  await expect(ProcessExplorer.acquire()).rejects.toThrow(error)
+  await jest.runOnlyPendingTimersAsync()
+
+  expect(ProcessExplorer.state.refCount).toBe(0)
+  expect(ProcessExplorer.state.ipc).toBeUndefined()
+})
+
+test('acquire - relaunches after ref count reaches zero', async () => {
+  jest.useFakeTimers()
+  await ProcessExplorer.acquire()
+  ProcessExplorer.decreaseRefCount()
+  await jest.runOnlyPendingTimersAsync()
+
+  await ProcessExplorer.acquire()
+
+  expect(launchProcessExplorer).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
## Summary
- add shared-process ref counting for process-explorer clients
- expose ProcessExplorer.decreaseRefCount for process-explorer close notifications
- clear and dispose the cached process-explorer IPC when the ref count reaches zero

## Validation
- npm run type-check
- npm test