### PR TITLE
feature: open editor in new app window

### DIFF
--- a/packages/shared-process/src/parts/AppWindow/AppWindow.js
+++ b/packages/shared-process/src/parts/AppWindow/AppWindow.js
@@ -23,3 +23,9 @@ export const openNew = async (url) => {
   const preloadUrl = PreloadUrl.getPreloadUrl()
   return createAppWindow({ preferences, parsedArgs: [], workingDirectory: '', url, preloadUrl })
 }
+
+export const openNewWithUri = async (uri) => {
+  const url = new URL(DefaultUrl.defaultUrl)
+  url.searchParams.set('openUri', uri)
+  return openNew(url.toString())
+}

--- a/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.ipc.js
+++ b/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.ipc.js
@@ -9,6 +9,7 @@ export const Commands = {
   maximize: ElectronWindow.maximize,
   minimize: ElectronWindow.minimize,
   openNew: ElectronWindow.openNew,
+  openNewWithUri: ElectronWindow.openNewWithUri,
   reload: ElectronWindow.reload,
   toggleDevtools: ElectronWindow.toggleDevtools,
   unmaximize: ElectronWindow.unmaximize,

--- a/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.js
+++ b/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.js
@@ -3,8 +3,13 @@ import * as Assert from '../Assert/Assert.js'
 import * as Clamp from '../Clamp/Clamp.js'
 import * as ParentIpc from '../MainProcess/MainProcess.js'
 
-export const openNew = () => {
-  return AppWindow.openNew()
+export const openNew = (_windowId, url) => {
+  return AppWindow.openNew(url)
+}
+
+export const openNewWithUri = (_windowId, uri) => {
+  Assert.string(uri)
+  return AppWindow.openNewWithUri(uri)
 }
 
 export const minimize = (windowId) => {

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.js
@@ -254,6 +254,7 @@ export const getModuleId = (commandId) => {
     case 'ElectronWindow.maximize':
     case 'ElectronWindow.minimize':
     case 'ElectronWindow.openNew':
+    case 'ElectronWindow.openNewWithUri':
     case 'ElectronWindow.reload':
     case 'ElectronWindow.toggleDevtools':
     case 'ElectronWindow.unmaximize':

--- a/packages/shared-process/test/AppWindow.test.ts
+++ b/packages/shared-process/test/AppWindow.test.ts
@@ -1,0 +1,35 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetAppWindowOptions/GetAppWindowOptions.js', () => ({
+  getAppWindowOptions: jest.fn(() => ({})),
+}))
+
+jest.unstable_mockModule('../src/parts/GetTitleBarItems/GetTitleBarItems.js', () => ({
+  getTitleBarItems: jest.fn(() => []),
+}))
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
+  invoke: jest.fn(() => {}),
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  getAll: jest.fn(() => ({})),
+}))
+
+jest.unstable_mockModule('../src/parts/PreloadUrl/PreloadUrl.js', () => ({
+  getPreloadUrl: jest.fn(() => 'file:///preload.js'),
+}))
+
+jest.unstable_mockModule('../src/parts/Screen/Screen.js', () => ({
+  getBounds: jest.fn(() => ({ width: 1920, height: 1080 })),
+}))
+
+const AppWindow = await import('../src/parts/AppWindow/AppWindow.js')
+const ParentIpc = await import('../src/parts/MainProcess/MainProcess.js')
+
+test('openNewWithUri', async () => {
+  await AppWindow.openNewWithUri('/workspace/file.txt')
+
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, [], '', [], 'lvce-oss://-/?openUri=%2Fworkspace%2Ffile.txt')
+})

--- a/packages/shared-process/test/ElectronWindow.test.ts
+++ b/packages/shared-process/test/ElectronWindow.test.ts
@@ -4,6 +4,12 @@ jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
   invoke: jest.fn(() => {}),
 }))
 
+jest.unstable_mockModule('../src/parts/AppWindow/AppWindow.js', () => ({
+  openNew: jest.fn(() => {}),
+  openNewWithUri: jest.fn(() => {}),
+}))
+
+const AppWindow = await import('../src/parts/AppWindow/AppWindow.js')
 const ElectronWindow = await import('../src/parts/ElectronWindow/ElectronWindow.js')
 const ParentIpc = await import('../src/parts/MainProcess/MainProcess.js')
 
@@ -11,4 +17,16 @@ test('toggleDevtools', async () => {
   await ElectronWindow.toggleDevtools(1)
   expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
   expect(ParentIpc.invoke).toHaveBeenCalledWith('ElectronWindow.executeWindowFunction', 1, 'toggleDevtools')
+})
+
+test('openNewWithUri', async () => {
+  await ElectronWindow.openNewWithUri(1, '/workspace/file.txt')
+  expect(AppWindow.openNewWithUri).toHaveBeenCalledTimes(1)
+  expect(AppWindow.openNewWithUri).toHaveBeenCalledWith('/workspace/file.txt')
+})
+
+test('openNew forwards url', async () => {
+  await ElectronWindow.openNew(1, 'lvce-oss://-/?test=1')
+  expect(AppWindow.openNew).toHaveBeenCalledTimes(1)
+  expect(AppWindow.openNew).toHaveBeenCalledWith('lvce-oss://-/?test=1')
 })


### PR DESCRIPTION
Adds shared-process support for opening a normal app window with a startup editor URI.