### PR TITLE
feature: style icons in split buttons

### DIFF
--- a/static/css/parts/MaskIcon.css
+++ b/static/css/parts/MaskIcon.css
@@ -205,6 +205,11 @@
   mask-image: url(/icons/check.svg);
 }
 
+.MaskIconLock,
+.IconLock {
+  mask-image: url(/icons/lock.svg);
+}
+
 .MaskIconEllipsis,
 .IconEllipsis {
   mask-image: url(/icons/ellipsis.svg);

--- a/static/css/parts/SplitButton.css
+++ b/static/css/parts/SplitButton.css
@@ -1,4 +1,5 @@
 .SplitButton {
+  --MaskIconSize: 16px;
   background: var(--SplitButtonBackground, rgb(35, 112, 112));
   color: var(--SplitButtonForeground, white);
   height: 28px;
@@ -18,6 +19,13 @@
   align-items: center;
   cursor: pointer;
   outline: none;
+}
+
+.SplitButtonContent > .MaskIcon {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+  flex-shrink: 0;
 }
 
 .SplitButtonContent:where(:hover),


### PR DESCRIPTION
Add the shared lock mask mapping and size contributed icons beside split-button labels.