### PR TITLE
fix: size simple browser preview correctly

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -37,3 +37,22 @@ test('bundleCss does not add filename comment to App.css', async () => {
     await rm(dir, { recursive: true, force: true })
   }
 }, 30_000)
+
+test('bundleCss preserves the simple browser preview width', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletSimpleBrowser.css'), 'utf8')
+
+    expect(css).toContain(`.ContentArea > .SimpleBrowser {
+  flex: 0 0 var(--PreviewWidth);
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -5,6 +5,10 @@
   flex-direction: column;
 }
 
+.ContentArea > .SimpleBrowser {
+  flex: 0 0 var(--PreviewWidth);
+}
+
 .SimpleBrowserHeader {
   height: 30px;
   width: 100%;


### PR DESCRIPTION
Fixes Simple Browser using editor-area flex sizing when it is mounted in the preview pane. The preview instance now uses the configured preview width while regular Simple Browser tabs keep their existing flexible layout.