### PR TITLE
fix: route about dialog through worker

### DIFF
--- a/packages/renderer-worker/src/parts/About/About.js
+++ b/packages/renderer-worker/src/parts/About/About.js
@@ -1,23 +1,6 @@
-import * as AboutElectron from '../AboutElectron/AboutElectron.js'
+import * as AboutViewWorker from '../AboutViewWorker/AboutViewWorker.js'
 import * as Platform from '../Platform/Platform.js'
-import * as PlatformType from '../PlatformType/PlatformType.js'
-import * as Viewlet from '../Viewlet/Viewlet.js'
-import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
-
-const showAboutDefault = async () => {
-  await Viewlet.openWidget(ViewletModuleId.About)
-}
-
-const getFn = () => {
-  switch (Platform.getPlatform()) {
-    case PlatformType.Electron:
-      return AboutElectron.showAboutElectron
-    default:
-      return showAboutDefault
-  }
-}
 
 export const showAbout = async () => {
-  const fn = getFn()
-  await fn()
+  await AboutViewWorker.invoke('About.showAbout', Platform.getPlatform())
 }

--- a/packages/renderer-worker/test/About.test.js
+++ b/packages/renderer-worker/test/About.test.js
@@ -5,15 +5,9 @@ beforeEach(() => {
   jest.resetAllMocks()
 })
 
-jest.unstable_mockModule('../src/parts/ElectronWindowAbout/ElectronWindowAbout.js', () => {
+jest.unstable_mockModule('../src/parts/AboutViewWorker/AboutViewWorker.js', () => {
   return {
-    open: jest.fn(),
-  }
-})
-
-jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
-  return {
-    openWidget: jest.fn(),
+    invoke: jest.fn(),
   }
 })
 
@@ -28,11 +22,10 @@ test('showAbout - electron', async () => {
     }
   })
   const About = await import('../src/parts/About/About.js')
-  const ElectronWindowAbout = await import('../src/parts/ElectronWindowAbout/ElectronWindowAbout.js')
-  const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+  const AboutViewWorker = await import('../src/parts/AboutViewWorker/AboutViewWorker.js')
   await About.showAbout()
-  expect(ElectronWindowAbout.open).toHaveBeenCalledTimes(1)
-  expect(Viewlet.openWidget).not.toHaveBeenCalled()
+  expect(AboutViewWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(AboutViewWorker.invoke).toHaveBeenCalledWith('About.showAbout', PlatformType.Electron)
 })
 
 test('showAbout - web', async () => {
@@ -46,10 +39,8 @@ test('showAbout - web', async () => {
     }
   })
   const About = await import('../src/parts/About/About.js')
-  const ElectronWindowAbout = await import('../src/parts/ElectronWindowAbout/ElectronWindowAbout.js')
-  const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+  const AboutViewWorker = await import('../src/parts/AboutViewWorker/AboutViewWorker.js')
   await About.showAbout()
-  expect(ElectronWindowAbout.open).not.toHaveBeenCalled()
-  expect(Viewlet.openWidget).toHaveBeenCalledTimes(1)
-  expect(Viewlet.openWidget).toHaveBeenCalledWith('About')
+  expect(AboutViewWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(AboutViewWorker.invoke).toHaveBeenCalledWith('About.showAbout', PlatformType.Web)
 })


### PR DESCRIPTION
Route the About command through the about-view worker so it prepares the platform-specific dialog data before invoking Electron's main-process dialog. Update renderer-worker coverage for both Electron and web routing.