### PR TITLE
fix: add keyboard tab mask icon

### DIFF
--- a/static/css/parts/MaskIcon.css
+++ b/static/css/parts/MaskIcon.css
@@ -404,6 +404,10 @@
   mask-image: url(/icons/record-keys.svg);
 }
 
+.MaskIconKeyboardTab {
+  mask-image: url(/icons/keyboard-tab.svg);
+}
+
 .MaskIconSortPrecedence {
   mask-image: url(/icons/sort-precedence.svg);
 }


### PR DESCRIPTION
Adds the Keyboard Shortcuts tab mask icon class backed by the VS Code keyboard-tab codicon.