### PR TITLE
fix: expand error view

### DIFF
--- a/static/css/parts/ViewletEditorError.css
+++ b/static/css/parts/ViewletEditorError.css
@@ -2,6 +2,10 @@
   --IconErrorForeground: rgb(182, 78, 78);
 }
 
+.Viewlet.Error {
+  flex: 1;
+}
+
 .TextEditorError {
   display: flex;
   flex: 1;


### PR DESCRIPTION
Restores flex growth for the generic error view so strict containment does not collapse it and hide its message.