### PR TITLE
fix: align extension detail aside

### DIFF
--- a/static/css/parts/AdditionalDetails.css
+++ b/static/css/parts/AdditionalDetails.css
@@ -13,6 +13,7 @@
 }
 
 .Aside {
+  flex: 0 0 var(--ExtensionDetailSideBarWidth);
   min-width: 175px;
   contain: strict;
   scrollbar-color: var(--EditorScrollBarBackground, rgba(57, 71, 71, 0.6)) transparent;

--- a/static/css/parts/ViewletExtensionDetail.css
+++ b/static/css/parts/ViewletExtensionDetail.css
@@ -49,6 +49,8 @@
 
 /* TODO use separate classname and avoid nesting */
 .ExtensionDetail .Markdown {
+  flex: 1;
+  min-width: 0;
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary

Fixes the extension detail layout so the readme column fills the available space and the additional details aside stays aligned to the right edge.