### PR TITLE
feature: test editor layout split menu actions

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-down.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-down.ts
@@ -1,0 +1,20 @@
+export const name = 'viewlet.title-bar-editor-layout-split-down'
+
+export const test = async ({ Command, Main, TitleBarMenuBar, Locator, expect }) => {
+  await TitleBarMenuBar.focus()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowDown()
+  await Command.execute('TitleBar.handleMenuClick', 0, 4)
+
+  const item = Locator('#Menu-1 .MenuItem', { hasText: 'Split Down' })
+  await expect(item).toBeVisible()
+  await Command.execute('TitleBar.handleMenuClick', 1, 1)
+  await expect(item).toBeHidden()
+  await Main.shouldHaveLayout({
+    activeGroupIndex: 1,
+    direction: 'vertical',
+    groups: [{ size: 50 }, { size: 50 }],
+  })
+}

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-left.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-left.ts
@@ -1,0 +1,20 @@
+export const name = 'viewlet.title-bar-editor-layout-split-left'
+
+export const test = async ({ Command, Main, TitleBarMenuBar, Locator, expect }) => {
+  await TitleBarMenuBar.focus()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowDown()
+  await Command.execute('TitleBar.handleMenuClick', 0, 4)
+
+  const item = Locator('#Menu-1 .MenuItem', { hasText: 'Split Left' })
+  await expect(item).toBeVisible()
+  await Command.execute('TitleBar.handleMenuClick', 1, 2)
+  await expect(item).toBeHidden()
+  await Main.shouldHaveLayout({
+    activeGroupIndex: 0,
+    direction: 'horizontal',
+    groups: [{ size: 50 }, { size: 50 }],
+  })
+}

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-right.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-right.ts
@@ -1,0 +1,20 @@
+export const name = 'viewlet.title-bar-editor-layout-split-right'
+
+export const test = async ({ Command, Main, TitleBarMenuBar, Locator, expect }) => {
+  await TitleBarMenuBar.focus()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowDown()
+  await Command.execute('TitleBar.handleMenuClick', 0, 4)
+
+  const item = Locator('#Menu-1 .MenuItem', { hasText: 'Split Right' })
+  await expect(item).toBeVisible()
+  await Command.execute('TitleBar.handleMenuClick', 1, 3)
+  await expect(item).toBeHidden()
+  await Main.shouldHaveLayout({
+    activeGroupIndex: 1,
+    direction: 'horizontal',
+    groups: [{ size: 50 }, { size: 50 }],
+  })
+}

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-up.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-editor-layout-split-up.ts
@@ -1,0 +1,20 @@
+export const name = 'viewlet.title-bar-editor-layout-split-up'
+
+export const test = async ({ Command, Main, TitleBarMenuBar, Locator, expect }) => {
+  await TitleBarMenuBar.focus()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowRight()
+  await TitleBarMenuBar.handleKeyArrowDown()
+  await Command.execute('TitleBar.handleMenuClick', 0, 4)
+
+  const item = Locator('#Menu-1 .MenuItem', { hasText: 'Split Up' })
+  await expect(item).toBeVisible()
+  await Command.execute('TitleBar.handleMenuClick', 1, 0)
+  await expect(item).toBeHidden()
+  await Main.shouldHaveLayout({
+    activeGroupIndex: 0,
+    direction: 'vertical',
+    groups: [{ size: 50 }, { size: 50 }],
+  })
+}

--- a/packages/extension-host-worker-tests/typings/Main.d.ts
+++ b/packages/extension-host-worker-tests/typings/Main.d.ts
@@ -1,3 +1,8 @@
 declare const Main: {
   readonly openUri: (uri: string) => Promise<void>
+  readonly shouldHaveLayout: (expectedLayout: {
+    readonly activeGroupIndex?: number
+    readonly direction?: 'horizontal' | 'vertical' | number
+    readonly groups?: readonly { readonly size?: number }[]
+  }) => Promise<void>
 }


### PR DESCRIPTION
Adds full-app e2e coverage for View → Editor Layout → Split Up, Down, Left, and Right, verifying each selection produces the expected main-area direction, group sizes, and active side.