### PR TITLE
feature: add electron prompt mode

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -18,6 +18,12 @@
     "created": "2025-02-10"
   },
   {
+    "name": "builtin.chat-view-2",
+    "repository": "github.com/lvce-editor/chat-view-2",
+    "version": "1.1.0",
+    "created": "2026-07-14"
+  },
+  {
     "name": "builtin.language-basics-bat",
     "repository": "github.com/lvce-editor/language-basics-bat",
     "version": "0.7.0",

--- a/packages/renderer-worker/src/parts/Exit/Exit.js
+++ b/packages/renderer-worker/src/parts/Exit/Exit.js
@@ -1,5 +1,8 @@
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 
-export const exit = () => {
-  return SharedProcess.invoke('Exit.exit')
+export const exit = (code) => {
+  if (code === undefined) {
+    return SharedProcess.invoke('Exit.exit')
+  }
+  return SharedProcess.invoke('Exit.exit', code)
 }

--- a/packages/renderer-worker/src/parts/Process/Process.ipc.js
+++ b/packages/renderer-worker/src/parts/Process/Process.ipc.js
@@ -3,6 +3,7 @@ import * as Process from './Process.js'
 export const name = 'Process'
 
 export const Commands = {
+  getArgv: Process.getArgv,
   getNodeVersion: Process.getNodeVersion,
   getElectronVersion: Process.getElectronVersion,
   getChromeVersion: Process.getChromeVersion,
@@ -11,4 +12,6 @@ export const Commands = {
   getCommit: Process.getCommit,
   getVersion: Process.getVersion,
   getProductNameLong: Process.getProductNameLong,
+  writeStderr: Process.writeStderr,
+  writeStdout: Process.writeStdout,
 }

--- a/packages/renderer-worker/src/parts/Process/Process.js
+++ b/packages/renderer-worker/src/parts/Process/Process.js
@@ -47,3 +47,15 @@ export const getDate = () => {
 export const getArch = () => {
   return SharedProcess.invoke('Process.getArch')
 }
+
+export const getArgv = () => {
+  return SharedProcess.invoke('ElectronProcess.getArgv')
+}
+
+export const writeStderr = (value) => {
+  return SharedProcess.invoke('ElectronProcess.writeStderr', value)
+}
+
+export const writeStdout = (value) => {
+  return SharedProcess.invoke('ElectronProcess.writeStdout', value)
+}

--- a/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
+++ b/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
@@ -1,0 +1,62 @@
+import * as Command from '../Command/Command.js'
+import * as Exit from '../Exit/Exit.js'
+import * as Process from '../Process/Process.js'
+
+const promptFlag = '--prompt'
+const promptWithValuePrefix = `${promptFlag}=`
+
+export const parsePrompt = (argv) => {
+  for (let index = 1; index < argv.length; index++) {
+    const argument = argv[index]
+    if (argument === promptFlag) {
+      return typeof argv[index + 1] === 'string' ? argv[index + 1] : ''
+    }
+    if (typeof argument === 'string' && argument.startsWith(promptWithValuePrefix)) {
+      return argument.slice(promptWithValuePrefix.length)
+    }
+  }
+  return undefined
+}
+
+export const getPrompt = async () => {
+  const argv = await Process.getArgv()
+  return parsePrompt(argv)
+}
+
+const getFinalAssistantMessage = (task) => {
+  if (!task || !Array.isArray(task.events)) {
+    return ''
+  }
+  for (let index = task.events.length - 1; index >= 0; index--) {
+    const event = task.events[index]
+    if (event?.type === 'assistant-message' && typeof event.text === 'string') {
+      return event.text
+    }
+  }
+  return ''
+}
+
+const getErrorMessage = (error) => {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+export const run = async (prompt) => {
+  try {
+    if (!prompt.trim()) {
+      throw new TypeError('Prompt must be a non-empty string')
+    }
+    await Command.execute('ExtensionHost.executeCommand', 'chat2.createSession')
+    const task = await Command.execute('ExtensionHost.executeCommand', 'chat2.sendMessage', prompt)
+    const finalMessage = getFinalAssistantMessage(task)
+    if (finalMessage) {
+      await Process.writeStdout(`${finalMessage}\n`)
+    }
+    await Exit.exit(0)
+  } catch (error) {
+    await Process.writeStderr(`${getErrorMessage(error)}\n`)
+    await Exit.exit(1)
+  }
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -23,6 +23,7 @@ import * as Performance from '../Performance/Performance.js'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as PromptMode from '../PromptMode/PromptMode.js'
 import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as SaveState from '../SaveState/SaveState.js'
@@ -122,6 +123,8 @@ export const startup = async (platform, assetDir) => {
 
   IpcState.setConfig(initData.Config?.shouldLaunchMultipleWorkers)
 
+  const prompt = platform === PlatformType.Electron ? await PromptMode.getPrompt() : undefined
+
   if (initData.Location.href.includes('?replayId')) {
     const url = new URL(initData.Location.href)
     const replayId = url.searchParams.get('replayId')
@@ -140,7 +143,7 @@ export const startup = async (platform, assetDir) => {
   Performance.mark(PerformanceMarkerType.DidLoadPreferences)
 
   // TODO only load this if session replay is enabled in preferences
-  if (Preferences.get('sessionReplay.enabled')) {
+  if (prompt === undefined && Preferences.get('sessionReplay.enabled')) {
     Performance.mark(PerformanceMarkerType.WillLoadSessionReplay)
     await SessionReplay.startRecording()
     Performance.mark(PerformanceMarkerType.DidLoadSessionReplay)
@@ -157,6 +160,13 @@ export const startup = async (platform, assetDir) => {
   Performance.mark(PerformanceMarkerType.WillOpenWorkspace)
   await Workspace.hydrate(initData.Location)
   Performance.mark(PerformanceMarkerType.DidOpenWorkspace)
+
+  if (prompt !== undefined) {
+    await InstalledWebExtensions.restore()
+    await PromptMode.run(prompt)
+    return
+  }
+
   const isTestRun = Workspace.isTest() || initData.Location.href.includes('/tests/')
 
   await Focus.hydrate()

--- a/packages/renderer-worker/test/PromptMode.test.js
+++ b/packages/renderer-worker/test/PromptMode.test.js
@@ -1,0 +1,74 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Exit/Exit.js', () => ({
+  exit: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Process/Process.js', () => ({
+  getArgv: jest.fn(),
+  writeStderr: jest.fn(),
+  writeStdout: jest.fn(),
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const Exit = await import('../src/parts/Exit/Exit.js')
+const Process = await import('../src/parts/Process/Process.js')
+const PromptMode = await import('../src/parts/PromptMode/PromptMode.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('parsePrompt - separate value', () => {
+  expect(PromptMode.parsePrompt(['/usr/bin/lvce', '--prompt', 'Fix the tests'])).toBe('Fix the tests')
+})
+
+test('parsePrompt - equals value', () => {
+  expect(PromptMode.parsePrompt(['/usr/bin/lvce', '--prompt=Fix the tests'])).toBe('Fix the tests')
+})
+
+test('parsePrompt - absent', () => {
+  expect(PromptMode.parsePrompt(['/usr/bin/lvce', '.'])).toBeUndefined()
+})
+
+test('getPrompt - reads the Electron argv', async () => {
+  // @ts-ignore
+  Process.getArgv.mockResolvedValue(['/usr/bin/lvce', '--prompt', 'Fix the tests'])
+  await expect(PromptMode.getPrompt()).resolves.toBe('Fix the tests')
+})
+
+test('run - executes the headless chat and exits successfully', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce('session-1')
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce({
+    events: [
+      { text: 'Working', type: 'assistant-message' },
+      { status: 'completed', type: 'status' },
+      { text: 'Done', type: 'assistant-message' },
+    ],
+  })
+
+  await PromptMode.run('Fix the tests')
+
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'ExtensionHost.executeCommand', 'chat2.createSession')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'ExtensionHost.executeCommand', 'chat2.sendMessage', 'Fix the tests')
+  expect(Process.writeStdout).toHaveBeenCalledWith('Done\n')
+  expect(Process.writeStderr).not.toHaveBeenCalled()
+  expect(Exit.exit).toHaveBeenCalledWith(0)
+})
+
+test('run - reports failures and exits unsuccessfully', async () => {
+  // @ts-ignore
+  Command.execute.mockRejectedValue(new Error('Model request failed'))
+
+  await PromptMode.run('Fix the tests')
+
+  expect(Process.writeStderr).toHaveBeenCalledWith('Model request failed\n')
+  expect(Process.writeStdout).not.toHaveBeenCalled()
+  expect(Exit.exit).toHaveBeenCalledWith(1)
+})

--- a/packages/shared-process/src/parts/ElectronProcess/ElectronProcess.ipc.ts
+++ b/packages/shared-process/src/parts/ElectronProcess/ElectronProcess.ipc.ts
@@ -3,6 +3,9 @@ import * as ElectronProcess from './ElectronProcess.ts'
 export const name = 'ElectronProcess'
 
 export const Commands = {
+  getArgv: ElectronProcess.getArgv,
   getChromeVersion: ElectronProcess.getChromeVersion,
   getElectronVersion: ElectronProcess.getElectronVersion,
+  writeStderr: ElectronProcess.writeStderr,
+  writeStdout: ElectronProcess.writeStdout,
 }

--- a/packages/shared-process/src/parts/ElectronProcess/ElectronProcess.ts
+++ b/packages/shared-process/src/parts/ElectronProcess/ElectronProcess.ts
@@ -1,9 +1,21 @@
 import * as ParentIpc from '../MainProcess/MainProcess.ts'
 
+export const getArgv = (): any => {
+  return ParentIpc.invoke('Process.getArgv')
+}
+
 export const getElectronVersion = (): any => {
   return ParentIpc.invoke('Process.getElectronVersion')
 }
 
 export const getChromeVersion = (): any => {
   return ParentIpc.invoke('Process.getChromeVersion')
+}
+
+export const writeStderr = (value: string): any => {
+  return ParentIpc.invoke('Process.writeStderr', value)
+}
+
+export const writeStdout = (value: string): any => {
+  return ParentIpc.invoke('Process.writeStdout', value)
 }

--- a/packages/shared-process/src/parts/Exit/Exit.ts
+++ b/packages/shared-process/src/parts/Exit/Exit.ts
@@ -1,5 +1,8 @@
 import * as ParentIpc from '../MainProcess/MainProcess.ts'
 
-export const exit = (): any => {
-  return ParentIpc.invoke('Exit.exit')
+export const exit = (code?: number): any => {
+  if (code === undefined) {
+    return ParentIpc.invoke('Exit.exit')
+  }
+  return ParentIpc.invoke('Exit.exit', code)
 }

--- a/packages/shared-process/src/parts/IsPromptMode/IsPromptMode.ts
+++ b/packages/shared-process/src/parts/IsPromptMode/IsPromptMode.ts
@@ -1,0 +1,6 @@
+const promptFlag = '--prompt'
+const promptWithValuePrefix = `${promptFlag}=`
+
+export const isPromptMode = (argv: readonly string[]): boolean => {
+  return argv.some((argument) => argument === promptFlag || argument.startsWith(promptWithValuePrefix))
+}

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -67,8 +67,11 @@ export const getModuleId = (commandId: any): any => {
     case 'ElectronPowerSaveBlocker.start':
     case 'ElectronPowerSaveBlocker.stop':
       return ModuleId.ElectronPowerSaveBlocker
+    case 'ElectronProcess.getArgv':
     case 'ElectronProcess.getChromeVersion':
     case 'ElectronProcess.getElectronVersion':
+    case 'ElectronProcess.writeStderr':
+    case 'ElectronProcess.writeStdout':
       return ModuleId.ElectronProcess
     case 'ElectronSafeStorage.decryptString':
     case 'ElectronSafeStorage.encryptString':

--- a/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
+++ b/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
@@ -5,6 +5,7 @@ import * as Env from '../Env/Env.ts'
 import * as GetWorkspaceId from '../GetWorkspaceId/GetWorkspaceId.ts'
 import * as IsAbsolutePath from '../IsAbsolutePath/IsAbsolutePath.ts'
 import * as IsElectron from '../IsElectron/IsElectron.ts'
+import * as IsPromptMode from '../IsPromptMode/IsPromptMode.ts'
 import * as ParentIpc from '../MainProcess/MainProcess.ts'
 import * as Platform from '../Platform/Platform.ts'
 import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
@@ -33,7 +34,7 @@ export const resolveRoot = async (): Promise<any> => {
     const argv = await ParentIpc.invoke('Process.getArgv')
     const relevantArgv = argv.slice(1)
     const last = relevantArgv.at(-1)
-    if (last && last === '.') {
+    if (IsPromptMode.isPromptMode(relevantArgv) || (last && last === '.')) {
       const actual = process.cwd()
       return {
         homeDir: PlatformPaths.getHomeDir(),

--- a/packages/shared-process/test/ElectronProcess.test.ts
+++ b/packages/shared-process/test/ElectronProcess.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.ts')
+const ElectronProcess = await import('../src/parts/ElectronProcess/ElectronProcess.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('getArgv', async () => {
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(['/usr/bin/lvce', '--prompt', 'Fix the tests'])
+  await expect(ElectronProcess.getArgv()).resolves.toEqual(['/usr/bin/lvce', '--prompt', 'Fix the tests'])
+  expect(MainProcess.invoke).toHaveBeenCalledWith('Process.getArgv')
+})
+
+test('writeStdout', async () => {
+  await ElectronProcess.writeStdout('Done\n')
+  expect(MainProcess.invoke).toHaveBeenCalledWith('Process.writeStdout', 'Done\n')
+})
+
+test('writeStderr', async () => {
+  await ElectronProcess.writeStderr('Failed\n')
+  expect(MainProcess.invoke).toHaveBeenCalledWith('Process.writeStderr', 'Failed\n')
+})

--- a/packages/shared-process/test/IsPromptMode.test.ts
+++ b/packages/shared-process/test/IsPromptMode.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import * as IsPromptMode from '../src/parts/IsPromptMode/IsPromptMode.ts'
+
+test('isPromptMode - separate prompt value', () => {
+  expect(IsPromptMode.isPromptMode(['--prompt', 'Fix the tests'])).toBe(true)
+})
+
+test('isPromptMode - equals prompt value', () => {
+  expect(IsPromptMode.isPromptMode(['--prompt=Fix the tests'])).toBe(true)
+})
+
+test('isPromptMode - absent', () => {
+  expect(IsPromptMode.isPromptMode(['.'])).toBe(false)
+})

--- a/packages/shared-process/test/ResolveRoot.test.ts
+++ b/packages/shared-process/test/ResolveRoot.test.ts
@@ -41,3 +41,16 @@ test('resolveRoot - resolves dot from development electron arguments', async () 
     uri: pathToFileURL(process.cwd()).toString(),
   })
 })
+
+test('resolveRoot - uses cwd in prompt mode', async () => {
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(['/usr/lib/lvce-oss/lvce-oss', '--prompt', 'Fix the tests'])
+
+  const resolvedRoot = await ResolveRoot.resolveRoot()
+
+  expect(resolvedRoot).toMatchObject({
+    path: process.cwd(),
+    source: 'shared-process-cli-arg',
+    uri: pathToFileURL(process.cwd()).toString(),
+  })
+})


### PR DESCRIPTION
Adds a headless Electron prompt mode for coding-agent benchmarks. The renderer starts the chat extension against the invocation cwd, executes the supplied task through the existing headless chat commands, prints the final assistant response, and exits with an appropriate status code.

Also bundles chat-view-2 1.1.0 so packaged Electron builds expose the required headless commands.