### PR TITLE
fix: use file uris for workspace storage

### DIFF
--- a/packages/renderer-worker/src/parts/GetStateToSave/GetStateToSave.js
+++ b/packages/renderer-worker/src/parts/GetStateToSave/GetStateToSave.js
@@ -6,9 +6,9 @@ import * as Workspace from '../Workspace/Workspace.js'
 export const getStateToSave = async () => {
   const instances = ViewletStates.getAllInstances()
   const savedInstances = await SerializeViewlet.serializeInstances(instances)
-  const workspacePath = Workspace.getWorkspacePath()
+  const workspaceUri = Workspace.getWorkspaceUri()
   return {
-    instances: GetWorkspaceScopedViewletStates.getWorkspaceScopedViewletStates(savedInstances, workspacePath),
+    instances: GetWorkspaceScopedViewletStates.getWorkspaceScopedViewletStates(savedInstances, workspaceUri),
     mainEditors: [],
     workspace: {
       path: Workspace.state.workspacePath,

--- a/packages/renderer-worker/src/parts/GetViewletStorageKey/GetViewletStorageKey.js
+++ b/packages/renderer-worker/src/parts/GetViewletStorageKey/GetViewletStorageKey.js
@@ -1,8 +1,8 @@
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
-export const getViewletStorageKey = (viewletId, workspacePath) => {
+export const getViewletStorageKey = (viewletId, workspaceUri) => {
   if (viewletId === ViewletModuleId.Layout) {
     return viewletId
   }
-  return `viewlet:${encodeURIComponent(workspacePath || '')}:${viewletId}`
+  return `viewlet:${workspaceUri || ''}:${viewletId}`
 }

--- a/packages/renderer-worker/src/parts/GetWorkspaceScopedViewletStates/GetWorkspaceScopedViewletStates.js
+++ b/packages/renderer-worker/src/parts/GetWorkspaceScopedViewletStates/GetWorkspaceScopedViewletStates.js
@@ -1,9 +1,9 @@
 import * as GetViewletStorageKey from '../GetViewletStorageKey/GetViewletStorageKey.js'
 
-export const getWorkspaceScopedViewletStates = (instances, workspacePath) => {
+export const getWorkspaceScopedViewletStates = (instances, workspaceUri) => {
   const scopedInstances = Object.create(null)
   for (const [viewletId, savedState] of Object.entries(instances)) {
-    const storageKey = GetViewletStorageKey.getViewletStorageKey(viewletId, workspacePath)
+    const storageKey = GetViewletStorageKey.getViewletStorageKey(viewletId, workspaceUri)
     scopedInstances[storageKey] = savedState
   }
   return scopedInstances

--- a/packages/renderer-worker/src/parts/SaveState/SaveState.js
+++ b/packages/renderer-worker/src/parts/SaveState/SaveState.js
@@ -9,7 +9,7 @@ import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as Workspace from '../Workspace/Workspace.js'
 
 const getStorageKey = (viewletId) => {
-  return GetViewletStorageKey.getViewletStorageKey(viewletId, Workspace.getWorkspacePath())
+  return GetViewletStorageKey.getViewletStorageKey(viewletId, Workspace.getWorkspaceUri())
 }
 
 const saveViewletStateAs = async (instanceId, storageId) => {

--- a/packages/renderer-worker/test/GetViewletStorageKey.test.js
+++ b/packages/renderer-worker/test/GetViewletStorageKey.test.js
@@ -2,16 +2,28 @@ import { expect, test } from '@jest/globals'
 import * as GetViewletStorageKey from '../src/parts/GetViewletStorageKey/GetViewletStorageKey.js'
 
 test('namespaces viewlet state by workspace', () => {
-  expect(GetViewletStorageKey.getViewletStorageKey('Explorer', '/home/user/project')).toBe('viewlet:%2Fhome%2Fuser%2Fproject:Explorer')
+  expect(GetViewletStorageKey.getViewletStorageKey('Explorer', 'file:///home/user/project')).toBe('viewlet:file:///home/user/project:Explorer')
 })
 
 test('keeps layout state global', () => {
-  expect(GetViewletStorageKey.getViewletStorageKey('Layout', '/home/user/project')).toBe('Layout')
+  expect(GetViewletStorageKey.getViewletStorageKey('Layout', 'file:///home/user/project')).toBe('Layout')
+})
+
+test('preserves escaped file uri characters', () => {
+  expect(GetViewletStorageKey.getViewletStorageKey('Explorer', 'file:///home/user/my%20project')).toBe(
+    'viewlet:file:///home/user/my%20project:Explorer',
+  )
+})
+
+test('supports windows file uris', () => {
+  expect(GetViewletStorageKey.getViewletStorageKey('Explorer', 'file:///C:/Users/user/project')).toBe(
+    'viewlet:file:///C:/Users/user/project:Explorer',
+  )
 })
 
 test('uses distinct keys for the same viewlet in different workspaces', () => {
-  const first = GetViewletStorageKey.getViewletStorageKey('Main', '/workspace/one')
-  const second = GetViewletStorageKey.getViewletStorageKey('Main', '/workspace/two')
+  const first = GetViewletStorageKey.getViewletStorageKey('Main', 'file:///workspace/one')
+  const second = GetViewletStorageKey.getViewletStorageKey('Main', 'file:///workspace/two')
 
   expect(first).not.toBe(second)
 })

--- a/packages/renderer-worker/test/GetWorkspaceScopedViewletStates.test.js
+++ b/packages/renderer-worker/test/GetWorkspaceScopedViewletStates.test.js
@@ -8,11 +8,11 @@ test('namespaces viewlet states while preserving global layout state', () => {
     Main: { groups: [] },
   }
 
-  const result = GetWorkspaceScopedViewletStates.getWorkspaceScopedViewletStates(instances, '/workspace')
+  const result = GetWorkspaceScopedViewletStates.getWorkspaceScopedViewletStates(instances, 'file:///workspace')
 
   expect(result).toEqual({
-    'viewlet:%2Fworkspace:Explorer': instances.Explorer,
+    'viewlet:file:///workspace:Explorer': instances.Explorer,
     Layout: instances.Layout,
-    'viewlet:%2Fworkspace:Main': instances.Main,
+    'viewlet:file:///workspace:Main': instances.Main,
   })
 })

--- a/packages/renderer-worker/test/SaveState.test.js
+++ b/packages/renderer-worker/test/SaveState.test.js
@@ -14,7 +14,7 @@ jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({
 }))
 
 jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
-  getWorkspacePath: jest.fn(() => '/workspace'),
+  getWorkspaceUri: jest.fn(() => 'file:///workspace'),
   isTest: jest.fn(() => false),
 }))
 
@@ -28,7 +28,7 @@ beforeEach(() => {
 test('saves viewlet state under the current workspace key', async () => {
   await SaveState.saveViewletState('Explorer')
 
-  expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:%2Fworkspace:Explorer', { value: 1 })
+  expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:file:///workspace:Explorer', { value: 1 })
 })
 
 test('saves layout state under its global key', async () => {
@@ -40,11 +40,11 @@ test('saves layout state under its global key', async () => {
 test('saves an instance under a different storage id', async () => {
   await SaveState.saveViewletStateWithStorageId(7, 'SimpleBrowser')
 
-  expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:%2Fworkspace:SimpleBrowser', { value: 1 })
+  expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:file:///workspace:SimpleBrowser', { value: 1 })
 })
 
 test('loads viewlet state from the current workspace key', async () => {
   await SaveState.getSavedViewletState('Main')
 
-  expect(InstanceStorage.getJson).toHaveBeenCalledWith('viewlet:%2Fworkspace:Main')
+  expect(InstanceStorage.getJson).toHaveBeenCalledWith('viewlet:file:///workspace:Main')
 })


### PR DESCRIPTION
Use canonical workspace URIs for workspace-scoped viewlet state keys. This keeps file URI path separators readable instead of encoding them as %2F.