### PR TITLE
fix: create layout in prompt mode

### DIFF
--- a/packages/renderer-worker/src/parts/HeadlessLayout/HeadlessLayout.js
+++ b/packages/renderer-worker/src/parts/HeadlessLayout/HeadlessLayout.js
@@ -1,7 +1,21 @@
-import * as Command from '../Command/Command.js'
-import * as Preferences from '../Preferences/Preferences.js'
-import * as Product from '../Product/Product.js'
+import * as Id from '../Id/Id.js'
+import * as ViewletManager from '../ViewletManager/ViewletManager.js'
+import * as ViewletModule from '../ViewletModule/ViewletModule.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
-export const initialize = () => {
-  Command.register('Layout.getBackendUrl', () => Preferences.get('layout.backendUrl') || Product.getBackendUrl())
+export const initialize = async (initData) => {
+  const uid = Id.create()
+  const viewlet = {
+    disposed: false,
+    focus: false,
+    getModule: ViewletModule.load,
+    id: ViewletModuleId.Layout,
+    render: false,
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid,
+    uri: '',
+  }
+  await ViewletManager.load(viewlet, false, false, { ...initData, restore: false })
 }

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -163,7 +163,8 @@ export const startup = async (platform, assetDir) => {
   Performance.mark(PerformanceMarkerType.DidOpenWorkspace)
 
   if (prompt !== undefined) {
-    HeadlessLayout.initialize()
+    await HeadlessLayout.initialize(initData)
+    await Command.execute('Layout.setAuthState', authState)
     await InstalledWebExtensions.restore()
     await PromptMode.run(prompt)
     return

--- a/packages/renderer-worker/test/HeadlessLayout.test.js
+++ b/packages/renderer-worker/test/HeadlessLayout.test.js
@@ -1,31 +1,46 @@
 import { expect, jest, test } from '@jest/globals'
 
-jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
-  register: jest.fn(),
+jest.unstable_mockModule('../src/parts/Id/Id.js', () => ({
+  create: jest.fn(() => 42),
 }))
 
-jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
-  get: jest.fn(),
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => ({
+  load: jest.fn(),
 }))
 
-jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({
-  getBackendUrl: jest.fn(),
+jest.unstable_mockModule('../src/parts/ViewletModule/ViewletModule.js', () => ({
+  load: jest.fn(),
 }))
 
-const Command = await import('../src/parts/Command/Command.js')
 const HeadlessLayout = await import('../src/parts/HeadlessLayout/HeadlessLayout.js')
-const Preferences = await import('../src/parts/Preferences/Preferences.js')
-const Product = await import('../src/parts/Product/Product.js')
+const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const ViewletModule = await import('../src/parts/ViewletModule/ViewletModule.js')
 
-test('initialize - registers the backend URL command without loading Layout', () => {
+test('initialize - creates Layout without rendering child components', async () => {
+  const initData = {
+    Layout: {
+      bounds: {
+        windowHeight: 768,
+        windowWidth: 1024,
+      },
+    },
+  }
+
+  await HeadlessLayout.initialize(initData)
+
+  const expectedViewlet = {
+    disposed: false,
+    focus: false,
+    getModule: ViewletModule.load,
+    id: 'Layout',
+    render: false,
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid: 42,
+    uri: '',
+  }
+  expect(ViewletManager.load).toHaveBeenCalledTimes(1)
   // @ts-ignore
-  Preferences.get.mockReturnValue('https://configured.example')
-
-  HeadlessLayout.initialize()
-
-  expect(Command.register).toHaveBeenCalledWith('Layout.getBackendUrl', expect.any(Function))
-  // @ts-ignore
-  const getBackendUrl = Command.register.mock.calls[0][1]
-  expect(getBackendUrl()).toBe('https://configured.example')
-  expect(Product.getBackendUrl).not.toHaveBeenCalled()
+  expect(ViewletManager.load.mock.calls[0]).toEqual([expectedViewlet, false, false, { ...initData, restore: false }])
 })


### PR DESCRIPTION
Creates a non-rendered Layout instance during Electron prompt startup so extensions can call Layout APIs such as Layout.getBackendUrl without loading workbench child components.