### PR TITLE
feature: integrate running extensions view

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -58,6 +58,7 @@
         "@lvce-editor/references-view": "^2.7.0",
         "@lvce-editor/rename-worker": "^1.30.0",
         "@lvce-editor/renderer-process": "^30.6.0",
+        "@lvce-editor/running-extensions-view": "^1.0.0",
         "@lvce-editor/settings-view": "^2.12.0",
         "@lvce-editor/settings-worker": "^1.3.0",
         "@lvce-editor/simple-browser-view": "^2.2.0",
@@ -415,6 +416,12 @@
       "version": "30.6.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/renderer-process/-/renderer-process-30.6.0.tgz",
       "integrity": "sha512-HqdK7eDEepsXWlKoMnfIxOp6kOQFLQU0KjyqxFmz8LUj+kgabhubl/vNV7ggh5qdi1jN6ALjkfkDLU6VSZ+sug==",
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/running-extensions-view": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/running-extensions-view/-/running-extensions-view-1.0.0.tgz",
+      "integrity": "sha512-h+I/iLkLl8/fNiFIA7nTTBmPdWgm9vo/6tIDMV7bLa9zpxosCmIim+PMN3j9JxsPN37YbeltHl/lPfQMlu1KaA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/settings-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -90,6 +90,7 @@
     "@lvce-editor/references-view": "^2.7.0",
     "@lvce-editor/rename-worker": "^1.30.0",
     "@lvce-editor/renderer-process": "^30.6.0",
+    "@lvce-editor/running-extensions-view": "^1.0.0",
     "@lvce-editor/settings-view": "^2.12.0",
     "@lvce-editor/settings-worker": "^1.3.0",
     "@lvce-editor/simple-browser-view": "^2.2.0",

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -146,6 +146,7 @@ export const commandMap = {
   'ExtensionManagement.getExtension': lazy('ExtensionManagement.getExtension'),
   'ExtensionManagement.getExtensions': lazy('ExtensionManagement.getExtensions'),
   'ExtensionManagement.getExtensionsEtag': lazy('ExtensionManagement.getExtensionsEtag'),
+  'ExtensionManagement.getRunningExtensions': lazy('ExtensionManagement.getRunningExtensions'),
   'ExtensionManagement.handleExtensionStatusUpdate': lazy('ExtensionManagement.handleExtensionStatusUpdate'),
   'ExtensionManagement.handleViewContextChange': lazy('ExtensionManagement.handleViewContextChange'),
   'ExtensionManagement.invalidateExtensionsCache': lazy('ExtensionManagement.invalidateExtensionsCache'),

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
@@ -9,6 +9,7 @@ export const Commands = {
   getExtension: ExtensionManagement.getExtension2,
   getExtensions: ExtensionManagement.getAllExtensions,
   getExtensionsEtag: ExtensionManagement.getExtensionsEtag,
+  getRunningExtensions: ExtensionManagement.getRunningExtensions,
   handleExtensionStatusUpdate: ExtensionManagement.handleExtensionStatusUpdate,
   handleViewContextChange: ExtensionManagement.handleViewContextChange,
   showViewContextMenu: ExtensionManagement.showViewContextMenu,

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -1,3 +1,4 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as Command from '../Command/Command.js'
 import * as ContextMenu from '../ContextMenu/ContextMenu.js'
 import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.js'
@@ -122,4 +123,8 @@ export const getWorkingExtensions = async () => {
 export const getExtensionsEtag = async () => {
   const etag = await SharedProcess.invoke('ExtensionManagement.getExtensionsEtag')
   return etag
+}
+
+export const getRunningExtensions = async () => {
+  return ExtensionManagementWorker.invoke('Extensions.getRunningExtensions', AssetDir.assetDir, Platform.getPlatform())
 }

--- a/packages/renderer-worker/src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts
@@ -1,0 +1,15 @@
+import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as HandleIpc from '../HandleIpc/HandleIpc.js'
+import * as IpcParent from '../IpcParent/IpcParent.js'
+import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import { runningExtensionsViewWorkerUrl } from '../RunningExtensionsViewWorkerUrl/RunningExtensionsViewWorkerUrl.ts'
+
+export const launchRunningExtensionsViewWorker = async () => {
+  const ipc = await IpcParent.create({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Running Extensions View Worker',
+    url: getConfiguredWorkerUrl('develop.runningExtensionsViewPath', runningExtensionsViewWorkerUrl),
+  })
+  HandleIpc.handleIpc(ipc)
+  return ipc
+}

--- a/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
+++ b/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
@@ -27,6 +27,9 @@ export const getLabel = (uri) => {
   if (uri.startsWith('process-explorer://')) {
     return 'Process Explorer'
   }
+  if (uri.startsWith('running-extensions://')) {
+    return 'Running Extensions'
+  }
   return Workspace.pathBaseName(uri)
 }
 
@@ -44,6 +47,9 @@ export const getFileIcon = (uri) => {
   }
   if (uri.startsWith('process-explorer://')) {
     return `MaskIcon${Icon.DebugAlt2}`
+  }
+  if (uri.startsWith('running-extensions://')) {
+    return `MaskIcon${Icon.Extensions}`
   }
   const baseName = Workspace.pathBaseName(uri)
   const icon = IconTheme.getFileIcon({ name: baseName })

--- a/packages/renderer-worker/src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts
@@ -1,0 +1,6 @@
+import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
+import { launchRunningExtensionsViewWorker } from '../LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts'
+
+const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(launchRunningExtensionsViewWorker)
+
+export { invoke, restart }

--- a/packages/renderer-worker/src/parts/RunningExtensionsViewWorkerUrl/RunningExtensionsViewWorkerUrl.ts
+++ b/packages/renderer-worker/src/parts/RunningExtensionsViewWorkerUrl/RunningExtensionsViewWorkerUrl.ts
@@ -1,0 +1,3 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+
+export const runningExtensionsViewWorkerUrl = `${AssetDir.assetDir}/packages/renderer-worker/node_modules/@lvce-editor/running-extensions-view/dist/runningExtensionsViewMain.js`

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -33,6 +33,9 @@ export const getModuleId = async (uri, opener) => {
   if (uri.startsWith('process-explorer://')) {
     return ViewletModuleId.ProcessExplorer
   }
+  if (uri.startsWith('running-extensions://')) {
+    return ViewletModuleId.RunningExtensions
+  }
   if (uri.startsWith('simple-browser://')) {
     return ViewletModuleId.SimpleBrowser
   }

--- a/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
@@ -122,6 +122,8 @@ export const MarkDownPreview = 'MarkDownPreview'
 
 export const LanguageModels = 'LanguageModels'
 
+export const RunningExtensions = 'RunningExtensions'
+
 export const Confirm = 'Confirm'
 
 export const E2eTests = 'E2eTests'

--- a/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
@@ -41,6 +41,7 @@ export const map = {
   [ViewletModuleId.QuickPick]: () => import('../ViewletQuickPick/ViewletQuickPick.ipc.js'),
   [ViewletModuleId.References]: () => import('../ViewletReferences/ViewletReferences.ipc.js'),
   [ViewletModuleId.RunAndDebug]: () => import('../ViewletRunAndDebug/ViewletRunAndDebug.ipc.js'),
+  [ViewletModuleId.RunningExtensions]: () => import('../ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts'),
   [ViewletModuleId.ScreenCapture]: () => import('../ViewletScreenCapture/ViewletScreenCapture.ipc.js'),
   [ViewletModuleId.Search]: () => import('../ViewletSearch/ViewletSearch.ipc.ts'),
   [ViewletModuleId.Settings]: () => import('../ViewletSettings/ViewletSettings.ipc.js'),

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts
@@ -1,0 +1,4 @@
+export * from './ViewletRunningExtensions.ts'
+export * from './ViewletRunningExtensionsCommands.ts'
+export * from './ViewletRunningExtensionsCss.ts'
+export * from './ViewletRunningExtensionsRender.ts'

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
@@ -1,0 +1,26 @@
+import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
+import type { RunningExtensionsState } from './ViewletRunningExtensionsTypes.ts'
+
+export const create = (uid: number, uri: string, x: number, y: number, width: number, height: number): RunningExtensionsState => {
+  return {
+    commands: [],
+    height,
+    uid,
+    uri,
+    width,
+    x,
+    y,
+  }
+}
+
+export const loadContent = async (state: RunningExtensionsState): Promise<RunningExtensionsState> => {
+  const { height, uid, uri, width, x, y } = state
+  await RunningExtensionsViewWorker.invoke('RunningExtensions.create', uid, uri, x, y, width, height)
+  await RunningExtensionsViewWorker.invoke('RunningExtensions.loadContent', uid)
+  const diffResult = await RunningExtensionsViewWorker.invoke('RunningExtensions.diff2', uid)
+  const commands = await RunningExtensionsViewWorker.invoke('RunningExtensions.render2', uid, diffResult)
+  return {
+    ...state,
+    commands,
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCommands.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCommands.ts
@@ -1,0 +1,12 @@
+import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
+import { wrapRunningExtensionsCommand } from '../WrapRunningExtensionsCommand/WrapRunningExtensionsCommand.ts'
+
+export const Commands = {}
+
+export const getCommands = async () => {
+  const commands = await RunningExtensionsViewWorker.invoke('RunningExtensions.getCommandIds')
+  for (const command of commands) {
+    Commands[command] = wrapRunningExtensionsCommand(command)
+  }
+  return Commands
+}

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCss.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCss.ts
@@ -1,0 +1,1 @@
+export const Css = ['/css/parts/ViewletRunningExtensions.css']

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsRender.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsRender.ts
@@ -1,0 +1,21 @@
+import * as AdjustCommands from '../AdjustCommands/AdjustCommands.js'
+import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
+import type { RunningExtensionsState } from './ViewletRunningExtensionsTypes.ts'
+
+export const hasFunctionalEvents = true
+export const hasFunctionalRender = true
+export const hasFunctionalRootRender = true
+
+const renderDom = {
+  apply: AdjustCommands.apply,
+  isEqual(oldState: RunningExtensionsState, newState: RunningExtensionsState) {
+    return newState.commands.length === 0
+  },
+  multiple: true,
+}
+
+export const render = [renderDom]
+
+export const renderEventListeners = async () => {
+  return RunningExtensionsViewWorker.invoke('RunningExtensions.renderEventListeners')
+}

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsTypes.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsTypes.ts
@@ -1,0 +1,9 @@
+export interface RunningExtensionsState {
+  readonly commands: readonly any[]
+  readonly height: number
+  readonly uid: number
+  readonly uri: string
+  readonly width: number
+  readonly x: number
+  readonly y: number
+}

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -468,6 +468,15 @@
     "hotReloadCommand": ""
   },
   {
+    "id": "runningExtensionsView",
+    "fileName": "runningExtensionsViewMain.js",
+    "contentSecurityPolicy": ["default-src 'none'"],
+    "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/running-extensions-view/dist/runningExtensionsViewMain.js",
+    "productionPath": "/packages/running-extensions-view/dist/runningExtensionsViewMain.js",
+    "settingName": "develop.runningExtensionsViewPath",
+    "hotReloadCommand": ""
+  },
+  {
     "id": "settingsView",
     "fileName": "settingsViewWorkerMain.js",
     "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/settings-view/dist/settingsViewWorkerMain.js",

--- a/packages/renderer-worker/src/parts/WrapRunningExtensionsCommand/WrapRunningExtensionsCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapRunningExtensionsCommand/WrapRunningExtensionsCommand.ts
@@ -1,0 +1,14 @@
+import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
+import type { RunningExtensionsState } from '../ViewletRunningExtensions/ViewletRunningExtensionsTypes.ts'
+
+export const wrapRunningExtensionsCommand = (key: string) => {
+  return async (state: RunningExtensionsState, ...args: readonly any[]): Promise<RunningExtensionsState> => {
+    await RunningExtensionsViewWorker.invoke(`RunningExtensions.${key}`, state.uid, ...args)
+    const diffResult = await RunningExtensionsViewWorker.invoke('RunningExtensions.diff2', state.uid)
+    const commands = await RunningExtensionsViewWorker.invoke('RunningExtensions.render2', state.uid, diffResult)
+    return {
+      ...state,
+      commands,
+    }
+  }
+}

--- a/packages/renderer-worker/test/LaunchRunningExtensionsViewWorker.test.js
+++ b/packages/renderer-worker/test/LaunchRunningExtensionsViewWorker.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as IpcParentType from '../src/parts/IpcParentType/IpcParentType.js'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => {
+  return {
+    getConfiguredWorkerUrl: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => {
+  return {
+    handleIpc: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
+  return {
+    create: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
+const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
+const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
+const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const LaunchRunningExtensionsViewWorker = await import('../src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts')
+
+test('launchRunningExtensionsViewWorker', async () => {
+  const ipc = {
+    send() {},
+  }
+  // @ts-ignore
+  GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///running-extensions-view-worker.js')
+  // @ts-ignore
+  IpcParent.create.mockResolvedValue(ipc)
+  // @ts-ignore
+  HandleIpc.handleIpc.mockReturnValue(undefined)
+
+  const result = await LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker()
+
+  expect(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).toHaveBeenCalledTimes(1)
+  expect(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).toHaveBeenCalledWith(
+    'develop.runningExtensionsViewPath',
+    expect.stringContaining('/@lvce-editor/running-extensions-view/dist/runningExtensionsViewMain.js'),
+  )
+  expect(IpcParent.create).toHaveBeenCalledTimes(1)
+  expect(IpcParent.create).toHaveBeenCalledWith({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Running Extensions View Worker',
+    url: 'file:///running-extensions-view-worker.js',
+  })
+  expect(HandleIpc.handleIpc).toHaveBeenCalledTimes(1)
+  expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(result).toBe(ipc)
+})

--- a/packages/renderer-worker/test/PathDisplay.test.js
+++ b/packages/renderer-worker/test/PathDisplay.test.js
@@ -8,3 +8,11 @@ test('getLabel - process explorer', () => {
 test('getFileIcon - process explorer', () => {
   expect(PathDisplay.getFileIcon('process-explorer://')).toBe('MaskIconDebugAlt2')
 })
+
+test('getLabel - running extensions', () => {
+  expect(PathDisplay.getLabel('running-extensions://')).toBe('Running Extensions')
+})
+
+test('getFileIcon - running extensions', () => {
+  expect(PathDisplay.getFileIcon('running-extensions://')).toBe('MaskIconExtensions')
+})

--- a/packages/renderer-worker/test/ViewletMap.test.js
+++ b/packages/renderer-worker/test/ViewletMap.test.js
@@ -25,3 +25,7 @@ test('audio - opus', async () => {
 test('process explorer', async () => {
   expect(await ViewletMap.getModuleId('process-explorer://')).toBe(ViewletModuleId.ProcessExplorer)
 })
+
+test('running extensions', async () => {
+  expect(await ViewletMap.getModuleId('running-extensions://')).toBe(ViewletModuleId.RunningExtensions)
+})

--- a/packages/renderer-worker/test/ViewletModuleMap.test.js
+++ b/packages/renderer-worker/test/ViewletModuleMap.test.js
@@ -21,3 +21,11 @@ test('process explorer uses worker-backed module', async () => {
   expect(typeof module.getCommands).toBe('function')
   expect(typeof module.getKeyBindings).toBe('function')
 })
+
+test('running extensions uses worker-backed module', async () => {
+  const module = await ViewletModuleMap.map[ViewletModuleId.RunningExtensions]()
+
+  expect(module.hasFunctionalRender).toBe(true)
+  expect(typeof module.loadContent).toBe('function')
+  expect(typeof module.getCommands).toBe('function')
+})

--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -1,0 +1,38 @@
+.RunningExtensions {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  margin: 0;
+  overflow: auto;
+  padding: 16px;
+}
+
+.RunningExtension {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.RunningExtensionIcon {
+  flex: none;
+  height: 32px;
+  width: 32px;
+}
+
+.RunningExtensionDetails {
+  min-width: 0;
+}
+
+.RunningExtensionTitle {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+}
+
+.RunningExtensionId,
+.RunningExtensionActivationTime,
+.RunningExtensionsEmpty {
+  color: var(--DescriptionForeground, rgba(156, 162, 160, 0.7));
+}


### PR DESCRIPTION
Adds the published running extensions view worker to the core renderer and configures its development and production paths, IPC bridge, viewlet integration, styling, and regression coverage.