### PR TITLE
fix: increase css build test timeout

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -19,7 +19,7 @@ test('bundleCss adds filename comment to generated part css files', async () => 
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
-})
+}, 30_000)
 
 test('bundleCss does not add filename comment to App.css', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
@@ -36,4 +36,4 @@ test('bundleCss does not add filename comment to App.css', async () => {
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
-})
+}, 30_000)


### PR DESCRIPTION
Increase the per-test timeout for the CSS bundling build tests so they have enough time to complete on slower Windows CI runners.