### PR TITLE
fix: show overlays above simple browser

### DIFF
--- a/packages/renderer-worker/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js
+++ b/packages/renderer-worker/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js
@@ -38,6 +38,10 @@ export const cancelNavigation = (id) => {
   return EmbedsWorker.invoke('ElectronWebContentsView.cancelNavigation', id)
 }
 
+export const capturePage = (id) => {
+  return EmbedsWorker.invoke('ElectronWebContentsView.capturePage', id)
+}
+
 export const show = (id) => {
   return EmbedsWorker.invoke('ElectronWebContentsView.show', id)
 }

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -3,12 +3,13 @@ import * as HtmlInputType from '../HtmlInputType/HtmlInputType.js'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
 
-export const getSimpleBrowserVirtualDom = (canGoBack, canGoForward, isLoading, value) => {
-  return [
+export const getSimpleBrowserVirtualDom = (canGoBack, canGoForward, isLoading, value, snapshot = '') => {
+  /** @type {any[]} */
+  const dom = [
     {
       type: VirtualDomElements.Div,
       className: 'Viewlet SimpleBrowser',
-      childCount: 1,
+      childCount: snapshot ? 2 : 1,
     },
     {
       type: VirtualDomElements.Div,
@@ -74,4 +75,14 @@ export const getSimpleBrowserVirtualDom = (canGoBack, canGoForward, isLoading, v
       onClick: DomEventListenerFunctions.HandleClickOpenExternal,
     },
   ]
+  if (snapshot) {
+    dom.push({
+      type: VirtualDomElements.Img,
+      className: 'SimpleBrowserSnapshot',
+      src: snapshot,
+      draggable: false,
+      childCount: 0,
+    })
+  }
+  return dom
 }

--- a/packages/renderer-worker/src/parts/Menu/Menu.js
+++ b/packages/renderer-worker/src/parts/Menu/Menu.js
@@ -1,11 +1,24 @@
 import * as MenuWorker from '../MenuWorker/MenuWorker.js'
+import * as SimpleBrowserOverlay from '../SimpleBrowserOverlay/SimpleBrowserOverlay.js'
 
 export const show = async (x, y, menuId, ...args) => {
-  await MenuWorker.invoke('Menu.show', menuId, x, y, ...args)
+  await SimpleBrowserOverlay.show('menu')
+  try {
+    await MenuWorker.invoke('Menu.show', menuId, x, y, ...args)
+  } catch (error) {
+    await SimpleBrowserOverlay.hide('menu')
+    throw error
+  }
 }
 
 export const show2 = async (uid, menuId, x, y, ...args) => {
-  await MenuWorker.invoke('Menu.show2', uid, menuId, x, y, ...args)
+  await SimpleBrowserOverlay.show('menu')
+  try {
+    await MenuWorker.invoke('Menu.show2', uid, menuId, x, y, ...args)
+  } catch (error) {
+    await SimpleBrowserOverlay.hide('menu')
+    throw error
+  }
 }
 
 export const closeSubMenu = async () => {
@@ -29,7 +42,11 @@ export const selectCurrent = async (level) => {
 }
 
 export const hide = async (restoreFocus = true) => {
-  await MenuWorker.invoke('Menu.hide', restoreFocus)
+  try {
+    await MenuWorker.invoke('Menu.hide', restoreFocus)
+  } finally {
+    await SimpleBrowserOverlay.hide('menu')
+  }
 }
 
 // TODO difference between focusing with mouse or keyboard

--- a/packages/renderer-worker/src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js
@@ -1,0 +1,17 @@
+import * as Command from '../Command/Command.js'
+
+const run = async (method, overlayId) => {
+  try {
+    await Command.execute(`SimpleBrowser.${method}`, overlayId)
+  } catch (error) {
+    console.error(`[renderer-worker] Failed to ${method} for Simple Browser`, error)
+  }
+}
+
+export const show = (overlayId) => {
+  return run('showOverlay', overlayId)
+}
+
+export const hide = (overlayId) => {
+  return run('hideOverlay', overlayId)
+}

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -5,6 +5,7 @@ import * as Id from '../Id/Id.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 import * as Logger from '../Logger/Logger.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as SimpleBrowserOverlay from '../SimpleBrowserOverlay/SimpleBrowserOverlay.js'
 import * as UpdateDynamicFocusContext from '../UpdateDynamicFocusContext/UpdateDynamicFocusContext.js'
 import { VError } from '../VError/VError.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
@@ -369,7 +370,18 @@ export const openWidget = async (moduleId, ...args) => {
   // TODO send focus changes to renderer process together with other message
   UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
   commands.push(['Viewlet.focus', childUid])
-  await RendererProcess.invoke('Viewlet.executeCommands', commands)
+  const hasSimpleBrowserOverlay = moduleId === ViewletModuleId.QuickPick
+  if (hasSimpleBrowserOverlay) {
+    await SimpleBrowserOverlay.show('quick-pick')
+  }
+  try {
+    await RendererProcess.invoke('Viewlet.executeCommands', commands)
+  } catch (error) {
+    if (hasSimpleBrowserOverlay) {
+      await SimpleBrowserOverlay.hide('quick-pick')
+    }
+    throw error
+  }
 }
 
 export const closeWidget = async (id) => {
@@ -381,10 +393,17 @@ export const closeWidget = async (id) => {
     if (!childInstance) {
       return
     }
+    const hasSimpleBrowserOverlay = childInstance.moduleId === ViewletModuleId.QuickPick
     const child = childInstance.state
     const childUid = child.uid
     const commands = disposeFunctional(childUid)
-    await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.sendMultiple', commands)
+    try {
+      await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.sendMultiple', commands)
+    } finally {
+      if (hasSimpleBrowserOverlay) {
+        await SimpleBrowserOverlay.hide('quick-pick')
+      }
+    }
     // TODO restore focus
   } catch (error) {
     throw new VError(error, `Failed to close widget ${id}`)

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -30,6 +30,8 @@ export const create = (id, uri, x, y, width, height) => {
     canGoBack: true,
     isLoading: false,
     hasSuggestionsOverlay: false,
+    overlayIds: [],
+    snapshot: '',
     suggestionsEnabled: false,
     shortcuts: [],
   }
@@ -137,6 +139,54 @@ export const show = async (state) => {
 export const hide = async (state) => {
   const { browserViewId } = state
   await ElectronWebContentsViewFunctions.hide(browserViewId)
+}
+
+export const showOverlay = async (state, overlayId) => {
+  if (state.overlayIds.includes(overlayId)) {
+    return state
+  }
+  const overlayIds = [...state.overlayIds, overlayId]
+  if (state.snapshot) {
+    return {
+      ...state,
+      overlayIds,
+    }
+  }
+  try {
+    const snapshot = await ElectronWebContentsViewFunctions.capturePage(state.browserViewId)
+    await ElectronWebContentsViewFunctions.hide(state.browserViewId)
+    return {
+      ...state,
+      overlayIds,
+      snapshot,
+    }
+  } catch (error) {
+    console.error('[renderer-worker] Failed to capture Simple Browser page', error)
+    return state
+  }
+}
+
+export const hideOverlay = async (state, overlayId) => {
+  if (!state.overlayIds.includes(overlayId)) {
+    return state
+  }
+  const overlayIds = state.overlayIds.filter((id) => id !== overlayId)
+  if (overlayIds.length > 0) {
+    return {
+      ...state,
+      overlayIds,
+    }
+  }
+  try {
+    await ElectronWebContentsViewFunctions.show(state.browserViewId)
+  } catch (error) {
+    console.error('[renderer-worker] Failed to restore Simple Browser page', error)
+  }
+  return {
+    ...state,
+    overlayIds,
+    snapshot: '',
+  }
 }
 
 export const handleInput = async (state, value) => {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -12,9 +12,11 @@ export const Commands = {
   handleKeyBinding: SimpleBrowser.handleKeyBinding,
   handleTitleUpdated: SimpleBrowser.handleTitleUpdated,
   handleWillNavigate: SimpleBrowser.handleWillNavigate,
+  hideOverlay: SimpleBrowser.hideOverlay,
   insertCss: ViewletSimpleBrowserInsertCss.insertCss,
   insertJavaScript: ViewletSimpleBrowserInsertJavaScript.insertJavaScript,
   setUrl: SimpleBrowser.setUrl,
+  showOverlay: SimpleBrowser.showOverlay,
 }
 
 export const LazyCommands = {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -11,7 +11,8 @@ const renderDom = {
       oldState.iframeSrc === newState.iframeSrc &&
       oldState.canGoBack === newState.canGoBack &&
       oldState.canGoForward === newState.canGoForward &&
-      oldState.isLoading === newState.isLoading
+      oldState.isLoading === newState.isLoading &&
+      oldState.snapshot === newState.snapshot
     )
   },
   apply(oldState, newState) {
@@ -20,6 +21,7 @@ const renderDom = {
       newState.canGoForward,
       newState.isLoading,
       newState.iframeSrc,
+      newState.snapshot,
     )
     return ['Viewlet.setDom2', dom]
   },

--- a/packages/renderer-worker/test/ElectronWebContentsViewFunctions.test.js
+++ b/packages/renderer-worker/test/ElectronWebContentsViewFunctions.test.js
@@ -1,0 +1,16 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/EmbedsWorker/EmbedsWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const EmbedsWorker = await import('../src/parts/EmbedsWorker/EmbedsWorker.js')
+const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
+
+test('capturePage forwards to the embeds worker', async () => {
+  // @ts-ignore
+  EmbedsWorker.invoke.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+
+  await expect(ElectronWebContentsViewFunctions.capturePage(12)).resolves.toBe('data:image/png;base64,c25hcHNob3Q=')
+  expect(EmbedsWorker.invoke).toHaveBeenCalledWith('ElectronWebContentsView.capturePage', 12)
+})

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.js
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.js
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import * as GetSimpleBrowserVirtualDom from '../src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
+
+test('renders a snapshot below the browser header', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(true, true, false, 'https://example.com', 'data:image/png;base64,c25hcHNob3Q=')
+
+  expect(dom[0].childCount).toBe(2)
+  expect(dom.at(-1)).toEqual({
+    type: VirtualDomElements.Img,
+    className: 'SimpleBrowserSnapshot',
+    src: 'data:image/png;base64,c25hcHNob3Q=',
+    draggable: false,
+    childCount: 0,
+  })
+})

--- a/packages/renderer-worker/test/Menu.test.js
+++ b/packages/renderer-worker/test/Menu.test.js
@@ -1,0 +1,39 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MenuWorker/MenuWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+jest.unstable_mockModule('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js', () => ({
+  hide: jest.fn(),
+  show: jest.fn(),
+}))
+
+const MenuWorker = await import('../src/parts/MenuWorker/MenuWorker.js')
+const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
+const Menu = await import('../src/parts/Menu/Menu.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('show hides the Simple Browser while a menu is open', async () => {
+  await Menu.show(10, 20, 'EditorContextMenu', 'arg')
+
+  expect(SimpleBrowserOverlay.show).toHaveBeenCalledWith('menu')
+  expect(MenuWorker.invoke).toHaveBeenCalledWith('Menu.show', 'EditorContextMenu', 10, 20, 'arg')
+})
+
+test('show2 hides the Simple Browser while a menu is open', async () => {
+  await Menu.show2(7, 'EditorContextMenu', 10, 20, 'arg')
+
+  expect(SimpleBrowserOverlay.show).toHaveBeenCalledWith('menu')
+  expect(MenuWorker.invoke).toHaveBeenCalledWith('Menu.show2', 7, 'EditorContextMenu', 10, 20, 'arg')
+})
+
+test('hide restores the Simple Browser even when hiding the menu fails', async () => {
+  // @ts-ignore
+  MenuWorker.invoke.mockRejectedValue(new Error('failed'))
+
+  await expect(Menu.hide()).rejects.toThrow('failed')
+  expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('menu')
+})

--- a/packages/renderer-worker/test/Viewlet.test.js
+++ b/packages/renderer-worker/test/Viewlet.test.js
@@ -35,9 +35,16 @@ jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
     },
   }
 })
+jest.unstable_mockModule('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js', () => {
+  return {
+    hide: jest.fn(),
+    show: jest.fn(),
+  }
+})
 
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 
 test.skip('focus', () => {
@@ -64,6 +71,7 @@ test('openWidget - once', async () => {
     return []
   })
   await Viewlet.openWidget('QuickPick', ['everything'])
+  expect(SimpleBrowserOverlay.show).toHaveBeenCalledWith('quick-pick')
   expect(ViewletManager.load).toHaveBeenCalledTimes(1)
   expect(ViewletManager.load).toHaveBeenCalledWith({
     // @ts-ignore
@@ -76,6 +84,21 @@ test('openWidget - once', async () => {
     uri: 'quickPick://everything',
     args: [['everything']],
   })
+})
+
+test('closeWidget restores Simple Browser after closing Quick Pick', async () => {
+  ViewletStates.set(2, {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'QuickPick',
+    factory: {},
+  })
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(() => {})
+
+  await Viewlet.closeWidget(2)
+
+  expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('quick-pick')
 })
 
 test('openWidget - should not open again when already open', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.js
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.js
@@ -6,6 +6,12 @@ beforeEach(() => {
 
 jest.unstable_mockModule('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js', () => {
   return {
+    capturePage: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+    hide: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
     reload: jest.fn(() => {
       throw new Error('not implemented')
     }),
@@ -25,6 +31,9 @@ jest.unstable_mockModule('../src/parts/ElectronWebContentsViewFunctions/Electron
       throw new Error('not implemented')
     }),
     setFallthroughKeyBindings: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+    show: jest.fn(() => {
       throw new Error('not implemented')
     }),
     getStats() {
@@ -134,5 +143,45 @@ test('handleDidNavigate', () => {
   // @ts-ignore
   expect(ViewletSimpleBrowser.handleDidNavigate(state, 'https://example.com', false, false)).toMatchObject({
     isLoading: false,
+  })
+})
+
+test('showOverlay captures and hides the WebContentsView', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12 }
+
+  const newState = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
+
+  expect(newState).toMatchObject({
+    overlayIds: ['quick-pick'],
+    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+  })
+  expect(ElectronWebContentsViewFunctions.capturePage).toHaveBeenCalledWith(12)
+  expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
+})
+
+test('overlays share one snapshot and restore after the last overlay closes', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12 }
+
+  const withQuickPick = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
+  const withBoth = await ViewletSimpleBrowser.showOverlay(withQuickPick, 'menu')
+  const withMenu = await ViewletSimpleBrowser.hideOverlay(withBoth, 'quick-pick')
+  const restored = await ViewletSimpleBrowser.hideOverlay(withMenu, 'menu')
+
+  expect(ElectronWebContentsViewFunctions.capturePage).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledTimes(1)
+  expect(restored).toMatchObject({
+    overlayIds: [],
+    snapshot: '',
   })
 })

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -26,3 +26,13 @@
   height: 100%;
   contain: strict;
 }
+
+.SimpleBrowserSnapshot {
+  contain: strict;
+  flex: 1;
+  filter: brightness(0.8);
+  min-height: 0;
+  object-fit: fill;
+  pointer-events: none;
+  width: 100%;
+}


### PR DESCRIPTION
Style Simple Browser page snapshots to fill the native view area with light dimming behind overlays.