### PR TITLE
fix: return file watcher results from shared process

### DIFF
--- a/packages/shared-process/src/parts/FileWatcher/FileWatcher.ts
+++ b/packages/shared-process/src/parts/FileWatcher/FileWatcher.ts
@@ -13,7 +13,7 @@ const internalIdMap = Object.create(null)
 export const watch = async (ipc: any, id: any, { exclude, roots }: any): Promise<any> => {
   const internalId = Id.create()
   internalIdMap[internalId] = { id, ipc }
-  await FileWatcherProcess.invoke('FileWatcher.watchFolders', {
+  return FileWatcherProcess.invoke('FileWatcher.watchFolders', {
     exclude,
     id: internalId,
     roots,

--- a/packages/shared-process/test/FileWatcher.test.ts
+++ b/packages/shared-process/test/FileWatcher.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/FileWatcherProcess/FileWatcherProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Id/Id.js', () => ({
+  create: jest.fn(() => 123),
+}))
+
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  send: jest.fn(),
+}))
+
+const FileWatcher = await import('../src/parts/FileWatcher/FileWatcher.js')
+const FileWatcherProcess = await import('../src/parts/FileWatcherProcess/FileWatcherProcess.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test.each([
+  { ok: true },
+  {
+    error: {
+      code: 'ENOSPC',
+      message: 'System limit for number of file watchers reached',
+      name: 'Error',
+    },
+    ok: false,
+  },
+])('watch - returns file watcher process result %#', async (result) => {
+  // @ts-ignore
+  FileWatcherProcess.invoke.mockResolvedValue(result)
+  const ipc = {}
+  const options = {
+    exclude: ['node_modules'],
+    roots: ['file:///workspace'],
+  }
+
+  await expect(FileWatcher.watch(ipc, 1, options)).resolves.toBe(result)
+
+  expect(FileWatcherProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(FileWatcherProcess.invoke).toHaveBeenCalledWith('FileWatcher.watchFolders', {
+    exclude: options.exclude,
+    id: 123,
+    roots: options.roots,
+  })
+})


### PR DESCRIPTION
Return the file-watcher process result unchanged from the shared-process watch handler, allowing success and setup-error results to flow predictably to callers.