### PR TITLE
feature: add prompt file sandbox flags

### DIFF
--- a/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
+++ b/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
@@ -5,6 +5,22 @@ import * as PromptTrace from '../PromptTrace/PromptTrace.js'
 
 const promptFlag = '--prompt'
 const promptWithValuePrefix = `${promptFlag}=`
+const allowReadFlag = '--allow-read'
+const allowWriteFlag = '--allow-write'
+
+const parseFlagValue = (argv, flag) => {
+  const prefix = `${flag}=`
+  for (let index = 1; index < argv.length; index++) {
+    const argument = argv[index]
+    if (argument === flag) {
+      return typeof argv[index + 1] === 'string' ? argv[index + 1] : ''
+    }
+    if (typeof argument === 'string' && argument.startsWith(prefix)) {
+      return argument.slice(prefix.length)
+    }
+  }
+  return undefined
+}
 
 export const parsePrompt = (argv) => {
   for (let index = 1; index < argv.length; index++) {
@@ -22,6 +38,42 @@ export const parsePrompt = (argv) => {
 export const getPrompt = async () => {
   const argv = await Process.getArgv()
   return parsePrompt(argv)
+}
+
+export const parsePromptOptions = (argv) => {
+  const prompt = parsePrompt(argv)
+  if (prompt === undefined) {
+    return undefined
+  }
+  const allowReadRoot = parseFlagValue(argv, allowReadFlag)
+  const allowWriteRoot = parseFlagValue(argv, allowWriteFlag)
+  return {
+    ...(allowReadRoot !== undefined && { allowReadRoot }),
+    ...(allowWriteRoot !== undefined && { allowWriteRoot }),
+    prompt,
+  }
+}
+
+export const getPromptOptions = async () => {
+  const argv = await Process.getArgv()
+  return parsePromptOptions(argv)
+}
+
+const getFileSystemAccess = ({ allowReadRoot, allowWriteRoot }) => {
+  if (allowReadRoot === undefined && allowWriteRoot === undefined) {
+    return undefined
+  }
+  if (allowReadRoot !== undefined && allowReadRoot !== '.') {
+    throw new TypeError('--allow-read currently only supports the workspace root "."')
+  }
+  if (allowWriteRoot !== undefined && allowWriteRoot !== '.') {
+    throw new TypeError('--allow-write currently only supports the workspace root "."')
+  }
+  return {
+    allowRead: allowReadRoot === '.' || allowWriteRoot === '.',
+    allowWrite: allowWriteRoot === '.',
+    root: '.',
+  }
 }
 
 const getFinalAssistantMessage = (task) => {
@@ -44,16 +96,22 @@ const getErrorMessage = (error) => {
   return String(error)
 }
 
-export const run = async (prompt) => {
+export const run = async (promptOrOptions) => {
+  const options = typeof promptOrOptions === 'string' ? { prompt: promptOrOptions } : promptOrOptions
+  const prompt = options?.prompt
   const id = PromptTrace.createId()
   const startedAt = new Date().toISOString()
   let errorMessage = ''
+  let fileSystemAccess
   let result
   try {
-    if (!prompt.trim()) {
+    if (typeof prompt !== 'string' || !prompt.trim()) {
       throw new TypeError('Prompt must be a non-empty string')
     }
-    result = await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', prompt)
+    fileSystemAccess = getFileSystemAccess(options)
+    result = fileSystemAccess
+      ? await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', prompt, undefined, fileSystemAccess)
+      : await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', prompt)
     if (result?.status !== 'completed') {
       throw new Error(result?.error || 'Chat task failed without an error message')
     }
@@ -69,6 +127,7 @@ export const run = async (prompt) => {
     const trace = PromptTrace.create({
       error: errorMessage,
       finishedAt: new Date().toISOString(),
+      fileSystemAccess,
       id,
       prompt,
       result,

--- a/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
+++ b/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
@@ -5,7 +5,7 @@ const join = (separator, left, right) => {
   return left.endsWith(separator) ? `${left}${right}` : `${left}${separator}${right}`
 }
 
-export const create = ({ error, finishedAt, id, prompt, result, startedAt }) => {
+export const create = ({ error, fileSystemAccess, finishedAt, id, prompt, result, startedAt }) => {
   return {
     cwd: Workspace.getPath(),
     ...(error && { error }),
@@ -14,6 +14,7 @@ export const create = ({ error, finishedAt, id, prompt, result, startedAt }) => 
     messages: Array.isArray(result?.trace) ? result.trace : [],
     prompt,
     sessionId: typeof result?.sessionId === 'string' ? result.sessionId : '',
+    ...(fileSystemAccess && { sandbox: { fileSystem: fileSystemAccess } }),
     status: error ? 'failed' : 'completed',
     task: result?.task || null,
     timestamp: startedAt,

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -124,7 +124,7 @@ export const startup = async (platform, assetDir) => {
 
   IpcState.setConfig(initData.Config?.shouldLaunchMultipleWorkers)
 
-  const prompt = platform === PlatformType.Electron ? await PromptMode.getPrompt() : undefined
+  const promptOptions = platform === PlatformType.Electron ? await PromptMode.getPromptOptions() : undefined
 
   if (initData.Location.href.includes('?replayId')) {
     const url = new URL(initData.Location.href)
@@ -144,7 +144,7 @@ export const startup = async (platform, assetDir) => {
   Performance.mark(PerformanceMarkerType.DidLoadPreferences)
 
   // TODO only load this if session replay is enabled in preferences
-  if (prompt === undefined && Preferences.get('sessionReplay.enabled')) {
+  if (promptOptions === undefined && Preferences.get('sessionReplay.enabled')) {
     Performance.mark(PerformanceMarkerType.WillLoadSessionReplay)
     await SessionReplay.startRecording()
     Performance.mark(PerformanceMarkerType.DidLoadSessionReplay)
@@ -162,11 +162,11 @@ export const startup = async (platform, assetDir) => {
   await Workspace.hydrate(initData.Location)
   Performance.mark(PerformanceMarkerType.DidOpenWorkspace)
 
-  if (prompt !== undefined) {
+  if (promptOptions !== undefined) {
     await HeadlessLayout.initialize(initData)
     await Command.execute('Layout.setAuthState', authState)
     await InstalledWebExtensions.restore()
-    await PromptMode.run(prompt)
+    await PromptMode.run(promptOptions)
     return
   }
 

--- a/packages/renderer-worker/test/PromptMode.test.js
+++ b/packages/renderer-worker/test/PromptMode.test.js
@@ -48,6 +48,24 @@ test('getPrompt - reads the Electron argv', async () => {
   await expect(PromptMode.getPrompt()).resolves.toBe('Fix the tests')
 })
 
+test('parsePromptOptions - reads workspace sandbox flags', () => {
+  expect(PromptMode.parsePromptOptions(['/usr/bin/lvce', '--prompt=Fix the tests', '--allow-read', '.', '--allow-write=.'])).toEqual({
+    allowReadRoot: '.',
+    allowWriteRoot: '.',
+    prompt: 'Fix the tests',
+  })
+})
+
+test('getPromptOptions - reads prompt mode options from the Electron argv', async () => {
+  // @ts-ignore
+  Process.getArgv.mockResolvedValue(['/usr/bin/lvce', '--prompt', 'Inspect files', '--allow-read', '.'])
+
+  await expect(PromptMode.getPromptOptions()).resolves.toEqual({
+    allowReadRoot: '.',
+    prompt: 'Inspect files',
+  })
+})
+
 test('run - executes the headless chat and exits successfully', async () => {
   // @ts-ignore
   Command.execute.mockResolvedValueOnce({
@@ -70,6 +88,53 @@ test('run - executes the headless chat and exits successfully', async () => {
   expect(Process.writeStderr).toHaveBeenCalledWith('Trace: /workspace/.agent-logs/trace-trace-1.json\n')
   expect(PromptTrace.write).toHaveBeenCalledWith({ id: 'trace-1' })
   expect(Exit.exit).toHaveBeenCalledWith(0)
+})
+
+test('run - passes a read-only workspace sandbox to headless chat', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce({
+    sessionId: 'session-1',
+    status: 'completed',
+    task: { events: [] },
+    trace: [],
+  })
+
+  await PromptMode.run({ allowReadRoot: '.', prompt: 'Inspect the tests' })
+
+  const fileSystemAccess = {
+    allowRead: true,
+    allowWrite: false,
+    root: '.',
+  }
+  expect(Command.execute).toHaveBeenCalledWith('ExtensionHost.executeCommand', 'chat2.runPrompt', 'Inspect the tests', undefined, fileSystemAccess)
+  expect(PromptTrace.create).toHaveBeenCalledWith(expect.objectContaining({ fileSystemAccess }))
+  expect(Exit.exit).toHaveBeenCalledWith(0)
+})
+
+test('run - makes workspace write access imply read access', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce({
+    sessionId: 'session-1',
+    status: 'completed',
+    task: { events: [] },
+    trace: [],
+  })
+
+  await PromptMode.run({ allowWriteRoot: '.', prompt: 'Fix the tests' })
+
+  expect(Command.execute).toHaveBeenCalledWith('ExtensionHost.executeCommand', 'chat2.runPrompt', 'Fix the tests', undefined, {
+    allowRead: true,
+    allowWrite: true,
+    root: '.',
+  })
+})
+
+test('run - rejects sandbox roots outside the workspace', async () => {
+  await PromptMode.run({ allowReadRoot: '/tmp', prompt: 'Inspect files' })
+
+  expect(Command.execute).not.toHaveBeenCalled()
+  expect(Process.writeStderr).toHaveBeenCalledWith('--allow-read currently only supports the workspace root "."\n')
+  expect(Exit.exit).toHaveBeenCalledWith(1)
 })
 
 test('run - reports failures and exits unsuccessfully', async () => {

--- a/packages/renderer-worker/test/PromptTrace.test.js
+++ b/packages/renderer-worker/test/PromptTrace.test.js
@@ -27,6 +27,11 @@ test('create - creates a Pi-inspired completed trace object', () => {
     error: '',
     finishedAt: '2026-07-14T00:01:00.000Z',
     id: 'trace-id',
+    fileSystemAccess: {
+      allowRead: true,
+      allowWrite: false,
+      root: '.',
+    },
     prompt: 'Fix the tests',
     result: {
       sessionId: 'session-1',
@@ -42,6 +47,13 @@ test('create - creates a Pi-inspired completed trace object', () => {
     id: 'trace-id',
     messages: [{ content: 'Fix the tests', role: 'user', timestamp: 1 }],
     prompt: 'Fix the tests',
+    sandbox: {
+      fileSystem: {
+        allowRead: true,
+        allowWrite: false,
+        root: '.',
+      },
+    },
     sessionId: 'session-1',
     status: 'completed',
     task: { id: 'task-1' },
@@ -56,8 +68,5 @@ test('write - writes formatted JSON below the workspace', async () => {
 
   await expect(PromptTrace.write(trace)).resolves.toBe('/workspace/.agent-logs/trace-trace-id.json')
   expect(FileSystemDisk.mkdir).toHaveBeenCalledWith('/workspace/.agent-logs')
-  expect(FileSystemDisk.writeFile).toHaveBeenCalledWith(
-    '/workspace/.agent-logs/trace-trace-id.json',
-    JSON.stringify(trace, null, 2),
-  )
+  expect(FileSystemDisk.writeFile).toHaveBeenCalledWith('/workspace/.agent-logs/trace-trace-id.json', JSON.stringify(trace, null, 2))
 })


### PR DESCRIPTION
Adds workspace-scoped file permissions to Electron prompt mode after integrating `builtin.chat-view-2` v1.3.0.

- parses `--allow-read .` and `--allow-write .`
- forwards the normalized policy to `chat2.runPrompt`
- makes write access imply read access
- rejects unsupported roots and records the active sandbox in traces
- preserves current behavior when neither flag is supplied

Validation: renderer type-check; all 228 active renderer suites; focused PromptMode/PromptTrace tests after rebase; changed-file Prettier check. The package-wide XO command reports the existing repository-wide 86k style baseline.