### PR TITLE
fix: dock devtools at bottom

### DIFF
--- a/packages/renderer-worker/src/parts/ToElectronMenuItem/ToElectronMenuItem.js
+++ b/packages/renderer-worker/src/parts/ToElectronMenuItem/ToElectronMenuItem.js
@@ -75,11 +75,6 @@ export const toElectronMenuItem = (entry) => {
         label: entry.label,
         role: ElectronMenuItemRole.SelectAll,
       }
-    case UiStrings.ToggleDeveloperTools:
-      return {
-        label: entry.label,
-        role: ElectronMenuItemRole.ToggleDevTools,
-      }
     default:
       break
   }

--- a/packages/renderer-worker/test/ToElectronMenuItem.test.js
+++ b/packages/renderer-worker/test/ToElectronMenuItem.test.js
@@ -62,6 +62,16 @@ test('Undo', () => {
   })
 })
 
+test('Toggle Developer Tools', () => {
+  expect(
+    ToElectronMenuItem.toElectronMenuItem({
+      label: 'Toggle Developer Tools',
+    }),
+  ).toEqual({
+    label: 'Toggle Developer Tools',
+  })
+})
+
 test('Separator', () => {
   expect(
     ToElectronMenuItem.toElectronMenuItem({

--- a/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.js
+++ b/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.js
@@ -14,7 +14,7 @@ export const minimize = (windowId) => {
 
 export const toggleDevtools = (windowId) => {
   Assert.number(windowId)
-  return ParentIpc.invoke('ElectronWindow.executeWebContentsFunction', windowId, 'toggleDevTools')
+  return ParentIpc.invoke('ElectronWindow.executeWindowFunction', windowId, 'toggleDevtools')
 }
 
 export const maximize = (windowId) => {

--- a/packages/shared-process/test/ElectronWindow.test.ts
+++ b/packages/shared-process/test/ElectronWindow.test.ts
@@ -1,0 +1,14 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
+  invoke: jest.fn(() => {}),
+}))
+
+const ElectronWindow = await import('../src/parts/ElectronWindow/ElectronWindow.js')
+const ParentIpc = await import('../src/parts/MainProcess/MainProcess.js')
+
+test('toggleDevtools', async () => {
+  await ElectronWindow.toggleDevtools(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('ElectronWindow.executeWindowFunction', 1, 'toggleDevtools')
+})


### PR DESCRIPTION
Routes Toggle Developer Tools through the app command path and avoids Electron's built-in popup toggle so DevTools opens docked at the bottom.