### PR TITLE
feature: add view license help action

### DIFF
--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
@@ -11,6 +11,10 @@ import * as GetStaticFiles from '../GetStaticFiles/GetStaticFiles.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 
 const copyStaticFiles = async ({ commitHash }) => {
+  await Copy.copyFile({
+    from: 'LICENSE',
+    to: `packages/build/.tmp/server/static-server/static/${commitHash}/LICENSE`,
+  })
   await Copy.copy({
     from: 'static/config',
     to: `packages/build/.tmp/server/static-server/static/${commitHash}/config`,

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-view-license.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-view-license.ts
@@ -1,0 +1,16 @@
+export const name = 'viewlet.title-bar-view-license'
+
+export const test = async ({ TitleBarMenuBar, Locator, expect }) => {
+  await TitleBarMenuBar.focus()
+  await TitleBarMenuBar.handleKeyEnd()
+  await TitleBarMenuBar.handleKeyArrowDown()
+
+  const viewLicenseItem = Locator('.MenuItem', { hasText: 'View License' })
+  await expect(viewLicenseItem).toBeVisible()
+  await viewLicenseItem.click()
+
+  const tabTitle = Locator('.MainTab .TabTitle')
+  await expect(tabTitle).toHaveText('LICENSE')
+  const editor = Locator('.Editor')
+  await expect(editor).toContainText('The MIT License (MIT)')
+}

--- a/packages/renderer-worker/src/parts/GetLicenseUri/GetLicenseUri.js
+++ b/packages/renderer-worker/src/parts/GetLicenseUri/GetLicenseUri.js
@@ -1,0 +1,12 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+export const getLicenseUri = async (platform = Platform.getPlatform(), assetDir = AssetDir.assetDir) => {
+  if (platform === PlatformType.Web) {
+    return `${assetDir}/LICENSE`
+  }
+  const rootUri = await SharedProcess.invoke('Platform.getRootUri')
+  return `${rootUri.replace(/\/$/, '')}/LICENSE`
+}

--- a/packages/renderer-worker/src/parts/License/License.ipc.js
+++ b/packages/renderer-worker/src/parts/License/License.ipc.js
@@ -1,0 +1,7 @@
+import * as License from './License.js'
+
+export const name = 'License'
+
+export const Commands = {
+  openLicense: License.openLicense,
+}

--- a/packages/renderer-worker/src/parts/License/License.js
+++ b/packages/renderer-worker/src/parts/License/License.js
@@ -1,0 +1,7 @@
+import * as GetLicenseUri from '../GetLicenseUri/GetLicenseUri.js'
+import * as OpenUri from '../OpenUri/OpenUri.js'
+
+export const openLicense = async () => {
+  const uri = await GetLicenseUri.getLicenseUri()
+  await OpenUri.openUri(uri)
+}

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -94,6 +94,8 @@ export const load = (moduleId) => {
       return import('../KeyBindings/KeyBindings.ipc.js')
     case ModuleId.KeyBindingsInitial:
       return import('../KeyBindingsInitial/KeyBindingsInitial.ipc.js')
+    case ModuleId.License:
+      return import('../License/License.ipc.js')
     case ModuleId.LaunchIsolatedExtensionHostWorker:
       return import('../LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.ipc.js')
     case ModuleId.Listener:

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -112,3 +112,4 @@ export const Exec = 146
 export const OAuthServer = 147
 export const LaunchIsolatedExtensionHostWorker = 148
 export const ExtensionNodeRpc = 149
+export const License = 150

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -196,6 +196,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.OffscreenCanvas
     case 'Languages':
       return ModuleId.Languages
+    case 'License':
+      return ModuleId.License
     case 'FileWatcher':
       return ModuleId.FileWatcher
     case 'ExtensionHostTypeDefinition':

--- a/packages/renderer-worker/test/GetLicenseUri.test.js
+++ b/packages/renderer-worker/test/GetLicenseUri.test.js
@@ -1,0 +1,37 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(() => {
+    throw new Error('not implemented')
+  }),
+}))
+
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const GetLicenseUri = await import('../src/parts/GetLicenseUri/GetLicenseUri.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('web', async () => {
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Web, '/abc123')
+  expect(uri).toBe('/abc123/LICENSE')
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('electron', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue('file:///opt/lvce-editor')
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Electron, '')
+  expect(uri).toBe('file:///opt/lvce-editor/LICENSE')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getRootUri')
+})
+
+test('remote', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue('file:///home/test/lvce-editor/')
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Remote, '')
+  expect(uri).toBe('file:///home/test/lvce-editor/LICENSE')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getRootUri')
+})

--- a/packages/renderer-worker/test/License.test.js
+++ b/packages/renderer-worker/test/License.test.js
@@ -1,0 +1,19 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetLicenseUri/GetLicenseUri.js', () => ({
+  getLicenseUri: jest.fn(() => 'file:///test/LICENSE'),
+}))
+
+jest.unstable_mockModule('../src/parts/OpenUri/OpenUri.js', () => ({
+  openUri: jest.fn(),
+}))
+
+const GetLicenseUri = await import('../src/parts/GetLicenseUri/GetLicenseUri.js')
+const OpenUri = await import('../src/parts/OpenUri/OpenUri.js')
+const License = await import('../src/parts/License/License.js')
+
+test('openLicense', async () => {
+  await License.openLicense()
+  expect(GetLicenseUri.getLicenseUri).toHaveBeenCalledTimes(1)
+  expect(OpenUri.openUri).toHaveBeenCalledWith('file:///test/LICENSE')
+})

--- a/packages/renderer-worker/test/ModuleMap.test.js
+++ b/packages/renderer-worker/test/ModuleMap.test.js
@@ -8,4 +8,5 @@ test('getModule - not found', () => {
 
 test('getModule', () => {
   expect(ModuleMap.getModuleId('About.showAbout')).toBe(ModuleId.About)
+  expect(ModuleMap.getModuleId('License.openLicense')).toBe(ModuleId.License)
 })


### PR DESCRIPTION
Adds the renderer command and platform-aware license URI resolution, publishes LICENSE with static web assets, and verifies the Help menu action opens the license in the main area.