### PR TITLE
feature: disable test layout restore

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -51,6 +51,7 @@ export interface LayoutState {
   readonly previewUri: string
   readonly previewVisible: boolean
   readonly previewWidth: number
+  readonly restore: boolean
   readonly sashId: any
   readonly sideBarHeight: number
   readonly sideBarId: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -167,6 +167,7 @@ export const create = (id: number): LayoutState => {
     previewMaxWidth: 0,
     previewMinHeight: 0,
     previewMinWidth: 0,
+    restore: true,
     sideBarMaxWidth: 0,
     sideBarMinWidth: 0,
     secondarySideBarMaxWidth: 0,
@@ -283,11 +284,13 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
   const { bounds } = Layout
   const { windowWidth, windowHeight } = bounds
   const sideBarLocation = getSideBarLocationType()
+  const restore = savedState?.restore !== false
+  const stateToRestore = restore ? savedState : undefined
   const { panelHeight, panelVisible, sideBarVisible, sideBarWidth, secondarySideBarVisible, secondarySideBarWidth, previewVisible, previewWidth } =
-    getSavedPoints(savedState)
-  const savedView = getSavedSideBarView(savedState)
-  const savedSecondaryView = getSavedSecondarySideBarView(savedState)
-  const previewUri = savedState?.previewUri || ''
+    getSavedPoints(stateToRestore)
+  const savedView = getSavedSideBarView(stateToRestore)
+  const savedSecondaryView = getSavedSecondarySideBarView(stateToRestore)
+  const previewUri = stateToRestore?.previewUri || ''
   const intermediateState: LayoutState = {
     ...state,
     activityBarVisible: true,
@@ -325,6 +328,7 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
     panelSashVisible: true,
     previewSashVisible: previewVisible,
     previewUri,
+    restore,
     sideBarLocation,
     sideBarSashVisible: true,
     sideBarView: savedView,
@@ -816,6 +820,8 @@ const loadIfVisible = async (
     let childUid = -1
     if (visible) {
       childUid = Id.create()
+      const restore = state.restore !== false
+      const restoreState = restore ? undefined : { restore: false }
       commands = await ViewletManager.load(
         {
           getModule: ViewletModule.load,
@@ -833,7 +839,8 @@ const loadIfVisible = async (
           // render: false,
         },
         false,
-        true,
+        restore,
+        restoreState,
       )
     }
     const orderedCommands = reorderCommands(commands)

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -47,12 +47,13 @@ export const create = (id, uri, x, y, width, height) => {
 
 export const loadContent = async (state, savedState, targetViewletId) => {
   // TODO get it from layout state
-  let savedViewletId = targetViewletId || (await Command.execute('Layout.getActiveSideBarView'))
+  const restore = savedState?.restore !== false
+  let savedViewletId = restore ? targetViewletId || (await Command.execute('Layout.getActiveSideBarView')) : ViewletModuleId.Explorer
   if (!savedViewletId) {
     savedViewletId = ViewletModuleId.Explorer
   }
   // const savedViewletId = getSavedViewletId(savedState)
-  return handleSideBarViewletChange(state, savedViewletId)
+  return handleSideBarViewletChange(state, savedViewletId, restore)
 }
 
 // export const contentLoaded = async (state, savedState) => {
@@ -102,7 +103,7 @@ const getChildModuleId = (moduleId) => {
 //   ]
 // }
 
-export const handleSideBarViewletChange = async (state, moduleId) => {
+export const handleSideBarViewletChange = async (state, moduleId, restore = true) => {
   console.assert(typeof moduleId === 'string')
   if (!moduleId) {
     // const currentViewletState = ViewletStates.getState(state.currentViewletId)
@@ -148,7 +149,8 @@ export const handleSideBarViewletChange = async (state, moduleId) => {
       shouldRenderEvents: false,
     },
     false,
-    true,
+    restore,
+    restore ? undefined : { restore: false },
   )
   if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
     Viewlet.disposeFunctional(childUid)

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -159,6 +159,7 @@ export const startup = async (platform, assetDir) => {
   Performance.mark(PerformanceMarkerType.WillOpenWorkspace)
   await Workspace.hydrate(initData.Location)
   Performance.mark(PerformanceMarkerType.DidOpenWorkspace)
+  const isTestRun = Workspace.isTest() || initData.Location.href.includes('/tests/')
 
   await Focus.hydrate()
 
@@ -187,7 +188,7 @@ export const startup = async (platform, assetDir) => {
     },
     false,
     false,
-    { ...initData, ...layoutState },
+    { ...initData, ...layoutState, restore: !isTestRun },
   )
   commands.splice(1, 1)
 

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.js
@@ -72,6 +72,33 @@ test('loadContent enables preview sash when preview is restored', () => {
   })
 })
 
+test('loadContent ignores saved layout when restore is disabled', () => {
+  const state = ViewletLayout.create(1)
+
+  const result = ViewletLayout.loadContent(state, {
+    Layout: {
+      bounds: {
+        windowWidth: 1200,
+        windowHeight: 800,
+      },
+    },
+    panelVisible: true,
+    previewVisible: true,
+    restore: false,
+    secondarySideBarVisible: true,
+    sideBarView: 'Search',
+  })
+
+  expect(result).toMatchObject({
+    panelVisible: false,
+    previewVisible: false,
+    restore: false,
+    secondarySideBarVisible: false,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  })
+})
+
 test('showPreview enables preview sash', async () => {
   const state = {
     ...ViewletLayout.create(1),

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.js
@@ -45,6 +45,7 @@ const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts'
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 const activityBarInvokeMock = /** @type {any} */ (ActivityBarWorker.invoke)
+const viewletManagerLoadMock = /** @type {any} */ (ViewletManager.load)
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -174,6 +175,31 @@ test('hideSideBar updates activity bar through shared sidebar render helper', as
       sideBarVisible: false,
     }),
   })
+})
+
+test('loadSideBarIfVisible disables child restore when layout restore is disabled', async () => {
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'SideBar', 1, true]])
+  const state = {
+    ...ViewletLayout.create(1),
+    restore: false,
+    sideBarHeight: 400,
+    sideBarLeft: 0,
+    sideBarTop: 0,
+    sideBarVisible: true,
+    sideBarWidth: 300,
+  }
+
+  await ViewletLayout.loadSideBarIfVisible(state)
+
+  expect(viewletManagerLoadMock.mock.calls[0]).toEqual([
+    expect.objectContaining({
+      id: 'SideBar',
+    }),
+    false,
+    false,
+    { restore: false },
+  ])
 })
 
 test('createPanelViewlet creates a linked actions root for child-contributed actions', async () => {

--- a/packages/renderer-worker/test/ViewletSideBar.test.js
+++ b/packages/renderer-worker/test/ViewletSideBar.test.js
@@ -1,10 +1,46 @@
 // @ts-nocheck
-import { jest } from '@jest/globals'
-import { beforeAll, afterAll, test, expect, beforeEach, afterEach } from '@jest/globals'
-import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.js'
-import * as ViewletSideBar from '../src/parts/ViewletSideBar/ViewletSideBar.js'
-import * as SharedProcess from '../src/parts/SharedProcess/SharedProcess.js'
-import * as JsonRpcVersion from '../src/parts/JsonRpcVersion/JsonRpcVersion.js'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: jest.fn(() => undefined),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
+  return {
+    invoke: jest.fn(() => undefined),
+    state: {},
+  }
+})
+
+jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
+  return {
+    saveViewletState: jest.fn(() => undefined),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => {
+  return {
+    load: jest.fn(() => []),
+  }
+})
+
+const Command = await import('../src/parts/Command/Command.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const SaveState = await import('../src/parts/SaveState/SaveState.js')
+const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const ViewletSideBar = await import('../src/parts/ViewletSideBar/ViewletSideBar.js')
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const JsonRpcVersion = await import('../src/parts/JsonRpcVersion/JsonRpcVersion.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  Command.execute.mockResolvedValue('Search')
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  SaveState.saveViewletState.mockResolvedValue(undefined)
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'Explorer', 2, true]])
+})
 
 test.skip('openViewlet', async () => {
   RendererProcess.state.send = jest.fn()
@@ -72,5 +108,25 @@ test.skip('loadContent - get viewlet id from savedState', async () => {
   })
   expect(newState).toMatchObject({
     currentViewletId: 'Test',
+  })
+})
+
+test('loadContent opens explorer when restore is disabled', async () => {
+  const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
+
+  const newState = await ViewletSideBar.loadContent(state, { restore: false }, 'Search')
+
+  expect(Command.execute).not.toHaveBeenCalled()
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'Explorer',
+      uri: 'Explorer',
+    }),
+    false,
+    false,
+    { restore: false },
+  )
+  expect(newState).toMatchObject({
+    currentViewletId: 'Explorer',
   })
 })


### PR DESCRIPTION
## Summary
- disable persisted layout restore when the workbench starts in e2e test mode
- pass restore: false through startup child viewlet loads
- make sidebar startup open Explorer when restore is disabled

## Validation
- npm test -- ViewletLayoutPreview.test.js ViewletLayoutSideBar.test.js ViewletSideBar.test.js
- npm run type-check