### PR TITLE
fix: use theme colors for native title bar

### DIFF
--- a/packages/shared-process/src/parts/AppWindow/AppWindow.js
+++ b/packages/shared-process/src/parts/AppWindow/AppWindow.js
@@ -8,7 +8,7 @@ import * as Screen from '../Screen/Screen.js'
 
 export const createAppWindow = async ({ preferences, parsedArgs, workingDirectory, url = DefaultUrl.defaultUrl, preloadUrl }) => {
   const { width, height } = await Screen.getBounds()
-  const windowOptions = GetAppWindowOptions.getAppWindowOptions({
+  const windowOptions = await GetAppWindowOptions.getAppWindowOptions({
     preferences,
     screenWidth: width,
     screenHeight: height,

--- a/packages/shared-process/src/parts/GetAppWindowOptions/GetAppWindowOptions.js
+++ b/packages/shared-process/src/parts/GetAppWindowOptions/GetAppWindowOptions.js
@@ -1,7 +1,41 @@
 import * as GetBrowserWindowOptions from '../GetBrowserWindowOptions/GetBrowserWindowOptions.js'
+import * as ExtensionManagementColorTheme from '../ExtensionManagement/ExtensionManagementColorTheme.js'
 import * as Platform from '../Platform/Platform.js'
 
-export const getAppWindowOptions = ({ preferences, screenWidth, screenHeight, preloadUrl }) => {
+const fallbackBackground = '#1e2324'
+const fallbackSymbolColor = '#74b1be'
+
+const getColor = (colors, keys, fallback) => {
+  for (const key of keys) {
+    if (colors[key]) {
+      return colors[key]
+    }
+  }
+  return fallback
+}
+
+const getColorThemeJson = async (preferences) => {
+  const colorThemeId = preferences['workbench.colorTheme']
+  if (!colorThemeId) {
+    return {}
+  }
+  try {
+    return await ExtensionManagementColorTheme.getColorThemeJson(colorThemeId)
+  } catch {
+    return {}
+  }
+}
+
+export const getAppWindowOptions = async ({ preferences, screenWidth, screenHeight, preloadUrl }) => {
+  const colorThemeJson = await getColorThemeJson(preferences)
+  const colors = colorThemeJson.colors && typeof colorThemeJson.colors === 'object' ? colorThemeJson.colors : {}
+  const background = getColor(colors, ['MainBackground'], fallbackBackground)
+  const titleBarBackground = getColor(colors, ['TitleBarActiveBackground', 'TitleBarBackground', 'MainBackground'], fallbackBackground)
+  const titleBarSymbolColor = getColor(
+    colors,
+    ['TitleBarForegroundActive', 'TitleBarForeground', 'TitleBarColor', 'TitleBarColorInactive'],
+    fallbackSymbolColor,
+  )
   const titleBarPreference = preferences['window.titleBarStyle']
   const frame = titleBarPreference !== 'custom'
   const titleBarStyle = titleBarPreference === 'custom' ? 'hidden' : undefined
@@ -12,8 +46,8 @@ export const getAppWindowOptions = ({ preferences, screenWidth, screenHeight, pr
 
   const titleBarOverlay = windowControlsOverlayPreference
     ? {
-        color: '#1e2324',
-        symbolColor: '#74b1be',
+        color: titleBarBackground,
+        symbolColor: titleBarSymbolColor,
         height: 29,
       }
     : undefined
@@ -23,7 +57,7 @@ export const getAppWindowOptions = ({ preferences, screenWidth, screenHeight, pr
     x: screenWidth - 800,
     width: 800,
     height: screenHeight,
-    background: '#1e2324',
+    background,
     titleBarStyle,
     frame,
     titleBarOverlay,

--- a/packages/shared-process/test/GetAppWindowOptions.test.ts
+++ b/packages/shared-process/test/GetAppWindowOptions.test.ts
@@ -1,0 +1,77 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ExtensionManagement/ExtensionManagementColorTheme.js', () => ({
+  getColorThemeJson: jest.fn(),
+}))
+
+const ExtensionManagementColorTheme = await import('../src/parts/ExtensionManagement/ExtensionManagementColorTheme.js')
+const GetAppWindowOptions = await import('../src/parts/GetAppWindowOptions/GetAppWindowOptions.js')
+
+const getOptions = (preferences: any) => {
+  return GetAppWindowOptions.getAppWindowOptions({
+    preferences: {
+      'window.titleBarStyle': 'custom',
+      'window.controlsOverlay.enabled': true,
+      ...preferences,
+    },
+    screenWidth: 1600,
+    screenHeight: 900,
+    preloadUrl: 'file:///preload.js',
+  })
+}
+
+test('getAppWindowOptions - uses active color theme for native title bar overlay', async () => {
+  // @ts-ignore
+  ExtensionManagementColorTheme.getColorThemeJson.mockResolvedValue({
+    colors: {
+      MainBackground: '#101820',
+      TitleBarBackground: '#202830',
+      TitleBarActiveBackground: '#303840',
+      TitleBarForeground: '#a0a8b0',
+      TitleBarForegroundActive: '#f0f8ff',
+    },
+  })
+
+  await expect(getOptions({ 'workbench.colorTheme': 'test-theme' })).resolves.toMatchObject({
+    backgroundColor: '#101820',
+    titleBarOverlay: {
+      color: '#303840',
+      symbolColor: '#f0f8ff',
+      height: 29,
+    },
+  })
+  expect(ExtensionManagementColorTheme.getColorThemeJson).toHaveBeenCalledWith('test-theme')
+})
+
+test('getAppWindowOptions - falls back when color theme cannot be loaded', async () => {
+  // @ts-ignore
+  ExtensionManagementColorTheme.getColorThemeJson.mockRejectedValue(new Error('theme not found'))
+
+  await expect(getOptions({ 'workbench.colorTheme': 'missing-theme' })).resolves.toMatchObject({
+    backgroundColor: '#1e2324',
+    titleBarOverlay: {
+      color: '#1e2324',
+      symbolColor: '#74b1be',
+      height: 29,
+    },
+  })
+})
+
+test('getAppWindowOptions - supports older title bar color keys', async () => {
+  // @ts-ignore
+  ExtensionManagementColorTheme.getColorThemeJson.mockResolvedValue({
+    colors: {
+      MainBackground: '#111111',
+      TitleBarBackground: '#222222',
+      TitleBarColor: '#dddddd',
+    },
+  })
+
+  await expect(getOptions({ 'workbench.colorTheme': 'legacy-theme' })).resolves.toMatchObject({
+    backgroundColor: '#111111',
+    titleBarOverlay: {
+      color: '#222222',
+      symbolColor: '#dddddd',
+    },
+  })
+})


### PR DESCRIPTION
## Summary
- load the active color theme before creating Electron app window options
- use theme title bar/background colors for Electron native title bar overlay controls
- add shared-process coverage for theme and fallback color selection