### PR TITLE
feature: add layout reset command

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -510,6 +510,7 @@ export const commandMap = {
   'Layout.handleSashPointerUp': lazy('Layout.handleSashPointerUp'),
   'Layout.handleWorkspaceRefresh': lazy('Layout.handleWorkspaceRefresh'),
   'Layout.refreshSourceControlBadgeCount': lazy('Layout.refreshSourceControlBadgeCount'),
+  'Layout.reset': lazy('Layout.reset'),
   'Layout.closeChat': lazy('Layout.closeChat'),
   'Layout.enterSideBarFocusMode': lazy('Layout.enterSideBarFocusMode'),
   'Layout.hideActivityBar': lazy('Layout.hideActivityBar'),

--- a/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
+++ b/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
@@ -1,0 +1,54 @@
+import * as Command from '../Command/Command.js'
+import type { LayoutState, LayoutStateResult } from '../ViewletLayout/LayoutState.ts'
+import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+
+const defaultColorTheme = 'slime'
+
+const closeWidgets = async (): Promise<void> => {
+  await Command.execute('Viewlet.closeWidget', ViewletModuleId.QuickPick)
+  await Command.execute('Viewlet.closeWidget', ViewletModuleId.Dialog)
+  await Command.execute('Viewlet.closeWidget', ViewletModuleId.Confirm)
+}
+
+const getActivityBarBounds = (): { readonly height: number; readonly width: number; readonly x: number; readonly y: number } => {
+  const state: LayoutState = ViewletStates.getState(ViewletModuleId.Layout)
+  return {
+    height: state.activityBarHeight,
+    width: state.activityBarWidth,
+    x: state.activityBarLeft,
+    y: state.activityBarTop,
+  }
+}
+
+export const reset = async (state: LayoutState): Promise<LayoutStateResult> => {
+  await Command.execute('Menu.hide', false)
+  await closeWidgets()
+  await Command.execute('ColorTheme.setColorTheme', defaultColorTheme)
+  await Command.execute('Main.closeAllEditors')
+  const workspacePath = await Command.execute('Workspace.getPath')
+  if (workspacePath) {
+    await Command.execute('Workspace.close')
+  }
+  if (state.sideBarFocusMode) {
+    await Command.execute('Layout.leaveSideBarFocusMode')
+  }
+  if (state.sideBarLocation !== SideBarLocationType.Right) {
+    await Command.execute('Layout.moveSideBarRight')
+  }
+  if (!state.sideBarVisible || state.sideBarView !== ViewletModuleId.Explorer) {
+    await Command.execute('Layout.showSideBar', ViewletModuleId.Explorer)
+  }
+  if (state.panelVisible) {
+    if (state.panelMaximized) {
+      await Command.execute('Layout.unmaximizePanel')
+    }
+    await Command.execute('Layout.hidePanel')
+  }
+  await Command.execute('ActivityBar.reset', getActivityBarBounds())
+  return {
+    commands: [],
+    newState: state,
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -1,4 +1,5 @@
 import * as ViewletLayout from './ViewletLayout.ts'
+import * as ResetLayout from '../ResetLayout/ResetLayout.ts'
 
 // prettier-ignore
 export const Commands = {
@@ -39,6 +40,7 @@ export const CommandsWithSideEffects = {
   handleSashPointerUp: ViewletLayout.handleSashPointerUp,
   handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
   refreshSourceControlBadgeCount: ViewletLayout.refreshSourceControlBadgeCount,
+  reset: ResetLayout.reset,
   closeChat: ViewletLayout.closeChat,
   enterSideBarFocusMode: ViewletLayout.enterSideBarFocusMode,
   hideActivityBar: ViewletLayout.hideActivityBar,

--- a/packages/renderer-worker/test/ResetLayout.test.js
+++ b/packages/renderer-worker/test/ResetLayout.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as SideBarLocationType from '../src/parts/SideBarLocationType/SideBarLocationType.js'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({
+  getState: jest.fn(),
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const ResetLayout = await import('../src/parts/ResetLayout/ResetLayout.ts')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.spyOn(Command, 'execute').mockImplementation((command) => {
+    if (command === 'Workspace.getPath') {
+      return '/test'
+    }
+    return undefined
+  })
+  jest.spyOn(ViewletStates, 'getState').mockReturnValue({
+    activityBarHeight: 718,
+    activityBarLeft: 976,
+    activityBarTop: 30,
+    activityBarWidth: 48,
+  })
+})
+
+test('reset restores the initial application state', async () => {
+  /** @type {any} */
+  const state = {
+    panelVisible: true,
+    panelMaximized: true,
+    sideBarLocation: SideBarLocationType.Left,
+    sideBarFocusMode: true,
+    sideBarView: 'Search',
+    sideBarVisible: false,
+  }
+
+  await expect(ResetLayout.reset(state)).resolves.toEqual({
+    commands: [],
+    newState: state,
+  })
+
+  expect(Command.execute).toHaveBeenCalledTimes(14)
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'Menu.hide', false)
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'Viewlet.closeWidget', 'QuickPick')
+  expect(Command.execute).toHaveBeenNthCalledWith(3, 'Viewlet.closeWidget', 'Dialog')
+  expect(Command.execute).toHaveBeenNthCalledWith(4, 'Viewlet.closeWidget', 'Confirm')
+  expect(Command.execute).toHaveBeenNthCalledWith(5, 'ColorTheme.setColorTheme', 'slime')
+  expect(Command.execute).toHaveBeenNthCalledWith(6, 'Main.closeAllEditors')
+  expect(Command.execute).toHaveBeenNthCalledWith(7, 'Workspace.getPath')
+  expect(Command.execute).toHaveBeenNthCalledWith(8, 'Workspace.close')
+  expect(Command.execute).toHaveBeenNthCalledWith(9, 'Layout.leaveSideBarFocusMode')
+  expect(Command.execute).toHaveBeenNthCalledWith(10, 'Layout.moveSideBarRight')
+  expect(Command.execute).toHaveBeenNthCalledWith(11, 'Layout.showSideBar', 'Explorer')
+  expect(Command.execute).toHaveBeenNthCalledWith(12, 'Layout.unmaximizePanel')
+  expect(Command.execute).toHaveBeenNthCalledWith(13, 'Layout.hidePanel')
+  expect(Command.execute).toHaveBeenNthCalledWith(14, 'ActivityBar.reset', {
+    height: 718,
+    width: 48,
+    x: 976,
+    y: 30,
+  })
+})
+
+test('reset leaves an initial layout in place', async () => {
+  /** @type {any} */
+  const state = {
+    panelMaximized: false,
+    panelVisible: false,
+    sideBarLocation: SideBarLocationType.Right,
+    sideBarFocusMode: false,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  }
+
+  jest.spyOn(Command, 'execute').mockResolvedValue(undefined)
+
+  await ResetLayout.reset(state)
+
+  expect(Command.execute).not.toHaveBeenCalledWith('Workspace.close')
+  expect(Command.execute).not.toHaveBeenCalledWith('Layout.leaveSideBarFocusMode')
+  expect(Command.execute).not.toHaveBeenCalledWith('Layout.moveSideBarRight')
+  expect(Command.execute).not.toHaveBeenCalledWith('Layout.showSideBar', 'Explorer')
+  expect(Command.execute).not.toHaveBeenCalledWith('Layout.unmaximizePanel')
+  expect(Command.execute).not.toHaveBeenCalledWith('Layout.hidePanel')
+  expect(Command.execute).toHaveBeenLastCalledWith('ActivityBar.reset', expect.any(Object))
+})


### PR DESCRIPTION
Add a Layout.reset command that restores the initial theme, editors, workspace, sidebar, panel, widgets, menus, and activity bar state.