### PR TITLE
feature: test electron cli prompt mode

### DIFF
--- a/packages/main-process/package-lock.json
+++ b/packages/main-process/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "@lvce-editor/main-process": "^6.9.0"
       },
+      "devDependencies": {
+        "electron": "43.1.0"
+      },
       "engines": {
         "node": ">=24"
       }

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -7,6 +7,8 @@
   "main": "src/mainProcessMain.js",
   "type": "module",
   "scripts": {
+    "test": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --detectOpenHandles --forceExit",
+    "test:watch": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --watch",
     "type-check": "tsc"
   },
   "keywords": [],
@@ -20,7 +22,14 @@
   "engines": {
     "node": ">=24"
   },
+  "jest": {
+    "injectGlobals": false,
+    "testEnvironment": "node"
+  },
   "dependencies": {
     "@lvce-editor/main-process": "^6.9.0"
+  },
+  "devDependencies": {
+    "electron": "43.1.0"
   }
 }

--- a/packages/main-process/src/mainProcessMain.js
+++ b/packages/main-process/src/mainProcessMain.js
@@ -3,6 +3,12 @@ import { join } from 'node:path'
 
 const root = process.env.LVCE_ROOT || process.cwd()
 const iconPath = join(root, 'packages', 'build', 'files', 'icon.png')
+const isPromptMode = process.argv.some((argument) => argument === '--prompt' || argument.startsWith('--prompt='))
+
+if (isPromptMode) {
+  console.info = () => {}
+  process.env.NODE_NO_WARNINGS = '1'
+}
 
 app.setName('Lvce Editor')
 app.on('browser-window-created', (_event, window) => {

--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, expect, test } from '@jest/globals'
 import electronPath from 'electron'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
@@ -14,8 +14,28 @@ const mainProcessPath = join(root, 'packages', 'main-process')
 const sharedProcessPath = join(root, 'packages', 'shared-process', 'src', 'sharedProcessMain.ts')
 
 let backendUrl = ''
+let dbusAddress = ''
+let dbusPid = 0
 let server
 let temporaryDirectory = ''
+
+const startDbus = () => {
+  if (process.platform !== 'linux') {
+    return
+  }
+  const result = spawnSync('dbus-daemon', ['--session', '--fork', '--print-address=1', '--print-pid=1', '--syslog-only'], {
+    encoding: 'utf8',
+  })
+  if (result.status !== 0) {
+    throw new Error(`Failed to start D-Bus: ${result.stderr}`)
+  }
+  const [address, pid] = result.stdout.trim().split(/\r?\n/)
+  dbusAddress = address
+  dbusPid = Number(pid)
+  if (!dbusAddress || !Number.isInteger(dbusPid)) {
+    throw new Error('D-Bus did not return a valid address and process id')
+  }
+}
 
 const setCorsHeaders = (request, response) => {
   response.setHeader('Access-Control-Allow-Credentials', 'true')
@@ -54,6 +74,7 @@ const handleRequest = (request, response) => {
 
 beforeAll(async () => {
   temporaryDirectory = await mkdtemp(join(tmpdir(), 'lvce-cli-prompt-'))
+  startDbus()
   server = createServer(handleRequest)
   await new Promise((resolve, reject) => {
     server.once('error', reject)
@@ -71,6 +92,9 @@ afterAll(async () => {
     server.close((error) => (error ? reject(error) : resolve(undefined)))
   })
   await rm(temporaryDirectory, { force: true, recursive: true })
+  if (dbusPid) {
+    process.kill(dbusPid)
+  }
 })
 
 const runElectron = () => {
@@ -78,8 +102,10 @@ const runElectron = () => {
   const env = {
     ...process.env,
     HOME: temporaryDirectory,
+    ...(dbusAddress && { DBUS_SESSION_BUS_ADDRESS: dbusAddress }),
     LVCE_ROOT: root,
     LVCE_SHARED_PROCESS_PATH: sharedProcessPath,
+    NO_AT_BRIDGE: '1',
     XDG_CACHE_HOME: join(temporaryDirectory, 'cache'),
   }
   delete env.ELECTRON_RUN_AS_NODE

--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -97,6 +97,7 @@ afterAll(async () => {
   }
 })
 
+/** @returns {Promise<{code: number | null, signal: NodeJS.Signals | null, stderr: string, stdout: string}>} */
 const runElectron = () => {
   /** @type {NodeJS.ProcessEnv} */
   const env = {
@@ -153,10 +154,9 @@ const runElectron = () => {
 }
 
 test('runs a prompt against the configured backend', async () => {
-  await expect(runElectron()).resolves.toEqual({
-    code: 0,
-    signal: null,
-    stderr: '',
-    stdout: `${expectedOutput}\n`,
-  })
+  const result = await runElectron()
+  expect(result.code).toBe(0)
+  expect(result.signal).toBeNull()
+  expect(result.stderr).toBe('')
+  expect(result.stdout.trim()).toBe(expectedOutput)
 }, 60_000)

--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -1,0 +1,136 @@
+import { afterAll, beforeAll, expect, test } from '@jest/globals'
+import electronPath from 'electron'
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const expectedOutput = 'Mock response'
+const electronExecutable = String(electronPath)
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const mainProcessPath = join(root, 'packages', 'main-process')
+const sharedProcessPath = join(root, 'packages', 'shared-process', 'src', 'sharedProcessMain.ts')
+
+let backendUrl = ''
+let server
+let temporaryDirectory = ''
+
+const setCorsHeaders = (request, response) => {
+  response.setHeader('Access-Control-Allow-Credentials', 'true')
+  response.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  response.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  response.setHeader('Access-Control-Allow-Origin', request.headers.origin || '*')
+}
+
+const handleRequest = (request, response) => {
+  setCorsHeaders(request, response)
+  if (request.method === 'OPTIONS') {
+    response.writeHead(204)
+    response.end()
+    return
+  }
+  if (request.method === 'GET' && request.url === '/v1/models') {
+    response.setHeader('Content-Type', 'application/json')
+    response.end(JSON.stringify({ data: [{ id: 'test-model', label: 'Test Model' }] }))
+    return
+  }
+  if (request.method === 'POST' && request.url === '/v1/responses') {
+    response.setHeader('Content-Type', 'text/event-stream')
+    response.end(
+      [
+        `data: ${JSON.stringify({ delta: expectedOutput, type: 'response.output_text.delta' })}`,
+        '',
+        `data: ${JSON.stringify({ response: { id: 'response-1' }, type: 'response.completed' })}`,
+        '',
+      ].join('\n'),
+    )
+    return
+  }
+  response.writeHead(404)
+  response.end()
+}
+
+beforeAll(async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), 'lvce-cli-prompt-'))
+  server = createServer(handleRequest)
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, 'localhost', () => resolve(undefined))
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Mock backend did not bind to a TCP port')
+  }
+  backendUrl = `http://localhost:${address.port}`
+})
+
+afterAll(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve(undefined)))
+  })
+  await rm(temporaryDirectory, { force: true, recursive: true })
+})
+
+const runElectron = () => {
+  /** @type {NodeJS.ProcessEnv} */
+  const env = {
+    ...process.env,
+    HOME: temporaryDirectory,
+    LVCE_ROOT: root,
+    LVCE_SHARED_PROCESS_PATH: sharedProcessPath,
+    XDG_CACHE_HOME: join(temporaryDirectory, 'cache'),
+  }
+  delete env.ELECTRON_RUN_AS_NODE
+  const electronArguments = [
+    '--disable-logging',
+    '--no-sandbox',
+    `--user-data-dir=${join(temporaryDirectory, 'user-data')}`,
+    mainProcessPath,
+    '--prompt',
+    'test',
+    '--backend-url',
+    backendUrl,
+  ]
+  const command = process.platform === 'linux' ? 'xvfb-run' : electronExecutable
+  const args = process.platform === 'linux' ? ['--auto-servernum', electronExecutable, ...electronArguments] : electronArguments
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: temporaryDirectory,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stderr = ''
+    let stdout = ''
+    const timeout = setTimeout(() => {
+      child.kill()
+      reject(new Error('Electron prompt process did not exit within 45 seconds'))
+    }, 45_000)
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout)
+      resolve({ code, signal, stderr, stdout })
+    })
+  })
+}
+
+test('runs a prompt against the configured backend', async () => {
+  await expect(runElectron()).resolves.toEqual({
+    code: 0,
+    signal: null,
+    stderr: '',
+    stdout: `${expectedOutput}\n`,
+  })
+}, 60_000)

--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url'
 
 const expectedOutput = 'Mock response'
 const electronExecutable = String(electronPath)
+const macOsTaskPolicyError =
+  /^\[\d+:\d+\/\d+\.\d+:ERROR:base\/process\/process_mac\.cc:(?:53|98)\] task_policy_set TASK_(?:CATEGORY|SUPPRESSION)_POLICY: \(os\/kern\) invalid argument \(4\)$/
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const mainProcessPath = join(root, 'packages', 'main-process')
 const sharedProcessPath = join(root, 'packages', 'shared-process', 'src', 'sharedProcessMain.ts')
@@ -35,6 +37,13 @@ const startDbus = () => {
   if (!dbusAddress || !Number.isInteger(dbusPid)) {
     throw new Error('D-Bus did not return a valid address and process id')
   }
+}
+
+const getApplicationStderr = (stderr) => {
+  return stderr
+    .split(/\r?\n/)
+    .filter((line) => !macOsTaskPolicyError.test(line))
+    .join('\n')
 }
 
 const setCorsHeaders = (request, response) => {
@@ -157,6 +166,6 @@ test('runs a prompt against the configured backend', async () => {
   const result = await runElectron()
   expect(result.code).toBe(0)
   expect(result.signal).toBeNull()
-  expect(result.stderr).toBe('')
+  expect(getApplicationStderr(result.stderr)).toBe('')
   expect(result.stdout.trim()).toBe(expectedOutput)
 }, 60_000)

--- a/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
+++ b/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
@@ -7,6 +7,7 @@ const promptFlag = '--prompt'
 const promptWithValuePrefix = `${promptFlag}=`
 const allowReadFlag = '--allow-read'
 const allowWriteFlag = '--allow-write'
+const backendUrlFlag = '--backend-url'
 
 const parseFlagValue = (argv, flag) => {
   const prefix = `${flag}=`
@@ -47,9 +48,11 @@ export const parsePromptOptions = (argv) => {
   }
   const allowReadRoot = parseFlagValue(argv, allowReadFlag)
   const allowWriteRoot = parseFlagValue(argv, allowWriteFlag)
+  const backendUrl = parseFlagValue(argv, backendUrlFlag)
   return {
     ...(allowReadRoot !== undefined && { allowReadRoot }),
     ...(allowWriteRoot !== undefined && { allowWriteRoot }),
+    ...(backendUrl !== undefined && { backendUrl }),
     prompt,
   }
 }
@@ -134,7 +137,9 @@ export const run = async (promptOrOptions) => {
       startedAt,
     })
     const tracePath = await PromptTrace.write(trace)
-    await Process.writeStderr(`Trace: ${tracePath}\n`)
+    if (errorMessage) {
+      await Process.writeStderr(`Trace: ${tracePath}\n`)
+    }
   } catch (error) {
     errorMessage ||= getErrorMessage(error)
     await Process.writeStderr(`Failed to write agent trace: ${getErrorMessage(error)}\n`)

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -23,6 +23,7 @@ import * as Performance from '../Performance/Performance.js'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as PreferencesState from '../PreferencesState/PreferencesState.js'
 import * as PromptMode from '../PromptMode/PromptMode.js'
 import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
@@ -140,6 +141,9 @@ export const startup = async (platform, assetDir) => {
 
   Performance.mark(PerformanceMarkerType.WillLoadPreferences)
   await Preferences.hydrate()
+  if (promptOptions?.backendUrl) {
+    PreferencesState.set('layout.backendUrl', promptOptions.backendUrl)
+  }
   Performance.mark(PerformanceMarkerType.DidLoadPreferences)
 
   // TODO only load this if session replay is enabled in preferences

--- a/packages/renderer-worker/test/PromptMode.test.js
+++ b/packages/renderer-worker/test/PromptMode.test.js
@@ -48,10 +48,21 @@ test('getPrompt - reads the Electron argv', async () => {
   await expect(PromptMode.getPrompt()).resolves.toBe('Fix the tests')
 })
 
-test('parsePromptOptions - reads workspace sandbox flags', () => {
-  expect(PromptMode.parsePromptOptions(['/usr/bin/lvce', '--prompt=Fix the tests', '--allow-read', '.', '--allow-write=.'])).toEqual({
+test('parsePromptOptions - reads workspace sandbox and backend flags', () => {
+  expect(
+    PromptMode.parsePromptOptions([
+      '/usr/bin/lvce',
+      '--prompt=Fix the tests',
+      '--allow-read',
+      '.',
+      '--allow-write=.',
+      '--backend-url',
+      'http://localhost:3000',
+    ]),
+  ).toEqual({
     allowReadRoot: '.',
     allowWriteRoot: '.',
+    backendUrl: 'http://localhost:3000',
     prompt: 'Fix the tests',
   })
 })
@@ -85,7 +96,7 @@ test('run - executes the headless chat and exits successfully', async () => {
 
   expect(Command.execute).toHaveBeenCalledWith('ExtensionHost.executeCommand', 'chat2.runPrompt', 'Fix the tests')
   expect(Process.writeStdout).toHaveBeenCalledWith('Done\n')
-  expect(Process.writeStderr).toHaveBeenCalledWith('Trace: /workspace/.agent-logs/trace-trace-1.json\n')
+  expect(Process.writeStderr).not.toHaveBeenCalled()
   expect(PromptTrace.write).toHaveBeenCalledWith({ id: 'trace-1' })
   expect(Exit.exit).toHaveBeenCalledWith(0)
 })


### PR DESCRIPTION
Adds a main-process Jest integration test that launches Electron prompt mode against a local mock backend and verifies its exit code and output streams. Also wires the CLI backend override and keeps successful prompt output free of diagnostics.