### PR TITLE
fix: refcount viewlet keybindings

### DIFF
--- a/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
@@ -6,6 +6,7 @@ import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 export const state = {
   keyBindings: [],
   keyBindingSets: Object.create(null),
+  keyBindingSetCounts: Object.create(null),
   /**
    * @type {Uint32Array}
    */
@@ -56,10 +57,11 @@ export const addKeyBindings = (id, keyBindings) => {
   Assert.string(id)
   Assert.array(keyBindings)
   if (id in state.keyBindingSets) {
-    Logger.warn(`cannot add keybindings multiple times: ${id}`)
+    state.keyBindingSetCounts[id]++
     return
   }
   state.keyBindingSets[id] = keyBindings
+  state.keyBindingSetCounts[id] = 1
   update()
 }
 
@@ -67,16 +69,22 @@ export const setKeyBindings = (id, keyBindings) => {
   Assert.string(id)
   Assert.array(keyBindings)
   state.keyBindingSets[id] = keyBindings
+  state.keyBindingSetCounts[id] = 1
   update()
 }
 
 export const removeKeyBindings = (id) => {
-  const { keyBindingSets } = state
+  const { keyBindingSets, keyBindingSetCounts } = state
   if (!(id in keyBindingSets)) {
     Logger.warn(`cannot remove keybindings that are not registered: ${id}`)
     return
   }
+  keyBindingSetCounts[id]--
+  if (keyBindingSetCounts[id] > 0) {
+    return
+  }
   delete keyBindingSets[id]
+  delete keyBindingSetCounts[id]
   update()
 }
 

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -13,6 +13,10 @@ import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as ViewletElectron from './ViewletElectron.js'
 
+const getKeyBindingSetId = (instance, fallback) => {
+  return instance.moduleId || fallback
+}
+
 export const focus = async (id) => {
   const instance = ViewletStates.getInstance(id)
   if (!instance) {
@@ -118,7 +122,7 @@ export const dispose = async (id) => {
     instance.factory.dispose(instance.state)
     await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     if (instance.factory.getKeyBindings) {
-      KeyBindingsState.removeKeyBindings(instanceUid)
+      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, instanceUid))
     }
   } catch (error) {
     console.error(error)
@@ -154,7 +158,7 @@ export const disposeFunctional = (id) => {
     const commands = [[/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid]]
 
     if (instance.factory.getKeyBindings) {
-      KeyBindingsState.removeKeyBindings(id)
+      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, id))
     }
     if (instance.factory.getChildren) {
       const children = instance.factory.getChildren(instance.state)
@@ -218,7 +222,7 @@ export const hideFunctional = (id) => {
     const commands = [[/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid]]
 
     if (instance.factory.getKeyBindings) {
-      KeyBindingsState.removeKeyBindings(id)
+      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, id))
     }
     if (instance.factory.getChildren) {
       const children = instance.factory.getChildren(instance.state)
@@ -468,7 +472,7 @@ export const disposeWidgetWithValue = async (id, value) => {
     Assert.number(uid)
     const commands = [[/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid]]
     if (instance.factory.getKeyBindings) {
-      KeyBindingsState.removeKeyBindings(uid)
+      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, uid))
     }
     if (instance.factory.getChildren) {
       const children = instance.factory.getChildren(instance.state)

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -541,19 +541,20 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       await module.show(newState)
     }
     const extraCommands = []
+    const moduleId = viewlet.moduleId || viewlet.id || ''
 
     if (viewlet.id === ViewletModuleId.Layout) {
       ViewletStates.set(viewletUid, {
         state: newState,
         renderedState: viewletState,
         factory: module,
-        moduleId: viewlet.moduleId || viewlet.id || '',
+        moduleId,
       })
     }
 
     if (module.getKeyBindings) {
       const keyBindings = await module.getKeyBindings(viewletUid)
-      KeyBindingsState.addKeyBindings(viewlet.id, keyBindings)
+      KeyBindingsState.addKeyBindings(moduleId, keyBindings)
     }
     if (module.Commands && module.Commands.getMouseActions) {
       const mouseActions = await module.Commands.getMouseActions(viewletUid)
@@ -618,13 +619,13 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       state: newState,
       renderedState: viewletState,
       factory: module,
-      moduleId: viewlet.moduleId || viewlet.id || '',
+      moduleId,
     }
     ViewletStates.set(viewletUid, instance)
     if (viewlet.id === ViewletModuleId.Layout) {
       ViewletStates.set(ViewletModuleId.Layout, instance)
     }
-    ViewletStates.setFocusedInstanceByType(viewletUid, viewlet.moduleId || viewlet.id || '')
+    ViewletStates.setFocusedInstanceByType(viewletUid, moduleId)
     if (newState.badgeCount) {
       await Command.execute('Layout.handleBadgeCountChange')
     }

--- a/packages/renderer-worker/test/KeyBindings.test.js
+++ b/packages/renderer-worker/test/KeyBindings.test.js
@@ -1,3 +1,68 @@
-import { test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
-test('', () => {})
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/Logger/Logger.js', () => {
+  return {
+    warn: jest.fn(),
+  }
+})
+
+const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
+const Logger = await import('../src/parts/Logger/Logger.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  KeyBindingsState.state.keyBindings = []
+  KeyBindingsState.state.keyBindingSets = Object.create(null)
+  KeyBindingsState.state.keyBindingSetCounts = Object.create(null)
+  KeyBindingsState.state.keyBindingIdentifiers = new Uint32Array()
+  KeyBindingsState.state.matchingKeyBindings = []
+})
+
+test('addKeyBindings increments refcount when keybinding set is already registered', () => {
+  const keyBindings = [
+    {
+      key: 1,
+      command: 'test.command',
+    },
+  ]
+
+  KeyBindingsState.addKeyBindings('Editor', keyBindings)
+  KeyBindingsState.addKeyBindings('Editor', keyBindings)
+
+  expect(Logger.warn).not.toHaveBeenCalled()
+  expect(KeyBindingsState.state.keyBindingSets.Editor).toBe(keyBindings)
+  expect(KeyBindingsState.state.keyBindingSetCounts.Editor).toBe(2)
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('KeyBindings.setIdentifiers', new Uint32Array([1]))
+})
+
+test('removeKeyBindings unregisters keybinding set after last reference is removed', () => {
+  const keyBindings = [
+    {
+      key: 1,
+      command: 'test.command',
+    },
+  ]
+
+  KeyBindingsState.addKeyBindings('Editor', keyBindings)
+  KeyBindingsState.addKeyBindings('Editor', keyBindings)
+  KeyBindingsState.removeKeyBindings('Editor')
+
+  expect(KeyBindingsState.state.keyBindingSets.Editor).toBe(keyBindings)
+  expect(KeyBindingsState.state.keyBindingSetCounts.Editor).toBe(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+
+  KeyBindingsState.removeKeyBindings('Editor')
+
+  expect(KeyBindingsState.state.keyBindingSets.Editor).toBeUndefined()
+  expect(KeyBindingsState.state.keyBindingSetCounts.Editor).toBeUndefined()
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
+  expect(RendererProcess.invoke).toHaveBeenLastCalledWith('KeyBindings.setIdentifiers', new Uint32Array())
+})


### PR DESCRIPTION
Summary:\n- Refcount viewlet keybinding sets so duplicate component loads do not re-register the same bindings.\n- Remove keybindings by the same module id used during registration.\n- Add regression coverage for duplicate add/remove behavior.