### PR TITLE
fix: include license in electron app bundle

### DIFF
--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -11,6 +11,7 @@ import * as CommitHash from '../CommitHash/CommitHash.ts'
 import * as CodiconsPath from '../CodiconsPath/CodiconsPath.ts'
 import * as Copy from '../Copy/Copy.ts'
 import * as CopyElectron from '../CopyElectron/CopyElectron.ts'
+import * as CopyElectronLicense from '../CopyElectronLicense/CopyElectronLicense.ts'
 import * as GetCommitDate from '../GetCommitDate/GetCommitDate.ts'
 import * as GetElectronVersion from '../GetElectronVersion/GetElectronVersion.ts'
 import * as Hash from '../Hash/Hash.ts'
@@ -291,6 +292,10 @@ export const build = async ({
     version,
   })
   console.timeEnd('copyElectron')
+
+  console.time('copyLicense')
+  await CopyElectronLicense.copyElectronLicense({ resourcesPath })
+  console.timeEnd('copyLicense')
 
   if (shouldRemoveUnusedLocales) {
     console.time('removeUnusedLocales')

--- a/packages/build/src/parts/CopyElectronLicense/CopyElectronLicense.ts
+++ b/packages/build/src/parts/CopyElectronLicense/CopyElectronLicense.ts
@@ -1,0 +1,8 @@
+import * as Copy from '../Copy/Copy.ts'
+
+export const copyElectronLicense = async ({ resourcesPath }) => {
+  await Copy.copyFile({
+    from: 'LICENSE',
+    to: `${resourcesPath}/app/LICENSE`,
+  })
+}

--- a/packages/build/test/CopyElectronLicense.test.ts
+++ b/packages/build/test/CopyElectronLicense.test.ts
@@ -1,0 +1,19 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Copy/Copy.ts', () => ({
+  copyFile: jest.fn(),
+}))
+
+const CopyElectronLicense = await import('../src/parts/CopyElectronLicense/CopyElectronLicense.ts')
+const Copy = await import('../src/parts/Copy/Copy.ts')
+
+test('copyElectronLicense copies the license into the Electron app root', async () => {
+  await CopyElectronLicense.copyElectronLicense({
+    resourcesPath: 'packages/build/.tmp/electron-bundle/x64/resources',
+  })
+
+  expect(Copy.copyFile).toHaveBeenCalledWith({
+    from: 'LICENSE',
+    to: 'packages/build/.tmp/electron-bundle/x64/resources/app/LICENSE',
+  })
+})


### PR DESCRIPTION
Copies the project LICENSE into the packaged Electron app root so Help → View License opens the file successfully in production builds.