### PR TITLE
Route isolated quick picks to the quick pick worker

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -129,6 +129,7 @@ export const commandMap = {
   'ExtensionHostManagement.getStatusBarItems': lazy('ExtensionHostManagement.getStatusBarItems'),
   'ExtensionHostOrganizeImports.organizeImports': lazy('ExtensionHostOrganizeImports.organizeImports'),
   'ExtensionHostQuickPick.show': lazy('ExtensionHostQuickPick.show'),
+  'ExtensionHostQuickPick.showQuickPick': lazy('ExtensionHostQuickPick.showQuickPick'),
   'ExtensionHostSelection.executeGrowSelection': lazy('ExtensionHostSelection.executeGrowSelection'),
   'ExtensionHostState.getSavedState': lazy('ExtensionHostState.getSavedState'),
   'ExtensionHostState.saveState': lazy('ExtensionHostState.saveState'),

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.ipc.js
@@ -5,4 +5,5 @@ export const name = 'ExtensionHostQuickPick'
 // prettier-ignore
 export const Commands = {
   show: ExtensionHostQuickPick.show,
+  showQuickPick: ExtensionHostQuickPick.showQuickPick,
 }

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.js
@@ -1,8 +1,13 @@
 import * as Command from '../Command/Command.js'
 import * as Promises from '../Promises/Promises.js'
+import * as QuickPickWorker from '../QuickPickWorker/QuickPickWorker.js'
 
 export const show = async (picks) => {
   const { resolve, promise } = Promises.withResolvers()
   await Command.execute('QuickPick.showCustom', picks, resolve)
   return promise
+}
+
+export const showQuickPick = (options) => {
+  return QuickPickWorker.invoke('QuickPick.showQuickPick', options)
 }

--- a/packages/renderer-worker/test/ExtensionHostQuickPick.test.js
+++ b/packages/renderer-worker/test/ExtensionHostQuickPick.test.js
@@ -1,0 +1,24 @@
+import { expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn(async (..._args) => 'main')
+
+jest.unstable_mockModule('../src/parts/QuickPickWorker/QuickPickWorker.js', () => ({
+  invoke,
+}))
+
+const ExtensionHostQuickPick = await import('../src/parts/ExtensionHost/ExtensionHostQuickPick.js')
+
+test('showQuickPick forwards options to the quick pick worker', async () => {
+  const options = {
+    items: [
+      {
+        label: 'main',
+        value: 'main',
+      },
+    ],
+    placeholder: 'Select a branch',
+  }
+  await expect(ExtensionHostQuickPick.showQuickPick(options)).resolves.toBe('main')
+
+  expect(invoke).toHaveBeenCalledWith('QuickPick.showQuickPick', options)
+})


### PR DESCRIPTION
## Summary\n- expose the isolated quick-pick renderer command\n- forward quick-pick options to the quick-pick worker that owns callbacks\n- add renderer unit coverage\n\n## Validation\n- npm run type-check\n- renderer-worker tests (818 passed, 245 skipped)\n- root npm run lint\n- focused Git branch-picker e2e with local producer bundles\n\nNote: renderer-worker's package-level xo command currently reports the repository's existing style migration backlog; root lint passes.