### PR TITLE
fix: handle partial keybindings load failures

### DIFF
--- a/packages/renderer-worker/src/parts/KeyBindingsInitial/KeyBindingsInitial.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsInitial/KeyBindingsInitial.js
@@ -1,12 +1,26 @@
 import * as ExtensionKeyBindings from '../ExtensionKeyBindings/ExtensionKeyBindings.js'
+import * as Logger from '../Logger/Logger.js'
 import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
-const getViewletKeyBindings = (module) => {
+const getViewletKeyBindings = async (module) => {
   if (module.getKeyBindings) {
-    return module.getKeyBindings()
+    try {
+      return await module.getKeyBindings()
+    } catch (error) {
+      Logger.warn(`Failed to load keybindings for ${module.name}: ${error}`)
+    }
   }
   return []
+}
+
+const getExtensionKeyBindings = async () => {
+  try {
+    return await ExtensionKeyBindings.getKeyBindings()
+  } catch (error) {
+    Logger.warn(`Failed to load extension keybindings: ${error}`)
+    return []
+  }
 }
 
 const maybeLoad = async (id) => {
@@ -20,6 +34,6 @@ const maybeLoad = async (id) => {
 export const getKeyBindings = async () => {
   const ids = Object.keys(ViewletModuleId)
   const modules = await Promise.all(ids.map(maybeLoad))
-  const keyBindingsPromises = await Promise.all([...modules.map(getViewletKeyBindings), ExtensionKeyBindings.getKeyBindings()])
+  const keyBindingsPromises = await Promise.all([...modules.map(getViewletKeyBindings), getExtensionKeyBindings()])
   return keyBindingsPromises.flat(1)
 }

--- a/packages/renderer-worker/test/KeyBindingsInitial.test.js
+++ b/packages/renderer-worker/test/KeyBindingsInitial.test.js
@@ -1,3 +1,73 @@
-import { test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 
-test.skip('getKeyBindings', async () => {})
+jest.unstable_mockModule('../src/parts/ExtensionKeyBindings/ExtensionKeyBindings.js', () => {
+  return {
+    getKeyBindings: jest.fn(() => {
+      return [
+        {
+          key: 3,
+          command: 'ExtensionHost.executeCommand',
+          args: ['extension.command'],
+        },
+      ]
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/Logger/Logger.js', () => {
+  return {
+    warn: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ViewletModule/ViewletModule.js', () => {
+  return {
+    load: jest.fn((id) => {
+      if (id === 'Broken') {
+        return {
+          name: 'BrokenView',
+          getKeyBindings() {
+            throw new Error('Command not found BrokenView.getKeyBindings')
+          },
+        }
+      }
+      return {
+        name: 'WorkingView',
+        getKeyBindings() {
+          return [
+            {
+              key: 2,
+              command: 'WorkingView.focus',
+            },
+          ]
+        },
+      }
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ViewletModuleId/ViewletModuleId.js', () => {
+  return {
+    Broken: 'Broken',
+    Working: 'Working',
+  }
+})
+
+const KeyBindingsInitial = await import('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js')
+const Logger = await import('../src/parts/Logger/Logger.js')
+
+test('getKeyBindings', async () => {
+  expect(await KeyBindingsInitial.getKeyBindings()).toEqual([
+    {
+      key: 2,
+      command: 'WorkingView.focus',
+    },
+    {
+      key: 3,
+      command: 'ExtensionHost.executeCommand',
+      args: ['extension.command'],
+    },
+  ])
+  expect(Logger.warn).toHaveBeenCalledTimes(1)
+  expect(Logger.warn).toHaveBeenCalledWith('Failed to load keybindings for BrokenView: Error: Command not found BrokenView.getKeyBindings')
+})


### PR DESCRIPTION
Summary:

- Keep loading and displaying keybindings when one provider fails.
- Log a warning for failed viewlet or extension keybinding providers.
- Add a regression test for partial keybinding load failures.