### PR TITLE
fix: open current folder from cli

### DIFF
--- a/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
+++ b/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
@@ -31,7 +31,7 @@ const toUri = (path: any): any => {
 export const resolveRoot = async (): Promise<any> => {
   if (IsElectron.isElectron) {
     const argv = await ParentIpc.invoke('Process.getArgv')
-    const relevantArgv = argv.slice(2)
+    const relevantArgv = argv.slice(1)
     const last = relevantArgv.at(-1)
     if (last && last === '.') {
       const actual = process.cwd()

--- a/packages/shared-process/test/ResolveRoot.test.ts
+++ b/packages/shared-process/test/ResolveRoot.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { pathToFileURL } from 'node:url'
+
+jest.unstable_mockModule('../src/parts/IsElectron/IsElectron.js', () => ({
+  isElectron: true,
+}))
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.js')
+const ResolveRoot = await import('../src/parts/ResolveRoot/ResolveRoot.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('resolveRoot - resolves dot from packaged app arguments', async () => {
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(['/usr/lib/lvce-oss/lvce-oss', '.'])
+
+  const resolvedRoot = await ResolveRoot.resolveRoot()
+
+  expect(resolvedRoot).toMatchObject({
+    path: process.cwd(),
+    source: 'shared-process-cli-arg',
+    uri: pathToFileURL(process.cwd()).toString(),
+  })
+})
+
+test('resolveRoot - resolves dot from development electron arguments', async () => {
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(['/test/dist/electron', '/test/app', '.'])
+
+  const resolvedRoot = await ResolveRoot.resolveRoot()
+
+  expect(resolvedRoot).toMatchObject({
+    path: process.cwd(),
+    source: 'shared-process-cli-arg',
+    uri: pathToFileURL(process.cwd()).toString(),
+  })
+})


### PR DESCRIPTION
Fixes packaged CLI argument handling so running `lvce .` opens the invoking working directory in Explorer. Adds regression coverage for packaged and development Electron argument layouts.