### PR TITLE
feature: support view defined sidebar titles

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExplorer/ViewletExplorer.js
+++ b/packages/renderer-worker/src/parts/ViewletExplorer/ViewletExplorer.js
@@ -22,6 +22,15 @@ export const create = (id, uri, x, y, width, height, args, parentUid) => {
     height,
     platform: Platform.getPlatform(),
     assetDir: AssetDir.assetDir,
+    title: '',
+  }
+}
+
+export const getTitle = async (uid) => {
+  try {
+    return await ExplorerViewWorker.invoke('Explorer.getTitle', uid)
+  } catch {
+    return 'Explorer'
   }
 }
 
@@ -43,10 +52,12 @@ export const loadContent = async (state, savedState) => {
   const diffResult = await ExplorerViewWorker.invoke('Explorer.diff2', state.uid)
   const commands = await ExplorerViewWorker.invoke('Explorer.render2', state.uid, diffResult)
   const actionsDom = await ExplorerViewWorker.invoke('Explorer.renderActions2', state.uid)
+  const title = await getTitle(state.uid)
   return {
     ...state,
     commands,
     actionsDom,
+    title,
   }
 }
 

--- a/packages/renderer-worker/src/parts/ViewletExplorer/ViewletExplorerRenderTitle.js
+++ b/packages/renderer-worker/src/parts/ViewletExplorer/ViewletExplorerRenderTitle.js
@@ -1,20 +1,8 @@
-import * as ExplorerStrings from '../ViewletExplorer/ViewletExplorerStrings.js'
-
-const getPostFix = (root) => {
-  if (!root) {
-    return ExplorerStrings.noFolderOpen()
-  }
-  return ''
-}
-
 export const renderTitle = {
   isEqual(oldState, newState) {
-    return oldState.root === newState.root
+    return oldState.title === newState.title
   },
   apply(oldState, newState) {
-    const postFix = getPostFix(newState.root)
-    const prefix = 'Explorer'
-    const title = postFix ? `${prefix}: ${postFix}` : prefix
-    return title
+    return newState.title
   },
 }

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -238,7 +238,7 @@ const getRenderCommands = (module, oldState, newState, uid = newState.uid || mod
   if (module.renderTitle && !module.renderTitle.isEqual(oldState, newState)) {
     const title = module.renderTitle.apply(oldState, newState)
     if (parentId) {
-      // commands.push(['Viewlet.send', parentId, 'setTitle', title])
+      commands.push(['Viewlet.send', parentId, 'setTitle', title])
     }
   }
 

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -159,12 +159,18 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   }
   let actionsDom = []
   let actionsUid = -1
+  let title = Character.EmptyString
   if (commands) {
     const actionsDomIndex = commands.findIndex((command) => command[2] === 'setActionsDom')
     if (actionsDomIndex >= 0) {
       const nextActionsDom = commands[actionsDomIndex][3]
       actionsDom = Array.isArray(nextActionsDom) ? nextActionsDom : []
       commands.splice(actionsDomIndex, 1)
+    }
+    const titleIndex = commands.findIndex((command) => command[2] === 'setTitle')
+    title = titleIndex === -1 ? Character.EmptyString : commands[titleIndex][3]
+    if (titleIndex !== -1) {
+      commands.splice(titleIndex, 1)
     }
     const eventsIndex = commands.findIndex((command) => command[0] === 'Viewlet.registerEventListeners')
     if (actionsDom.length > 0) {
@@ -194,6 +200,14 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     currentViewletId: moduleId,
     childUid,
     actionsUid,
+    title,
+  }
+}
+
+export const setTitle = (state, title) => {
+  return {
+    ...state,
+    title,
   }
 }
 

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBarCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBarCommands.js
@@ -9,4 +9,5 @@ export const Commands = {
   handleClickAction: ViewletSideBar.handleClickAction,
   handleUpdateStateChange: ViewletSideBar.handleUpdateStateChange,
   handleSideBarViewletChange: ViewletSideBar.handleSideBarViewletChange,
+  setTitle: ViewletSideBar.setTitle,
 }

--- a/packages/renderer-worker/src/parts/WrapExplorerCommand/WrapExplorerCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapExplorerCommand/WrapExplorerCommand.ts
@@ -1,19 +1,34 @@
 import * as ExplorerViewWorker from '../ExplorerViewWorker/ExplorerViewWorker.js'
+import * as ViewletExplorer from '../ViewletExplorer/ViewletExplorer.js'
 
 export const wrapExplorerCommand = (key: string) => {
   const fn = async (state, ...args) => {
     await ExplorerViewWorker.invoke(`Explorer.${key}`, state.uid, ...args)
     const diffResult = await ExplorerViewWorker.invoke('Explorer.diff2', state.uid)
+    const title = await ViewletExplorer.getTitle(state.uid)
     if (diffResult.length === 0) {
-      return state
+      if (state.title === title) {
+        return state
+      }
+      return {
+        ...state,
+        title,
+      }
     }
     const commands = await ExplorerViewWorker.invoke('Explorer.render2', state.uid, diffResult)
     if (commands.length === 0) {
-      return state
+      if (state.title === title) {
+        return state
+      }
+      return {
+        ...state,
+        title,
+      }
     }
     return {
       ...state,
       commands,
+      title,
     }
   }
   return fn

--- a/packages/renderer-worker/test/ViewletSideBar.test.js
+++ b/packages/renderer-worker/test/ViewletSideBar.test.js
@@ -130,3 +130,28 @@ test('loadContent opens explorer when restore is disabled', async () => {
     currentViewletId: 'Explorer',
   })
 })
+
+test('handleSideBarViewletChange uses child title', async () => {
+  const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
+  ViewletManager.load.mockResolvedValue([
+    ['Viewlet.createFunctionalRoot', 'Explorer', 2, true],
+    ['Viewlet.send', 1, 'setTitle', 'workspace-name'],
+  ])
+
+  const newState = await ViewletSideBar.handleSideBarViewletChange(state, 'Explorer')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.createFunctionalRoot', 'Explorer', 2, true]])
+  expect(newState).toMatchObject({
+    currentViewletId: 'Explorer',
+    title: 'workspace-name',
+  })
+})
+
+test('setTitle', () => {
+  const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
+
+  expect(ViewletSideBar.setTitle(state, 'workspace-name')).toEqual({
+    ...state,
+    title: 'workspace-name',
+  })
+})


### PR DESCRIPTION
Allows sidebar child views to provide their own title and wires Explorer to use the view-provided workspace title when available.