### PR TITLE
feature: pass account info to activity bar

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -405,11 +405,17 @@ const renderSideBarActivityBarCommands = async (activityBarId: number, sideBarVi
   return activityBarCommands
 }
 
-const renderActivityBarAuthCommands = async (activityBarId: number, userState: string) => {
+const renderActivityBarAuthCommands = async (state: LayoutState) => {
+  const { activityBarId, userState } = state
   if (activityBarId === -1) {
     return []
   }
-  await ActivityBarWorker.invoke('ActivityBar.setUserLoginState', activityBarId, toActivityBarUserLoginState(userState))
+  await ActivityBarWorker.invoke(
+    'ActivityBar.setUserLoginState',
+    activityBarId,
+    toActivityBarUserLoginState(userState),
+    toFilteredUserInfo(state, { includeAccessToken: false }),
+  )
   const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', activityBarId)
   return ActivityBarWorker.invoke('ActivityBar.render2', activityBarId, diffResult)
 }
@@ -424,10 +430,7 @@ const renderChatAuthCommands = async (state: LayoutState) => {
 }
 
 const getAuthFanoutCommands = async (state: LayoutState) => {
-  const [activityBarCommands, chatCommands] = await Promise.all([
-    renderActivityBarAuthCommands(state.activityBarId, state.userState),
-    renderChatAuthCommands(state),
-  ])
+  const [activityBarCommands, chatCommands] = await Promise.all([renderActivityBarAuthCommands(state), renderChatAuthCommands(state)])
   return [...(Array.isArray(activityBarCommands) ? activityBarCommands : []), ...(Array.isArray(chatCommands) ? chatCommands : [])]
 }
 

--- a/packages/renderer-worker/test/ViewletLayoutAuth.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutAuth.test.js
@@ -198,7 +198,13 @@ test('setAuthState fans auth changes out to activity bar and chat when visible',
     userUsedTokens: 42,
   })
 
-  expect(ActivityBarWorker.invoke).toHaveBeenCalledWith('ActivityBar.setUserLoginState', 2, 'logged in')
+  expect(ActivityBarWorker.invoke).toHaveBeenCalledWith('ActivityBar.setUserLoginState', 2, 'logged in', {
+    authErrorMessage: '',
+    userName: 'Test User',
+    userState: 'loggedIn',
+    userSubscriptionPlan: 'pro',
+    userUsedTokens: 42,
+  })
   expect(ChatViewWorker.invoke).toHaveBeenCalledWith('Chat.handleAuthStateChange', 3, {
     authAccessToken: 'token-1',
     authErrorMessage: '',


### PR DESCRIPTION
Passes filtered account information to the activity bar when auth state changes so account menus can show the signed-in user.