### PR TITLE
fix: validate electron app window urls

### DIFF
--- a/packages/shared-process/src/parts/AppWindow/AppWindow.ts
+++ b/packages/shared-process/src/parts/AppWindow/AppWindow.ts
@@ -6,7 +6,25 @@ import * as Preferences from '../Preferences/Preferences.ts'
 import * as PreloadUrl from '../PreloadUrl/PreloadUrl.ts'
 import * as Screen from '../Screen/Screen.ts'
 
+const getValidatedAppUrl = (url: unknown): string => {
+  if (typeof url !== 'string') {
+    throw new TypeError('Expected url to be a string')
+  }
+  const defaultUrl = new URL(DefaultUrl.defaultUrl)
+  const parsedUrl = new URL(url, defaultUrl)
+  const isAppUrl =
+    parsedUrl.protocol === defaultUrl.protocol &&
+    parsedUrl.host === defaultUrl.host &&
+    parsedUrl.username === defaultUrl.username &&
+    parsedUrl.password === defaultUrl.password
+  if (!isAppUrl) {
+    throw new TypeError('Only application URLs can be opened in an app window')
+  }
+  return parsedUrl.toString()
+}
+
 export const createAppWindow = async ({ preferences, parsedArgs, workingDirectory, url = DefaultUrl.defaultUrl, preloadUrl }: any): Promise<any> => {
+  const validatedUrl = getValidatedAppUrl(url)
   const { width, height } = await Screen.getBounds()
   const windowOptions = await GetAppWindowOptions.getAppWindowOptions({
     preferences,
@@ -15,7 +33,7 @@ export const createAppWindow = async ({ preferences, parsedArgs, workingDirector
     preloadUrl,
   })
   const titleBarItems = GetTitleBarItems.getTitleBarItems()
-  return ParentIpc.invoke('AppWindow.createAppWindow', windowOptions, parsedArgs, workingDirectory, titleBarItems, url)
+  return ParentIpc.invoke('AppWindow.createAppWindow', windowOptions, parsedArgs, workingDirectory, titleBarItems, validatedUrl)
 }
 
 export const openNew = async (url: any): Promise<any> => {

--- a/packages/shared-process/test/AppWindow.test.ts
+++ b/packages/shared-process/test/AppWindow.test.ts
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('../src/parts/GetAppWindowOptions/GetAppWindowOptions.js', () => ({
   getAppWindowOptions: jest.fn(() => ({})),
@@ -26,6 +26,37 @@ jest.unstable_mockModule('../src/parts/Screen/Screen.js', () => ({
 
 const AppWindow = await import('../src/parts/AppWindow/AppWindow.js')
 const ParentIpc = await import('../src/parts/MainProcess/MainProcess.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('openNew with trusted app url', async () => {
+  await AppWindow.openNew('lvce-oss://-/?test=1')
+
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, [], '', [], 'lvce-oss://-/?test=1')
+})
+
+test('openNew with relative app url', async () => {
+  await AppWindow.openNew('/tests/example.html')
+
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, [], '', [], 'lvce-oss://-/tests/example.html')
+})
+
+test.each(['https://example.com', 'file:///tmp/index.html', 'javascript:alert(1)', 'lvce-oss://example.com/', 'lvce-oss://user@-/'])(
+  'openNew rejects untrusted url %s',
+  async (url) => {
+    await expect(AppWindow.openNew(url)).rejects.toThrow(new TypeError('Only application URLs can be opened in an app window'))
+    expect(ParentIpc.invoke).not.toHaveBeenCalled()
+  },
+)
+
+test('openNew rejects non-string url', async () => {
+  await expect(AppWindow.openNew({})).rejects.toThrow(new TypeError('Expected url to be a string'))
+  expect(ParentIpc.invoke).not.toHaveBeenCalled()
+})
 
 test('openNewWithUri', async () => {
   await AppWindow.openNewWithUri('/workspace/file.txt')


### PR DESCRIPTION
## Summary

- restrict privileged Electron app windows to the LVCE scheme and authority
- reject remote, local-file, and credential-bearing URLs before main-process IPC
- add regression coverage for trusted and untrusted URL handling