### PR TITLE
feature: add css filename comments

### DIFF
--- a/packages/build/src/parts/BundleCss/BundleCss.js
+++ b/packages/build/src/parts/BundleCss/BundleCss.js
@@ -25,6 +25,18 @@ const toSorted = (array) => {
   return [...array].sort().reverse()
 }
 
+const shouldPrependFileNameComment = (fileName) => {
+  return !EagerLoadedCss.eagerLoadedCss.includes(fileName)
+}
+
+const prependFileNameComment = async (path, fileName) => {
+  const content = await readFile(path, EncodingType.Utf8)
+  await WriteFile.writeFile({
+    to: path,
+    content: `/* ${fileName} */\n${content}`,
+  })
+}
+
 export const bundleCss = async ({ outDir, additionalCss = '', assetDir = '', pathPrefix = '' }) => {
   try {
     let css = ``
@@ -47,10 +59,14 @@ export const bundleCss = async ({ outDir, additionalCss = '', assetDir = '', pat
       if (parts.includes(dirent)) {
         // ignore
       } else {
+        const outPath = Path.join(outDir, 'parts', dirent)
         await Copy.copy({
           from: `static/css/parts/${dirent}`,
-          to: Path.join(outDir, 'parts', dirent),
+          to: outPath,
         })
+        if (shouldPrependFileNameComment(dirent)) {
+          await prependFileNameComment(outPath, dirent)
+        }
       }
     }
 

--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { bundleCss } from '../src/parts/BundleCss/BundleCss.js'
+
+test('bundleCss adds filename comment to generated part css files', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'Markdown.css'), 'utf8')
+
+    expect(css.startsWith('/* Markdown.css */\n')).toBe(true)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('bundleCss does not add filename comment to App.css', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'App.css'), 'utf8')
+
+    expect(css.startsWith('/* App.css */\n')).toBe(false)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Adds filename comments to generated standalone production CSS files so adopted stylesheets are easier to identify in DevTools. App.css remains unchanged as the aggregate app stylesheet.