### PR TITLE
fix: prevent static route traversal

### DIFF
--- a/packages/build/src/parts/BuildServer/BuildServer.js
+++ b/packages/build/src/parts/BuildServer/BuildServer.js
@@ -79,7 +79,7 @@ const copyServerFiles = async ({ commitHash }) => {
   if (url.startsWith('/manifest.json')) {
     return true
   }
-  if (url.startsWith('/auth/')) {
+  if (url === '/auth/callback' || url.startsWith('/auth/callback?')) {
     return true
   }
   if (url.startsWith('/packages') && url.endsWith('.js')) {
@@ -97,7 +97,7 @@ const copyServerFiles = async ({ commitHash }) => {
   if (url.startsWith('/favicon.ico')) {
     return true
   }
-  if (url.startsWith('/auth/')) {
+  if (url === '/auth/callback' || url.startsWith('/auth/callback?')) {
     return true
   }
   if (url.startsWith('/manifest.ico')) {

--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.js
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.js
@@ -241,7 +241,7 @@ export const getResponseInfo = async ({ request, isImmutable, applicationName = 
   await Replace.replace({
     path: 'packages/build/.tmp/server/static-server/src/parts/GetAbsolutePath/GetAbsolutePath.js',
     occurrence: `  if (pathName.startsWith('/packages')) {
-    return Path.join(root, pathName)
+    return getContainedPath(root, pathName)
   }
 `,
     replacement: '',

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -79,7 +79,7 @@ const isStatic = (url) => {
   if (url.startsWith('/manifest.json')) {
     return true
   }
-  if (url.startsWith('/auth/')) {
+  if (url === '/auth/callback' || url.startsWith('/auth/callback?')) {
     return true
   }
   if (url.startsWith('/packages') && url.endsWith('.js')) {

--- a/packages/static-server/src/parts/GetAbsolutePath/GetAbsolutePath.js
+++ b/packages/static-server/src/parts/GetAbsolutePath/GetAbsolutePath.js
@@ -1,11 +1,26 @@
 import { existsSync } from 'node:fs'
-import { join } from 'path'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import * as CodiconsPath from '../CodiconsPath/CodiconsPath.js'
-import * as Path from '../Path/Path.js'
 import { STATIC } from '../Static/Static.js'
 import { root } from '../Root/Root.js'
 
 const invalidIconsPath = join(STATIC, '__missing_vscode_icon__.svg')
+const invalidStaticPath = join(STATIC, '__invalid_path__')
+
+const getContainedPath = (basePath, pathName) => {
+  let decodedPathName
+  try {
+    decodedPathName = decodeURIComponent(pathName)
+  } catch {
+    return invalidStaticPath
+  }
+  const absolutePath = resolve(basePath, decodedPathName.replace(/^[/\\]+/, ''))
+  const relativePath = relative(basePath, absolutePath)
+  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    return invalidStaticPath
+  }
+  return absolutePath
+}
 
 const getIconAbsolutePath = (pathName) => {
   const relativePath = pathName.startsWith('/static/icons/') ? pathName.slice('/static/icons/'.length) : pathName.slice('/icons/'.length)
@@ -37,7 +52,7 @@ export const getAbsolutePath = (pathName) => {
     return getIconAbsolutePath(pathName)
   }
   if (pathName.startsWith('/packages')) {
-    return Path.join(root, pathName)
+    return getContainedPath(root, pathName)
   }
-  return Path.join(STATIC, pathName)
+  return getContainedPath(STATIC, pathName)
 }

--- a/packages/static-server/test/GetAbsolutePath.test.ts
+++ b/packages/static-server/test/GetAbsolutePath.test.ts
@@ -29,6 +29,15 @@ test('maps oauth callback route to callback html', () => {
   expect(normalizePath(absolutePath)).toContain('/static/auth/callback.html')
 })
 
+test.each(['/auth/../../secret', '/css/../../secret', '/css/%2e%2e/%2e%2e/secret', '/packages/../../secret.js'])(
+  'prevents path traversal for %s',
+  (pathName) => {
+    const absolutePath = GetAbsolutePath.getAbsolutePath(pathName)
+
+    expect(normalizePath(absolutePath)).toContain('/static/__invalid_path__')
+  },
+)
+
 test('returns 200 for oauth callback route with query params', async () => {
   const response = await GetResponseInfo.getResponseInfo({
     request: {


### PR DESCRIPTION
Prevent static requests from resolving outside their intended roots and restrict the OAuth static route to the callback endpoint.