### PR TITLE
feature: render extension view actions

### DIFF
--- a/packages/renderer-worker/src/parts/HandleClickAction/HandleClickAction.js
+++ b/packages/renderer-worker/src/parts/HandleClickAction/HandleClickAction.js
@@ -14,6 +14,10 @@ export const handleClickAction = async (state, index, command) => {
     throw new Error(`command is undefined`)
   }
   const currentViewletId = getId(state)
+  if (currentViewletId.includes('.')) {
+    await Command.execute('ExtensionHost.executeCommand', command)
+    return state
+  }
   const fullCommand = `${currentViewletId}.${command}`
   await Command.execute(fullCommand)
   return state

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -1,5 +1,8 @@
 import { assetDir } from '../AssetDir/AssetDir.js'
+import * as ActionType from '../ActionType/ActionType.js'
+import * as Command from '../Command/Command.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as GetActionsVirtualDom from '../GetActionsVirtualDom/GetActionsVirtualDom.js'
 import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
 import type { ExtensionView } from '../GetExtensionViews/GetExtensionViews.ts'
 import { getPlatform } from '../Platform/Platform.js'
@@ -23,6 +26,12 @@ interface CreateViewInstanceError {
 }
 
 type CreateViewInstanceResult = CreateViewInstanceSuccess | CreateViewInstanceError
+
+interface ViewAction {
+  readonly command: string
+  readonly icon: string
+  readonly title: string
+}
 
 const getCssId = (view: ExtensionView): string => {
   return `ExtensionView:${view.id}`
@@ -71,8 +80,33 @@ const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRe
   }
 }
 
+const getActionsDom = async (state: ViewletExtensionViewState): Promise<readonly unknown[]> => {
+  if (state.kind !== 'virtualDom') {
+    return []
+  }
+  const actions = (await ExtensionManagementWorker.invoke(
+    'Extensions.getViewActions',
+    state.uri,
+    state.uid,
+    assetDir,
+    getPlatform(),
+  )) as readonly ViewAction[]
+  if (actions.length === 0) {
+    return []
+  }
+  return GetActionsVirtualDom.getActionsVirtualDom(
+    actions.map((action) => ({
+      command: action.command,
+      icon: action.icon,
+      id: action.title,
+      type: ActionType.Button,
+    })),
+  )
+}
+
 export const create = (id: number, uri: string, x: number, y: number, width: number, height: number): ViewletExtensionViewState => {
   return {
+    actionsDom: [],
     commands: [],
     css: '',
     cssId: '',
@@ -116,6 +150,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
     if (createResult.ok === false) {
       return {
         ...state,
+        actionsDom: [],
         commands: [],
         css,
         cssId,
@@ -127,7 +162,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
       }
     }
     const renderResult = createResult.ok === true ? createResult.result : (result as ViewRenderResult)
-    return {
+    const newState = {
       ...renderVirtualDomResult(state, renderResult),
       css,
       cssId,
@@ -135,12 +170,17 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
       kind: view.kind,
       title: view.title,
     }
+    return {
+      ...newState,
+      actionsDom: await getActionsDom(newState),
+    }
   }
   if (!view.iframe) {
     throw new Error(`view ${state.uri} is missing iframe contribution`)
   }
   return {
     ...state,
+    actionsDom: [],
     css,
     cssId,
     csp: view.iframe.csp,
@@ -167,7 +207,11 @@ const dispatchEvent = async (state: ViewletExtensionViewState, event: unknown): 
     return state
   }
   const result = await ExtensionManagementWorker.invoke('Extensions.dispatchViewEvent', state.uri, state.uid, event, assetDir, getPlatform())
-  return renderVirtualDomResult(state, result as ViewRenderResult | undefined)
+  const newState = renderVirtualDomResult(state, result as ViewRenderResult | undefined)
+  return {
+    ...newState,
+    actionsDom: await getActionsDom(newState),
+  }
 }
 
 export const handleViewEvent = (
@@ -188,7 +232,17 @@ export const rerender = async (state: ViewletExtensionViewState): Promise<Viewle
     return state
   }
   const result = await ExtensionManagementWorker.invoke('Extensions.renderViewInstance', state.uri, state.uid, assetDir, getPlatform())
-  return renderVirtualDomResult(state, result as ViewRenderResult)
+  const newState = renderVirtualDomResult(state, result as ViewRenderResult)
+  return {
+    ...newState,
+    actionsDom: await getActionsDom(newState),
+  }
+}
+
+export const handleClickAction = async (state: ViewletExtensionViewState, index: number, command: string): Promise<ViewletExtensionViewState> => {
+  void index
+  await Command.execute('ExtensionHost.executeCommand', command)
+  return state
 }
 
 export const handleInput = (state: ViewletExtensionViewState, name: string, value: string): Promise<ViewletExtensionViewState> => {
@@ -224,6 +278,7 @@ export const Commands = {
   handleBlur,
   handleContextMenu,
   handleClick,
+  handleClickAction,
   handleFocus,
   handleInput,
   handleSubmit,

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts
@@ -70,6 +70,15 @@ const renderCommands = {
 
 export const render = [renderIframe, renderDom, renderPatches, renderFocus, renderCss, renderCommands]
 
+export const renderActions = {
+  isEqual(oldState: ViewletExtensionViewState, newState: ViewletExtensionViewState): boolean {
+    return oldState.actionsDom === newState.actionsDom
+  },
+  apply(oldState: ViewletExtensionViewState, newState: ViewletExtensionViewState): readonly unknown[] {
+    return newState.actionsDom
+  },
+}
+
 const defaultEventListeners = [
   {
     name: 'handleInput',

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -1,5 +1,6 @@
 export interface ViewletExtensionViewState {
   readonly commands: readonly (readonly unknown[])[]
+  readonly actionsDom: readonly unknown[]
   readonly css: string
   readonly cssId: string
   readonly csp: string

--- a/packages/renderer-worker/test/HandleClickAction.test.js
+++ b/packages/renderer-worker/test/HandleClickAction.test.js
@@ -1,0 +1,34 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: jest.fn(async () => {}),
+  }
+})
+
+const HandleClickAction = await import('../src/parts/HandleClickAction/HandleClickAction.js')
+const Command = await import('../src/parts/Command/Command.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('handleClickAction prefixes built-in viewlet actions', async () => {
+  const state = {
+    currentViewletId: 'Explorer',
+  }
+
+  await HandleClickAction.handleClickAction(state, 0, 'refresh')
+
+  expect(Command.execute).toHaveBeenCalledWith('Explorer.refresh')
+})
+
+test('handleClickAction executes extension view action commands directly', async () => {
+  const state = {
+    currentViewletId: 'trello.views.boards',
+  }
+
+  await HandleClickAction.handleClickAction(state, 0, 'trello.refreshBoards')
+
+  expect(Command.execute).toHaveBeenCalledWith('ExtensionHost.executeCommand', 'trello.refreshBoards')
+})

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -19,6 +19,16 @@ const extensionViews = {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockImplementation(async (method) => {
+    if (method === 'Extensions.getViewActions') {
+      return []
+    }
+    return {
+      dom: [],
+      type: 'setDom',
+    }
+  })
   globalThis.fetch = /** @type {any} */ (
     jest.fn(async () => {
       return {
@@ -37,7 +47,10 @@ jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', 
 
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => {
   return {
-    invoke: jest.fn(async () => {
+    invoke: jest.fn(async (method) => {
+      if (method === 'Extensions.getViewActions') {
+        return []
+      }
       return {
         dom: [],
         type: 'setDom',
@@ -46,10 +59,17 @@ jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManage
   }
 })
 
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: jest.fn(async () => {}),
+  }
+})
+
 const ViewletExtensionView = await import('../src/parts/ViewletExtensionView/ViewletExtensionView.ts')
 const ViewletExtensionViewRender = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts')
 const ViewletExtensionViewMenuEntries = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const Command = await import('../src/parts/Command/Command.js')
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 test('render supports functional events', () => {
@@ -59,6 +79,7 @@ test('render supports functional events', () => {
 test('exports virtual dom event commands', () => {
   expect(ViewletExtensionView.Commands.handleInput).toBe(ViewletExtensionView.handleInput)
   expect(ViewletExtensionView.Commands.handleClick).toBe(ViewletExtensionView.handleClick)
+  expect(ViewletExtensionView.Commands.handleClickAction).toBe(ViewletExtensionView.handleClickAction)
   expect(ViewletExtensionView.Commands.handleContextMenu).toBe(ViewletExtensionView.handleContextMenu)
   expect(ViewletExtensionView.Commands.handleViewEvent).toBe(ViewletExtensionView.handleViewEvent)
   expect(ViewletExtensionView.Commands.rerender).toBe(ViewletExtensionView.rerender)
@@ -94,6 +115,7 @@ test('loadContent stores virtual dom without duplicate commands', async () => {
   const newState = await ViewletExtensionView.loadContent(state, undefined)
 
   expect(newState.commands).toEqual([])
+  expect(newState.actionsDom).toEqual([])
   expect(newState.dom).toBe(dom)
   expect(newState.eventListeners).toBe(extensionViews.view.eventListeners)
   expect(newState.focusSelector).toBe('')
@@ -128,6 +150,51 @@ test('handleClick stores patches without duplicate commands', async () => {
 
   expect(newState.commands).toEqual([])
   expect(newState.patches).toBe(patches)
+})
+
+test('loadContent stores rendered sidebar actions', async () => {
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockImplementation(async (method) => {
+    if (method === 'Extensions.getViewActions') {
+      return [
+        {
+          command: 'sample.refresh',
+          icon: 'Refresh',
+          title: 'Refresh',
+        },
+      ]
+    }
+    return {
+      dom: [],
+      type: 'setDom',
+    }
+  })
+  const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
+
+  const newState = await ViewletExtensionView.loadContent(state, undefined)
+
+  expect(newState.actionsDom).toEqual([
+    {
+      childCount: 1,
+      className: 'Actions',
+      role: 'toolbar',
+      type: 4,
+    },
+    {
+      'data-command': 'sample.refresh',
+      childCount: 1,
+      className: 'IconButton',
+      title: 'Refresh',
+      type: 1,
+    },
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconRefresh',
+      role: 'none',
+      type: 4,
+    },
+  ])
+  expect(ViewletExtensionViewRender.renderActions.apply(state, newState)).toBe(newState.actionsDom)
 })
 
 test('handleClick stores focus selector from render result', async () => {
@@ -188,6 +255,15 @@ test('rerender stores patches without duplicate commands', async () => {
   expect(newState.commands).toEqual([])
   expect(newState.focusSelector).toBe('')
   expect(newState.patches).toBe(patches)
+})
+
+test('handleClickAction executes extension command', async () => {
+  const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
+
+  const newState = await ViewletExtensionView.handleClickAction(state, 0, 'sample.refresh')
+
+  expect(newState).toBe(state)
+  expect(Command.execute).toHaveBeenCalledWith('ExtensionHost.executeCommand', 'sample.refresh')
 })
 
 test('rerender ignores iframe views', async () => {


### PR DESCRIPTION
Renders extension-provided view actions in the sidebar action area.\n\nVirtual DOM extension views now fetch actions after load, rerender, and view events, expose renderActions for sidebar setActionsDom, and route extension action clicks through ExtensionHost.executeCommand.\n\nValidation: npm test -- --runTestsByPath test/ViewletExtensionViewCss.test.js test/HandleClickAction.test.js; npm run type-check. Package lint currently reports existing whole-package XO issues unrelated to this patch.