### PR TITLE
fix: normalize windows extension node paths

### DIFF
--- a/packages/extension-host-helper-process/src/parts/ImportScript/ImportScript.js
+++ b/packages/extension-host-helper-process/src/parts/ImportScript/ImportScript.js
@@ -2,9 +2,16 @@ import { pathToFileURL } from 'node:url'
 import * as CleanImportError from '../CleanImportError/CleanImportError.js'
 import { VError } from '../VError/VError.js'
 
+const windowsPathRegex = /^\/[A-Za-z]:\//
+
+export const normalizePath = (path, platform = process.platform) => {
+  return platform === 'win32' && windowsPathRegex.test(path) ? path.slice(1) : path
+}
+
 export const importScript = async (path) => {
   try {
-    const url = pathToFileURL(path).toString()
+    const normalizedPath = normalizePath(path)
+    const url = pathToFileURL(normalizedPath).toString()
     const module = await import(url)
     return module
   } catch (error) {

--- a/packages/extension-host-helper-process/src/parts/ImportScript/ImportScript.test.js
+++ b/packages/extension-host-helper-process/src/parts/ImportScript/ImportScript.test.js
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { normalizePath } from './ImportScript.js'
+
+test('normalizes a windows drive path with a leading slash', () => {
+  expect(normalizePath('/D:/a/git/git/packages/node/src/gitClient.js', 'win32')).toBe('D:/a/git/git/packages/node/src/gitClient.js')
+})
+
+test('keeps a windows drive path without a leading slash', () => {
+  expect(normalizePath('D:/a/git/git/packages/node/src/gitClient.js', 'win32')).toBe('D:/a/git/git/packages/node/src/gitClient.js')
+})
+
+test('keeps a posix path', () => {
+  expect(normalizePath('/workspace/git/packages/node/src/gitClient.js', 'linux')).toBe('/workspace/git/packages/node/src/gitClient.js')
+})


### PR DESCRIPTION
## Summary
- normalize leading-slash Windows drive paths at the extension Node import boundary
- preserve already-normalized Windows paths and POSIX paths
- add focused regression tests for all three cases

## Context
Git PR #530 isolated Node worker reaches this boundary with a leading-slash drive path. Passing that directly to pathToFileURL produces a duplicated drive prefix on Windows.

## Verification
- helper ImportScript tests: 3 passed
- ESLint
- Prettier
- package TypeScript check