### PR TITLE
fix: update activity bar source control badge

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -501,6 +501,7 @@ export const commandMap = {
   'Layout.handleSashPointerMove': lazy('Layout.handleSashPointerMove'),
   'Layout.handleSashPointerUp': lazy('Layout.handleSashPointerUp'),
   'Layout.handleWorkspaceRefresh': lazy('Layout.handleWorkspaceRefresh'),
+  'Layout.refreshSourceControlBadgeCount': lazy('Layout.refreshSourceControlBadgeCount'),
   'Layout.closeChat': lazy('Layout.closeChat'),
   'Layout.hideActivityBar': lazy('Layout.hideActivityBar'),
   'Layout.hideMain': lazy('Layout.hideMain'),

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -1,7 +1,12 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Command from '../Command/Command.js'
 import * as EncodingType from '../EncodingType/EncodingType.js'
 import * as GetFileSystem from '../GetFileSystem/GetFileSystem.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
+
+const notifyWorkspaceChanged = async () => {
+  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh'), Command.execute('Layout.refreshSourceControlBadgeCount')])
+}
 
 export const readFile = async (uri, encoding = EncodingType.Utf8) => {
   const protocol = GetProtocol.getProtocol(uri)
@@ -22,12 +27,14 @@ export const remove = async (uri) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.remove(uri)
+  await notifyWorkspaceChanged()
 }
 
 export const rename = async (oldUri, newUri) => {
   const protocol = GetProtocol.getProtocol(oldUri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.rename(oldUri, newUri)
+  await notifyWorkspaceChanged()
 }
 
 export const mkdir = async (uri) => {
@@ -40,6 +47,7 @@ export const writeFile = async (uri, content, encoding = EncodingType.Utf8) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.writeFile(uri, content, encoding)
+  await notifyWorkspaceChanged()
 }
 
 export const writeBlob = async (uri, blob) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -22,6 +22,7 @@ import { reorderCommands } from '../ReorderCommands/ReorderCommands.js'
 import * as SashType from '../SashType/SashType.js'
 import * as SaveState from '../SaveState/SaveState.js'
 import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
+import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker.js'
 import { VError } from '../VError/VError.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
@@ -30,6 +31,7 @@ import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import * as Workspace from '../Workspace/Workspace.js'
 import { getPoints } from './LayoutPoints.ts'
 import type { LayoutState, LayoutStateResult } from './LayoutState.ts'
 
@@ -1668,6 +1670,22 @@ export const setUpdateState = async (state, updateState) => {
 
 export const handleWorkspaceRefresh = async (state: LayoutState) => {
   return callGlobalEvent(state, 'handleWorkspaceRefresh')
+}
+
+export const refreshSourceControlBadgeCount = async (state: LayoutState): Promise<LayoutStateResult> => {
+  try {
+    const badgeCount = await SourceControlWorker.invoke('SourceControl.getWorkspaceBadgeCount', Workspace.state.workspacePath, assetDir, Platform.platform)
+    return setBadgeCount(state, ViewletModuleId.SourceControl, badgeCount)
+  } catch {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
+}
+
+export const contentLoadedEffects = async (): Promise<void> => {
+  await Command.execute('Layout.refreshSourceControlBadgeCount')
 }
 
 export const handleBadgeCountChange = async (state, changes) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -37,6 +37,7 @@ export const CommandsWithSideEffects = {
   handleSashPointerMove: ViewletLayout.handleSashPointerMove,
   handleSashPointerUp: ViewletLayout.handleSashPointerUp,
   handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
+  refreshSourceControlBadgeCount: ViewletLayout.refreshSourceControlBadgeCount,
   closeChat: ViewletLayout.closeChat,
   hideActivityBar: ViewletLayout.hideActivityBar,
   hideMain: ViewletLayout.hideMain,

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Command from '../Command/Command.js'
 import * as DirentType from '../DirentType/DirentType.js'
 import * as IconTheme from '../IconTheme/IconTheme.js'
 import * as SourceControlActions from '../SourceControlActions/SourceControlActions.js'
@@ -6,6 +7,7 @@ import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker
 import * as Workspace from '../Workspace/Workspace.js'
 import * as Platform from '../Platform/Platform.js'
 import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
 // TODO when accept input is invoked multiple times, it should not lead to errors
 
@@ -54,17 +56,7 @@ export const loadContent = async (state, savedState) => {
   const commands = await SourceControlWorker.invoke('SourceControl.render2', state.uid, diffResult)
   const actionsDom = await SourceControlWorker.invoke('SourceControl.renderActions2', state.uid)
   const badgeCount = await SourceControlWorker.invoke('SourceControl.getBadgeCount', state.uid)
-  // if (badgeCount > 0) {
-  //   const newState = {
-  //     ...state,
-  //     commands,
-  //     actionsDom,
-  //     badgeCount,
-  //   }
-  //   ViewletStates.setState(state.uid, newState)
-  //   ViewletStates.setRenderedState(state.uid, newState)
-  //   await Command.execute('Layout.handleBadgeCountChange')
-  // }
+  await Command.execute('Layout.setBadgeCount', ViewletModuleId.SourceControl, badgeCount)
   return {
     ...state,
     commands,

--- a/packages/renderer-worker/src/parts/WrapSourceControlCommand/WrapSourceControlCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapSourceControlCommand/WrapSourceControlCommand.ts
@@ -1,6 +1,7 @@
 import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker.js'
 import * as Command from '../Command/Command.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
 export const wrapSourceControlCommand = (key: string) => {
   const fn = async (state, ...args) => {
@@ -23,7 +24,7 @@ export const wrapSourceControlCommand = (key: string) => {
 
       ViewletStates.setState(state.uid, newState)
       ViewletStates.setRenderedState(state.uid, newState)
-      await Command.execute('Layout.handleBadgeCountChange')
+      await Command.execute('Layout.setBadgeCount', ViewletModuleId.SourceControl, badgeCount)
     }
     return {
       ...state,


### PR DESCRIPTION
Publishes source control badge counts into layout on startup, source control load, source control commands, and filesystem changes so the activity bar can refresh its badge.