### PR TITLE
fix: replace builtin static export extensions

### DIFF
--- a/packages/shared-process/index.js
+++ b/packages/shared-process/index.js
@@ -4,14 +4,36 @@ const __dirname = import.meta.dirname
 
 export const sharedProcessPath = join(__dirname, 'src', 'sharedProcessMain.js')
 
-export const exportStatic = async ({ extensionPath = process.cwd(), testPath = '', root = '' } = {}) => {
+const toArray = (value) => {
+  if (!value) {
+    return []
+  }
+  if (Array.isArray(value)) {
+    return value
+  }
+  return [value]
+}
+
+const toAbsoluteExtensionPath = (root, extensionPath) => {
+  if (extensionPath && extensionPath !== root && !isAbsolute(extensionPath)) {
+    return join(root, extensionPath)
+  }
+  return extensionPath
+}
+
+/**
+ * @param {{extensionPath?: string, extensionPaths?: string[] | string, testPath?: string, root?: string}} [options]
+ */
+export const exportStatic = async (options = {}) => {
+  const { extensionPath, extensionPaths = [], testPath = '', root = '' } = options
   if (!root) {
     throw new Error(`root argument is required`)
   }
   const fn = await import('./src/parts/ExportStatic/ExportStatic.js')
-  if (extensionPath && extensionPath !== root && !isAbsolute(extensionPath)) {
-    extensionPath = join(root, extensionPath)
-  }
+  const extensionPathList = toArray(extensionPaths)
+  const defaultExtensionPath = extensionPath === undefined && extensionPathList.length === 0 ? process.cwd() : extensionPath
+  const absoluteExtensionPath = toAbsoluteExtensionPath(root, defaultExtensionPath)
+  const absoluteExtensionPaths = extensionPathList.map((extensionPath) => toAbsoluteExtensionPath(root, extensionPath))
   const pathPrefix = process.env.PATH_PREFIX || ''
-  return fn.exportStatic({ root, pathPrefix, extensionPath, testPath })
+  return fn.exportStatic({ root, pathPrefix, extensionPath: absoluteExtensionPath, extensionPaths: absoluteExtensionPaths, testPath })
 }

--- a/packages/shared-process/src/parts/ExportStatic/ExportStatic.js
+++ b/packages/shared-process/src/parts/ExportStatic/ExportStatic.js
@@ -285,21 +285,23 @@ const addExtensionThemes = async ({ root, extensionPath, extensionJson, commitHa
   }
   for (const colorTheme of colorThemes) {
     const { id, path } = colorTheme
-    await FileSystem.mkdir(Path.join(root, 'dist', commitHash, 'extensions', `builtin.theme-${id}`))
+    const extensionId = `builtin.theme-${id}`
+    await FileSystem.forceRemove(Path.join(root, 'dist', commitHash, 'extensions', extensionId))
+    await FileSystem.mkdir(Path.join(root, 'dist', commitHash, 'extensions', extensionId))
     await FileSystem.copy(Path.join(extensionPath, path), Path.join(root, 'dist', commitHash, 'themes', `${id}.json`))
     await replace(
       Path.join(root, 'dist', commitHash, 'config', 'defaultSettings.json'),
       `"workbench.colorTheme": "slime"`,
       `"workbench.colorTheme": "${id}"`,
     )
-    await FileSystem.copyFile(Path.join(root, 'README.md'), Path.join(root, 'dist', commitHash, 'extensions', `builtin.theme-${id}`, 'README.md'))
+    await FileSystem.copyFile(Path.join(root, 'README.md'), Path.join(root, 'dist', commitHash, 'extensions', extensionId, 'README.md'))
     await FileSystem.copyFile(
       Path.join(extensionPath, 'extension.json'),
-      Path.join(root, 'dist', commitHash, 'extensions', `builtin.theme-${id}`, 'extension.json'),
+      Path.join(root, 'dist', commitHash, 'extensions', extensionId, 'extension.json'),
     )
     await FileSystem.copyFile(
       Path.join(extensionPath, 'color-theme.json'),
-      Path.join(root, 'dist', commitHash, 'extensions', `builtin.theme-${id}`, 'color-theme.json'),
+      Path.join(root, 'dist', commitHash, 'extensions', extensionId, 'color-theme.json'),
     )
   }
   const themesJson = await JsonFile.readJson(Path.join(root, 'dist', commitHash, 'config', 'themes.json'))
@@ -369,6 +371,29 @@ const addExtensionLanguages = async ({ root, extensionPath, extensionJson, commi
   }
 }
 
+export const mergeExtensionManifests = (manifests, extraExtensions) => {
+  const replacements = Object.create(null)
+  for (const extension of extraExtensions) {
+    replacements[extension.id] = extension
+  }
+  const used = Object.create(null)
+  const merged = manifests.map((manifest) => {
+    const replacement = replacements[manifest.id]
+    if (replacement) {
+      used[manifest.id] = true
+      return replacement
+    }
+    return manifest
+  })
+  for (const extension of extraExtensions) {
+    if (used[extension.id]) {
+      continue
+    }
+    merged.push(extension)
+  }
+  return merged
+}
+
 const updateExtensionsJson = async ({ root, commitHash, pathPrefix, extraExtensions }) => {
   const dirents = await FileSystem.readDir(Path.join(root, 'dist', commitHash, 'extensions'))
   const manifests = await Promise.all(
@@ -381,10 +406,13 @@ const updateExtensionsJson = async ({ root, commitHash, pathPrefix, extraExtensi
       }
     }),
   )
-  for (const extension of extraExtensions) {
-    extension.path = `${pathPrefix}/${commitHash}/extensions/${extension.id}`
-  }
-  const newExtensions = [...manifests, ...extraExtensions]
+  const localExtensions = extraExtensions.map((extension) => {
+    return {
+      ...extension,
+      path: `${pathPrefix}/${commitHash}/extensions/${extension.id}`,
+    }
+  })
+  const newExtensions = mergeExtensionManifests(manifests, localExtensions)
   await JsonFile.writeJson(Path.join(root, 'dist', commitHash, 'config', 'extensions.json'), newExtensions)
 }
 
@@ -408,6 +436,7 @@ const addExtensionWebExtension = async ({ root, extensionPath, commitHash, exten
     },
   ]
   await JsonFile.writeJson(Path.join(root, 'dist', commitHash, 'config', 'webExtensions.json'), webExtensions)
+  await FileSystem.forceRemove(Path.join(root, 'dist', commitHash, 'extensions', extensionJson.id))
   for (const dirent of ['src', 'extension.json']) {
     await FileSystem.copy(Path.join(extensionPath, dirent), Path.join(root, 'dist', commitHash, 'extensions', extensionJson.id, dirent))
   }
@@ -618,21 +647,51 @@ const resolveServerStaticPath = (root) => {
   throw new Error(`server static path not found`)
 }
 
+const toArray = (value) => {
+  if (!value) {
+    return []
+  }
+  if (Array.isArray(value)) {
+    return value
+  }
+  return [value]
+}
+
+const getExtensionPaths = (extensionPath, extensionPaths) => {
+  const seen = Object.create(null)
+  const allExtensionPaths = []
+  for (const path of [...toArray(extensionPath), ...toArray(extensionPaths)]) {
+    if (!path || seen[path]) {
+      continue
+    }
+    seen[path] = true
+    allExtensionPaths.push(path)
+  }
+  return allExtensionPaths
+}
+
 /**
  *
- * @param {{root:string, pathPrefix:string , extensionPath:string, testPath:string, useSimpleWebExtensionFile?:boolean, serverStaticPath?:string }} param0
+ * @param {{root:string, pathPrefix:string , extensionPath:string, extensionPaths?:string[], testPath:string, useSimpleWebExtensionFile?:boolean, serverStaticPath?:string }} param0
  */
-export const exportStatic = async ({ root, pathPrefix, extensionPath, testPath, useSimpleWebExtensionFile, serverStaticPath }) => {
+export const exportStatic = async ({ root, pathPrefix, extensionPath, extensionPaths, testPath, useSimpleWebExtensionFile, serverStaticPath }) => {
   if (!existsSync(root)) {
     throw new Error(`root path does not exist: ${root}`)
   }
-  if (extensionPath && !existsSync(extensionPath)) {
-    throw new Error(`extension path does not exist: ${extensionPath}`)
+  const allExtensionPaths = getExtensionPaths(extensionPath, extensionPaths)
+  for (const extensionPath of allExtensionPaths) {
+    if (!existsSync(extensionPath)) {
+      throw new Error(`extension path does not exist: ${extensionPath}`)
+    }
   }
   if (!serverStaticPath) {
     serverStaticPath = resolveServerStaticPath(root)
   }
   if (pathPrefix === 'auto') {
+    if (allExtensionPaths.length === 0) {
+      throw new Error(`extension path is required when path prefix is auto`)
+    }
+    const [extensionPath] = allExtensionPaths
     const extensionJson = await readExtensionManifest(Path.join(extensionPath, 'extension.json'))
     const { id } = extensionJson
     const [author, name] = id.split('.')
@@ -660,7 +719,7 @@ export const exportStatic = async ({ root, pathPrefix, extensionPath, testPath, 
 
   await updateExtensionsJson({ root, commitHash, pathPrefix, extraExtensions: [] })
 
-  if (extensionPath) {
+  for (const extensionPath of allExtensionPaths) {
     console.time('addExtension')
     await addExtension({
       extensionPath,

--- a/packages/shared-process/test/ExportStatic.test.ts
+++ b/packages/shared-process/test/ExportStatic.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import { mergeExtensionManifests } from '../src/parts/ExportStatic/ExportStatic.js'
+
+test('mergeExtensionManifests replaces existing extension with matching id', () => {
+  const builtinCobalt = {
+    id: 'builtin.theme-cobalt2',
+    name: 'Cobalt 2 Theme',
+    path: '/static/hash/extensions/builtin.theme-cobalt2',
+    source: 'builtin',
+  }
+  const localCobalt = {
+    id: 'builtin.theme-cobalt2',
+    name: 'Cobalt 2 Theme',
+    path: '/theme-cobalt2/hash/extensions/builtin.theme-cobalt2',
+    source: 'local',
+  }
+  const material = {
+    id: 'builtin.theme-material',
+    name: 'Material Theme',
+    path: '/static/hash/extensions/builtin.theme-material',
+    source: 'builtin',
+  }
+
+  expect(mergeExtensionManifests([builtinCobalt, material], [localCobalt])).toEqual([localCobalt, material])
+})
+
+test('mergeExtensionManifests appends local extension when id is new', () => {
+  const builtinExtension = {
+    id: 'builtin.theme-material',
+    name: 'Material Theme',
+  }
+  const localExtension = {
+    id: 'test.local-extension',
+    name: 'Local Extension',
+  }
+
+  expect(mergeExtensionManifests([builtinExtension], [localExtension])).toEqual([builtinExtension, localExtension])
+})

--- a/packages/shared-process/test/SharedProcessIndex.test.ts
+++ b/packages/shared-process/test/SharedProcessIndex.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { join } from 'node:path'
 
 jest.unstable_mockModule('../src/parts/ExportStatic/ExportStatic.js', () => ({
   exportStatic: jest.fn(),
@@ -29,7 +30,7 @@ test('exportStatic forwards multiple extension paths', async () => {
     root: '/test/root',
     pathPrefix: '',
     extensionPath: undefined,
-    extensionPaths: ['/test/root/packages/extension-a', '/test/root/packages/extension-b'],
+    extensionPaths: [join('/test/root', 'packages', 'extension-a'), join('/test/root', 'packages', 'extension-b')],
     testPath: '',
   })
 })

--- a/packages/shared-process/test/SharedProcessIndex.test.ts
+++ b/packages/shared-process/test/SharedProcessIndex.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ExportStatic/ExportStatic.js', () => ({
+  exportStatic: jest.fn(),
+}))
+
+const SharedProcess = await import('../index.js')
+const ExportStatic = await import('../src/parts/ExportStatic/ExportStatic.js')
+
+beforeEach(() => {
+  // @ts-ignore
+  ExportStatic.exportStatic.mockReset()
+  // @ts-ignore
+  ExportStatic.exportStatic.mockResolvedValue({
+    commitHash: 'test-commit',
+  })
+  delete process.env.PATH_PREFIX
+})
+
+test('exportStatic forwards multiple extension paths', async () => {
+  await SharedProcess.exportStatic({
+    root: '/test/root',
+    extensionPaths: ['packages/extension-a', 'packages/extension-b'],
+  })
+
+  // @ts-ignore
+  const [options] = ExportStatic.exportStatic.mock.calls[0]
+  expect(options).toEqual({
+    root: '/test/root',
+    pathPrefix: '',
+    extensionPath: undefined,
+    extensionPaths: ['/test/root/packages/extension-a', '/test/root/packages/extension-b'],
+    testPath: '',
+  })
+})

--- a/packages/shared-process/tsconfig.json
+++ b/packages/shared-process/tsconfig.json
@@ -18,5 +18,5 @@
     "composite": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src", "test"]
+  "include": ["index.js", "src", "test"]
 }


### PR DESCRIPTION
## Summary

- allow static export to include multiple local extension paths
- replace matching bundled extension manifests by id instead of adding duplicates
- clear replaced theme/web extension folders before copying local files