### PR TITLE
fix: suppress electron cli diagnostics

### DIFF
--- a/packages/build/src/parts/BuildDeb/BuildDeb.ts
+++ b/packages/build/src/parts/BuildDeb/BuildDeb.ts
@@ -36,6 +36,15 @@ const copyElectronResult = async ({ product, version, arch, debArch, platform, t
     from: `packages/build/.tmp/electron-bundle/${arch}`,
     to: `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}`,
   })
+  await Template.write(
+    'linux_cli',
+    `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}/resources/app/bin/${product.applicationName}`,
+    {
+      '@@APPLICATION_NAME@@': product.applicationName,
+    },
+    755,
+  )
+  await Template.write('linux_cli_js', `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}/resources/app/bin/cli.js`, {})
   await Remove.remove(
     `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}/resources/app/packages/shared-process/node_modules/@lvce-editor/ripgrep`,
   )
@@ -56,7 +65,7 @@ const copyMetaFiles = async ({ product, version, debArch }) => {
     '@@NAME_LONG@@': product.nameLong,
     '@@NAME_SHORT@@': product.nameShort,
     '@@NAME@@': product.applicationName,
-    '@@EXEC@@': `${product.applicationName} %U`,
+    '@@EXEC@@': `/usr/lib/${product.applicationName}/${product.applicationName} %U`,
     '@@ICON@@': product.applicationName,
     '@@URL_PROTOCOL@@': product.applicationName,
     '@@SUMMARY@@': product.linuxSummary,
@@ -103,7 +112,7 @@ const copyMetaFiles = async ({ product, version, debArch }) => {
   await Remove.remove(`packages/build/.tmp/linux/deb/${debArch}/app/usr/bin`)
   await Mkdir.mkdir(`packages/build/.tmp/linux/deb/${debArch}/app/usr/bin`)
   await Symlink.symlink(
-    `../lib/${product.applicationName}/${product.applicationName}`,
+    `../lib/${product.applicationName}/resources/app/bin/${product.applicationName}`,
     Path.absolute(`packages/build/.tmp/linux/deb/${debArch}/app/usr/bin/${product.applicationName}`),
   )
 }

--- a/packages/build/src/parts/Template/template_linux_cli.txt
+++ b/packages/build/src/parts/Template/template_linux_cli.txt
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if command -v readlink >/dev/null 2>&1; then
+  CLI_PATH=$(readlink -f "$0")
+else
+  CLI_PATH=$0
+fi
+
+APP_ROOT=$(CDPATH= cd -- "$(dirname -- "$CLI_PATH")/.." && pwd)
+ELECTRON_ROOT=$(CDPATH= cd -- "$APP_ROOT/../.." && pwd)
+
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON_ROOT/@@APPLICATION_NAME@@" "$APP_ROOT/bin/cli.js" "$@"

--- a/packages/build/src/parts/Template/template_linux_cli_js.txt
+++ b/packages/build/src/parts/Template/template_linux_cli_js.txt
@@ -1,0 +1,84 @@
+import { spawn } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+
+const foregroundCommands = new Set(['install', 'link', 'list', 'unlink'])
+const electronDiagnosticPattern = /^\[\d+:\d+\/\d+\.\d+:(?:ERROR|WARNING):/
+
+const isVersionRequest = (args) => args.includes('--version') || args.includes('-v')
+
+const isForegroundRequest = (args) => {
+  if (args.some((arg) => ['--built-in-self-test', '--help', '--status', '--verbose', '--wait', '--web'].includes(arg))) {
+    return true
+  }
+  return args.some((arg) => foregroundCommands.has(arg))
+}
+
+const forwardElectronStderr = (stream) => {
+  let pending = ''
+  stream.setEncoding('utf8')
+  stream.on('data', (chunk) => {
+    pending += chunk
+    const lines = pending.split('\n')
+    pending = lines.pop() || ''
+    for (const line of lines) {
+      if (!electronDiagnosticPattern.test(line)) {
+        process.stderr.write(`${line}\n`)
+      }
+    }
+  })
+  stream.on('end', () => {
+    if (pending && !electronDiagnosticPattern.test(pending)) {
+      process.stderr.write(pending)
+    }
+  })
+}
+
+const launchElectron = async (args) => {
+  const env = { ...process.env }
+  delete env.ELECTRON_RUN_AS_NODE
+
+  const foreground = isForegroundRequest(args)
+  const verbose = args.includes('--verbose')
+  const child = spawn(process.execPath, args, {
+    detached: !foreground,
+    env,
+    stdio: foreground ? ['inherit', 'inherit', 'pipe'] : 'ignore',
+  })
+
+  if (!foreground) {
+    await new Promise((resolve, reject) => {
+      child.once('error', reject)
+      child.once('spawn', resolve)
+    })
+    child.unref()
+    return 0
+  }
+
+  if (verbose) {
+    child.stderr.pipe(process.stderr)
+  } else {
+    forwardElectronStderr(child.stderr)
+  }
+
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code) => resolve(code ?? 1))
+  })
+}
+
+const main = async () => {
+  const args = process.argv.slice(2)
+  if (isVersionRequest(args)) {
+    const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+    console.log(packageJson.version)
+    return 0
+  }
+  return launchElectron(args)
+}
+
+try {
+  process.exitCode = await main()
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+}

--- a/packages/build/test/LinuxCliTemplate.test.ts
+++ b/packages/build/test/LinuxCliTemplate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
 import { execFile } from 'node:child_process'
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
@@ -35,8 +35,9 @@ describe('linux cli templates', () => {
       await symlink(join(binPath, 'lvce'), commandPath)
 
       const { stdout } = await execFileAsync(commandPath, ['--version'])
+      const realAppRoot = await realpath(appRoot)
 
-      expect(stdout).toBe(`1|${join(appRoot, 'bin', 'cli.js')} --version\n`)
+      expect(stdout).toBe(`1|${join(realAppRoot, 'bin', 'cli.js')} --version\n`)
     } finally {
       await rm(root, { recursive: true })
     }

--- a/packages/build/test/LinuxCliTemplate.test.ts
+++ b/packages/build/test/LinuxCliTemplate.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
+const testPosix = process.platform === 'win32' ? test.skip : test
 
 const readTemplate = async (name: string) => {
   const url = new URL(`../src/parts/Template/template_${name}.txt`, import.meta.url)
@@ -20,7 +21,7 @@ describe('linux cli templates', () => {
     expect(launcher).toContain('"$APP_ROOT/bin/cli.js" "$@"')
   })
 
-  test('resolves the native executable when invoked through a symlink', async () => {
+  testPosix('resolves the native executable when invoked through a symlink', async () => {
     const root = await mkdtemp(join(tmpdir(), 'lvce-linux-cli-'))
     try {
       const appRoot = join(root, 'resources', 'app')

--- a/packages/build/test/LinuxCliTemplate.test.ts
+++ b/packages/build/test/LinuxCliTemplate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from '@jest/globals'
+import { execFile } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const readTemplate = async (name: string) => {
+  const url = new URL(`../src/parts/Template/template_${name}.txt`, import.meta.url)
+  return readFile(url, 'utf8')
+}
+
+describe('linux cli templates', () => {
+  test('runs the cli through Electron in Node mode', async () => {
+    const launcher = await readTemplate('linux_cli')
+
+    expect(launcher).toContain('ELECTRON_RUN_AS_NODE=1 exec')
+    expect(launcher).toContain('"$APP_ROOT/bin/cli.js" "$@"')
+  })
+
+  test('resolves the native executable when invoked through a symlink', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'lvce-linux-cli-'))
+    try {
+      const appRoot = join(root, 'resources', 'app')
+      const binPath = join(appRoot, 'bin')
+      await mkdir(binPath, { recursive: true })
+      const launcher = (await readTemplate('linux_cli')).replaceAll('@@APPLICATION_NAME@@', 'lvce')
+      await writeFile(join(binPath, 'lvce'), launcher)
+      await chmod(join(binPath, 'lvce'), 0o755)
+      await writeFile(join(root, 'lvce'), '#!/bin/sh\nprintf "%s\\n" "$ELECTRON_RUN_AS_NODE|$*"\n')
+      await chmod(join(root, 'lvce'), 0o755)
+      const commandPath = join(root, 'command')
+      await symlink(join(binPath, 'lvce'), commandPath)
+
+      const { stdout } = await execFileAsync(commandPath, ['--version'])
+
+      expect(stdout).toBe(`1|${join(appRoot, 'bin', 'cli.js')} --version\n`)
+    } finally {
+      await rm(root, { recursive: true })
+    }
+  })
+
+  test('handles version without launching the Electron app', async () => {
+    const cli = await readTemplate('linux_cli_js')
+
+    expect(cli).toContain('if (isVersionRequest(args))')
+    expect(cli).toContain("new URL('../package.json', import.meta.url)")
+  })
+
+  test('prints the packaged version without Electron', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'lvce-linux-cli-version-'))
+    try {
+      const binPath = join(root, 'bin')
+      await mkdir(binPath)
+      await writeFile(join(root, 'package.json'), JSON.stringify({ type: 'module', version: '1.2.3' }))
+      await writeFile(join(binPath, 'cli.js'), await readTemplate('linux_cli_js'))
+
+      const { stderr, stdout } = await execFileAsync(process.execPath, [join(binPath, 'cli.js'), '-v'])
+
+      expect(stdout).toBe('1.2.3\n')
+      expect(stderr).toBe('')
+    } finally {
+      await rm(root, { recursive: true })
+    }
+  })
+
+  test('detaches graphical launches and ignores their output', async () => {
+    const cli = await readTemplate('linux_cli_js')
+
+    expect(cli).toContain('detached: !foreground')
+    expect(cli).toContain("stdio: foreground ? ['inherit', 'inherit', 'pipe'] : 'ignore'")
+  })
+
+  test('only filters structured Electron diagnostics for non-verbose cli commands', async () => {
+    const cli = await readTemplate('linux_cli_js')
+
+    expect(cli).toContain('const electronDiagnosticPattern = /^\\[\\d+:\\d+\\/\\d+\\.\\d+:(?:ERROR|WARNING):/')
+    expect(cli).toContain('child.stderr.pipe(process.stderr)')
+  })
+})

--- a/packages/build/test/LinuxDesktopTemplate.test.ts
+++ b/packages/build/test/LinuxDesktopTemplate.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 
 const defaultReplacements: Record<string, string> = {
   '@@APPLICATION_NAME@@': 'lvce',
-  '@@EXEC@@': 'lvce %U',
+  '@@EXEC@@': '/usr/lib/lvce/lvce %U',
   '@@ICON@@': 'lvce',
   '@@KEYWORDS@@': 'lvce;',
   '@@NAME@@': 'lvce',
@@ -28,5 +28,11 @@ describe('linux desktop template', () => {
 
     expect(desktopFile).toContain('StartupWMClass=lvce')
     expect(desktopFile).toContain('X-GNOME-WMClass=lvce')
+  })
+
+  test('launches Electron directly from the desktop', async () => {
+    const desktopFile = await renderTemplate('linux_desktop')
+
+    expect(desktopFile).toContain('Exec=/usr/lib/lvce/lvce %U')
   })
 })


### PR DESCRIPTION
## Summary

Add a dedicated Linux CLI entry point that runs through Electron's Node mode, handles version output without starting Chromium, and launches the graphical app detached. Keep desktop launches pointed directly at the native Electron executable.