### PR TITLE
feature: extension view focus management

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -7,6 +7,7 @@ import type { ViewletExtensionViewState } from './ViewletExtensionViewState.ts'
 
 interface ViewRenderResult {
   readonly dom?: readonly unknown[]
+  readonly focusSelector?: string
   readonly patches?: readonly unknown[]
   readonly type: string
 }
@@ -56,6 +57,7 @@ const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRe
     return {
       ...state,
       commands: [],
+      focusSelector: '',
       patches: [],
     }
   }
@@ -64,6 +66,7 @@ const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRe
     commands: [],
     dom: result.type === 'setDom' ? result.dom || [] : state.dom,
     error: undefined,
+    focusSelector: typeof result.focusSelector === 'string' ? result.focusSelector : '',
     patches: result.type === 'setPatches' ? result.patches || [] : [],
   }
 }
@@ -77,6 +80,7 @@ export const create = (id: number, uri: string, x: number, y: number, width: num
     credentialless: true,
     dom: [],
     eventListeners: [],
+    focusSelector: '',
     height,
     iframeSandbox: [],
     iframeSrc: '',

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
@@ -38,6 +38,16 @@ const renderPatches = {
   },
 }
 
+const renderFocus = {
+  isEqual(oldState: ViewletExtensionViewState, newState: ViewletExtensionViewState): boolean {
+    return newState.kind !== 'virtualDom' || !newState.focusSelector || oldState.focusSelector === newState.focusSelector
+  },
+  apply(oldState: ViewletExtensionViewState, newState: ViewletExtensionViewState): readonly unknown[] {
+    return [['Viewlet.focusSelector', newState.uid, newState.focusSelector]]
+  },
+  multiple: true,
+}
+
 const renderCss = {
   isEqual(oldState: ViewletExtensionViewState, newState: ViewletExtensionViewState): boolean {
     return !newState.css || (oldState.css === newState.css && oldState.cssId === newState.cssId)
@@ -58,7 +68,7 @@ const renderCommands = {
   multiple: true,
 }
 
-export const render = [renderIframe, renderDom, renderPatches, renderCss, renderCommands]
+export const render = [renderIframe, renderDom, renderPatches, renderFocus, renderCss, renderCommands]
 
 const defaultEventListeners = [
   {
@@ -112,8 +122,5 @@ const defaultEventListeners = [
 ]
 
 export const renderEventListeners = (state?: ViewletExtensionViewState): readonly any[] => {
-  return [
-    ...defaultEventListeners,
-    ...(state?.eventListeners || []),
-  ]
+  return [...defaultEventListeners, ...(state?.eventListeners || [])]
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -7,6 +7,7 @@ export interface ViewletExtensionViewState {
   readonly dom: readonly unknown[]
   readonly error?: unknown
   readonly eventListeners: readonly unknown[]
+  readonly focusSelector: string
   readonly height: number
   readonly iframeSandbox: readonly string[]
   readonly iframeSrc: string

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -96,6 +96,7 @@ test('loadContent stores virtual dom without duplicate commands', async () => {
   expect(newState.commands).toEqual([])
   expect(newState.dom).toBe(dom)
   expect(newState.eventListeners).toBe(extensionViews.view.eventListeners)
+  expect(newState.focusSelector).toBe('')
   expect(newState.patches).toEqual([])
 })
 
@@ -129,6 +130,45 @@ test('handleClick stores patches without duplicate commands', async () => {
   expect(newState.patches).toBe(patches)
 })
 
+test('handleClick stores focus selector from render result', async () => {
+  const patches = [{ type: 1 }]
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    focusSelector: '[name="newCardTitle:list-1"]',
+    patches,
+    type: 'setPatches',
+  })
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    kind: 'virtualDom',
+  }
+
+  const newState = await ViewletExtensionView.handleClick(state, 'connect')
+
+  expect(newState.focusSelector).toBe('[name="newCardTitle:list-1"]')
+  expect(ViewletExtensionViewRender.render[3].apply(/** @type {any} */ (state), /** @type {any} */ (newState))).toEqual([
+    ['Viewlet.focusSelector', 1, '[name="newCardTitle:list-1"]'],
+  ])
+})
+
+test('renderFocus ignores missing, empty, and repeated selectors', () => {
+  const oldState = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    focusSelector: '[name="newCardTitle:list-1"]',
+    kind: 'virtualDom',
+  }
+  const resetState = {
+    ...oldState,
+    focusSelector: '',
+  }
+  const repeatedState = {
+    ...oldState,
+  }
+
+  expect(ViewletExtensionViewRender.render[3].isEqual(/** @type {any} */ (oldState), /** @type {any} */ (resetState))).toBe(true)
+  expect(ViewletExtensionViewRender.render[3].isEqual(/** @type {any} */ (oldState), /** @type {any} */ (repeatedState))).toBe(true)
+})
+
 test('rerender stores patches without duplicate commands', async () => {
   const patches = [{ type: 1 }]
   // @ts-ignore
@@ -146,6 +186,7 @@ test('rerender stores patches without duplicate commands', async () => {
 
   expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.renderViewInstance', 'sample.views.testing', 1, '', 4)
   expect(newState.commands).toEqual([])
+  expect(newState.focusSelector).toBe('')
   expect(newState.patches).toBe(patches)
 })
 
@@ -251,7 +292,7 @@ test('render emits set css command', () => {
     cssId: 'ExtensionView:sample.views.testing',
   }
 
-  expect(ViewletExtensionViewRender.render[3].apply(/** @type {any} */ (oldState), /** @type {any} */ (newState))).toEqual([
+  expect(ViewletExtensionViewRender.render[4].apply(/** @type {any} */ (oldState), /** @type {any} */ (newState))).toEqual([
     ['Viewlet.setCss', 'ExtensionView:sample.views.testing', '.Testing { color: red; }'],
   ])
 })


### PR DESCRIPTION
## Summary
- carry focusSelector through extension view renderer state
- emit Viewlet.focusSelector after virtual DOM updates
- add renderer-worker tests for focus command emission and selector reset

## Validation
- npm test -- ViewletExtensionViewCss.test.js
- npm run type-check