### PR TITLE
fix: avoid persisting preferences in tests

### DIFF
--- a/packages/renderer-worker/src/parts/Preferences/Preferences.js
+++ b/packages/renderer-worker/src/parts/Preferences/Preferences.js
@@ -68,6 +68,9 @@ export const getAll = () => {
 
 export const set = async (key, value) => {
   PreferencesState.set(key, value)
+  if (isTest()) {
+    return
+  }
   if (Platform.getPlatform() === PlatformType.Web) {
     const preferences = { ...PreferencesState.getAll(), [key]: value }
     await Command.execute(/* LocalStorage.setJson */ 'LocalStorage.setJson', /* key */ 'preferences', /* value */ preferences)

--- a/packages/renderer-worker/test/Preferences.test.js
+++ b/packages/renderer-worker/test/Preferences.test.js
@@ -140,6 +140,12 @@ test('get', () => {
   expect(Preferences.get('x')).toBe(42)
 })
 
+test('set - does not persist preferences in test mode', async () => {
+  await Preferences.set('x', 42)
+
+  expect(Preferences.state.x).toBe(42)
+})
+
 test('toggleAutoSave - turns auto save on', async () => {
   Object.assign(Preferences.state, { 'files.autoSave': 'off' })
 


### PR DESCRIPTION
## Summary
- keep `Preferences.set` updates in memory during tests
- avoid filesystem and local-storage writes from test reset operations
- cover the test-mode behavior with a regression test

## Verification
- renderer-worker: 225 suites passed, 837 tests passed, 245 skipped
- renderer-worker type-check passed

## Context
`Layout.reset` restores the default color theme between reused-page e2e tests. On Windows, persisting that test-only theme update attempted to create a malformed `file://` settings dirname. `Preferences.update` already skips persistence in test mode; this makes `Preferences.set` consistent.