### PR TITLE
feature: support hidden sidebar headers

### DIFF
--- a/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
+++ b/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
@@ -29,6 +29,7 @@ export interface ExtensionView {
   readonly iframe?: ExtensionViewIframe
   readonly kind?: string
   readonly name?: string
+  readonly showSideBarHeader?: boolean
   readonly title: string
 }
 

--- a/packages/renderer-worker/src/parts/GetSideBarDom/GetSideBarDom.js
+++ b/packages/renderer-worker/src/parts/GetSideBarDom/GetSideBarDom.js
@@ -41,13 +41,14 @@ const getTitleAreaDom = (newState) => {
 
 export const getSideBarDom = (newState) => {
   const { childUid } = newState
+  const showHeader = newState.titleAreaHeight !== 0
   return [
     {
       type: VirtualDomElements.Div,
       className: 'SideBar',
-      childCount: 2,
+      childCount: showHeader ? 2 : 1,
     },
-    ...getTitleAreaDom(newState),
+    ...(showHeader ? getTitleAreaDom(newState) : []),
     {
       type: VirtualDomElements.Reference,
       uid: childUid,

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -1,5 +1,6 @@
 import * as Character from '../Character/Character.js'
 import * as Command from '../Command/Command.js'
+import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as SaveState from '../SaveState/SaveState.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
@@ -10,6 +11,8 @@ import * as ViewletModuleMap from '../ViewletModuleMap/ViewletModuleMap.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as Id from '../Id/Id.js'
 
+const defaultTitleAreaHeight = 35
+
 export const create = (id, uri, x, y, width, height) => {
   return {
     uid: id,
@@ -19,7 +22,7 @@ export const create = (id, uri, x, y, width, height) => {
     y,
     width,
     height,
-    titleAreaHeight: 35,
+    titleAreaHeight: defaultTitleAreaHeight,
     actions: [],
     title: Character.EmptyString,
     childUid: -1,
@@ -91,6 +94,11 @@ const getChildModuleId = (moduleId) => {
   return ViewletModuleId.ExtensionView
 }
 
+const getExtensionViewTitleAreaHeight = async (moduleId) => {
+  const view = await GetExtensionViews.getExtensionView(moduleId)
+  return view?.showSideBarHeader === false ? 0 : defaultTitleAreaHeight
+}
+
 // TODO
 // export const getChildren = (state) => {
 //   const { titleAreaHeight, currentViewletId } = state
@@ -116,17 +124,23 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     return state
   }
   // TODO set it in layout
-  const { currentViewletId, titleAreaHeight } = state
+  const { currentViewletId } = state
   const requestId = state.currentViewletRequestId + 1
   const savePromise = SaveState.saveViewletState(currentViewletId)
   state.currentViewletRequestId = requestId
   state.currentViewletId = moduleId
 
-  const childDimensions = getContentDimensions(state, titleAreaHeight)
   const uid = state.uid
 
-  const childUid = Id.create()
   const childModuleId = getChildModuleId(moduleId)
+  const titleAreaHeight =
+    childModuleId === ViewletModuleId.ExtensionView ? await getExtensionViewTitleAreaHeight(moduleId) : defaultTitleAreaHeight
+  if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
+    await savePromise
+    return state
+  }
+  const childDimensions = getContentDimensions(state, titleAreaHeight)
+  const childUid = Id.create()
 
   const commands = await ViewletManager.load(
     {
@@ -177,7 +191,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
       title = childInstance?.state?.title || Character.EmptyString
     }
     const eventsIndex = commands.findIndex((command) => command[0] === 'Viewlet.registerEventListeners')
-    if (actionsDom.length > 0) {
+    if (titleAreaHeight > 0 && actionsDom.length > 0) {
       const events = eventsIndex >= 0 ? commands[eventsIndex][2] : []
       actionsUid = Id.create()
       commands.push(
@@ -204,6 +218,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     currentViewletId: moduleId,
     childUid,
     actionsUid,
+    titleAreaHeight,
     title,
   }
 }

--- a/packages/renderer-worker/test/ViewletExtensionView.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionView.test.js
@@ -127,6 +127,27 @@ test('sidebar dom uses custom view title instead of id', () => {
   })
 })
 
+test('sidebar dom omits the header when the view opts out', () => {
+  const dom = GetSideBarDom.getSideBarDom({
+    childUid: 2,
+    currentViewletId: 'chat2.views.chat',
+    title: 'Chat 2',
+    titleAreaHeight: 0,
+  })
+
+  expect(dom).toEqual([
+    {
+      childCount: 1,
+      className: 'SideBar',
+      type: 4,
+    },
+    {
+      type: 100,
+      uid: 2,
+    },
+  ])
+})
+
 test('rerender requests virtual dom patches from extension management worker', async () => {
   const patches = [['setText', 0, 'updated']]
   const invoke = /** @type {any} */ (ExtensionManagementWorker.invoke)

--- a/packages/renderer-worker/test/ViewletSideBar.test.js
+++ b/packages/renderer-worker/test/ViewletSideBar.test.js
@@ -14,6 +14,12 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => {
+  return {
+    getExtensionView: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
   return {
     saveViewletState: jest.fn(() => undefined),
@@ -27,6 +33,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
 })
 
 const Command = await import('../src/parts/Command/Command.js')
+const GetExtensionViews = await import('../src/parts/GetExtensionViews/GetExtensionViews.ts')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
@@ -40,6 +47,7 @@ beforeEach(() => {
   RendererProcess.invoke.mockResolvedValue(undefined)
   SaveState.saveViewletState.mockResolvedValue(undefined)
   ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'Explorer', 2, true]])
+  GetExtensionViews.getExtensionView.mockResolvedValue(undefined)
 })
 
 test.skip('openViewlet', async () => {
@@ -144,6 +152,37 @@ test('handleSideBarViewletChange uses child title', async () => {
   expect(newState).toMatchObject({
     currentViewletId: 'Explorer',
     title: 'workspace-name',
+  })
+})
+
+test('handleSideBarViewletChange gives an opted-out extension view the full sidebar', async () => {
+  const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
+  GetExtensionViews.getExtensionView.mockResolvedValue({
+    id: 'chat2.views.chat',
+    showSideBarHeader: false,
+  })
+  ViewletManager.load.mockResolvedValue([
+    ['Viewlet.createFunctionalRoot', 'ExtensionView', 2, true],
+    ['Viewlet.send', 1, 'setActionsDom', ['chat-actions']],
+  ])
+
+  const newState = await ViewletSideBar.handleSideBarViewletChange(state, 'chat2.views.chat')
+
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      height: 500,
+      id: 'ExtensionView',
+      uri: 'chat2.views.chat',
+      y: 0,
+    }),
+    false,
+    true,
+    undefined,
+  )
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.createFunctionalRoot', 'ExtensionView', 2, true]])
+  expect(newState).toMatchObject({
+    actionsUid: -1,
+    titleAreaHeight: 0,
   })
 })
 

--- a/packages/renderer-worker/test/ViewletSideBarRace.test.js
+++ b/packages/renderer-worker/test/ViewletSideBarRace.test.js
@@ -8,6 +8,12 @@ jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => {
+  return {
+    getExtensionView: jest.fn(() => undefined),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
   return {
     invoke: jest.fn(() => {


### PR DESCRIPTION
Lets extension views use the full sidebar when `showSideBarHeader` is false, omitting the default title and actions area while preserving current behavior by default.