### PR TITLE
fix: restore Electron Linux app icon

### DIFF
--- a/packages/build/src/parts/AddRootPackageJson/AddRootPackageJson.js
+++ b/packages/build/src/parts/AddRootPackageJson/AddRootPackageJson.js
@@ -8,6 +8,7 @@ export const addRootPackageJson = async ({ cachePath, electronVersion, product, 
     value: {
       name: product.applicationName,
       productName: product.nameLong,
+      desktopName: `${product.applicationName}.desktop`,
       version: version,
       electronVersion,
       type,

--- a/packages/build/test/AddRootPackageJson.test.ts
+++ b/packages/build/test/AddRootPackageJson.test.ts
@@ -1,0 +1,34 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/JsonFile/JsonFile.js', () => ({
+  writeJson: jest.fn(),
+}))
+
+const AddRootPackageJson = await import('../src/parts/AddRootPackageJson/AddRootPackageJson.js')
+const JsonFile = await import('../src/parts/JsonFile/JsonFile.js')
+
+test('addRootPackageJson - includes stable linux desktop name', async () => {
+  await AddRootPackageJson.addRootPackageJson({
+    cachePath: '/test/cache',
+    electronVersion: '44.0.0-alpha.2',
+    product: {
+      applicationName: 'lvce-oss',
+      nameLong: 'Lvce Editor - OSS',
+    },
+    bundleMainProcess: true,
+    version: '1.0.0',
+  })
+
+  expect(JsonFile.writeJson).toHaveBeenCalledWith({
+    to: '/test/cache/package.json',
+    value: {
+      name: 'lvce-oss',
+      productName: 'Lvce Editor - OSS',
+      desktopName: 'lvce-oss.desktop',
+      version: '1.0.0',
+      electronVersion: '44.0.0-alpha.2',
+      type: 'module',
+      main: 'packages/main-process/dist/mainProcessMain.js',
+    },
+  })
+})

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lvce-editor/main-process-legacy",
   "productName": "Lvce Editor",
+  "desktopName": "lvce-oss.desktop",
   "version": "0.0.0-dev",
   "description": "Lvce Editor",
   "main": "src/mainProcessMain.js",

--- a/packages/shared-process/src/parts/GetIcon/GetIcon.ts
+++ b/packages/shared-process/src/parts/GetIcon/GetIcon.ts
@@ -2,21 +2,16 @@ import * as IsLinux from '../IsLinux/IsLinux.ts'
 import * as IsProduction from '../IsProduction/IsProduction.ts'
 import * as IsWindows from '../IsWindows/IsWindows.ts'
 import * as Path from '../Path/Path.ts'
-import * as Platform from '../Platform/Platform.ts'
 import * as Root from '../Root/Root.ts'
 
 export const getIcon = (): any => {
-  if (!IsProduction.isProduction && IsLinux.isLinux) {
-    return Path.join(Root.root, 'packages', 'build', 'files', 'icon.png')
+  if (IsLinux.isLinux) {
+    return IsProduction.isProduction
+      ? Path.join(Root.root, 'static', 'icons', 'icon.png')
+      : Path.join(Root.root, 'packages', 'build', 'files', 'icon.png')
   }
   if (!IsProduction.isProduction && IsWindows.isWindows) {
     return Path.join(Root.root, 'packages', 'build', 'files', 'icon.png')
-  }
-  if (IsProduction.isProduction && Platform.isArchLinux) {
-    return Path.join(Root.root, 'static', 'icons', 'icon.png')
-  }
-  if (IsProduction.isProduction && Platform.isAppImage) {
-    return Path.join(Root.root, 'static', 'icons', 'icon.png')
   }
   return undefined
 }

--- a/packages/shared-process/test/GetIcon.test.ts
+++ b/packages/shared-process/test/GetIcon.test.ts
@@ -1,0 +1,23 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/IsLinux/IsLinux.js', () => ({
+  isLinux: true,
+}))
+
+jest.unstable_mockModule('../src/parts/IsProduction/IsProduction.js', () => ({
+  isProduction: true,
+}))
+
+jest.unstable_mockModule('../src/parts/IsWindows/IsWindows.js', () => ({
+  isWindows: false,
+}))
+
+jest.unstable_mockModule('../src/parts/Root/Root.js', () => ({
+  root: '/test/root',
+}))
+
+const GetIcon = await import('../src/parts/GetIcon/GetIcon.js')
+
+test('getIcon - production linux', () => {
+  expect(GetIcon.getIcon().replaceAll('\\', '/')).toBe('/test/root/static/icons/icon.png')
+})


### PR DESCRIPTION
## Summary

- give development and packaged Electron apps a stable Linux desktop identity
- pass the bundled PNG when creating production Linux windows so Electron 44 can show the app icon
- cover the packaged desktop metadata and production icon path with regression tests