### PR TITLE
feature: register running extensions context menu

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -58,7 +58,7 @@
         "@lvce-editor/references-view": "^2.7.0",
         "@lvce-editor/rename-worker": "^1.30.0",
         "@lvce-editor/renderer-process": "^30.7.0",
-        "@lvce-editor/running-extensions-view": "^1.0.0",
+        "@lvce-editor/running-extensions-view": "^1.3.0",
         "@lvce-editor/settings-view": "^2.12.0",
         "@lvce-editor/settings-worker": "^1.4.0",
         "@lvce-editor/simple-browser-view": "^2.2.0",
@@ -419,9 +419,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/running-extensions-view": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/running-extensions-view/-/running-extensions-view-1.2.0.tgz",
-      "integrity": "sha512-W8znFII4FO5oSe4WFvpEfSO4DtPOdamKkTaPe9sUWH8Gqv8AiZJhnduOJ9OKZbBcFJjBaC5HjCGOcep+D99Onw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/running-extensions-view/-/running-extensions-view-1.3.0.tgz",
+      "integrity": "sha512-/QvNUQtU6ZkICLfosfGJMG6EktJUpkaNj+88Fe7U8sB5oRvmcBTxyEFAyzVFgzZVzZVzJkjgglCsCgQp67ktUQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/settings-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -90,7 +90,7 @@
     "@lvce-editor/references-view": "^2.7.0",
     "@lvce-editor/rename-worker": "^1.30.0",
     "@lvce-editor/renderer-process": "^30.7.0",
-    "@lvce-editor/running-extensions-view": "^1.0.0",
+    "@lvce-editor/running-extensions-view": "^1.3.0",
     "@lvce-editor/settings-view": "^2.12.0",
     "@lvce-editor/settings-worker": "^1.4.0",
     "@lvce-editor/simple-browser-view": "^2.2.0",

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
@@ -36,3 +36,21 @@ export const loadContent = async (state: RunningExtensionsState): Promise<Runnin
     commands,
   }
 }
+
+export const menus = []
+
+export const getMenus = async () => {
+  try {
+    const ids = await RunningExtensionsViewWorker.invoke('RunningExtensions.getMenuEntryIds')
+    return ids.map((id) => {
+      return {
+        id,
+        async getMenuEntries(...args) {
+          return RunningExtensionsViewWorker.invoke('RunningExtensions.getMenuEntries', ...args)
+        },
+      }
+    })
+  } catch {
+    return []
+  }
+}

--- a/packages/renderer-worker/test/ViewletRunningExtensions.test.js
+++ b/packages/renderer-worker/test/ViewletRunningExtensions.test.js
@@ -1,9 +1,20 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+let shouldFail = false
+
 jest.unstable_mockModule('../src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts', () => ({
   invoke: jest.fn(async (command) => {
+    if (shouldFail) {
+      throw new Error('Failed to load worker')
+    }
     if (command === 'RunningExtensions.diff2' || command === 'RunningExtensions.render2') {
       return []
+    }
+    if (command === 'RunningExtensions.getMenuEntryIds') {
+      return [32]
+    }
+    if (command === 'RunningExtensions.getMenuEntries') {
+      return [{ command: 'RunningExtensions.copyId', id: 'copy-id', label: 'Copy id (test.extension)' }]
     }
     return undefined
   }),
@@ -22,6 +33,7 @@ const ViewletRunningExtensions = await import('../src/parts/ViewletRunningExtens
 
 beforeEach(() => {
   jest.clearAllMocks()
+  shouldFail = false
 })
 
 test('loadContent passes the platform and asset directory to the view worker', async () => {
@@ -41,4 +53,21 @@ test('loadContent passes the platform and asset directory to the view worker', a
     2,
     '/test-assets',
   )
+})
+
+test('getMenus provides running extensions menu entries', async () => {
+  const menus = await ViewletRunningExtensions.getMenus()
+
+  expect(menus).toHaveLength(1)
+  expect(menus[0].id).toBe(32)
+
+  const entries = await menus[0].getMenuEntries(0)
+  expect(entries).toEqual([{ command: 'RunningExtensions.copyId', id: 'copy-id', label: 'Copy id (test.extension)' }])
+  expect(RunningExtensionsViewWorker.invoke).toHaveBeenLastCalledWith('RunningExtensions.getMenuEntries', 0)
+})
+
+test('getMenus returns an empty array when the view worker is unavailable', async () => {
+  shouldFail = true
+
+  await expect(ViewletRunningExtensions.getMenus()).resolves.toEqual([])
 })


### PR DESCRIPTION
## Summary
- register running extensions menu providers with the renderer
- update the running extensions view dependency to v1.3.0
- cover menu forwarding and worker-unavailable fallback

## Validation
- `npm test -- ViewletRunningExtensions.test.js --runInBand` (renderer-worker)
- `npm run type-check` (renderer-worker)
- `npm run lint` (repository root)