### PR TITLE
feature: update typescript to version 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "nodemon": "^3.1.14",
         "prettier": "^3.9.5",
         "ts-jest": "^29.4.11",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=24"
@@ -12012,6 +12012,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/lerna/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -17180,9 +17194,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "nodemon": "^3.1.14",
     "prettier": "^3.9.5",
     "ts-jest": "^29.4.11",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "prettier": {
     "semi": false,

--- a/packages/renderer-worker/src/parts/FileSystemDirectoryHandle/FileSystemDirectoryHandle.js
+++ b/packages/renderer-worker/src/parts/FileSystemDirectoryHandle/FileSystemDirectoryHandle.js
@@ -6,7 +6,7 @@ import * as Assert from '../Assert/Assert.ts'
  * instead which prompts for the required permission to
  * retrieve the child handles
  *
- * @param {FileSystemDirectoryHandle} handle
+ * @param {Pick<FileSystemDirectoryHandle, 'values'>} handle
  * @returns {Promise<FileSystemHandle[]>}
  */
 export const getChildHandles = async (handle) => {

--- a/packages/renderer-worker/test/FileSystemDirectoryHandle.test.js
+++ b/packages/renderer-worker/test/FileSystemDirectoryHandle.test.js
@@ -5,7 +5,7 @@ import * as FileSystemDirectoryHandle from '../src/parts/FileSystemDirectoryHand
 
 test('getChildHandles', async () => {
   /**
-   * @type {FileSystemDirectoryHandle}
+   * @type {Pick<FileSystemDirectoryHandle, 'values'>}
    */
   const handle = {
     // @ts-ignore
@@ -38,7 +38,7 @@ test('getChildHandles', async () => {
 
 test('getChildHandles - error - not allowed', async () => {
   /**
-   * @type {FileSystemDirectoryHandle}
+   * @type {Pick<FileSystemDirectoryHandle, 'values'>}
    */
   const handle = {
     // @ts-ignore


### PR DESCRIPTION
Update the root TypeScript dependency to 6.0.3 and refine the file-system directory handle contract for TypeScript 6 compatibility.