### PR TITLE
fix: implement web open file picker

### DIFF
--- a/packages/renderer-worker/src/parts/Dialog/Dialog.js
+++ b/packages/renderer-worker/src/parts/Dialog/Dialog.js
@@ -8,13 +8,30 @@ import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as OpenUri from '../OpenUri/OpenUri.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as IsAbortError from '../IsAbortError/IsAbortError.js'
+import { VError } from '../VError/VError.js'
 
 export const state = {
   dialog: undefined,
 }
 
-const openFileWeb = () => {
-  Logger.warn('open file - not implemented')
+const openFileWeb = async () => {
+  try {
+    const [fileHandle] = await Command.execute('FilePicker.showFilePicker', {
+      multiple: false,
+    })
+    if (!fileHandle) {
+      return
+    }
+    const uri = `html:///${fileHandle.name}`
+    await Command.execute('PersistentFileHandle.addHandle', uri, fileHandle)
+    await OpenUri.openUri(uri)
+  } catch (error) {
+    if (IsAbortError.isAbortError(error)) {
+      return
+    }
+    throw new VError(error, 'Failed to open file')
+  }
 }
 
 const openFileRemote = () => {

--- a/packages/renderer-worker/src/parts/FilePicker/FilePicker.js
+++ b/packages/renderer-worker/src/parts/FilePicker/FilePicker.js
@@ -17,8 +17,19 @@ export const showDirectoryPicker = async (options) => {
   }
 }
 
-export const showFilePicker = (options) => {
-  return RendererProcess.invoke('FilePicker.showFilePicker', options)
+export const showFilePicker = async (options) => {
+  try {
+    return await RendererProcess.invoke('FilePicker.showFilePicker', options)
+  } catch (error) {
+    if (
+      error &&
+      // @ts-ignore
+      (error.message === 'window.showOpenFilePicker is not a function' || error.message === 'window.showFilePicker is not a function')
+    ) {
+      throw new Error('showFilePicker not supported on this browser')
+    }
+    throw error
+  }
 }
 
 const doShowSaveFilePicker = async (options) => {

--- a/packages/renderer-worker/test/Dialog.test.js
+++ b/packages/renderer-worker/test/Dialog.test.js
@@ -58,6 +58,69 @@ test('showMessage - electron', async () => {
   expect(ElectronDialog.showMessageBox).toHaveBeenCalledWith('Error: Oops', [], ElectronMessageBoxType.Error)
 })
 
+test('openFile - web', async () => {
+  const fileHandle = {
+    kind: 'file',
+    name: 'test.txt',
+  }
+  jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
+    return {
+      platform: PlatformType.Web,
+      getPlatform: jest.fn(() => {
+        return PlatformType.Web
+      }),
+      assetDir: '',
+    }
+  })
+  jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+    return {
+      execute: jest.fn((command) => {
+        if (command === 'FilePicker.showFilePicker') {
+          return [fileHandle]
+        }
+        return undefined
+      }),
+    }
+  })
+
+  const Command = await import('../src/parts/Command/Command.js')
+  const Dialog = await import('../src/parts/Dialog/Dialog.js')
+  await Dialog.openFile()
+  expect(Command.execute).toHaveBeenCalledTimes(3)
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'FilePicker.showFilePicker', {
+    multiple: false,
+  })
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'PersistentFileHandle.addHandle', 'html:///test.txt', fileHandle)
+  expect(Command.execute).toHaveBeenNthCalledWith(3, 'Main.openUri', 'html:///test.txt', true, {})
+})
+
+test('openFile - web - canceled', async () => {
+  jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
+    return {
+      platform: PlatformType.Web,
+      getPlatform: jest.fn(() => {
+        return PlatformType.Web
+      }),
+      assetDir: '',
+    }
+  })
+  jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+    return {
+      execute: jest.fn(() => {
+        throw new DOMException('The user aborted a request.', 'AbortError')
+      }),
+    }
+  })
+
+  const Command = await import('../src/parts/Command/Command.js')
+  const Dialog = await import('../src/parts/Dialog/Dialog.js')
+  await Dialog.openFile()
+  expect(Command.execute).toHaveBeenCalledTimes(1)
+  expect(Command.execute).toHaveBeenCalledWith('FilePicker.showFilePicker', {
+    multiple: false,
+  })
+})
+
 test.skip('close - web', async () => {
   jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
     return {

--- a/packages/renderer-worker/test/FilePicker.test.js
+++ b/packages/renderer-worker/test/FilePicker.test.js
@@ -47,6 +47,14 @@ test('showFilePicker - error', async () => {
   await expect(FilePicker.showFilePicker()).rejects.toThrow(new TypeError('x is not a function'))
 })
 
+test('showFilePicker - error - not supported', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(async () => {
+    throw new Error('window.showOpenFilePicker is not a function')
+  })
+  await expect(FilePicker.showFilePicker()).rejects.toThrow(new Error('showFilePicker not supported on this browser'))
+})
+
 test('showSaveFilePicker - error', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockImplementation(async () => {


### PR DESCRIPTION
Implements `Dialog.openFile` on the web platform by showing the native file picker, storing the selected file handle, and opening the resulting `html:///...` URI.

Abort/cancel is ignored like open folder, while unsupported picker errors are normalized for callers.
