### PR TITLE
fix: update extension management worker

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -33,7 +33,7 @@
         "@lvce-editor/extension-detail-view": "^7.11.0",
         "@lvce-editor/extension-host-sub-worker": "^3.14.0",
         "@lvce-editor/extension-host-worker": "^8.43.1",
-        "@lvce-editor/extension-management-worker": "^4.21.0",
+        "@lvce-editor/extension-management-worker": "^4.21.1",
         "@lvce-editor/extension-search-view": "^7.8.0",
         "@lvce-editor/file-search-worker": "^8.2.0",
         "@lvce-editor/file-system-worker": "^5.5.0",
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-management-worker": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-management-worker/-/extension-management-worker-4.21.0.tgz",
-      "integrity": "sha512-BV+/Te/FKQG2Kdr6R5He+eIRZWv6AfQmg5+BMKGIbhj0xl+DXPWJoS0RpApVDyvawBun40U/mxJ25KkOM5Lpqg==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-management-worker/-/extension-management-worker-4.21.1.tgz",
+      "integrity": "sha512-PVq6fp1fVYl5M5P2AFL5xbWRabQIru3ZHGQNU3i/cI0B4d6tnkzgz0dYOcv3onji/2/mEVL2irYk4UWxscy3Iw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-search-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -65,7 +65,7 @@
     "@lvce-editor/extension-detail-view": "^7.11.0",
     "@lvce-editor/extension-host-sub-worker": "^3.14.0",
     "@lvce-editor/extension-host-worker": "^8.43.1",
-    "@lvce-editor/extension-management-worker": "^4.21.0",
+    "@lvce-editor/extension-management-worker": "^4.21.1",
     "@lvce-editor/extension-search-view": "^7.8.0",
     "@lvce-editor/file-search-worker": "^8.2.0",
     "@lvce-editor/file-system-worker": "^5.5.0",


### PR DESCRIPTION
## Summary
- update extension-management-worker to 4.21.1
- preserve explicit Remote runtime selection for isolated server extensions

## Validation
- renderer-worker type-check