### PR TITLE
feature: install web extensions from disk

### DIFF
--- a/packages/build/src/parts/BuildStatic/BuildStatic.ts
+++ b/packages/build/src/parts/BuildStatic/BuildStatic.ts
@@ -90,6 +90,10 @@ const copyStaticFiles = async ({ pathPrefix, ignoreIconTheme, commitHash }) => {
     to: `packages/build/.tmp/dist/${commitHash}/js`,
   })
   await Copy.copyFile({
+    from: 'static/extension-file-system-service-worker.js',
+    to: `packages/build/.tmp/dist/extension-file-system-service-worker.js`,
+  })
+  await Copy.copyFile({
     from: 'static/favicon.ico',
     to: `packages/build/.tmp/dist/favicon.ico`,
   })
@@ -145,6 +149,11 @@ const copyStaticFiles = async ({ pathPrefix, ignoreIconTheme, commitHash }) => {
     path: `packages/build/.tmp/dist/index.html`,
     occurrence: '/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js',
     replacement: `${pathPrefix}/${commitHash}/packages/renderer-process/dist/rendererProcessMain.js`,
+  })
+  await Replace.replace({
+    path: `packages/build/.tmp/dist/index.html`,
+    occurrence: '/js/register-extension-file-system-service-worker.js',
+    replacement: `${pathPrefix}/${commitHash}/js/register-extension-file-system-service-worker.js`,
   })
   await Replace.replace({
     path: `packages/build/.tmp/dist/index.html`,

--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
@@ -19,6 +19,10 @@ const copyStaticFiles = async ({ commitHash }) => {
     from: 'static/js',
     to: `packages/build/.tmp/server/static-server/static/${commitHash}/js`,
   })
+  await Copy.copyFile({
+    from: 'static/extension-file-system-service-worker.js',
+    to: `packages/build/.tmp/server/static-server/static/extension-file-system-service-worker.js`,
+  })
   await Copy.copy({
     from: 'static/lib-css',
     to: `packages/build/.tmp/server/static-server/static/${commitHash}/lib-css`,
@@ -60,6 +64,11 @@ const copyStaticFiles = async ({ commitHash }) => {
     path: `packages/build/.tmp/server/static-server/static/index.html`,
     occurrence: '/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js',
     replacement: `/${commitHash}/packages/renderer-process/dist/rendererProcessMain.js`,
+  })
+  await Replace.replace({
+    path: `packages/build/.tmp/server/static-server/static/index.html`,
+    occurrence: '/js/register-extension-file-system-service-worker.js',
+    replacement: `/${commitHash}/js/register-extension-file-system-service-worker.js`,
   })
   await Replace.replace({
     path: `packages/build/.tmp/server/static-server/static/index.html`,

--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -169,6 +169,11 @@ const copyStaticFiles = async ({ resourcesPath, commitHash }) => {
   })
   await Replace.replace({
     path: `${resourcesPath}/app/static/index.html`,
+    occurrence: '\n    <script type="module" src="/js/register-extension-file-system-service-worker.js"></script>',
+    replacement: '',
+  })
+  await Replace.replace({
+    path: `${resourcesPath}/app/static/index.html`,
     occurrence: '/css/App.css',
     replacement: `/${commitHash}/css/App.css`,
   })

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -155,6 +155,7 @@ export const commandMap = {
   'ExtensionMeta.addWebExtension': lazy('ExtensionMeta.addWebExtension'),
   'Extensions.openCachedExtensionsFolder': lazy('Extensions.openCachedExtensionsFolder'),
   'Extensions.openExtensionsFolder': lazy('Extensions.openExtensionsFolder'),
+  'Extensions.installFromDisk': lazy('Extensions.installFromDisk'),
   'FilePicker.mockSaveFilePicker': lazy('FilePicker.mockSaveFilePicker'),
   'FilePicker.showDirectoryPicker': lazy('FilePicker.showDirectoryPicker'),
   'FilePicker.showFilePicker': lazy('FilePicker.showFilePicker'),

--- a/packages/renderer-worker/src/parts/Extensions/Extensions.ipc.js
+++ b/packages/renderer-worker/src/parts/Extensions/Extensions.ipc.js
@@ -7,6 +7,7 @@ export const Commands = {
   createViewInstance: Extensions.createViewInstance,
   dispatchViewEvent: Extensions.dispatchViewEvent,
   disposeViewInstance: Extensions.disposeViewInstance,
+  installFromDisk: Extensions.installFromDisk,
   openCachedExtensionsFolder: Extensions.openCachedExtensionsFolder,
   openExtensionsFolder: Extensions.openExtensionsFolder,
   saveViewInstanceState: Extensions.saveViewInstanceState,

--- a/packages/renderer-worker/src/parts/Extensions/Extensions.js
+++ b/packages/renderer-worker/src/parts/Extensions/Extensions.js
@@ -1,5 +1,6 @@
 import { assetDir } from '../AssetDir/AssetDir.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as InstalledWebExtensions from '../InstalledWebExtensions/InstalledWebExtensions.js'
 import * as OpenNativeFolder from '../OpenNativeFolder/OpenNativeFolder.js'
 import { getPlatform } from '../Platform/Platform.js'
 import * as PlatformPaths from '../PlatformPaths/PlatformPaths.js'
@@ -14,6 +15,10 @@ export const openCachedExtensionsFolder = async () => {
   const cachedExtensionsFolder = await PlatformPaths.getCachedExtensionsPath()
   await OpenNativeFolder.openNativeFolder(cachedExtensionsFolder)
 }
+
+export const installFromDisk = InstalledWebExtensions.installFromDisk
+
+export const restoreFromDisk = InstalledWebExtensions.restore
 
 const applyViewRenderResult = async (uid, result) => {
   if (result?.type === 'setDom') {

--- a/packages/renderer-worker/src/parts/InstalledWebExtensions/InstalledWebExtensions.js
+++ b/packages/renderer-worker/src/parts/InstalledWebExtensions/InstalledWebExtensions.js
@@ -1,0 +1,90 @@
+import { assetDir } from '../AssetDir/AssetDir.js'
+import * as ExtensionMeta from '../ExtensionMeta/ExtensionMeta.js'
+import * as FilePicker from '../FilePicker/FilePicker.js'
+import * as IsAbortError from '../IsAbortError/IsAbortError.js'
+import * as LocalStorage from '../LocalStorage/LocalStorage.js'
+import * as PersistentFileHandle from '../PersistentFileHandle/PersistentFileHandle.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import { VError } from '../VError/VError.js'
+
+const storageKey = 'installedWebExtensionsFromDisk'
+const handlePrefix = 'local-extension://'
+
+const getHandleKey = (id) => {
+  return `${handlePrefix}${id}`
+}
+
+const getExtensionUrl = async (id) => {
+  const href = await RendererProcess.invoke('Location.getHref')
+  const origin = new URL(href).origin
+  const assetBaseUrl = new URL(`${assetDir}/`, origin)
+  return new URL(`../local-extensions/${encodeURIComponent(id)}`, assetBaseUrl).href
+}
+
+const getManifest = async (handle) => {
+  const manifestHandle = await handle.getFileHandle('extension.json')
+  const manifestFile = await manifestHandle.getFile()
+  const content = await manifestFile.text()
+  const manifest = JSON.parse(content)
+  if (!manifest || typeof manifest !== 'object') {
+    throw new TypeError('Extension manifest must be an object')
+  }
+  if (typeof manifest.id !== 'string' || !manifest.id) {
+    throw new TypeError('Extension manifest must have an id')
+  }
+  return manifest
+}
+
+const getInstalledExtensionIds = async () => {
+  const ids = await LocalStorage.getJson(storageKey)
+  if (!Array.isArray(ids)) {
+    return []
+  }
+  return ids.filter((id) => typeof id === 'string' && id)
+}
+
+const saveInstalledExtensionId = async (id) => {
+  const ids = await getInstalledExtensionIds()
+  if (ids.includes(id)) {
+    return
+  }
+  await LocalStorage.setJson(storageKey, [...ids, id])
+}
+
+export const installFromDisk = async () => {
+  if (Platform.getPlatform() !== PlatformType.Web) {
+    return
+  }
+  try {
+    const handle = await FilePicker.showDirectoryPicker({
+      mode: 'read',
+    })
+    const manifest = await getManifest(handle)
+    await PersistentFileHandle.addHandle(getHandleKey(manifest.id), handle)
+    const extensionUrl = await getExtensionUrl(manifest.id)
+    await ExtensionMeta.addWebExtension(extensionUrl)
+    await saveInstalledExtensionId(manifest.id)
+  } catch (error) {
+    if (IsAbortError.isAbortError(error)) {
+      return
+    }
+    throw new VError(error, 'Failed to install extension from disk')
+  }
+}
+
+export const restore = async () => {
+  if (Platform.getPlatform() !== PlatformType.Web) {
+    return
+  }
+  const ids = await getInstalledExtensionIds()
+  for (const id of ids) {
+    try {
+      const extensionUrl = await getExtensionUrl(id)
+      await ExtensionMeta.addWebExtension(extensionUrl)
+    } catch (error) {
+      console.warn(new VError(error, `Failed to restore extension ${id} from disk`))
+    }
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -1,3 +1,6 @@
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+
 export const getQuickPickMenuEntries = () => {
   return [
     {
@@ -199,6 +202,14 @@ export const getQuickPickMenuEntries = () => {
       deprecated: true,
       TODO: 'add support for deprecated commands',
     },
+    ...(Platform.getPlatform() === PlatformType.Web
+      ? [
+          {
+            id: 'Extensions.installFromDisk',
+            label: 'Extensions: Install from Disk',
+          },
+        ]
+      : []),
     {
       id: 'Extensions.openCachedExtensionsFolder',
       label: 'Extensions: Open Cached Extensions Folder',

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -10,6 +10,7 @@ import * as Focus from '../Focus/Focus.js'
 import * as HasCodeQueryParam from '../HasCodeQueryParam/HasCodeQueryParam.js'
 import * as IconTheme from '../IconTheme/IconTheme.js'
 import * as Id from '../Id/Id.js'
+import * as InstalledWebExtensions from '../InstalledWebExtensions/InstalledWebExtensions.js'
 import * as InitData from '../InitData/InitData.js'
 import * as IpcState from '../IpcState/IpcState.js'
 import * as Languages from '../Languages/Languages.js'
@@ -198,6 +199,8 @@ export const startup = async (platform, assetDir) => {
   await Command.execute('Layout.setAuthState', authState)
   // await Layout.hydrate(initData)
   Performance.mark(PerformanceMarkerType.DidShowLayout)
+
+  await InstalledWebExtensions.restore()
 
   Performance.mark(PerformanceMarkerType.WillLoadLanguages)
   await Languages.hydrate(platform, assetDir)

--- a/packages/renderer-worker/test/InstalledWebExtensions.test.js
+++ b/packages/renderer-worker/test/InstalledWebExtensions.test.js
@@ -1,0 +1,114 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const storage = Object.create(null)
+
+jest.unstable_mockModule('../src/parts/ExtensionMeta/ExtensionMeta.js', () => ({
+  addWebExtension: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/FilePicker/FilePicker.js', () => ({
+  showDirectoryPicker: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/LocalStorage/LocalStorage.js', () => ({
+  getJson: jest.fn(async (/** @type {string} */ key) => storage[key]),
+  setJson: jest.fn(async (key, value) => {
+    // @ts-ignore
+    storage[key] = value
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/PersistentFileHandle/PersistentFileHandle.js', () => ({
+  addHandle: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 1),
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: jest.fn(async (method) => {
+    if (method === 'Location.getHref') {
+      return 'https://example.com/'
+    }
+    throw new Error(`unexpected method ${method}`)
+  }),
+}))
+
+const ExtensionMeta = await import('../src/parts/ExtensionMeta/ExtensionMeta.js')
+const FilePicker = await import('../src/parts/FilePicker/FilePicker.js')
+const InstalledWebExtensions = await import('../src/parts/InstalledWebExtensions/InstalledWebExtensions.js')
+const LocalStorage = await import('../src/parts/LocalStorage/LocalStorage.js')
+const PersistentFileHandle = await import('../src/parts/PersistentFileHandle/PersistentFileHandle.js')
+
+const createDirectoryHandle = (manifest) => {
+  return {
+    getFileHandle: jest.fn(async () => ({
+      getFile: jest.fn(async () => ({
+        text: jest.fn(async () => JSON.stringify(manifest)),
+      })),
+    })),
+    kind: 'directory',
+    name: 'sample-extension',
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  for (const key of Object.keys(storage)) {
+    delete storage[key]
+  }
+})
+
+test('installFromDisk', async () => {
+  const handle = createDirectoryHandle({
+    browser: 'dist/main.js',
+    id: 'sample.extension',
+  })
+  // @ts-ignore
+  FilePicker.showDirectoryPicker.mockResolvedValue(handle)
+
+  await InstalledWebExtensions.installFromDisk()
+
+  expect(FilePicker.showDirectoryPicker).toHaveBeenCalledWith({ mode: 'read' })
+  expect(PersistentFileHandle.addHandle).toHaveBeenCalledWith('local-extension://sample.extension', handle)
+  expect(ExtensionMeta.addWebExtension).toHaveBeenCalledWith('https://example.com/local-extensions/sample.extension')
+  expect(LocalStorage.setJson).toHaveBeenCalledWith('installedWebExtensionsFromDisk', ['sample.extension'])
+})
+
+test('installFromDisk ignores canceled picker', async () => {
+  // @ts-ignore
+  FilePicker.showDirectoryPicker.mockRejectedValue(new DOMException('The user aborted a request.', 'AbortError'))
+
+  await InstalledWebExtensions.installFromDisk()
+
+  expect(PersistentFileHandle.addHandle).not.toHaveBeenCalled()
+  expect(ExtensionMeta.addWebExtension).not.toHaveBeenCalled()
+})
+
+test('installFromDisk validates manifest', async () => {
+  const handle = createDirectoryHandle({ browser: 'dist/main.js' })
+  // @ts-ignore
+  FilePicker.showDirectoryPicker.mockResolvedValue(handle)
+
+  await expect(InstalledWebExtensions.installFromDisk()).rejects.toThrow(
+    'Failed to install extension from disk: TypeError: Extension manifest must have an id',
+  )
+})
+
+test('restore', async () => {
+  storage.installedWebExtensionsFromDisk = ['sample.extension', 'second.extension']
+
+  await InstalledWebExtensions.restore()
+
+  expect(ExtensionMeta.addWebExtension).toHaveBeenNthCalledWith(1, 'https://example.com/local-extensions/sample.extension')
+  expect(ExtensionMeta.addWebExtension).toHaveBeenNthCalledWith(2, 'https://example.com/local-extensions/second.extension')
+})
+
+test('restore ignores invalid stored values', async () => {
+  storage.installedWebExtensionsFromDisk = ['sample.extension', 42, '', null]
+
+  await InstalledWebExtensions.restore()
+
+  expect(ExtensionMeta.addWebExtension).toHaveBeenCalledTimes(1)
+})

--- a/static/extension-file-system-service-worker.js
+++ b/static/extension-file-system-service-worker.js
@@ -1,0 +1,111 @@
+const databaseName = 'handle'
+const databaseVersion = 1
+const objectStoreName = 'file-handles-store'
+const handlePrefix = 'local-extension://'
+const routeSegment = '/local-extensions/'
+
+const mimeTypes = {
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.json': 'application/json',
+  '.mjs': 'text/javascript',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+}
+
+const getMimeType = (path, fallback) => {
+  if (fallback) {
+    return fallback
+  }
+  const dotIndex = path.lastIndexOf('.')
+  if (dotIndex === -1) {
+    return 'application/octet-stream'
+  }
+  return mimeTypes[path.slice(dotIndex).toLowerCase()] || 'application/octet-stream'
+}
+
+const openDatabase = () => {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(databaseName, databaseVersion)
+    request.onerror = () => reject(request.error)
+    request.onsuccess = () => resolve(request.result)
+  })
+}
+
+const getHandle = async (id) => {
+  const database = await openDatabase()
+  try {
+    return await new Promise((resolve, reject) => {
+      const transaction = database.transaction(objectStoreName, 'readonly')
+      const request = transaction.objectStore(objectStoreName).get(`${handlePrefix}${id}`)
+      request.onerror = () => reject(request.error)
+      request.onsuccess = () => resolve(request.result)
+    })
+  } finally {
+    database.close()
+  }
+}
+
+const getFile = async (rootHandle, segments) => {
+  let directoryHandle = rootHandle
+  for (const segment of segments.slice(0, -1)) {
+    directoryHandle = await directoryHandle.getDirectoryHandle(segment)
+  }
+  const fileHandle = await directoryHandle.getFileHandle(segments.at(-1))
+  return fileHandle.getFile()
+}
+
+const getRequestPath = (url) => {
+  const routeIndex = url.pathname.lastIndexOf(routeSegment)
+  if (routeIndex === -1) {
+    return undefined
+  }
+  const encodedPath = url.pathname.slice(routeIndex + routeSegment.length)
+  const segments = encodedPath.split('/').filter(Boolean).map(decodeURIComponent)
+  if (segments.length < 2) {
+    return undefined
+  }
+  return {
+    id: segments[0],
+    segments: segments.slice(1),
+  }
+}
+
+const handleRequest = async (request) => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response('Method Not Allowed', { status: 405 })
+  }
+  const requestPath = getRequestPath(new URL(request.url))
+  if (!requestPath) {
+    return fetch(request)
+  }
+  try {
+    const rootHandle = await getHandle(requestPath.id)
+    if (!rootHandle) {
+      return new Response('Extension not found', { status: 404 })
+    }
+    const file = await getFile(rootHandle, requestPath.segments)
+    const headers = {
+      'Cache-Control': 'no-store',
+      'Content-Type': getMimeType(requestPath.segments.at(-1), file.type),
+    }
+    return new Response(request.method === 'HEAD' ? undefined : file, { headers })
+  } catch (error) {
+    return new Response(error instanceof Error ? error.message : 'Failed to read extension file', { status: 404 })
+  }
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('fetch', (event) => {
+  if (new URL(event.request.url).pathname.includes(routeSegment)) {
+    event.respondWith(handleRequest(event.request))
+  }
+})

--- a/static/index.html
+++ b/static/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/css/App.css" />
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link rel="apple-touch-icon" href="/icons/pwa-icon-192.png" />
+    <script type="module" src="/js/register-extension-file-system-service-worker.js"></script>
     <script type="module" src="/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js"></script>
   </head>
 </html>

--- a/static/js/register-extension-file-system-service-worker.js
+++ b/static/js/register-extension-file-system-service-worker.js
@@ -1,0 +1,6 @@
+if ('serviceWorker' in navigator) {
+  const serviceWorkerUrl = new URL('../../extension-file-system-service-worker.js', import.meta.url)
+  navigator.serviceWorker.register(serviceWorkerUrl).catch((error) => {
+    console.warn('Failed to register extension file system service worker', error)
+  })
+}


### PR DESCRIPTION
Adds a web-only command for installing a built extension folder from disk. Persists the directory handle, restores installed extensions on reload, and serves extension workers and assets through a same-origin filesystem-backed route.