### PR TITLE
feature: enable shared process return types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,6 @@ export default [
       ...disableConfiguredRules('regex/'),
       ...disableConfiguredRules('sonarjs/'),
       ...disableConfiguredRules('unicorn/'),
-      '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-deprecated': 'off',
       '@typescript-eslint/no-floating-promises': 'off',
       '@typescript-eslint/no-implied-eval': 'off',

--- a/packages/shared-process/src/parts/BuiltinExtensionsPath/BuiltinExtensionsPath.ts
+++ b/packages/shared-process/src/parts/BuiltinExtensionsPath/BuiltinExtensionsPath.ts
@@ -1,5 +1,5 @@
 import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
 
-export const getBuiltinExtensionsPath = () => {
+export const getBuiltinExtensionsPath = (): any => {
   return PlatformPaths.getBuiltinExtensionsPath()
 }

--- a/packages/shared-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
+++ b/packages/shared-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
@@ -53,7 +53,7 @@ export const wrap = (port: any): any => {
           break
         case 'message':
           // @ts-ignore
-          this.wrappedListener = (event: any) => {
+          this.wrappedListener = (event: any): void => {
             const syntheticEvent = {
               data: getActualData(event),
               target: this,

--- a/packages/shared-process/src/parts/PtyHost/PtyHost.ts
+++ b/packages/shared-process/src/parts/PtyHost/PtyHost.ts
@@ -22,7 +22,7 @@ export const disposeAll = (): any => {
       PtyHostState.state.ipc = undefined
     }
     PtyHostState.state.ptyHostState = /* None */ 0
-    PtyHostState.state.send = (message: any) => {
+    PtyHostState.state.send = (message: any): void => {
       PtyHostState.state.pendingMessages.push(message)
     }
   }

--- a/packages/shared-process/test/Command.test.ts
+++ b/packages/shared-process/test/Command.test.ts
@@ -69,7 +69,7 @@ test('execute - error - module has syntax error', async () => {
   ModuleMap.getModuleId.mockImplementation(() => {
     return 21
   })
-  Command.state.load = async () => {
+  Command.state.load = async (): Promise<never> => {
     const error = new SyntaxError(`Unexpected token ','`)
     error.stack = `SyntaxError: Unexpected token ','`
     throw error
@@ -88,7 +88,7 @@ test('execute - error - ERR_MODULE_NOT_FOUND', async () => {
   ModuleMap.getModuleId.mockImplementation(() => {
     return 22
   })
-  Command.state.load = async () => {
+  Command.state.load = async (): Promise<never> => {
     const error = new NodeError(
       `[ERR_MODULE_NOT_FOUND]: Cannot find package 'vscode-ripgrep-with-github-api-error-fix' imported from /test/packages/shared-process/src/parts/RgPath/RgPath.js`,
       'ERR_MODULE_NOT_FOUND',

--- a/packages/shared-process/test/Developer.test.ts
+++ b/packages/shared-process/test/Developer.test.ts
@@ -22,7 +22,7 @@ const exists = async (path: any): Promise<any> => {
 }
 
 test.skip('createHeapSnapshot', async () => {
-  Date.now = () => 123456
+  Date.now = (): number => 123456
   // TODO jest esm mock not working https://github.com/facebook/jest/issues/10025
   jest.mock('v8', () => ({
     getHeapSnapshot(): any {

--- a/packages/shared-process/test/HandleWebSocket.test.ts
+++ b/packages/shared-process/test/HandleWebSocket.test.ts
@@ -20,7 +20,7 @@ const createSocket = (): any => {
     end: jest.fn(),
     destroy: jest.fn(),
     pause: jest.fn(),
-    get output() {
+    get output(): string {
       return output
     },
   }

--- a/packages/shared-process/test/InstallExtension.test.ts
+++ b/packages/shared-process/test/InstallExtension.test.ts
@@ -116,7 +116,7 @@ test.skip('install', async () => {
     'main.js': 'export const activate = () => { console.info("hello world") }',
     'package.json': '{ "type" : "module" }',
   })
-  handler = async (request: any, response: any) => {
+  handler = async (request: any, response: any): Promise<void> => {
     switch (request.url) {
       case '/download/test-author.test-extension':
         response.statusCode = 200
@@ -149,7 +149,7 @@ test.skip('install', async () => {
 // TODO test is flaky https://github.com/lvce-editor/lvce-editor/actions/runs/3684799038/jobs/6234968296
 // probably should use unit test instead of e2e test here
 test.skip('install should fail when the server sends a bad status code', async () => {
-  handler = (request: any, response: any) => {
+  handler = (request: any, response: any): any => {
     switch (request.url) {
       default:
         response.statusCode = 404
@@ -186,7 +186,7 @@ test.skip('install should fail when the server sends an invalid compressed objec
   // @ts-ignore
   Platform.getCachedExtensionsPath.mockImplementation(() => tmpDir4)
   // TODO avoid side effect in tests, use createServer
-  handler = (request: any, res: any) => {
+  handler = (request: any, res: any): any => {
     switch (request.url) {
       case '/download/test-author.test-extension':
         res.statusCode = 200


### PR DESCRIPTION
Enable the explicit function return type rule for the shared process and annotate the remaining source and test functions.