### PR TITLE
fix: exclude incompatible web extensions

### DIFF
--- a/packages/build/src/parts/BuildStatic/BuildStatic.ts
+++ b/packages/build/src/parts/BuildStatic/BuildStatic.ts
@@ -11,6 +11,7 @@ import * as CopySourceFiles from '../CopySourceFiles/CopySourceFiles.ts'
 import * as GetCommitDate from '../GetCommitDate/GetCommitDate.ts'
 import * as GetAllExtensionsJson from '../GetAllExtensionsJson/GetAllExtensionsJson.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
+import { isWebCompatibleExtension } from '../IsWebCompatibleExtension/IsWebCompatibleExtension.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Mkdir from '../Mkdir/Mkdir.ts'
 import * as Path from '../Path/Path.ts'
@@ -374,6 +375,9 @@ const copyWebOtherExtensions = async ({ commitHash, pathPrefix }) => {
         continue
       }
       throw error
+    }
+    if (!isWebCompatibleExtension(manifest)) {
+      continue
     }
     const isLanguageBasics = extension.startsWith('builtin.language-basics')
     if (!manifest.browser && !isLanguageBasics) {

--- a/packages/build/src/parts/GetAllExtensionsJson/GetAllExtensionsJson.ts
+++ b/packages/build/src/parts/GetAllExtensionsJson/GetAllExtensionsJson.ts
@@ -1,6 +1,7 @@
 import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
+import { isWebCompatibleExtension } from '../IsWebCompatibleExtension/IsWebCompatibleExtension.ts'
 import * as Path from '../Path/Path.ts'
 
 interface GetAllExtensionsJsonOptions {
@@ -15,6 +16,9 @@ export const getAllExtensionsJson = async ({ pathPrefix, commitHash }: GetAllExt
   for (const extension of extensions) {
     const absolutePath = join(extensionPath, extension, 'extension.json')
     const content = await JsonFile.readJson(absolutePath)
+    if (!isWebCompatibleExtension(content)) {
+      continue
+    }
     allContent.push({
       ...content,
       builtin: true,

--- a/packages/build/src/parts/IsWebCompatibleExtension/IsWebCompatibleExtension.ts
+++ b/packages/build/src/parts/IsWebCompatibleExtension/IsWebCompatibleExtension.ts
@@ -1,0 +1,9 @@
+interface ExtensionManifest {
+  readonly compatibility?: {
+    readonly web?: boolean
+  }
+}
+
+export const isWebCompatibleExtension = (extension: ExtensionManifest): boolean => {
+  return extension.compatibility?.web !== false
+}

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -13,3 +13,12 @@ test('marks bundled extensions as builtin', async () => {
     path: '/test-prefix/test-commit/extensions/builtin.theme-ayu',
   })
 })
+
+test('excludes extensions that are not web compatible', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+
+  expect(extensions.some((item) => item.id === 'builtin.git')).toBe(false)
+})

--- a/packages/build/test/IsWebCompatibleExtension.test.ts
+++ b/packages/build/test/IsWebCompatibleExtension.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { isWebCompatibleExtension } from '../src/parts/IsWebCompatibleExtension/IsWebCompatibleExtension.ts'
+
+test('returns true when web compatibility is not specified', () => {
+  expect(isWebCompatibleExtension({})).toBe(true)
+})
+
+test('returns true when an extension is web compatible', () => {
+  expect(isWebCompatibleExtension({ compatibility: { web: true } })).toBe(true)
+})
+
+test('returns false when an extension is not web compatible', () => {
+  expect(isWebCompatibleExtension({ compatibility: { web: false } })).toBe(false)
+})

--- a/static/css/parts/ViewletExtensionDetail.css
+++ b/static/css/parts/ViewletExtensionDetail.css
@@ -14,6 +14,48 @@
   gap: 20px;
 }
 
+.ExtensionDetailError {
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.ExtensionDetailErrorCard {
+  background: var(--SideBarBackground, color-mix(in srgb, var(--WorkbenchForeground) 5%, var(--MainBackground)));
+  border: 1px solid var(--PanelBorderTopColor, color-mix(in srgb, var(--WorkbenchForeground) 22%, transparent));
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  contain: content;
+  display: grid;
+  gap: 8px 16px;
+  grid-template-columns: 40px minmax(0, 1fr);
+  max-width: 560px;
+  padding: 28px;
+  width: 100%;
+}
+
+.ExtensionDetailErrorIcon {
+  --MaskIconSize: 32px;
+  color: var(--InputValidationWarningBorder, #cca700);
+  grid-row: 1 / span 2;
+  height: 40px;
+  width: 40px;
+}
+
+.ExtensionDetailErrorTitle {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.ExtensionDetailErrorMessage {
+  color: var(--DescriptionForeground, color-mix(in srgb, var(--WorkbenchForeground) 76%, transparent));
+  line-height: 1.5;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 .ExtensionDetail::-webkit-scrollbar {
   width: 14px;
 }


### PR DESCRIPTION
Exclude extensions marked as web-incompatible from the static extension manifest and payload. This prevents Git from appearing in the web extension list, and adds styling for the extension detail error state.