### PR TITLE
fix: rerender editor on resize

### DIFF
--- a/packages/renderer-worker/src/parts/Editor/Editor.js
+++ b/packages/renderer-worker/src/parts/Editor/Editor.js
@@ -1,5 +1,6 @@
 import * as EditorCompletionState from '../EditorCompletionState/EditorCompletionState.js'
 import * as MinimumSliderSize from '../MinimumSliderSize/MinimumSliderSize.js'
+import * as ScrollBarFunctions from '../ScrollBarFunctions/ScrollBarFunctions.js'
 import * as EditorScrolling from './EditorScrolling.js'
 
 // TODO
@@ -76,9 +77,13 @@ export const setBounds = (editor, x, y, width, height, columnWidth) => {
   const { itemHeight } = editor
   const numberOfVisibleLines = Math.floor(height / itemHeight)
   const total = editor.lines.length
-  const maxLineY = Math.min(numberOfVisibleLines, total)
   const finalY = Math.max(total - numberOfVisibleLines, 0)
   const finalDeltaY = finalY * itemHeight
+  const deltaY = Math.min(editor.deltaY, finalDeltaY)
+  const minLineY = Math.floor(deltaY / itemHeight)
+  const maxLineY = Math.min(minLineY + numberOfVisibleLines, total)
+  const contentHeight = total * editor.rowHeight
+  const scrollBarHeight = ScrollBarFunctions.getScrollBarSize(height, contentHeight, editor.minimumSliderSize)
   return {
     ...editor,
     x,
@@ -86,10 +91,13 @@ export const setBounds = (editor, x, y, width, height, columnWidth) => {
     width,
     height,
     columnWidth,
+    deltaY,
     numberOfVisibleLines,
+    minLineY,
     maxLineY,
     finalY,
     finalDeltaY,
+    scrollBarHeight,
   }
 }
 

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -267,9 +267,10 @@ export const handleLanguagesChanged = async (state) => {
 
 export const hasFunctionalResize = true
 
-export const resize = (state, dimensions) => {
+export const resize = async (state, dimensions) => {
+  await EditorWorker.invoke('Editor.resize', state.id, dimensions)
   const newState = Editor.setBounds(state, dimensions.x, dimensions.y, dimensions.width, dimensions.height, state.columnWidth)
-  return newState
+  return rerender(newState)
 }
 
 export const dispose = (state) => {

--- a/packages/renderer-worker/test/ViewletEditorText.test.js
+++ b/packages/renderer-worker/test/ViewletEditorText.test.js
@@ -1,5 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const editorWorkerInvoke = jest.fn()
+
 beforeEach(() => {
   jest.resetAllMocks()
 })
@@ -12,9 +14,27 @@ jest.unstable_mockModule('../src/parts/MeasureTextWidth/MeasureTextWidth.js', ()
   }
 })
 
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => {
+  return {
+    invoke: editorWorkerInvoke,
+  }
+})
+
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
 
-test('resize - increase height', () => {
+test('resize - increase height', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.resize':
+        return undefined
+      case 'Editor.diff2':
+        return [1]
+      case 'Editor.render2':
+        return [['setRows']]
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
   const state = {
     ...ViewletEditorText.create(0, '', 0, 0, 20, 20),
     lines: ['line 1', 'line 2', 'line 3', 'line 4', 'line 5'],
@@ -25,7 +45,7 @@ test('resize - increase height', () => {
     width: 800,
     differences: [0, 0, 0, 0],
   }
-  const newState = ViewletEditorText.resize(state, {
+  const newState = await ViewletEditorText.resize(state, {
     x: 200,
     y: 200,
     width: 200,
@@ -36,13 +56,34 @@ test('resize - increase height', () => {
       minLineY: 0,
       maxLineY: 3,
       numberOfVisibleLines: 3,
-      scrollBarHeight: 0,
+      scrollBarHeight: 36,
       finalDeltaY: 40,
     }),
   )
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(1, 'Editor.resize', 0, {
+    x: 200,
+    y: 200,
+    width: 200,
+    height: 60,
+  })
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.diff2', 0)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(3, 'Editor.render2', 0, [1])
+  expect(newState.commands).toEqual([['setRows']])
 })
 
-test('resize - same height', () => {
+test('resize - same height', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.resize':
+        return undefined
+      case 'Editor.diff2':
+        return []
+      case 'Editor.render2':
+        return []
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
   const state = {
     ...ViewletEditorText.create(0, '', 0, 0, 20, 20),
     lines: ['line 1', 'line 2', 'line 3', 'line 4', 'line 5'],
@@ -53,7 +94,7 @@ test('resize - same height', () => {
     width: 800,
     differences: [0, 0, 0, 0],
   }
-  const newState = ViewletEditorText.resize(state, {
+  const newState = await ViewletEditorText.resize(state, {
     x: 200,
     y: 200,
     width: 200,
@@ -64,13 +105,25 @@ test('resize - same height', () => {
       minLineY: 0,
       maxLineY: 3,
       numberOfVisibleLines: 3,
-      scrollBarHeight: 0,
+      scrollBarHeight: 36,
       finalDeltaY: 40,
     }),
   )
 })
 
-test('resize - reduce height', () => {
+test('resize - reduce height', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.resize':
+        return undefined
+      case 'Editor.diff2':
+        return []
+      case 'Editor.render2':
+        return []
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
   const state = {
     ...ViewletEditorText.create(0, '', 0, 0, 20, 20),
     lines: ['line 1', 'line 2', 'line 3', 'line 4', 'line 5'],
@@ -82,7 +135,7 @@ test('resize - reduce height', () => {
     width: 800,
     differences: [0, 0, 0, 0],
   }
-  const newState = ViewletEditorText.resize(state, {
+  const newState = await ViewletEditorText.resize(state, {
     x: 200,
     y: 200,
     width: 200,
@@ -93,8 +146,53 @@ test('resize - reduce height', () => {
       minLineY: 0,
       maxLineY: 1,
       numberOfVisibleLines: 1,
-      scrollBarHeight: 0,
+      scrollBarHeight: 20,
       finalDeltaY: 80,
+    }),
+  )
+})
+
+test('resize - increase height while scrolled clamps visible rows to bottom', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.resize':
+        return undefined
+      case 'Editor.diff2':
+        return []
+      case 'Editor.render2':
+        return []
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+  const state = {
+    ...ViewletEditorText.create(0, '', 0, 0, 100, 200),
+    deltaY: 1800,
+    finalDeltaY: 1800,
+    finalY: 90,
+    lines: Array.from({ length: 100 }, (_, index) => `line ${index}`),
+    minLineY: 90,
+    maxLineY: 100,
+    numberOfVisibleLines: 10,
+    scrollBarHeight: 20,
+    focused: true,
+    width: 100,
+    differences: [0, 0, 0, 0],
+  }
+  const newState = await ViewletEditorText.resize(state, {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 400,
+  })
+  expect(newState).toEqual(
+    expect.objectContaining({
+      deltaY: 1600,
+      finalDeltaY: 1600,
+      minLineY: 80,
+      maxLineY: 100,
+      numberOfVisibleLines: 20,
+      scrollBarHeight: 80,
     }),
   )
 })


### PR DESCRIPTION
Updates editor resize handling to notify the editor worker and rerender visible rows when the editor bounds change. Depends on the editor-worker resize command.