### PR TITLE
fix: handle ipc response errors gracefully

### DIFF
--- a/packages/shared-process/src/parts/ApplyIncomingIpcResponse/ApplyIncomingIpcResponse.ts
+++ b/packages/shared-process/src/parts/ApplyIncomingIpcResponse/ApplyIncomingIpcResponse.ts
@@ -2,13 +2,18 @@ import * as HandleIpc from '../HandleIpc/HandleIpc.ts'
 import * as SendIncomingIpc from '../SendIncomingIpc/SendIncomingIpc.ts'
 
 export const applyIncomingIpcResponse = async (target: any, response: any, ipcId: any): Promise<any> => {
-  switch (response.type) {
-    case 'handle':
-      HandleIpc.handleIpc(target)
-      break
-    case 'send':
-      return SendIncomingIpc.sendIncomingIpc(target, response, ipcId)
-    default:
-      throw new Error('unexpected response')
+  try {
+    switch (response.type) {
+      case 'handle':
+        HandleIpc.handleIpc(target)
+        break
+      case 'send':
+        await SendIncomingIpc.sendIncomingIpc(target, response, ipcId)
+        break
+      default:
+        throw new Error('unexpected response')
+    }
+  } catch (error) {
+    return error
   }
 }

--- a/packages/shared-process/src/parts/HandleIncomingIpc/HandleIncomingIpc.ts
+++ b/packages/shared-process/src/parts/HandleIncomingIpc/HandleIncomingIpc.ts
@@ -33,12 +33,12 @@ export const handleIncomingIpc = async (ipcId: any, handle: any, message: any): 
   Assert.number(ipcId)
   const module = HandleIpcModule.getModule(ipcId)
   const { target, response } = await getIpcAndResponse(module, handle, message)
-  try {
-    await ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, response, ipcId)
-  } catch (error) {
-    if (ipcId === IpcId.ProcessExplorer) {
-      ProcessExplorer.decreaseRefCount()
-    }
-    throw error
+  const error = await ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, response, ipcId)
+  if (!error) {
+    return
   }
+  if (ipcId === IpcId.ProcessExplorer) {
+    ProcessExplorer.decreaseRefCount()
+  }
+  console.error(error)
 }

--- a/packages/shared-process/test/ApplyIncomingIpcResponse.test.ts
+++ b/packages/shared-process/test/ApplyIncomingIpcResponse.test.ts
@@ -1,0 +1,32 @@
+import { expect, jest, test } from '@jest/globals'
+import * as ApplyIncomingIpcResponse from '../src/parts/ApplyIncomingIpcResponse/ApplyIncomingIpcResponse.js'
+
+test('applyIncomingIpcResponse - handle', async () => {
+  const addEventListener = jest.fn()
+  const target = {
+    addEventListener,
+  }
+
+  await expect(ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, { type: 'handle' }, 1)).resolves.toBeUndefined()
+
+  expect(addEventListener).toHaveBeenCalledWith('message', expect.any(Function))
+})
+
+test('applyIncomingIpcResponse - send error', async () => {
+  const error = new Error('Failed to send IPC')
+  const target = {
+    send(): never {
+      throw error
+    },
+  }
+
+  await expect(
+    ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, { method: 'Test.execute', params: [], type: 'send' }, 1),
+  ).resolves.toBe(error)
+})
+
+test('applyIncomingIpcResponse - unexpected response', async () => {
+  const error = await ApplyIncomingIpcResponse.applyIncomingIpcResponse({}, { type: 'unexpected' }, 1)
+
+  expect(error).toEqual(new Error('unexpected response'))
+})

--- a/packages/shared-process/test/HandleIncomingIpcProcessExplorer.test.ts
+++ b/packages/shared-process/test/HandleIncomingIpcProcessExplorer.test.ts
@@ -1,9 +1,8 @@
 import { expect, jest, test } from '@jest/globals'
 import * as IpcId from '../src/parts/IpcId/IpcId.js'
 
-const applyIncomingIpcResponse = jest.fn(async () => {
-  throw new Error('Transfer failed')
-})
+const error = new Error('Transfer failed')
+const applyIncomingIpcResponse = jest.fn(async () => error)
 const decreaseRefCount = jest.fn()
 const getModule = jest.fn(() => ({}))
 const handleIncomingIpcWebSocket = jest.fn(async () => ({
@@ -41,8 +40,12 @@ jest.unstable_mockModule('../src/parts/ProcessExplorer/ProcessExplorer.js', () =
 
 const HandleIncomingIpc = await import('../src/parts/HandleIncomingIpc/HandleIncomingIpc.js')
 
-test('handleIncomingIpc - decrements process explorer ref count when forwarding fails', async () => {
-  await expect(HandleIncomingIpc.handleIncomingIpc(IpcId.ProcessExplorer, {}, {})).rejects.toThrow('Transfer failed')
+test('handleIncomingIpc - logs forwarding error and decrements process explorer ref count', async () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  await expect(HandleIncomingIpc.handleIncomingIpc(IpcId.ProcessExplorer, {}, {})).resolves.toBeUndefined()
 
   expect(decreaseRefCount).toHaveBeenCalledTimes(1)
+  expect(spy).toHaveBeenCalledWith(error)
+  spy.mockRestore()
 })


### PR DESCRIPTION
## Summary

Return IPC response application errors to the caller and log them without crashing the shared process. Preserve process-explorer cleanup when forwarding fails.