### PR TITLE
[codex] Support extension view context menus

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -148,6 +148,7 @@ export const commandMap = {
   'ExtensionManagement.handleExtensionStatusUpdate': lazy('ExtensionManagement.handleExtensionStatusUpdate'),
   'ExtensionManagement.handleViewContextChange': lazy('ExtensionManagement.handleViewContextChange'),
   'ExtensionManagement.invalidateExtensionsCache': lazy('ExtensionManagement.invalidateExtensionsCache'),
+  'ExtensionManagement.showViewContextMenu': lazy('ExtensionManagement.showViewContextMenu'),
   'ExtensionManagement.uninstall': lazy('ExtensionManagement.uninstall'),
   'ExtensionMeta.addNodeExtension': lazy('ExtensionMeta.addNodeExtension'),
   'ExtensionMeta.addWebExtension': lazy('ExtensionMeta.addWebExtension'),

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
@@ -11,6 +11,7 @@ export const Commands = {
   getExtensionsEtag: ExtensionManagement.getExtensionsEtag,
   handleExtensionStatusUpdate: ExtensionManagement.handleExtensionStatusUpdate,
   handleViewContextChange: ExtensionManagement.handleViewContextChange,
+  showViewContextMenu: ExtensionManagement.showViewContextMenu,
   uninstall: ExtensionManagement.uninstall,
   invalidateExtensionsCache: ExtensionManagement.invalidateExtensionsCache,
 }

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -1,9 +1,11 @@
 import * as Command from '../Command/Command.js'
+import * as ContextMenu from '../ContextMenu/ContextMenu.js'
 import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as ExtensionManifestStatus from '../ExtensionManifestStatus/ExtensionManifestStatus.js'
 import * as ExtensionViewContext from '../ExtensionViewContext/ExtensionViewContext.js'
 import * as InstallExtension from '../InstallExtension/InstallExtension.js'
+import * as MenuEntryId from '../MenuEntryId/MenuEntryId.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
@@ -25,6 +27,13 @@ export const invalidateExtensionsCache = async () => {
 
 export const handleViewContextChange = (uid, viewId, context) => {
   ExtensionViewContext.handleViewContextChange(uid, viewId, context)
+}
+
+export const showViewContextMenu = async (uid, viewId, menuId, x, y) => {
+  await ContextMenu.show2(uid, MenuEntryId.ExtensionView, x, y, false, {
+    menuId,
+    viewId,
+  })
 }
 
 export const install = async (id) => {

--- a/packages/renderer-worker/src/parts/MenuEntryId/MenuEntryId.js
+++ b/packages/renderer-worker/src/parts/MenuEntryId/MenuEntryId.js
@@ -53,3 +53,5 @@ export const KeyBindingsTable = 26
 export const E2eTests = 27
 
 export const DiffView = 28
+
+export const ExtensionView = 30

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ipc.ts
@@ -1,2 +1,3 @@
 export * from './ViewletExtensionView.ts'
 export * from './ViewletExtensionViewRender.ts'
+export * from './ViewletExtensionViewMenuEntries.ts'

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -207,8 +207,18 @@ export const handleBlur = (state: ViewletExtensionViewState, name: string): Prom
   return handleViewEvent(state, 'blur', name)
 }
 
+export const handleContextMenu = (state: ViewletExtensionViewState, name: string, x: number, y: number): Promise<ViewletExtensionViewState> => {
+  return dispatchEvent(state, {
+    name,
+    type: 'contextmenu',
+    x,
+    y,
+  })
+}
+
 export const Commands = {
   handleBlur,
+  handleContextMenu,
   handleClick,
   handleFocus,
   handleInput,

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts
@@ -1,0 +1,27 @@
+import { assetDir } from '../AssetDir/AssetDir.js'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as MenuEntryId from '../MenuEntryId/MenuEntryId.js'
+import { getPlatform } from '../Platform/Platform.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+
+interface ContextMenuProps {
+  readonly menuId?: string
+}
+
+const getMenuEntries = async (uid: number, props: ContextMenuProps = {}): Promise<readonly unknown[]> => {
+  const instance = ViewletStates.getByUid(uid)
+  const state = instance?.state
+  if (!state || typeof state.uri !== 'string' || typeof props.menuId !== 'string') {
+    return []
+  }
+  return ExtensionManagementWorker.invoke('Extensions.getViewMenuEntries', state.uri, uid, props.menuId, assetDir, getPlatform()) as Promise<
+    readonly unknown[]
+  >
+}
+
+export const menus = [
+  {
+    getMenuEntries,
+    id: MenuEntryId.ExtensionView,
+  },
+]

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
@@ -84,7 +84,7 @@ const defaultEventListeners = [
   },
   {
     name: 'handleContextMenu',
-    params: ['handleViewEvent', 'contextmenu', 'event.target.name'],
+    params: ['handleContextMenu', 'event.target.name', 'event.clientX', 'event.clientY'],
     preventDefault: true,
   },
   {

--- a/packages/renderer-worker/test/ExtensionManagement.test.js
+++ b/packages/renderer-worker/test/ExtensionManagement.test.js
@@ -25,7 +25,14 @@ jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/ContextMenu/ContextMenu.js', () => {
+  return {
+    show2: jest.fn(),
+  }
+})
+
 const ExtensionManagement = await import('../src/parts/ExtensionManagement/ExtensionManagement.js')
+const ContextMenu = await import('../src/parts/ContextMenu/ContextMenu.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 
 test.skip('install', async () => {
@@ -41,6 +48,15 @@ test.skip('install', async () => {
   await ExtensionManagement.install('test-author.test-extension')
   expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
   expect(SharedProcess.invoke).toHaveBeenCalledWith(SharedProcessCommandType.InstallExtensionInstallExtension, 'test-author.test-extension')
+})
+
+test('showViewContextMenu opens extension view context menu', async () => {
+  await ExtensionManagement.showViewContextMenu(1, 'sample.views.testing', 'sample.card', 10, 20)
+
+  expect(ContextMenu.show2).toHaveBeenCalledWith(1, 30, 10, 20, false, {
+    menuId: 'sample.card',
+    viewId: 'sample.views.testing',
+  })
 })
 
 test.skip('install - error', async () => {

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -48,7 +48,9 @@ jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManage
 
 const ViewletExtensionView = await import('../src/parts/ViewletExtensionView/ViewletExtensionView.ts')
 const ViewletExtensionViewRender = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts')
+const ViewletExtensionViewMenuEntries = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 test('render supports functional events', () => {
   expect(ViewletExtensionViewRender.hasFunctionalEvents).toBe(true)
@@ -57,8 +59,17 @@ test('render supports functional events', () => {
 test('exports virtual dom event commands', () => {
   expect(ViewletExtensionView.Commands.handleInput).toBe(ViewletExtensionView.handleInput)
   expect(ViewletExtensionView.Commands.handleClick).toBe(ViewletExtensionView.handleClick)
+  expect(ViewletExtensionView.Commands.handleContextMenu).toBe(ViewletExtensionView.handleContextMenu)
   expect(ViewletExtensionView.Commands.handleViewEvent).toBe(ViewletExtensionView.handleViewEvent)
   expect(ViewletExtensionView.Commands.rerender).toBe(ViewletExtensionView.rerender)
+})
+
+test('renderEventListeners includes context menu coordinates', () => {
+  expect(ViewletExtensionViewRender.renderEventListeners()).toContainEqual({
+    name: 'handleContextMenu',
+    params: ['handleContextMenu', 'event.target.name', 'event.clientX', 'event.clientY'],
+    preventDefault: true,
+  })
 })
 
 test('loadContent loads css from extension view metadata', async () => {
@@ -148,6 +159,69 @@ test('rerender ignores iframe views', async () => {
 
   expect(newState).toBe(state)
   expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
+})
+
+test('handleContextMenu dispatches coordinates to extension view', async () => {
+  const patches = [{ type: 1 }]
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    patches,
+    type: 'setPatches',
+  })
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    kind: 'virtualDom',
+  }
+
+  await ViewletExtensionView.handleContextMenu(state, 'card:card-1', 10, 20)
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith(
+    'Extensions.dispatchViewEvent',
+    'sample.views.testing',
+    1,
+    {
+      name: 'card:card-1',
+      type: 'contextmenu',
+      x: 10,
+      y: 20,
+    },
+    '',
+    4,
+  )
+})
+
+test('extension view menu entries delegate to extension management worker', async () => {
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce([
+    {
+      command: 'sample.open',
+      flags: 0,
+      id: 'open',
+      label: 'Open',
+    },
+  ])
+  ViewletStates.set(1, {
+    factory: {},
+    renderedState: {
+      uid: 1,
+    },
+    state: {
+      uid: 1,
+      uri: 'sample.views.testing',
+    },
+  })
+
+  await expect(ViewletExtensionViewMenuEntries.menus[0].getMenuEntries(1, { menuId: 'sample.card' })).resolves.toEqual([
+    {
+      command: 'sample.open',
+      flags: 0,
+      id: 'open',
+      label: 'Open',
+    },
+  ])
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.getViewMenuEntries', 'sample.views.testing', 1, 'sample.card', '', 4)
+  ViewletStates.remove(1)
 })
 
 test('loadContent ignores css load errors', async () => {


### PR DESCRIPTION
## Summary
- Add an internal ExtensionView menu ID and provider.
- Dispatch extension-view contextmenu events with target names and client coordinates.
- Add renderer command support for opening extension view context menus.

## Tests
- npm test -- --runInBand ViewletExtensionViewCss.test.js ExtensionManagement.test.js
- npm run type-check