### PR TITLE
fix: pass context to running extensions worker

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
@@ -1,3 +1,5 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as Platform from '../Platform/Platform.js'
 import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
 import type { RunningExtensionsState } from './ViewletRunningExtensionsTypes.ts'
 
@@ -15,7 +17,17 @@ export const create = (uid: number, uri: string, x: number, y: number, width: nu
 
 export const loadContent = async (state: RunningExtensionsState): Promise<RunningExtensionsState> => {
   const { height, uid, uri, width, x, y } = state
-  await RunningExtensionsViewWorker.invoke('RunningExtensions.create', uid, uri, x, y, width, height)
+  await RunningExtensionsViewWorker.invoke(
+    'RunningExtensions.create',
+    uid,
+    uri,
+    x,
+    y,
+    width,
+    height,
+    Platform.getPlatform(),
+    AssetDir.assetDir,
+  )
   await RunningExtensionsViewWorker.invoke('RunningExtensions.loadContent', uid)
   const diffResult = await RunningExtensionsViewWorker.invoke('RunningExtensions.diff2', uid)
   const commands = await RunningExtensionsViewWorker.invoke('RunningExtensions.render2', uid, diffResult)

--- a/packages/renderer-worker/test/ViewletRunningExtensions.test.js
+++ b/packages/renderer-worker/test/ViewletRunningExtensions.test.js
@@ -1,0 +1,44 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts', () => ({
+  invoke: jest.fn(async (command) => {
+    if (command === 'RunningExtensions.diff2' || command === 'RunningExtensions.render2') {
+      return []
+    }
+    return undefined
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 2),
+}))
+
+jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
+  assetDir: '/test-assets',
+}))
+
+const RunningExtensionsViewWorker = await import('../src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts')
+const ViewletRunningExtensions = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('loadContent passes the platform and asset directory to the view worker', async () => {
+  const state = ViewletRunningExtensions.create(1, 'running-extensions://', 10, 20, 800, 600)
+
+  await ViewletRunningExtensions.loadContent(state)
+
+  expect(RunningExtensionsViewWorker.invoke).toHaveBeenNthCalledWith(
+    1,
+    'RunningExtensions.create',
+    1,
+    'running-extensions://',
+    10,
+    20,
+    800,
+    600,
+    2,
+    '/test-assets',
+  )
+})


### PR DESCRIPTION
Passes the current platform and asset directory when creating the Running Extensions view so its direct extension-management connection can load runtime data.