### PR TITLE
fix: ignore missing diff view keybindings

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletDiffEditor2/ViewletExplorerKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletDiffEditor2/ViewletExplorerKeyBindings.js
@@ -1,5 +1,16 @@
 import * as DiffViewWorker from '../DiffViewWorker/DiffViewWorker.js'
 
-export const getKeyBindings = () => {
-  return DiffViewWorker.invoke('DiffView.getKeyBindings')
+const isDiffViewKeyBindingsNotFound = (error) => {
+  return error instanceof Error && error.name === 'CommandNotFoundError' && error.message.includes('DiffView.getKeyBindings')
+}
+
+export const getKeyBindings = async () => {
+  try {
+    return await DiffViewWorker.invoke('DiffView.getKeyBindings')
+  } catch (error) {
+    if (isDiffViewKeyBindingsNotFound(error)) {
+      return []
+    }
+    throw error
+  }
 }

--- a/packages/renderer-worker/test/ViewletDiffEditor2KeyBindings.test.js
+++ b/packages/renderer-worker/test/ViewletDiffEditor2KeyBindings.test.js
@@ -1,0 +1,47 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = /** @type {import('jest-mock').Mock<(...args: readonly any[]) => Promise<any>>} */ (jest.fn())
+
+jest.unstable_mockModule('../src/parts/DiffViewWorker/DiffViewWorker.js', () => {
+  return {
+    invoke,
+  }
+})
+
+const ViewletDiffEditor2KeyBindings = await import('../src/parts/ViewletDiffEditor2/ViewletExplorerKeyBindings.js')
+
+beforeEach(() => {
+  invoke.mockReset()
+})
+
+test('getKeyBindings', async () => {
+  invoke.mockResolvedValue([
+    {
+      key: 2,
+      command: 'DiffView.moveCursorDown',
+    },
+  ])
+
+  expect(await ViewletDiffEditor2KeyBindings.getKeyBindings()).toEqual([
+    {
+      key: 2,
+      command: 'DiffView.moveCursorDown',
+    },
+  ])
+  expect(invoke).toHaveBeenCalledWith('DiffView.getKeyBindings')
+})
+
+test('getKeyBindings - command not found', async () => {
+  const error = new Error('Command not found DiffView.getKeyBindings')
+  error.name = 'CommandNotFoundError'
+  invoke.mockRejectedValue(error)
+
+  expect(await ViewletDiffEditor2KeyBindings.getKeyBindings()).toEqual([])
+})
+
+test('getKeyBindings - error', async () => {
+  const error = new Error('Failed to load diff view worker')
+  invoke.mockRejectedValue(error)
+
+  await expect(ViewletDiffEditor2KeyBindings.getKeyBindings()).rejects.toThrow(error)
+})


### PR DESCRIPTION
## Summary

Handle older diff-view workers that do not expose `DiffView.getKeyBindings` by returning no diff editor keybindings instead of failing viewlet load.