### PR TITLE
feature: show tabs while files load

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.delayed-file-system-provider/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.delayed-file-system-provider/extension.json
@@ -1,0 +1,9 @@
+{
+  "browser": "main.js",
+  "activation": ["onFileSystem:delayed-files"],
+  "fileSystems": [
+    {
+      "scheme": "delayed-files"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.delayed-file-system-provider/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.delayed-file-system-provider/main.js
@@ -1,0 +1,24 @@
+const contents = {
+  '/fast.txt': 'fast content',
+  '/slow.txt': 'slow content',
+}
+
+const getDelay = (uri) => {
+  return uri === '/fast.txt' ? 100 : 1200
+}
+
+const fileSystemProvider = {
+  id: 'delayed-files',
+  pathSeparator: '/',
+  async readFile(uri) {
+    await new Promise((resolve) => setTimeout(resolve, getDelay(uri)))
+    return contents[uri]
+  },
+  readDirWithFileTypes() {
+    return []
+  },
+}
+
+export const activate = () => {
+  vscode.registerFileSystemProvider(fileSystemProvider)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-disabled.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-disabled.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-delayed-file-loading-disabled'
+
+export const test: Test = async ({ Extension, Locator, Main, Settings, expect }) => {
+  await Settings.update({
+    'workbench.editor.showTabsWhileLoading': false,
+  })
+  await Extension.addWebExtension(new URL('../fixtures/sample.delayed-file-system-provider', import.meta.url).toString())
+  const openPromise = Main.openUri('extension-host://delayed-files:///slow.txt')
+
+  await new Promise((resolve) => setTimeout(resolve, 700))
+
+  const tab = Locator('.MainTab[title$="slow.txt"]')
+  const loading = Locator('.EditorContent--loading')
+  await expect(tab).toBeHidden()
+  await expect(loading).toBeHidden()
+
+  await openPromise
+  await expect(tab).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-fast-path.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-fast-path.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-delayed-file-loading-fast-path'
+
+export const test: Test = async ({ Editor, Extension, FileSystem, Locator, Main, Settings, expect }) => {
+  await Settings.update({
+    'workbench.editor.showTabsWhileLoading': false,
+  })
+  const tmpDir = await FileSystem.getTmpDir()
+  const warmupFile = `${tmpDir}/warmup.txt`
+  await FileSystem.writeFile(warmupFile, 'warmup')
+  await Main.openUri(warmupFile)
+  await Main.closeAllEditors()
+
+  await Settings.update({
+    'workbench.editor.showTabsWhileLoading': true,
+  })
+  await Extension.addWebExtension(new URL('../fixtures/sample.delayed-file-system-provider', import.meta.url).toString())
+  const fastFile = 'extension-host://delayed-files:///fast.txt'
+  await FileSystem.readFile(fastFile)
+  const openPromise = Main.openUri(fastFile)
+
+  await new Promise((resolve) => setTimeout(resolve, 250))
+
+  const loading = Locator('.EditorContent--loading')
+  await expect(loading).toBeHidden()
+
+  await openPromise
+  await Editor.shouldHaveText('fast content')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-placeholder.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-placeholder.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-delayed-file-loading-placeholder'
+
+export const test: Test = async ({ Extension, Locator, Main, Settings, expect }) => {
+  await Settings.update({
+    'workbench.editor.showTabsWhileLoading': true,
+  })
+  await Extension.addWebExtension(new URL('../fixtures/sample.delayed-file-system-provider', import.meta.url).toString())
+  const openPromise = Main.openUri('extension-host://delayed-files:///slow.txt')
+
+  await new Promise((resolve) => setTimeout(resolve, 700))
+
+  const loading = Locator('.EditorContent--loading')
+  await expect(loading).toBeVisible()
+  await expect(loading).toHaveText('Loading...')
+
+  await openPromise
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-replacement.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-replacement.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-delayed-file-loading-replacement'
+
+export const test: Test = async ({ Editor, Extension, Locator, Main, Settings, expect }) => {
+  await Settings.update({
+    'workbench.editor.showTabsWhileLoading': true,
+  })
+  await Extension.addWebExtension(new URL('../fixtures/sample.delayed-file-system-provider', import.meta.url).toString())
+  const openPromise = Main.openUri('extension-host://delayed-files:///slow.txt')
+  const loading = Locator('.EditorContent--loading')
+
+  await new Promise((resolve) => setTimeout(resolve, 700))
+  await expect(loading).toBeVisible()
+
+  await openPromise
+
+  await expect(loading).toBeHidden()
+  await Editor.shouldHaveText('slow content')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-tab.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-delayed-file-loading-tab.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-delayed-file-loading-tab'
+
+export const test: Test = async ({ Extension, Locator, Main, Settings, expect }) => {
+  await Settings.update({
+    'workbench.editor.showTabsWhileLoading': true,
+  })
+  await Extension.addWebExtension(new URL('../fixtures/sample.delayed-file-system-provider', import.meta.url).toString())
+  const openPromise = Main.openUri('extension-host://delayed-files:///slow.txt')
+
+  await new Promise((resolve) => setTimeout(resolve, 700))
+
+  const tab = Locator('.MainTab[title$="slow.txt"]')
+  await expect(tab).toBeVisible()
+
+  await openPromise
+}

--- a/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
@@ -1,5 +1,49 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
+import * as Preferences from '../Preferences/Preferences.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+
+const loadingDelay = 500
+const loadingTimeout = Symbol('loadingTimeout')
+const commandsThatOpenEditors = new Set(['handleClickTab', 'openInput', 'openUri', 'openUris', 'restoreClosedTab', 'selectTab'])
+
+const shouldRenderLoadingState = (key: string): boolean => {
+  return commandsThatOpenEditors.has(key) && Preferences.get('workbench.editor.showTabsWhileLoading') === true
+}
+
+const renderPendingState = async (uid: number): Promise<void> => {
+  const diffResult = await MainAreaWorker.invoke('MainArea.diff2', uid)
+  if (diffResult.length === 0) {
+    return
+  }
+  const commands = await MainAreaWorker.invoke('MainArea.render2', uid, diffResult)
+  if (commands.length === 0) {
+    return
+  }
+  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+}
+
+const invokeMainAreaCommand = async (key: string, uid: number, args: readonly any[]): Promise<void> => {
+  const commandPromise = MainAreaWorker.invoke(`MainArea.${key}`, uid, ...args)
+  if (!shouldRenderLoadingState(key)) {
+    await commandPromise
+    return
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<typeof loadingTimeout>((resolve) => {
+    timeoutId = setTimeout(() => resolve(loadingTimeout), loadingDelay)
+  })
+
+  try {
+    const result = await Promise.race([commandPromise, timeoutPromise])
+    if (result === loadingTimeout) {
+      await Promise.all([commandPromise, renderPendingState(uid)])
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
 
 export const wrapMainAreaCommand = (key: string) => {
   const fn = async (state, ...args) => {
@@ -11,7 +55,7 @@ export const wrapMainAreaCommand = (key: string) => {
         commands,
       }
     }
-    await MainAreaWorker.invoke(`MainArea.${key}`, state.uid, ...args)
+    await invokeMainAreaCommand(key, state.uid, args)
     const diffResult = await MainAreaWorker.invoke('MainArea.diff2', state.uid)
     if (diffResult.length === 0) {
       return state

--- a/packages/renderer-worker/test/WrapMainAreaCommand.test.js
+++ b/packages/renderer-worker/test/WrapMainAreaCommand.test.js
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainAreaWorker/MainAreaWorker.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => {
+  return {
+    get: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
+const MainAreaWorker = await import('../src/parts/MainAreaWorker/MainAreaWorker.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const { wrapMainAreaCommand } = await import('../src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts')
+
+const state = {
+  uid: 7,
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.resetAllMocks()
+  // @ts-ignore
+  Preferences.get.mockReturnValue(false)
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('returns final render commands for a fast open', async () => {
+  const finalCommands = [['Viewlet.setDom2', 7, ['content']]]
+  // @ts-ignore
+  Preferences.get.mockReturnValue(true)
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.diff2') {
+      return [2]
+    }
+    if (method === 'MainArea.render2') {
+      return finalCommands
+    }
+    return undefined
+  })
+
+  const result = await wrapMainAreaCommand('openUri')(state, 'file:///test.txt')
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(result).toEqual({
+    ...state,
+    commands: finalCommands,
+  })
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('renders a pending loading state after 500ms and returns the final render', async () => {
+  const open = Promise.withResolvers()
+  const loadingCommands = [['Viewlet.setDom2', 7, ['Loading...']]]
+  const finalCommands = [['Viewlet.setDom2', 7, ['content']]]
+  let diffCount = 0
+  // @ts-ignore
+  Preferences.get.mockReturnValue(true)
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.openUri') {
+      return open.promise
+    }
+    if (method === 'MainArea.diff2') {
+      diffCount++
+      return diffCount === 1 ? [1] : [2]
+    }
+    if (method === 'MainArea.render2') {
+      return diffCount === 1 ? loadingCommands : finalCommands
+    }
+    return undefined
+  })
+
+  const resultPromise = wrapMainAreaCommand('openUri')(state, 'file:///test.txt')
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', loadingCommands)
+
+  open.resolve(undefined)
+  await expect(resultPromise).resolves.toEqual({
+    ...state,
+    commands: finalCommands,
+  })
+})
+
+test('does not schedule a loading render when the preference is disabled', async () => {
+  const open = Promise.withResolvers()
+  const finalCommands = [['Viewlet.setDom2', 7, ['content']]]
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.openUri') {
+      return open.promise
+    }
+    if (method === 'MainArea.diff2') {
+      return [2]
+    }
+    if (method === 'MainArea.render2') {
+      return finalCommands
+    }
+    return undefined
+  })
+
+  const resultPromise = wrapMainAreaCommand('openUri')(state, 'file:///test.txt')
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(MainAreaWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+
+  open.resolve(undefined)
+  await expect(resultPromise).resolves.toEqual({
+    ...state,
+    commands: finalCommands,
+  })
+})
+
+test('does not schedule a loading render for unrelated commands', async () => {
+  const close = Promise.withResolvers()
+  // @ts-ignore
+  Preferences.get.mockReturnValue(true)
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.closeAll') {
+      return close.promise
+    }
+    return []
+  })
+
+  const resultPromise = wrapMainAreaCommand('closeAll')(state)
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(MainAreaWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+
+  close.resolve(undefined)
+  await expect(resultPromise).resolves.toBe(state)
+})
+
+test('continues waiting when the pending state has no render diff', async () => {
+  const open = Promise.withResolvers()
+  const finalCommands = [['Viewlet.setDom2', 7, ['content']]]
+  let diffCount = 0
+  // @ts-ignore
+  Preferences.get.mockReturnValue(true)
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.openUri') {
+      return open.promise
+    }
+    if (method === 'MainArea.diff2') {
+      diffCount++
+      return diffCount === 1 ? [] : [2]
+    }
+    if (method === 'MainArea.render2') {
+      return finalCommands
+    }
+    return undefined
+  })
+
+  const resultPromise = wrapMainAreaCommand('openUri')(state, 'file:///test.txt')
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+
+  open.resolve(undefined)
+  await expect(resultPromise).resolves.toEqual({
+    ...state,
+    commands: finalCommands,
+  })
+})
+
+test('clears the timeout when opening fails before the delay', async () => {
+  const error = new Error('Failed to open')
+  // @ts-ignore
+  Preferences.get.mockReturnValue(true)
+  // @ts-ignore
+  MainAreaWorker.invoke.mockRejectedValue(error)
+
+  await expect(wrapMainAreaCommand('openUri')(state, 'file:///test.txt')).rejects.toThrow(error)
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(MainAreaWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('renders pending state for tab selection commands', async () => {
+  const select = Promise.withResolvers()
+  const loadingCommands = [['Viewlet.setDom2', 7, ['Loading...']]]
+  // @ts-ignore
+  Preferences.get.mockReturnValue(true)
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.selectTab') {
+      return select.promise
+    }
+    if (method === 'MainArea.diff2') {
+      return [1]
+    }
+    if (method === 'MainArea.render2') {
+      return loadingCommands
+    }
+    return undefined
+  })
+
+  const resultPromise = wrapMainAreaCommand('selectTab')(state, 0, 1)
+  await jest.advanceTimersByTimeAsync(500)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', loadingCommands)
+
+  select.resolve(undefined)
+  await resultPromise
+})

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -50,6 +50,7 @@
   "workbench.colorTheme": "slime",
   "workbench.iconTheme": "vscode-icons",
   "workbench.activityBar.visible": true,
+  "workbench.editor.showTabsWhileLoading": false,
   "workbench.sideBar.visible": true,
   "workbench.sideBarLocation": "right",
   "workbench.saveStateOnVisibilityChange": true,


### PR DESCRIPTION
Adds an opt-in `workbench.editor.showTabsWhileLoading` setting. When enabled, file opens that exceed 500 ms render the tab and existing loading placeholder immediately, then replace it with the completed editor.

Includes focused timer/race coverage and delayed file-system end-to-end scenarios for the loading tab, placeholder, final replacement, fast path, and disabled behavior.