### PR TITLE
fix: register config json path command

### DIFF
--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -270,6 +270,7 @@ export const getModuleId = (commandId: any): any => {
     case 'Platform.getCacheUri':
     case 'Platform.getCommit':
     case 'Platform.getConfigDir':
+    case 'Platform.getConfigJsonPath':
     case 'Platform.getDataDir':
     case 'Platform.getDate':
     case 'Platform.getDisabledExtensionsPath':

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals'
+import * as ModuleId from '../src/parts/ModuleId/ModuleId.js'
+import * as ModuleMap from '../src/parts/ModuleMap/ModuleMap.js'
+
+test('getModuleId - Platform.getConfigJsonPath', () => {
+  expect(ModuleMap.getModuleId('Platform.getConfigJsonPath')).toBe(ModuleId.Platform)
+})


### PR DESCRIPTION
Register `Platform.getConfigJsonPath` in the shared-process module map so production Electron builds can lazy-load the existing handler and the About view can read `config.json`. Adds a regression test for the command route.