### PR TITLE
fix: default to slime color theme

### DIFF
--- a/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
@@ -62,27 +62,30 @@ export const watch = async (id) => {
 }
 
 const getPreferredColorTheme = () => {
-  const preferredColorTheme = Preferences.get('workbench.colorTheme')
-  return preferredColorTheme
+  return Preferences.get('workbench.colorTheme') || FALLBACK_COLOR_THEME_ID
+}
+
+const applyPreferredColorTheme = async () => {
+  const colorThemeId = getPreferredColorTheme()
+  const error = await applyColorTheme(colorThemeId)
+  if (!error) {
+    return
+  }
+  if (colorThemeId === FALLBACK_COLOR_THEME_ID) {
+    throw error
+  }
+  await ErrorHandling.handleError(error)
+  const fallbackError = await applyColorTheme(FALLBACK_COLOR_THEME_ID)
+  if (fallbackError) {
+    throw fallbackError
+  }
 }
 
 export const reload = async () => {
-  const colorThemeId = getPreferredColorTheme()
-  await applyColorTheme(colorThemeId)
+  await applyPreferredColorTheme()
 }
 
-// TODO test this, and also the error case
 // TODO have icon theme, color theme together (maybe)
 export const hydrate = async () => {
-  const preferredColorTheme = getPreferredColorTheme()
-  const colorThemeId = preferredColorTheme || FALLBACK_COLOR_THEME_ID
-  try {
-    await applyColorTheme(colorThemeId)
-  } catch (error) {
-    if (colorThemeId === FALLBACK_COLOR_THEME_ID) {
-      throw error
-    }
-    ErrorHandling.handleError(error)
-    await applyColorTheme(FALLBACK_COLOR_THEME_ID)
-  }
+  await applyPreferredColorTheme()
 }

--- a/packages/renderer-worker/test/ColorTheme.test.js
+++ b/packages/renderer-worker/test/ColorTheme.test.js
@@ -1,0 +1,50 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  for (const key in Preferences.state) {
+    delete Preferences.state[key]
+  }
+  ColorTheme.state.watchedTheme = ''
+})
+
+jest.unstable_mockModule('../src/parts/Css/Css.js', () => ({
+  addCssStyleSheet: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/ErrorHandling/ErrorHandling.js', () => ({
+  handleError: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/GetColorThemeCss/GetColorThemeCss.js', () => ({
+  getColorThemeCss: jest.fn((colorThemeId) => {
+    if (colorThemeId === 'missing-theme') {
+      throw new Error('Color theme not found')
+    }
+    return `:root { --theme-id: "${colorThemeId}"; }`
+  }),
+}))
+
+const ColorTheme = await import('../src/parts/ColorTheme/ColorTheme.js')
+const Css = await import('../src/parts/Css/Css.js')
+const ErrorHandling = await import('../src/parts/ErrorHandling/ErrorHandling.js')
+const GetColorThemeCss = await import('../src/parts/GetColorThemeCss/GetColorThemeCss.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+
+test('reload applies slime when no color theme is selected', async () => {
+  await ColorTheme.reload()
+
+  expect(GetColorThemeCss.getColorThemeCss).toHaveBeenCalledWith('slime')
+  expect(Css.addCssStyleSheet).toHaveBeenCalledWith('ContributedColorTheme', ':root { --theme-id: "slime"; }')
+})
+
+test('hydrate falls back to slime when the selected color theme cannot be loaded', async () => {
+  Preferences.state['workbench.colorTheme'] = 'missing-theme'
+
+  await ColorTheme.hydrate()
+
+  expect(GetColorThemeCss.getColorThemeCss).toHaveBeenNthCalledWith(1, 'missing-theme')
+  expect(GetColorThemeCss.getColorThemeCss).toHaveBeenNthCalledWith(2, 'slime')
+  expect(ErrorHandling.handleError).toHaveBeenCalledTimes(1)
+  expect(Css.addCssStyleSheet).toHaveBeenCalledWith('ContributedColorTheme', ':root { --theme-id: "slime"; }')
+})


### PR DESCRIPTION
Apply the built-in slime theme whenever no color theme is selected. Also fall back to slime when a saved theme cannot be loaded, avoiding a blank unthemed workbench after reload.