### PR TITLE
feature: add running extensions command

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -369,6 +369,11 @@ export const getQuickPickMenuEntries = () => {
       label: 'Developer: Open Process Explorer',
     },
     {
+      id: 'Main.openUri',
+      label: 'Developer: Show Running Extensions',
+      args: ['running-extensions://'],
+    },
+    {
       id: 'Developer.showGpuInfo',
       label: 'Developer: Show GPU Info',
     },

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.js
@@ -39,6 +39,16 @@ test('getQuickPickMenuEntries includes GPU info command', () => {
   })
 })
 
+test('getQuickPickMenuEntries includes running extensions command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Main.openUri',
+    label: 'Developer: Show Running Extensions',
+    args: ['running-extensions://'],
+  })
+})
+
 test('getQuickPickMenuEntries includes extension management worker latency command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 


### PR DESCRIPTION
Adds a Developer: Show Running Extensions command to the command palette. Selecting it opens the running extensions editor view.