### PR TITLE
feature: show gpu info

### DIFF
--- a/packages/main-process/package-lock.json
+++ b/packages/main-process/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/main-process": "^6.7.0"
+        "@lvce-editor/main-process": "^6.8.0"
       },
       "engines": {
         "node": ">=24"
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@lvce-editor/main-process": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/main-process/-/main-process-6.7.0.tgz",
-      "integrity": "sha512-o1VsARifkNabRZ58xEUbpHrk4RoZVZvRdwEhS3hEwIW8zYnBGZUiwVYprlGSNIiUbAlwMAy9gYKGkZ0qjyzPQw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/main-process/-/main-process-6.8.0.tgz",
+      "integrity": "sha512-Nf5qS4rrtJE+Mkf+6ZzXxgi1RRZMLaNwUviLRciSKWgWbDlJIGAnF+fSzJ95o3j2+YDjgXu40UhWrSXVADj86w==",
       "license": "MIT",
       "dependencies": {
         "electron": "43.1.0"

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -21,6 +21,6 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@lvce-editor/main-process": "^6.7.0"
+    "@lvce-editor/main-process": "^6.8.0"
   }
 }

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -77,6 +77,7 @@ export const commandMap = {
   'Developer.reloadColorTheme': lazy('Developer.reloadColorTheme'),
   'Developer.reloadIconTheme': lazy('Developer.reloadIconTheme'),
   'Developer.showColorThemeCss': lazy('Developer.showColorThemeCss'),
+  'Developer.showGpuInfo': lazy('Developer.showGpuInfo'),
   'Developer.showMemoryUsage': lazy('Developer.showMemoryUsage'),
   'Developer.showStartupPerformance': lazy('Developer.showStartupPerformance'),
   'Developer.startupPerformance': lazy('Developer.startupPerformance'),

--- a/packages/renderer-worker/src/parts/Developer/Developer.ipc.js
+++ b/packages/renderer-worker/src/parts/Developer/Developer.ipc.js
@@ -29,6 +29,7 @@ export const Commands = {
   reloadColorTheme: Developer.reloadColorTheme,
   reloadIconTheme: Developer.reloadIconTheme,
   showColorThemeCss: Developer.showColorThemeCss,
+  showGpuInfo: Developer.showGpuInfo,
   showMemoryUsage: Developer.showMemoryUsage,
   showStartupPerformance: Developer.showStartupPerformance,
   startupPerformance: Developer.showStartupPerformance,

--- a/packages/renderer-worker/src/parts/Developer/Developer.js
+++ b/packages/renderer-worker/src/parts/Developer/Developer.js
@@ -224,6 +224,10 @@ export const openProcessExplorer = () => {
   return ProcessExplorer.open()
 }
 
+export const showGpuInfo = () => {
+  return SharedProcess.invoke('Developer.showGpuInfo')
+}
+
 export const downloadViewletState = async () => {
   const states = await Command.execute('Viewlet.getAllStates')
   await Command.execute('Download.downloadJson', /* json */ states, /* fileName */ 'viewlets.json')

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -354,6 +354,10 @@ export const getQuickPickMenuEntries = () => {
       label: 'Developer: Open Process Explorer',
     },
     {
+      id: 'Developer.showGpuInfo',
+      label: 'Developer: Show GPU Info',
+    },
+    {
       id: 'Developer.openStorageOverview',
       label: 'Developer: Open Storage Overview',
     },

--- a/packages/renderer-worker/test/Developer.test.js
+++ b/packages/renderer-worker/test/Developer.test.js
@@ -376,6 +376,16 @@ test('open process explorer - error', async () => {
   await expect(Developer.openProcessExplorer()).rejects.toThrow(new TypeError('x is not a function'))
 })
 
+test('showGpuInfo', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue(undefined)
+
+  await Developer.showGpuInfo()
+
+  expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Developer.showGpuInfo')
+})
+
 test('getAllStates', async () => {
   // @ts-ignore
   Viewlet.getAllStates.mockImplementation(() => {

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.js
@@ -29,3 +29,12 @@ test('getQuickPickMenuEntries includes chat commands', () => {
     ]),
   )
 })
+
+test('getQuickPickMenuEntries includes GPU info command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Developer.showGpuInfo',
+    label: 'Developer: Show GPU Info',
+  })
+})

--- a/packages/shared-process/src/parts/Developer/Developer.ipc.ts
+++ b/packages/shared-process/src/parts/Developer/Developer.ipc.ts
@@ -10,4 +10,5 @@ export const Commands = {
   'Developer.createProfile': CpuProfile.createProfile,
   'Developer.sharedProcessMemoryUsage': Developer.sharedProcessMemoryUsage,
   'Developer.sharedProcessStartupPerformance': Developer.sharedProcessStartupPerformance,
+  'Developer.showGpuInfo': Developer.showGpuInfo,
 }

--- a/packages/shared-process/src/parts/Developer/Developer.ts
+++ b/packages/shared-process/src/parts/Developer/Developer.ts
@@ -1,3 +1,4 @@
+import * as MainProcess from '../MainProcess/MainProcess.ts'
 import * as Process from '../Process/Process.ts'
 
 export const measureLatencyBetweenExtensionHostAndSharedProcess = async (socket: any, id: any): Promise<any> => {
@@ -27,6 +28,10 @@ export const sharedProcessStartupPerformance = (): any => {
 export const sharedProcessMemoryUsage = (): any => {
   // TODO also print out number of watched files
   return Process.memoryUsage()
+}
+
+export const showGpuInfo = (): any => {
+  return MainProcess.invoke('ElectronWindowGpuInfo.open')
 }
 
 // TODO not sure if this is actually useful

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -36,6 +36,7 @@ export const getModuleId = (commandId: any): any => {
     case 'Developer.createProfile':
     case 'Developer.sharedProcessMemoryUsage':
     case 'Developer.sharedProcessStartupPerformance':
+    case 'Developer.showGpuInfo':
       return ModuleId.Developer
     case 'Download.download':
       return ModuleId.Download

--- a/packages/shared-process/test/Developer.test.ts
+++ b/packages/shared-process/test/Developer.test.ts
@@ -1,6 +1,16 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import { access } from 'node:fs/promises'
-import * as Developer from '../src/parts/Developer/Developer.js'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const Developer = await import('../src/parts/Developer/Developer.js')
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 const exists = async (path: any): Promise<any> => {
   try {
@@ -32,4 +42,11 @@ test('sharedProcessMemoryUsage', () => {
     heapUsed: expect.any(Number),
     rss: expect.any(Number),
   })
+})
+
+test('showGpuInfo', async () => {
+  await Developer.showGpuInfo()
+
+  expect(MainProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(MainProcess.invoke).toHaveBeenCalledWith('ElectronWindowGpuInfo.open')
 })


### PR DESCRIPTION
Adds a Developer: Show GPU Info quick-pick command and routes it through the shared process to the dedicated GPU diagnostics window.