### PR TITLE
fix: open electron about dialog

### DIFF
--- a/packages/renderer-worker/src/parts/AboutElectron/AboutElectron.js
+++ b/packages/renderer-worker/src/parts/AboutElectron/AboutElectron.js
@@ -1,5 +1,5 @@
-import * as AboutViewWorker from '../AboutViewWorker/AboutViewWorker.js'
+import * as ElectronWindowAbout from '../ElectronWindowAbout/ElectronWindowAbout.js'
 
 export const showAboutElectron = async () => {
-  return AboutViewWorker.invoke('About.showAboutElectron')
+  return ElectronWindowAbout.open()
 }

--- a/packages/renderer-worker/test/About.test.js
+++ b/packages/renderer-worker/test/About.test.js
@@ -1,0 +1,55 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/ElectronWindowAbout/ElectronWindowAbout.js', () => {
+  return {
+    open: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
+  return {
+    openWidget: jest.fn(),
+  }
+})
+
+test('showAbout - electron', async () => {
+  jest.resetModules()
+  jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
+    return {
+      platform: PlatformType.Electron,
+      getPlatform: () => {
+        return PlatformType.Electron
+      },
+    }
+  })
+  const About = await import('../src/parts/About/About.js')
+  const ElectronWindowAbout = await import('../src/parts/ElectronWindowAbout/ElectronWindowAbout.js')
+  const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+  await About.showAbout()
+  expect(ElectronWindowAbout.open).toHaveBeenCalledTimes(1)
+  expect(Viewlet.openWidget).not.toHaveBeenCalled()
+})
+
+test('showAbout - web', async () => {
+  jest.resetModules()
+  jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
+    return {
+      platform: PlatformType.Web,
+      getPlatform: () => {
+        return PlatformType.Web
+      },
+    }
+  })
+  const About = await import('../src/parts/About/About.js')
+  const ElectronWindowAbout = await import('../src/parts/ElectronWindowAbout/ElectronWindowAbout.js')
+  const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+  await About.showAbout()
+  expect(ElectronWindowAbout.open).not.toHaveBeenCalled()
+  expect(Viewlet.openWidget).toHaveBeenCalledTimes(1)
+  expect(Viewlet.openWidget).toHaveBeenCalledWith('About')
+})


### PR DESCRIPTION
Fix the Electron About command so it opens the native About dialog directly instead of routing through the about-view worker.