### PR TITLE
feature: use node typescript stripping for static export

### DIFF
--- a/packages/shared-process/src/parts/ExportStatic/ExportStatic.js
+++ b/packages/shared-process/src/parts/ExportStatic/ExportStatic.js
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { stripTypeScriptTypes } from 'node:module'
 import { isAbsolute, join, relative } from 'node:path'
 import * as FileSystem from '../FileSystem/FileSystem.js'
 import * as GetContentSecurityPolicy from '../GetContentSecurityPolicy/GetContentSecurityPolicy.js'
@@ -518,22 +519,16 @@ const getTestFiles = (testFilesRaw) => {
   return testFilesRaw.filter(isTestFile).map(getName)
 }
 
-const transpileFile = (typescript, content) => {
-  const result = typescript.transpileModule(content, {
-    compilerOptions: {
-      target: 'esnext',
-    },
-  })
-  return result.outputText
+export const transpileFile = (content) => {
+  return stripTypeScriptTypes(content)
 }
 
 const transpileFiles = async (folder) => {
-  const typescript = await import('typescript')
   const dirents = await readdir(folder)
   for (const dirent of dirents) {
     if (dirent.endsWith('.ts')) {
       const content = await readFile(join(folder, dirent), 'utf-8')
-      const js = transpileFile(typescript, content)
+      const js = transpileFile(content)
       await writeFile(join(folder, dirent.slice(0, -2) + 'js'), js)
     }
   }

--- a/packages/shared-process/test/ExportStatic.test.ts
+++ b/packages/shared-process/test/ExportStatic.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from '@jest/globals'
-import { mergeExtensionManifests } from '../src/parts/ExportStatic/ExportStatic.js'
+import { mergeExtensionManifests, transpileFile } from '../src/parts/ExportStatic/ExportStatic.js'
+
+test('transpileFile removes typescript annotations', () => {
+  const content = `const value: number = 1
+export const getValue = (): number => value
+`
+
+  expect(transpileFile(content)).toContain(`export const getValue = ()         => value`)
+})
 
 test('mergeExtensionManifests replaces existing extension with matching id', () => {
   const builtinCobalt = {


### PR DESCRIPTION
## Summary

Use Node's built-in TypeScript type stripping for static export test file transpilation instead of importing the TypeScript package.