### PR TITLE
fix: remove process explorer port log

### DIFF
--- a/packages/shared-process/src/parts/HandleMessagePortForProcessExplorer/HandleMessagePortForProcessExplorer.js
+++ b/packages/shared-process/src/parts/HandleMessagePortForProcessExplorer/HandleMessagePortForProcessExplorer.js
@@ -4,6 +4,5 @@ import * as IpcId from '../IpcId/IpcId.js'
 
 export const handleMessagePortForProcessExplorer = (port) => {
   Assert.object(port)
-  console.log('got port', port)
   return HandleIncomingIpc.handleIncomingIpc(IpcId.ProcessExplorer, port, {})
 }


### PR DESCRIPTION
## Summary

Remove the debug log printed when the process explorer message port is received.