### PR TITLE
fix: load static server typescript headers

### DIFF
--- a/packages/shared-process/src/parts/GetExtraHeaders/GetExtraHeaders.ts
+++ b/packages/shared-process/src/parts/GetExtraHeaders/GetExtraHeaders.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'url'
 import * as StaticServerPath from '../StaticServerPath/StaticServerPath.ts'
 
 export const getExtraHeaders = async ({ absolutePath, etag, isForElectronProduction, pathName }: any): Promise<any> => {
-  const getHeadersPath = join(StaticServerPath.staticServerPath, 'src', 'parts', 'GetHeaders', 'GetHeaders.js')
+  const getHeadersPath = join(StaticServerPath.staticServerPath, 'src', 'parts', 'GetHeaders', 'GetHeaders.ts')
   const getHeadersUri = pathToFileURL(getHeadersPath).toString()
   const getHeadersModule = await import(getHeadersUri)
   const getHeadersFn = getHeadersModule.getHeaders

--- a/packages/shared-process/test/GetExtraHeaders.test.ts
+++ b/packages/shared-process/test/GetExtraHeaders.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@jest/globals'
+import * as GetExtraHeaders from '../src/parts/GetExtraHeaders/GetExtraHeaders.js'
+
+test('loads static server headers from typescript source', async () => {
+  const headers = await GetExtraHeaders.getExtraHeaders({
+    absolutePath: '/tmp/aboutWorkerMain.js',
+    etag: 'test-etag',
+    isForElectronProduction: false,
+    pathName: '/aboutWorkerMain.js',
+  })
+
+  expect(headers['Content-Type']).toBe('text/javascript')
+})


### PR DESCRIPTION
Fix Electron development requests after the static-server TypeScript migration by loading the existing GetHeaders.ts source. Add regression coverage for the shared-process dynamic import.