### PR TITLE
fix: open new terminal panel view

### DIFF
--- a/packages/renderer-worker/src/parts/MenuEntriesTerminal/MenuEntriesTerminal.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesTerminal/MenuEntriesTerminal.js
@@ -1,6 +1,7 @@
 import * as MenuItemFlags from '../MenuItemFlags/MenuItemFlags.js'
 import * as TerminalStrings from '../TerminalStrings/TerminalStrings.js'
 import * as MenuEntryId from '../MenuEntryId/MenuEntryId.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
 export const id = MenuEntryId.Terminal
 
@@ -10,8 +11,8 @@ export const getMenuEntries = () => {
       id: 'newTerminal',
       label: TerminalStrings.newTerminal(),
       flags: MenuItemFlags.None,
-      command: 'Layout.togglePanel',
-      args: ['Terminal'],
+      command: 'Layout.showPanel',
+      args: [ViewletModuleId.Terminals],
     },
   ]
 }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -560,9 +560,44 @@ export const openCommandPalette = async (state: LayoutState): Promise<LayoutStat
   }
 }
 
-export const showPanel = (state: LayoutState) => {
+const getPanelViewChangeCommands = async (moduleId: string) => {
+  if (!moduleId) {
+    return []
+  }
+  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId)
+  if (!instance) {
+    return []
+  }
+  const panelUid = instance.state.uid
+  await PanelWorker.invoke('Panel.toggleView', panelUid, moduleId)
+  const diffResult = await PanelWorker.invoke('Panel.diff2', panelUid)
+  if (diffResult.length === 0) {
+    return []
+  }
+  return PanelWorker.invoke('Panel.render2', panelUid, diffResult)
+}
+
+export const showPanel = async (state: LayoutState, moduleId = state.panelView) => {
+  if (state.panelVisible) {
+    const commands = await getPanelViewChangeCommands(moduleId)
+    return {
+      newState: {
+        ...state,
+        panelView: moduleId,
+      },
+      commands,
+    }
+  }
   // @ts-ignore
-  return show(state, LayoutModules.Panel)
+  const { newState, commands } = await show(state, LayoutModules.Panel)
+  const panelViewCommands = await getPanelViewChangeCommands(moduleId)
+  return {
+    newState: {
+      ...newState,
+      panelView: moduleId,
+    },
+    commands: [...commands, ...panelViewCommands],
+  }
 }
 
 export const hidePanel = (state: LayoutState) => {

--- a/packages/renderer-worker/test/MenuEntriesTerminal.test.js
+++ b/packages/renderer-worker/test/MenuEntriesTerminal.test.js
@@ -4,8 +4,8 @@ import * as MenuEntriesTerminal from '../src/parts/MenuEntriesTerminal/MenuEntri
 test('getMenuEntries', () => {
   const menuEntries = MenuEntriesTerminal.getMenuEntries()
   expect(menuEntries).toContainEqual({
-    args: ['Terminal'],
-    command: 'Layout.togglePanel',
+    args: ['Terminals'],
+    command: 'Layout.showPanel',
     flags: 0,
     id: 'newTerminal',
     label: 'New Terminal',

--- a/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.js
@@ -10,6 +10,7 @@ jest.unstable_mockModule('../src/parts/PanelWorker/PanelWorker.js', () => {
       panelWorkerInvocations.push([method, ...args])
       switch (method) {
         case 'Panel.handlePanelLayoutChanged':
+        case 'Panel.toggleView':
           return undefined
         case 'Panel.diff2':
           return panelWorkerDiffResult
@@ -154,6 +155,27 @@ test('maximizePanel enlarges panel and sets panelMaximized to true', async () =>
   // Maximized height = min(windowHeight - titleBar - statusBar - mainMin, panelMaxHeight)
   // = min(800 - 0 - 20 - 100, 600) = 600
   expect(result.newState.panelHeight).toBe(600)
+})
+
+test('showPanel selects requested panel view when panel is visible', async () => {
+  createPanelInstance()
+  panelWorkerDiffResult = [11]
+  panelWorkerRenderCommands = [['Viewlet.setPatches', 77, []]]
+  const state = {
+    ...ViewletLayout.create(1),
+    panelVisible: true,
+    panelView: 'Problems',
+  }
+
+  const result = await ViewletLayout.showPanel(state, 'Terminals')
+
+  expect(result.newState.panelView).toBe('Terminals')
+  expect(result.commands).toEqual([['Viewlet.setPatches', 77, []]])
+  expect(panelWorkerInvocations).toEqual([
+    ['Panel.toggleView', 77, 'Terminals'],
+    ['Panel.diff2', 77],
+    ['Panel.render2', 77, [11]],
+  ])
 })
 
 test('maximizePanel notifies panel worker when panel instance exists', async () => {


### PR DESCRIPTION
## Summary
- open the Terminals panel view from the Terminal > New Terminal menu entry
- keep layout panel state in sync when showing a specific panel view