### PR TITLE
fix: hide update command for deb

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2,9 +2,11 @@ import * as ActivityBarWorker from '../ActivityBarWorker/ActivityBarWorker.js'
 import * as Assert from '../Assert/Assert.ts'
 import { assetDir } from '../AssetDir/AssetDir.js'
 import * as AuthWorker from '../AuthWorker/AuthWorker.js'
+import * as AutoUpdateType from '../AutoUpdateType/AutoUpdateType.js'
 import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import * as Command from '../Command/Command.js'
 import * as Commit from '../Commit/Commit.js'
+import * as GetAutoUpdateType from '../GetAutoUpdateType/GetAutoUpdateType.js'
 import * as GetDefaultTitleBarHeight from '../GetDefaultTitleBarHeight/GetDefaultTitleBarHeight.js'
 import * as Id from '../Id/Id.js'
 import * as LayoutKeys from '../LayoutKeys/LayoutKeys.js'
@@ -1505,8 +1507,13 @@ export const isSideBarVisible = (state: LayoutState) => {
   return sideBarVisible
 }
 
-export const getAllQuickPickMenuEntries = () => {
-  return MenuEntriesState.getAll()
+export const getAllQuickPickMenuEntries = async () => {
+  const entries = MenuEntriesState.getAll()
+  const autoUpdateType = await GetAutoUpdateType.getAutoUpdateType()
+  if (autoUpdateType === AutoUpdateType.Deb) {
+    return entries.filter((entry) => entry.id !== 'AutoUpdater.checkForUpdates')
+  }
+  return entries
 }
 
 const callGlobalEvent = async (state: LayoutState, eventName, ...args): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/test/ViewletLayoutQuickPickMenuEntries.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutQuickPickMenuEntries.test.js
@@ -1,0 +1,51 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as AutoUpdateType from '../src/parts/AutoUpdateType/AutoUpdateType.js'
+
+const menuEntries = [
+  {
+    id: 'AutoUpdater.checkForUpdates',
+    label: 'Updater: Check for Updates',
+  },
+  {
+    id: 'Layout.toggleSideBar',
+    label: 'Layout: Toggle Side Bar',
+  },
+]
+
+const mockGetAutoUpdateType = jest.fn(() => AutoUpdateType.None)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetAutoUpdateType.mockImplementation(() => AutoUpdateType.None)
+})
+
+jest.unstable_mockModule('../src/parts/MenuEntriesState/MenuEntriesState.js', () => {
+  return {
+    getAll: jest.fn(() => menuEntries),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/GetAutoUpdateType/GetAutoUpdateType.js', () => {
+  return {
+    getAutoUpdateType: mockGetAutoUpdateType,
+  }
+})
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+
+test('getAllQuickPickMenuEntries - deb', async () => {
+  mockGetAutoUpdateType.mockImplementation(() => AutoUpdateType.Deb)
+
+  expect(await ViewletLayout.getAllQuickPickMenuEntries()).toEqual([
+    {
+      id: 'Layout.toggleSideBar',
+      label: 'Layout: Toggle Side Bar',
+    },
+  ])
+})
+
+test('getAllQuickPickMenuEntries - not deb', async () => {
+  mockGetAutoUpdateType.mockImplementation(() => AutoUpdateType.AppImage)
+
+  expect(await ViewletLayout.getAllQuickPickMenuEntries()).toEqual(menuEntries)
+})


### PR DESCRIPTION
Hides the command-palette "Updater: Check for Updates" entry when the app is packaged as a deb, since updates are handled by apt.