### PR TITLE
feature: measure extension management worker latency

### DIFF
--- a/packages/renderer-worker/src/parts/Developer/Developer.ipc.js
+++ b/packages/renderer-worker/src/parts/Developer/Developer.ipc.js
@@ -1,5 +1,6 @@
 import * as Crash from '../Crash/Crash.js'
 import * as Devtools from '../Devtools/Devtools.js'
+import * as MeasureExtensionManagementWorkerLatency from '../MeasureExtensionManagementWorkerLatency/MeasureExtensionManagementWorkerLatency.js'
 import * as OpenSpecialFolder from '../OpenSpecialFolder/OpenSpecialFolder.js'
 import * as Developer from './Developer.js'
 
@@ -18,6 +19,7 @@ export const Commands = {
   downloadViewletState: Developer.downloadViewletState,
   getMemoryUsageContent: Developer.getMemoryUsageContent,
   getStartupPerformanceContent: Developer.getStartupPerformanceContent,
+  measureExtensionManagementWorkerLatency: MeasureExtensionManagementWorkerLatency.measureExtensionManagementWorkerLatency,
   openBrowserViewOverview: Developer.openBrowserViewOverview,
   openCacheFolder: OpenSpecialFolder.openCacheFolder,
   openConfigFolder: OpenSpecialFolder.openConfigFolder,

--- a/packages/renderer-worker/src/parts/MeasureExtensionManagementWorkerLatency/MeasureExtensionManagementWorkerLatency.js
+++ b/packages/renderer-worker/src/parts/MeasureExtensionManagementWorkerLatency/MeasureExtensionManagementWorkerLatency.js
@@ -1,0 +1,19 @@
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as Notification from '../Notification/Notification.js'
+import * as Timestamp from '../Timestamp/Timestamp.js'
+
+const messageCount = 100
+
+export const measureExtensionManagementWorkerLatency = async () => {
+  await ExtensionManagementWorker.invoke('Extensions.handleData')
+
+  const startTime = Timestamp.now()
+  for (let i = 0; i < messageCount; i++) {
+    await ExtensionManagementWorker.invoke('Extensions.handleData')
+  }
+  const endTime = Timestamp.now()
+  const averageLatency = (endTime - startTime) / messageCount
+
+  await Notification.create('info', `Average extension management worker latency over ${messageCount} messages: ${averageLatency.toFixed(2)}ms`)
+  return averageLatency
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -272,6 +272,10 @@ export const getQuickPickMenuEntries = () => {
       aliases: ['Select Color Theme', 'Switch Color Theme', 'Theme Color'],
     },
     {
+      id: 'Developer.measureExtensionManagementWorkerLatency',
+      label: 'Developer: Measure Extension Management Worker Latency',
+    },
+    {
       id: 'Developer.measureLatencyBetweenExtensionHostAndSharedProcess',
       label: 'Developer: Measure Latency Between Extension Host and Shared Process',
     },

--- a/packages/renderer-worker/test/MeasureExtensionManagementWorkerLatency.test.js
+++ b/packages/renderer-worker/test/MeasureExtensionManagementWorkerLatency.test.js
@@ -1,0 +1,34 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Notification/Notification.js', () => ({
+  create: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Timestamp/Timestamp.js', () => ({
+  now: jest.fn(),
+}))
+
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const MeasureExtensionManagementWorkerLatency =
+  await import('../src/parts/MeasureExtensionManagementWorkerLatency/MeasureExtensionManagementWorkerLatency.js')
+const Notification = await import('../src/parts/Notification/Notification.js')
+const Timestamp = await import('../src/parts/Timestamp/Timestamp.js')
+const now = /** @type {jest.Mock} */ (Timestamp.now)
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('measures the average latency of 100 messages after warming up the worker', async () => {
+  now.mockReturnValueOnce(10).mockReturnValueOnce(35)
+
+  await expect(MeasureExtensionManagementWorkerLatency.measureExtensionManagementWorkerLatency()).resolves.toBe(0.25)
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledTimes(101)
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.handleData')
+  expect(Notification.create).toHaveBeenCalledWith('info', 'Average extension management worker latency over 100 messages: 0.25ms')
+})

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.js
@@ -38,3 +38,12 @@ test('getQuickPickMenuEntries includes GPU info command', () => {
     label: 'Developer: Show GPU Info',
   })
 })
+
+test('getQuickPickMenuEntries includes extension management worker latency command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Developer.measureExtensionManagementWorkerLatency',
+    label: 'Developer: Measure Extension Management Worker Latency',
+  })
+})


### PR DESCRIPTION
Add a Developer quick-pick command that measures 100 extension-management-worker round trips and reports their average latency.