### PR TITLE
feature: enable regex hoist lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,7 @@ export default [
       'no-useless-escape': 'off',
       'prefer-destructuring': 'off',
       'prefer-const': 'off',
-      'regex/hoist-regex': 'off',
+      'regex/hoist-regex': 'error',
     },
   },
 ]

--- a/packages/shared-process/src/parts/CreateTestOverviewHtml/CreateTestOverviewHtml.ts
+++ b/packages/shared-process/src/parts/CreateTestOverviewHtml/CreateTestOverviewHtml.ts
@@ -1,3 +1,5 @@
+const testFileExtensionRegex = /\.(js|ts)$/
+
 const isTestFile = (dirent: any): any => {
   if (dirent.startsWith('_')) {
     return false
@@ -6,7 +8,7 @@ const isTestFile = (dirent: any): any => {
 }
 
 const toTestName = (dirent: any): any => {
-  return dirent.replace(/\.(js|ts)$/, '')
+  return dirent.replace(testFileExtensionRegex, '')
 }
 
 export const createTestOverviewHtml = (dirents: any): any => {

--- a/packages/shared-process/src/parts/ExportStatic/ExportStatic.ts
+++ b/packages/shared-process/src/parts/ExportStatic/ExportStatic.ts
@@ -8,6 +8,9 @@ import * as Path from '../Path/Path.ts'
 import { readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import workers from '../../../../renderer-worker/src/parts/Workers/Workers.json' with { type: 'json' }
 
+const testFileExtensionRegex = /\.(js|ts)$/
+const backslashRegex = /\\/g
+
 const staticContentSecurityPolicy = GetContentSecurityPolicy.getContentSecurityPolicy([
   `default-src 'none'`,
   `font-src 'self'`,
@@ -513,7 +516,7 @@ const generateTestOverviewHtml = (dirents: any): any => {
 }
 
 const getName = (name: any): any => {
-  return name.replace(/\.(js|ts)$/, '')
+  return name.replace(testFileExtensionRegex, '')
 }
 const isTestFile = (file: any): any => {
   if (file.startsWith('_')) {
@@ -561,8 +564,8 @@ export const createFilemap = async (fixturesPath: any): Promise<any> => {
       } else {
         // Manually calculate relative path for cross-platform compatibility
         // Remove the fixturesPath prefix from parentPath and normalize separators
-        const normalizedFixturesPath = fixturesPath.replace(/\\/g, '/')
-        const normalizedParentPath = dirent.parentPath.replace(/\\/g, '/')
+        const normalizedFixturesPath = fixturesPath.replace(backslashRegex, '/')
+        const normalizedParentPath = dirent.parentPath.replace(backslashRegex, '/')
         const relativeDir = normalizedParentPath.replace(normalizedFixturesPath + '/', '')
         relativeFilePath = join(relativeDir, dirent.name)
       }

--- a/packages/shared-process/test/ExtensionManagement.test.ts
+++ b/packages/shared-process/test/ExtensionManagement.test.ts
@@ -41,6 +41,7 @@ jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
 const ExtensionManagement = await import('../src/parts/ExtensionManagement/ExtensionManagement.js')
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
 const originalArgv = process.argv
+const uninstallMissingExtensionErrorRegex = /^Failed to uninstall extension "test-author.test-extension": ENOENT: no such file or directory/
 
 const getTmpDir = (): any => {
   return mkdtemp(join(tmpdir(), 'foo-'))
@@ -128,7 +129,7 @@ test("uninstall should fail when extension doesn't exist", async () => {
   // @ts-ignore
   PlatformPaths.getExtensionsPath.mockImplementation(() => tmpDir)
   await expect(ExtensionManagement.uninstall('test-author.test-extension')).rejects.toThrow(
-    /^Failed to uninstall extension "test-author.test-extension": ENOENT: no such file or directory/,
+    uninstallMissingExtensionErrorRegex,
   )
 })
 

--- a/packages/shared-process/test/InstallExtension.test.ts
+++ b/packages/shared-process/test/InstallExtension.test.ts
@@ -35,6 +35,8 @@ jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
 
 const InstallExtension = await import('../src/parts/InstallExtension/InstallExtension.js')
 const Platform = await import('../src/parts/Platform/Platform.js')
+const badStatusCodeErrorRegex = /Failed to install extension "test-author.test-extension": Failed to download "http:\/\/localhost:\d+\/download\/test-author.test-extension": Response code 404 \(Not Found\)/
+const invalidCompressedObjectErrorRegex = /^Failed to install extension "test-author.test-extension": Failed to extract .* unexpected end of file/
 
 const getTmpDir = (): any => {
   return mkdtemp(join(tmpdir(), 'foo-'))
@@ -163,7 +165,7 @@ test.skip('install should fail when the server sends a bad status code', async (
   // @ts-ignore
   Platform.getCachedExtensionsPath.mockImplementation(() => tmpDir2)
   await expect(InstallExtension.installExtension('test-author.test-extension')).rejects.toThrow(
-    /Failed to install extension "test-author.test-extension": Failed to download "http:\/\/localhost:\d+\/download\/test-author.test-extension": Response code 404 \(Not Found\)/,
+    badStatusCodeErrorRegex,
   )
 })
 
@@ -200,6 +202,6 @@ test.skip('install should fail when the server sends an invalid compressed objec
   // @ts-ignore
   Platform.getExtensionsPath.mockImplementation(() => tmpDir)
   await expect(InstallExtension.installExtension('test-author.test-extension')).rejects.toThrow(
-    /^Failed to install extension "test-author.test-extension": Failed to extract .* unexpected end of file/,
+    invalidCompressedObjectErrorRegex,
   )
 })

--- a/packages/shared-process/test/OutputChannel.test.ts
+++ b/packages/shared-process/test/OutputChannel.test.ts
@@ -8,6 +8,8 @@ import waitForExpect from 'wait-for-expect'
 import * as OutputChannel from '../src/parts/OutputChannel/OutputChannel.js'
 import * as Platform from '../src/parts/Platform/Platform.js'
 
+const fileAccessErrorRegex = /^Error: ENOENT: no such file or directory, access /
+
 const getTmpDir = (): any => {
   return mkdtemp(join(tmpdir(), 'foo-'))
 }
@@ -60,7 +62,7 @@ if (Platform.isWindows) {
     const onData = jest.fn()
     const onError = jest.fn()
     const state = OutputChannel.open(join(tmpDir, 'non-existing-file.txt'), onData, onError)
-    expect(onError).toHaveBeenCalledWith(expect.stringMatching(/^Error: ENOENT: no such file or directory, access /))
+    expect(onError).toHaveBeenCalledWith(expect.stringMatching(fileAccessErrorRegex))
     OutputChannel.dispose(state)
   })
 }

--- a/packages/shared-process/test/Preferences.test.ts
+++ b/packages/shared-process/test/Preferences.test.ts
@@ -27,6 +27,8 @@ const Preferences = await import('../src/parts/Preferences/Preferences.js')
 const Logger = await import('../src/parts/Logger/Logger.js')
 
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
+const getAllErrorRegex = /^Failed to get all preferences: Failed to load default preferences: File not found/
+const startupPreferencesErrorRegex = /^\[shared-process\] Failed to load preferences on startup, continuing with defaults: VError: Failed to get all preferences:/
 
 const getTmpDir = (): any => {
   return mkdtemp(join(tmpdir(), 'foo-'))
@@ -114,7 +116,7 @@ test('getAll - error', async () => {
   const tmpDir = await getTmpDir()
   // @ts-ignore
   PlatformPaths.getDefaultSettingsPath.mockImplementation(() => join(tmpDir, 'static', 'config', 'defaultSettings.json'))
-  await expect(Preferences.getAll()).rejects.toThrow(/^Failed to get all preferences: Failed to load default preferences: File not found/)
+  await expect(Preferences.getAll()).rejects.toThrow(getAllErrorRegex)
 })
 
 test('getAll - uses custom title bar style by default', async () => {
@@ -154,9 +156,7 @@ test('getAllSafe - error', async () => {
   })
   expect(Logger.error).toHaveBeenCalledTimes(1)
   expect(Logger.error).toHaveBeenCalledWith(
-    expect.stringMatching(
-      /^\[shared-process\] Failed to load preferences on startup, continuing with defaults: VError: Failed to get all preferences:/,
-    ),
+    expect.stringMatching(startupPreferencesErrorRegex),
   )
 })
 


### PR DESCRIPTION
Enables the regex/hoist-regex ESLint rule for the shared process and hoists the existing inline regular expressions into named module-level constants.