### PR TITLE
fix: ignore empty ipc handles

### DIFF
--- a/packages/shared-process/src/parts/HandleIncomingIpc/HandleIncomingIpc.ts
+++ b/packages/shared-process/src/parts/HandleIncomingIpc/HandleIncomingIpc.ts
@@ -26,13 +26,20 @@ const getIpcAndResponse = (module: any, handle: any, message: any): any => {
   if (IsSocket.isSocket(handle)) {
     return HandleIncomingIpcWebSocket.handleIncomingIpcWebSocket(module, handle, message)
   }
+  if (handle?.constructor === Object && Object.keys(handle).length === 0) {
+    return undefined
+  }
   throw new Error(`Unexpected ipc handle: ${strinfyHandle(handle)}`)
 }
 
 export const handleIncomingIpc = async (ipcId: any, handle: any, message: any): Promise<any> => {
   Assert.number(ipcId)
   const module = HandleIpcModule.getModule(ipcId)
-  const { response, target } = await getIpcAndResponse(module, handle, message)
+  const ipcAndResponse = await getIpcAndResponse(module, handle, message)
+  if (!ipcAndResponse) {
+    return
+  }
+  const { response, target } = ipcAndResponse
   const error = await ApplyIncomingIpcResponse.applyIncomingIpcResponse(target, response, ipcId)
   if (!error) {
     return

--- a/packages/shared-process/test/HandleIncomingIpcProcessExplorer.test.ts
+++ b/packages/shared-process/test/HandleIncomingIpcProcessExplorer.test.ts
@@ -1,10 +1,11 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as IpcId from '../src/parts/IpcId/IpcId.js'
 
 const error = new Error('Transfer failed')
 const applyIncomingIpcResponse = jest.fn(async () => error)
 const decreaseRefCount = jest.fn()
 const getModule = jest.fn(() => ({}))
+const isSocket = jest.fn(() => true)
 const handleIncomingIpcWebSocket = jest.fn(async () => ({
   response: {
     method: 'HandleWebSocket.handleWebSocket',
@@ -31,7 +32,7 @@ jest.unstable_mockModule('../src/parts/IsMessagePortMain/IsMessagePortMain.js', 
 }))
 
 jest.unstable_mockModule('../src/parts/IsSocket/IsSocket.js', () => ({
-  isSocket: (): any => true,
+  isSocket,
 }))
 
 jest.unstable_mockModule('../src/parts/ProcessExplorer/ProcessExplorer.js', () => ({
@@ -40,6 +41,10 @@ jest.unstable_mockModule('../src/parts/ProcessExplorer/ProcessExplorer.js', () =
 
 const HandleIncomingIpc = await import('../src/parts/HandleIncomingIpc/HandleIncomingIpc.js')
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 test('handleIncomingIpc - logs forwarding error and decrements process explorer ref count', async () => {
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
@@ -47,5 +52,24 @@ test('handleIncomingIpc - logs forwarding error and decrements process explorer 
 
   expect(decreaseRefCount).toHaveBeenCalledTimes(1)
   expect(spy).toHaveBeenCalledWith(error)
+  spy.mockRestore()
+})
+
+test('handleIncomingIpc - ignores an empty object handle', async () => {
+  isSocket.mockReturnValueOnce(false)
+
+  await expect(HandleIncomingIpc.handleIncomingIpc(IpcId.SharedProcess, {}, {})).resolves.toBeUndefined()
+
+  expect(applyIncomingIpcResponse).not.toHaveBeenCalled()
+})
+
+test('handleIncomingIpc - rejects other unexpected handles', async () => {
+  const spy = jest.spyOn(console, 'log').mockImplementation(() => {})
+  isSocket.mockReturnValueOnce(false)
+
+  await expect(HandleIncomingIpc.handleIncomingIpc(IpcId.SharedProcess, { unexpected: true }, {})).rejects.toThrow(
+    'Unexpected ipc handle: Object',
+  )
+
   spy.mockRestore()
 })


### PR DESCRIPTION
Ignore unexpectedly serialized empty-object IPC handles without attempting response forwarding. Preserve errors for all other unexpected handle values and cover both paths with regression tests.