### PR TITLE
fix: expand text editor error view

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.main-open-not-found.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-open-not-found.ts
@@ -10,6 +10,8 @@ export const test = async ({ FileSystem, Workspace, Main, Locator, expect, SideB
   await Main.openUri(`${tmpDir}/not-found.txt`)
 
   // assert
+  const errorEditor = Locator('.TextEditorError')
+  await expect(errorEditor).toHaveCSS('flex-grow', '1')
   const errorMessage = Locator('.TextEditorErrorMessage')
   await expect(errorMessage).toBeVisible()
   await expect(errorMessage).toHaveText('The editor could not be opened because the file was not found')

--- a/static/css/parts/ViewletEditorError.css
+++ b/static/css/parts/ViewletEditorError.css
@@ -2,12 +2,9 @@
   --IconErrorForeground: rgb(182, 78, 78);
 }
 
-.Viewlet.Error {
-  flex: 1;
-}
-
 .TextEditorError {
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -16,6 +13,7 @@
   color: rgb(156, 162, 160);
   padding-left: 16px;
   padding-right: 16px;
+  user-select: text;
 }
 
 .EditorTextIcon {
@@ -27,8 +25,4 @@
 
 .EditorTextIconError {
   color: var(--IconErrorForeground);
-}
-
-.Viewlet.Error {
-  user-select: text;
 }


### PR DESCRIPTION
Summary:
- apply flex sizing to the rendered text editor error class
- preserve selectable error text and cover the layout rule with an e2e assertion