### PR TITLE
fix: hide uninstall for builtin extensions

### DIFF
--- a/packages/build/src/parts/BuildStatic/BuildStatic.ts
+++ b/packages/build/src/parts/BuildStatic/BuildStatic.ts
@@ -1,6 +1,5 @@
 import { existsSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
-import { join } from 'node:path'
 import * as BundleCss from '../BundleCss/BundleCss.ts'
 import * as BundleRendererProcess from '../BundleRendererProcess/BundleRendererProcess.ts'
 import * as BundleWorkers from '../BundleWorkers/BundleWorkers.ts'
@@ -10,6 +9,7 @@ import * as Copy from '../Copy/Copy.ts'
 import * as CodiconsPath from '../CodiconsPath/CodiconsPath.ts'
 import * as CopySourceFiles from '../CopySourceFiles/CopySourceFiles.ts'
 import * as GetCommitDate from '../GetCommitDate/GetCommitDate.ts'
+import * as GetAllExtensionsJson from '../GetAllExtensionsJson/GetAllExtensionsJson.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Mkdir from '../Mkdir/Mkdir.ts'
@@ -205,23 +205,8 @@ const exists = (path) => {
   return existsSync(path)
 }
 
-const getAllExtensionsJson = async ({ pathPrefix, commitHash }) => {
-  const extensionPath = Path.absolute('extensions')
-  const extensions = await readdir(extensionPath)
-  const allContent: any[] = []
-  for (const extension of extensions) {
-    const absolutePath = join(extensionPath, extension, 'extension.json')
-    const content = await JsonFile.readJson(absolutePath)
-    allContent.push({
-      ...content,
-      path: `${pathPrefix}/${commitHash}/extensions/${extension}`,
-    })
-  }
-  return allContent
-}
-
 const bundleExtensionsJson = async ({ commitHash, pathPrefix }) => {
-  const allContent = await getAllExtensionsJson({ pathPrefix, commitHash })
+  const allContent = await GetAllExtensionsJson.getAllExtensionsJson({ pathPrefix, commitHash })
   const outPath = Path.absolute(`packages/build/.tmp/dist/${commitHash}/config/extensions.json`)
   await JsonFile.writeJson({ to: outPath, value: allContent })
 }

--- a/packages/build/src/parts/GetAllExtensionsJson/GetAllExtensionsJson.ts
+++ b/packages/build/src/parts/GetAllExtensionsJson/GetAllExtensionsJson.ts
@@ -1,0 +1,25 @@
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import * as JsonFile from '../JsonFile/JsonFile.ts'
+import * as Path from '../Path/Path.ts'
+
+interface GetAllExtensionsJsonOptions {
+  readonly commitHash: string
+  readonly pathPrefix: string
+}
+
+export const getAllExtensionsJson = async ({ pathPrefix, commitHash }: GetAllExtensionsJsonOptions): Promise<readonly any[]> => {
+  const extensionPath = Path.absolute('extensions')
+  const extensions = await readdir(extensionPath)
+  const allContent: any[] = []
+  for (const extension of extensions) {
+    const absolutePath = join(extensionPath, extension, 'extension.json')
+    const content = await JsonFile.readJson(absolutePath)
+    allContent.push({
+      ...content,
+      builtin: true,
+      path: `${pathPrefix}/${commitHash}/extensions/${extension}`,
+    })
+  }
+  return allContent
+}

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import { getAllExtensionsJson } from '../src/parts/GetAllExtensionsJson/GetAllExtensionsJson.ts'
+
+test('marks bundled extensions as builtin', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+  const extension = extensions.find((item) => item.id === 'builtin.theme-ayu')
+
+  expect(extension).toMatchObject({
+    builtin: true,
+    path: '/test-prefix/test-commit/extensions/builtin.theme-ayu',
+  })
+})


### PR DESCRIPTION
Marks bundled web extensions as builtin in the generated extension metadata, preventing uninstall actions from appearing in extension search and detail views. Adds focused regression coverage for the generated metadata.