### PR TITLE
fix: complete electron prompt runs

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -20,7 +20,7 @@
   {
     "name": "builtin.chat-view-2",
     "repository": "github.com/lvce-editor/chat-view-2",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "created": "2026-07-14"
   },
   {

--- a/packages/renderer-worker/src/parts/HeadlessLayout/HeadlessLayout.js
+++ b/packages/renderer-worker/src/parts/HeadlessLayout/HeadlessLayout.js
@@ -1,0 +1,7 @@
+import * as Command from '../Command/Command.js'
+import * as Preferences from '../Preferences/Preferences.js'
+import * as Product from '../Product/Product.js'
+
+export const initialize = () => {
+  Command.register('Layout.getBackendUrl', () => Preferences.get('layout.backendUrl') || Product.getBackendUrl())
+}

--- a/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
+++ b/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
@@ -1,6 +1,7 @@
 import * as Command from '../Command/Command.js'
 import * as Exit from '../Exit/Exit.js'
 import * as Process from '../Process/Process.js'
+import * as PromptTrace from '../PromptTrace/PromptTrace.js'
 
 const promptFlag = '--prompt'
 const promptWithValuePrefix = `${promptFlag}=`
@@ -44,19 +45,40 @@ const getErrorMessage = (error) => {
 }
 
 export const run = async (prompt) => {
+  const id = PromptTrace.createId()
+  const startedAt = new Date().toISOString()
+  let errorMessage = ''
+  let result
   try {
     if (!prompt.trim()) {
       throw new TypeError('Prompt must be a non-empty string')
     }
-    await Command.execute('ExtensionHost.executeCommand', 'chat2.createSession')
-    const task = await Command.execute('ExtensionHost.executeCommand', 'chat2.sendMessage', prompt)
-    const finalMessage = getFinalAssistantMessage(task)
+    result = await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', prompt)
+    if (result?.status !== 'completed') {
+      throw new Error(result?.error || 'Chat task failed without an error message')
+    }
+    const finalMessage = getFinalAssistantMessage(result.task)
     if (finalMessage) {
       await Process.writeStdout(`${finalMessage}\n`)
     }
-    await Exit.exit(0)
   } catch (error) {
-    await Process.writeStderr(`${getErrorMessage(error)}\n`)
-    await Exit.exit(1)
+    errorMessage = getErrorMessage(error)
+    await Process.writeStderr(`${errorMessage}\n`)
   }
+  try {
+    const trace = PromptTrace.create({
+      error: errorMessage,
+      finishedAt: new Date().toISOString(),
+      id,
+      prompt,
+      result,
+      startedAt,
+    })
+    const tracePath = await PromptTrace.write(trace)
+    await Process.writeStderr(`Trace: ${tracePath}\n`)
+  } catch (error) {
+    errorMessage ||= getErrorMessage(error)
+    await Process.writeStderr(`Failed to write agent trace: ${getErrorMessage(error)}\n`)
+  }
+  await Exit.exit(errorMessage ? 1 : 0)
 }

--- a/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
+++ b/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
@@ -1,0 +1,36 @@
+import * as FileSystemDisk from '../FileSystem/FileSystemDisk.js'
+import * as Workspace from '../Workspace/Workspace.js'
+
+const join = (separator, left, right) => {
+  return left.endsWith(separator) ? `${left}${right}` : `${left}${separator}${right}`
+}
+
+export const create = ({ error, finishedAt, id, prompt, result, startedAt }) => {
+  return {
+    cwd: Workspace.getPath(),
+    ...(error && { error }),
+    finishedAt,
+    id,
+    messages: Array.isArray(result?.trace) ? result.trace : [],
+    prompt,
+    sessionId: typeof result?.sessionId === 'string' ? result.sessionId : '',
+    status: error ? 'failed' : 'completed',
+    task: result?.task || null,
+    timestamp: startedAt,
+    type: 'agent-trace',
+    version: 1,
+  }
+}
+
+export const createId = () => {
+  return globalThis.crypto.randomUUID()
+}
+
+export const write = async (trace) => {
+  const separator = await FileSystemDisk.getPathSeparator()
+  const directory = join(separator, trace.cwd, '.agent-logs')
+  const path = join(separator, directory, `trace-${trace.id}.json`)
+  await FileSystemDisk.mkdir(directory)
+  await FileSystemDisk.writeFile(path, JSON.stringify(trace, null, 2))
+  return path
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -8,6 +8,7 @@ import * as FileSystemMap from '../FileSystemMap/FileSystemMap.js'
 import * as FileSystemState from '../FileSystemState/FileSystemState.js'
 import * as Focus from '../Focus/Focus.js'
 import * as HasCodeQueryParam from '../HasCodeQueryParam/HasCodeQueryParam.js'
+import * as HeadlessLayout from '../HeadlessLayout/HeadlessLayout.js'
 import * as IconTheme from '../IconTheme/IconTheme.js'
 import * as Id from '../Id/Id.js'
 import * as InstalledWebExtensions from '../InstalledWebExtensions/InstalledWebExtensions.js'
@@ -162,6 +163,7 @@ export const startup = async (platform, assetDir) => {
   Performance.mark(PerformanceMarkerType.DidOpenWorkspace)
 
   if (prompt !== undefined) {
+    HeadlessLayout.initialize()
     await InstalledWebExtensions.restore()
     await PromptMode.run(prompt)
     return

--- a/packages/renderer-worker/test/HeadlessLayout.test.js
+++ b/packages/renderer-worker/test/HeadlessLayout.test.js
@@ -1,0 +1,31 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  register: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  get: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({
+  getBackendUrl: jest.fn(),
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const HeadlessLayout = await import('../src/parts/HeadlessLayout/HeadlessLayout.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+const Product = await import('../src/parts/Product/Product.js')
+
+test('initialize - registers the backend URL command without loading Layout', () => {
+  // @ts-ignore
+  Preferences.get.mockReturnValue('https://configured.example')
+
+  HeadlessLayout.initialize()
+
+  expect(Command.register).toHaveBeenCalledWith('Layout.getBackendUrl', expect.any(Function))
+  // @ts-ignore
+  const getBackendUrl = Command.register.mock.calls[0][1]
+  expect(getBackendUrl()).toBe('https://configured.example')
+  expect(Product.getBackendUrl).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/PromptMode.test.js
+++ b/packages/renderer-worker/test/PromptMode.test.js
@@ -14,13 +14,20 @@ jest.unstable_mockModule('../src/parts/Process/Process.js', () => ({
   writeStdout: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/PromptTrace/PromptTrace.js', () => ({
+  create: jest.fn(() => ({ id: 'trace-1' })),
+  createId: jest.fn(() => 'trace-1'),
+  write: jest.fn(async () => '/workspace/.agent-logs/trace-trace-1.json'),
+}))
+
 const Command = await import('../src/parts/Command/Command.js')
 const Exit = await import('../src/parts/Exit/Exit.js')
 const Process = await import('../src/parts/Process/Process.js')
 const PromptMode = await import('../src/parts/PromptMode/PromptMode.js')
+const PromptTrace = await import('../src/parts/PromptTrace/PromptTrace.js')
 
 beforeEach(() => {
-  jest.resetAllMocks()
+  jest.clearAllMocks()
 })
 
 test('parsePrompt - separate value', () => {
@@ -43,32 +50,58 @@ test('getPrompt - reads the Electron argv', async () => {
 
 test('run - executes the headless chat and exits successfully', async () => {
   // @ts-ignore
-  Command.execute.mockResolvedValueOnce('session-1')
-  // @ts-ignore
   Command.execute.mockResolvedValueOnce({
-    events: [
-      { text: 'Working', type: 'assistant-message' },
-      { status: 'completed', type: 'status' },
-      { text: 'Done', type: 'assistant-message' },
-    ],
+    sessionId: 'session-1',
+    status: 'completed',
+    task: {
+      events: [
+        { text: 'Working', type: 'assistant-message' },
+        { status: 'completed', type: 'status' },
+        { text: 'Done', type: 'assistant-message' },
+      ],
+    },
+    trace: [],
   })
 
   await PromptMode.run('Fix the tests')
 
-  expect(Command.execute).toHaveBeenNthCalledWith(1, 'ExtensionHost.executeCommand', 'chat2.createSession')
-  expect(Command.execute).toHaveBeenNthCalledWith(2, 'ExtensionHost.executeCommand', 'chat2.sendMessage', 'Fix the tests')
+  expect(Command.execute).toHaveBeenCalledWith('ExtensionHost.executeCommand', 'chat2.runPrompt', 'Fix the tests')
   expect(Process.writeStdout).toHaveBeenCalledWith('Done\n')
-  expect(Process.writeStderr).not.toHaveBeenCalled()
+  expect(Process.writeStderr).toHaveBeenCalledWith('Trace: /workspace/.agent-logs/trace-trace-1.json\n')
+  expect(PromptTrace.write).toHaveBeenCalledWith({ id: 'trace-1' })
   expect(Exit.exit).toHaveBeenCalledWith(0)
 })
 
 test('run - reports failures and exits unsuccessfully', async () => {
   // @ts-ignore
-  Command.execute.mockRejectedValue(new Error('Model request failed'))
+  Command.execute.mockResolvedValue({
+    error: 'Model request failed',
+    sessionId: 'session-1',
+    status: 'failed',
+    trace: [],
+  })
 
   await PromptMode.run('Fix the tests')
 
   expect(Process.writeStderr).toHaveBeenCalledWith('Model request failed\n')
+  expect(Process.writeStderr).toHaveBeenCalledWith('Trace: /workspace/.agent-logs/trace-trace-1.json\n')
   expect(Process.writeStdout).not.toHaveBeenCalled()
+  expect(Exit.exit).toHaveBeenCalledWith(1)
+})
+
+test('run - reports trace write failures and exits unsuccessfully', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValue({
+    sessionId: 'session-1',
+    status: 'completed',
+    task: { events: [] },
+    trace: [],
+  })
+  // @ts-ignore
+  PromptTrace.write.mockRejectedValue(new Error('Workspace is read-only'))
+
+  await PromptMode.run('Fix the tests')
+
+  expect(Process.writeStderr).toHaveBeenCalledWith('Failed to write agent trace: Workspace is read-only\n')
   expect(Exit.exit).toHaveBeenCalledWith(1)
 })

--- a/packages/renderer-worker/test/PromptTrace.test.js
+++ b/packages/renderer-worker/test/PromptTrace.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystemDisk.js', () => ({
+  getPathSeparator: jest.fn(),
+  mkdir: jest.fn(),
+  writeFile: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
+  getPath: jest.fn(),
+}))
+
+const FileSystemDisk = await import('../src/parts/FileSystem/FileSystemDisk.js')
+const PromptTrace = await import('../src/parts/PromptTrace/PromptTrace.js')
+const Workspace = await import('../src/parts/Workspace/Workspace.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  // @ts-ignore
+  FileSystemDisk.getPathSeparator.mockResolvedValue('/')
+  // @ts-ignore
+  Workspace.getPath.mockReturnValue('/workspace')
+})
+
+test('create - creates a Pi-inspired completed trace object', () => {
+  const trace = PromptTrace.create({
+    error: '',
+    finishedAt: '2026-07-14T00:01:00.000Z',
+    id: 'trace-id',
+    prompt: 'Fix the tests',
+    result: {
+      sessionId: 'session-1',
+      task: { id: 'task-1' },
+      trace: [{ content: 'Fix the tests', role: 'user', timestamp: 1 }],
+    },
+    startedAt: '2026-07-14T00:00:00.000Z',
+  })
+
+  expect(trace).toEqual({
+    cwd: '/workspace',
+    finishedAt: '2026-07-14T00:01:00.000Z',
+    id: 'trace-id',
+    messages: [{ content: 'Fix the tests', role: 'user', timestamp: 1 }],
+    prompt: 'Fix the tests',
+    sessionId: 'session-1',
+    status: 'completed',
+    task: { id: 'task-1' },
+    timestamp: '2026-07-14T00:00:00.000Z',
+    type: 'agent-trace',
+    version: 1,
+  })
+})
+
+test('write - writes formatted JSON below the workspace', async () => {
+  const trace = { cwd: '/workspace', id: 'trace-id' }
+
+  await expect(PromptTrace.write(trace)).resolves.toBe('/workspace/.agent-logs/trace-trace-id.json')
+  expect(FileSystemDisk.mkdir).toHaveBeenCalledWith('/workspace/.agent-logs')
+  expect(FileSystemDisk.writeFile).toHaveBeenCalledWith(
+    '/workspace/.agent-logs/trace-trace-id.json',
+    JSON.stringify(trace, null, 2),
+  )
+})


### PR DESCRIPTION
Fixes headless prompt execution by providing the backend URL command without loading Layout UI. Runs the bundled Chat 2 structured prompt command and saves a Pi-inspired JSON trace with task events, tool calls, arguments, results, verification output, and failures under the workspace.