### PR TITLE
fix: prevent startup layout race

### DIFF
--- a/packages/renderer-worker/src/parts/RunSequentially/RunSequentially.js
+++ b/packages/renderer-worker/src/parts/RunSequentially/RunSequentially.js
@@ -1,0 +1,5 @@
+export const runSequentially = async (actions, ...args) => {
+  for (const action of actions) {
+    await action(...args)
+  }
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -24,6 +24,7 @@ import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as RunSequentially from '../RunSequentially/RunSequentially.js'
 import * as SaveState from '../SaveState/SaveState.js'
 import * as SessionReplay from '../SessionReplay/SessionReplay.js'
 import * as StartupAuth from '../StartupAuth/StartupAuth.js'
@@ -36,7 +37,7 @@ import * as ViewletModuleMap from '../ViewletModuleMap/ViewletModuleMap.js'
 import * as WatchFilesForHotReload from '../WatchFilesForHotReload/WatchFilesForHotReload.js'
 import * as Workspace from '../Workspace/Workspace.js'
 
-const actions = [
+const layoutActions = [
   async () => {
     Performance.mark(PerformanceMarkerType.WillLoadMain)
     await Command.execute('Layout.loadMainIfVisible')
@@ -48,7 +49,8 @@ const actions = [
     LifeCycle.mark(LifeCyclePhase.Seven)
 
     Performance.mark(PerformanceMarkerType.WillLoadSideBar)
-    await Promise.all([Command.execute('Layout.loadSideBarIfVisible'), Command.execute('Layout.loadSecondarySideBarIfVisible')])
+    await Command.execute('Layout.loadSideBarIfVisible')
+    await Command.execute('Layout.loadSecondarySideBarIfVisible')
     Performance.mark(PerformanceMarkerType.DidLoadSideBar)
   },
   async () => {
@@ -77,14 +79,6 @@ const actions = [
   async () => {
     await Command.execute('Layout.loadPreviewIfVisible')
   },
-  async (platform, assetDir) => {
-    LifeCycle.mark(LifeCyclePhase.Eleven)
-
-    Performance.mark(PerformanceMarkerType.WillLoadIconTheme)
-    // TODO check preferences if icon theme is enabled
-    await IconTheme.hydrate(platform, assetDir)
-    Performance.mark(PerformanceMarkerType.DidLoadIconTheme)
-  },
   async (platform) => {
     LifeCycle.mark(LifeCyclePhase.Twelve)
 
@@ -98,8 +92,17 @@ const actions = [
   },
 ]
 
-const loadMainAction = actions[0]
-const deferredActions = actions.slice(1)
+const loadIconThemeAction = async (platform, assetDir) => {
+  LifeCycle.mark(LifeCyclePhase.Eleven)
+
+  Performance.mark(PerformanceMarkerType.WillLoadIconTheme)
+  // TODO check preferences if icon theme is enabled
+  await IconTheme.hydrate(platform, assetDir)
+  Performance.mark(PerformanceMarkerType.DidLoadIconTheme)
+}
+
+const loadMainAction = layoutActions[0]
+const deferredLayoutActions = layoutActions.slice(1)
 
 // TODO lazyload parts one by one (Main, SideBar, ActivityBar, TitleBar, StatusBar)
 export const startup = async (platform, assetDir) => {
@@ -208,8 +211,9 @@ export const startup = async (platform, assetDir) => {
 
   LifeCycle.mark(LifeCyclePhase.Five)
 
-  await loadMainAction(platform, assetDir)
-  await Promise.all(deferredActions.map((action) => action(platform, assetDir)))
+  await loadMainAction()
+  // Layout actions update the same state and must not overlap.
+  await Promise.all([RunSequentially.runSequentially(deferredLayoutActions, platform), loadIconThemeAction(platform, assetDir)])
 
   LifeCycle.mark(LifeCyclePhase.Fifteen)
 

--- a/packages/renderer-worker/test/RunSequentially.test.js
+++ b/packages/renderer-worker/test/RunSequentially.test.js
@@ -1,0 +1,39 @@
+import { expect, jest, test } from '@jest/globals'
+import * as RunSequentially from '../src/parts/RunSequentially/RunSequentially.js'
+
+const createDeferred = () => {
+  let resolve = () => {}
+  /** @type {Promise<void>} */
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+test('runs actions one at a time', async () => {
+  const deferred = createDeferred()
+  const calls = []
+  const first = jest.fn(async (...args) => {
+    calls.push(['first-start', ...args])
+    await deferred.promise
+    calls.push(['first-end', ...args])
+  })
+  const second = jest.fn(async (...args) => {
+    calls.push(['second', ...args])
+  })
+
+  const promise = RunSequentially.runSequentially([first, second], 'electron', '/assets')
+  await Promise.resolve()
+
+  expect(first).toHaveBeenCalledWith('electron', '/assets')
+  expect(second).not.toHaveBeenCalled()
+
+  deferred.resolve()
+  await promise
+
+  expect(calls).toEqual([
+    ['first-start', 'electron', '/assets'],
+    ['first-end', 'electron', '/assets'],
+    ['second', 'electron', '/assets'],
+  ])
+})


### PR DESCRIPTION
Fix startup layout viewlets being attached concurrently, which could let a later layout render drop the title bar, activity bar, panel, or status bar.

Serialize layout-loading actions while leaving icon-theme hydration parallel, and cover the ordering with a regression test.