### PR TITLE
feature: add running extensions side bar title

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts
@@ -1,4 +1,6 @@
 export * from './ViewletRunningExtensions.ts'
 export * from './ViewletRunningExtensionsCommands.ts'
 export * from './ViewletRunningExtensionsCss.ts'
+export * from './ViewletRunningExtensionsName.ts'
 export * from './ViewletRunningExtensionsRender.ts'
+export * from './ViewletRunningExtensionsRenderTitle.ts'

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
@@ -7,6 +7,7 @@ export const create = (uid: number, uri: string, x: number, y: number, width: nu
   return {
     commands: [],
     height,
+    title: 'Running Extensions',
     uid,
     uri,
     width,
@@ -17,17 +18,7 @@ export const create = (uid: number, uri: string, x: number, y: number, width: nu
 
 export const loadContent = async (state: RunningExtensionsState): Promise<RunningExtensionsState> => {
   const { height, uid, uri, width, x, y } = state
-  await RunningExtensionsViewWorker.invoke(
-    'RunningExtensions.create',
-    uid,
-    uri,
-    x,
-    y,
-    width,
-    height,
-    Platform.getPlatform(),
-    AssetDir.assetDir,
-  )
+  await RunningExtensionsViewWorker.invoke('RunningExtensions.create', uid, uri, x, y, width, height, Platform.getPlatform(), AssetDir.assetDir)
   await RunningExtensionsViewWorker.invoke('RunningExtensions.loadContent', uid)
   const diffResult = await RunningExtensionsViewWorker.invoke('RunningExtensions.diff2', uid)
   const commands = await RunningExtensionsViewWorker.invoke('RunningExtensions.render2', uid, diffResult)

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsName.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsName.ts
@@ -1,0 +1,1 @@
+export const name = 'RunningExtensions'

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsRenderTitle.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsRenderTitle.ts
@@ -1,0 +1,10 @@
+import type { RunningExtensionsState } from './ViewletRunningExtensionsTypes.ts'
+
+export const renderTitle = {
+  isEqual(oldState: RunningExtensionsState, newState: RunningExtensionsState): boolean {
+    return oldState.title === newState.title
+  },
+  apply(_oldState: RunningExtensionsState, newState: RunningExtensionsState): string {
+    return newState.title
+  },
+}

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsTypes.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsTypes.ts
@@ -1,6 +1,7 @@
 export interface RunningExtensionsState {
   readonly commands: readonly any[]
   readonly height: number
+  readonly title: string
   readonly uid: number
   readonly uri: string
   readonly width: number

--- a/packages/renderer-worker/test/ViewletRunningExtensions.test.js
+++ b/packages/renderer-worker/test/ViewletRunningExtensions.test.js
@@ -30,10 +30,19 @@ jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
 
 const RunningExtensionsViewWorker = await import('../src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts')
 const ViewletRunningExtensions = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts')
+const ViewletRunningExtensionsName = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensionsName.ts')
+const ViewletRunningExtensionsRenderTitle = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensionsRenderTitle.ts')
 
 beforeEach(() => {
   jest.clearAllMocks()
   shouldFail = false
+})
+
+test('provides the side bar name and title', () => {
+  const state = ViewletRunningExtensions.create(1, 'RunningExtensions', 10, 20, 800, 600)
+
+  expect(ViewletRunningExtensionsName.name).toBe('RunningExtensions')
+  expect(ViewletRunningExtensionsRenderTitle.renderTitle.apply(state, state)).toBe('Running Extensions')
 })
 
 test('loadContent passes the platform and asset directory to the view worker', async () => {


### PR DESCRIPTION
Adds the running extensions view name and title renderer so the view has a proper Running Extensions header when hosted in the side bar.