### PR TITLE
feature: use glob patterns for file excludes

### DIFF
--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -22,11 +22,11 @@
   "files.autoSave": "off",
 
   "files.exclude": {
-    ".git": true,
-    ".svn": true,
-    ".hg": true,
-    ".DS_Store": true,
-    "Thumbs.db": true
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true
   },
 
   "languages.jsFilesAsJsx": false,


### PR DESCRIPTION
Updates the default files.exclude keys to the requested VS Code-style recursive glob patterns for Git, SVN, Mercurial, macOS metadata, and Windows thumbnail files.