### PR TITLE
fix: update file watcher process

### DIFF
--- a/packages/shared-process/package-lock.json
+++ b/packages/shared-process/package-lock.json
@@ -35,7 +35,7 @@
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "^4.6.0",
         "@lvce-editor/file-system-process": "^5.3.0",
-        "@lvce-editor/file-watcher-process": "^4.1.0",
+        "@lvce-editor/file-watcher-process": "^4.1.1",
         "@lvce-editor/network-process": "^5.2.0",
         "@lvce-editor/preload": "^1.5.0",
         "@lvce-editor/preview-process": "^11.0.0",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.1.0.tgz",
-      "integrity": "sha512-b7981jjOtXayw7gikSqTkFXjIdgIF+/qGjD3xTlL5yawisMZpYYU7JhJu/7W8YpNafZgINsKpTyacqClWmDq1w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.1.1.tgz",
+      "integrity": "sha512-6Po7PqNGYBwjsL1eF41fSX/5X6tHU0Qh3fp7xXS5azgVppgqIe7GMERxpMTB6iCsK6fdKKKN3bxEwn2l3v52uA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/packages/shared-process/package.json
+++ b/packages/shared-process/package.json
@@ -37,7 +37,7 @@
   "optionalDependencies": {
     "@lvce-editor/embeds-process": "^4.6.0",
     "@lvce-editor/file-system-process": "^5.3.0",
-    "@lvce-editor/file-watcher-process": "^4.1.0",
+    "@lvce-editor/file-watcher-process": "^4.1.1",
     "@lvce-editor/network-process": "^5.2.0",
     "@lvce-editor/preload": "^1.5.0",
     "@lvce-editor/preview-process": "^11.0.0",


### PR DESCRIPTION
Update the shared process to file-watcher-process 4.1.1 so Electron file change callbacks use the transferred shared-process RPC instead of reaching main-process and causing an unhandled command-not-found rejection.