### PR TITLE
fix: register layout runtime commands

### DIFF
--- a/packages/renderer-worker/src/parts/Layout/Layout.ipc.js
+++ b/packages/renderer-worker/src/parts/Layout/Layout.ipc.js
@@ -1,0 +1,8 @@
+import * as Layout from './Layout.js'
+
+export const name = 'Layout'
+
+export const Commands = {
+  getAssetDir: Layout.getAssetDir,
+  getPlatform: Layout.getPlatform,
+}

--- a/packages/renderer-worker/src/parts/Layout/Layout.js
+++ b/packages/renderer-worker/src/parts/Layout/Layout.js
@@ -1,0 +1,10 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as Platform from '../Platform/Platform.js'
+
+export const getAssetDir = () => {
+  return AssetDir.assetDir
+}
+
+export const getPlatform = () => {
+  return Platform.getPlatform()
+}

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -94,6 +94,8 @@ export const load = (moduleId) => {
       return import('../KeyBindings/KeyBindings.ipc.js')
     case ModuleId.KeyBindingsInitial:
       return import('../KeyBindingsInitial/KeyBindingsInitial.ipc.js')
+    case ModuleId.Layout:
+      return import('../Layout/Layout.ipc.js')
     case ModuleId.License:
       return import('../License/License.ipc.js')
     case ModuleId.LaunchIsolatedExtensionHostWorker:

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -107,6 +107,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.KeyBindings
     case 'KeyBindingsInitial':
       return ModuleId.KeyBindingsInitial
+    case 'Layout':
+      return ModuleId.Layout
     case 'LaunchIsolatedExtensionHostWorker':
       return ModuleId.LaunchIsolatedExtensionHostWorker
     case 3444:

--- a/packages/renderer-worker/test/ModuleMap.test.js
+++ b/packages/renderer-worker/test/ModuleMap.test.js
@@ -1,6 +1,8 @@
 import { expect, test } from '@jest/globals'
+import * as Module from '../src/parts/Module/Module.js'
 import * as ModuleId from '../src/parts/ModuleId/ModuleId.js'
 import * as ModuleMap from '../src/parts/ModuleMap/ModuleMap.js'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
 
 test('getModule - not found', () => {
   expect(() => ModuleMap.getModuleId('NotFound.command')).toThrow(new Error('module NotFound not found'))
@@ -9,4 +11,16 @@ test('getModule - not found', () => {
 test('getModule', () => {
   expect(ModuleMap.getModuleId('About.showAbout')).toBe(ModuleId.About)
   expect(ModuleMap.getModuleId('License.openLicense')).toBe(ModuleId.License)
+})
+
+test('getModule - layout runtime context', async () => {
+  const moduleId = ModuleMap.getModuleId('Layout.getAssetDir')
+  const loadedModule = await Module.load(moduleId)
+  const Layout = await import('../src/parts/Layout/Layout.ipc.js')
+
+  expect(moduleId).toBe(ModuleId.Layout)
+  expect(loadedModule).toBe(Layout)
+  expect(Layout.name).toBe('Layout')
+  expect(Layout.Commands.getAssetDir()).toBe('')
+  expect(Layout.Commands.getPlatform()).toBe(PlatformType.Test)
 })


### PR DESCRIPTION
Register the Layout runtime-context commands required by the extension-management worker. This lets built-in color themes resolve the renderer asset directory and platform during startup instead of failing with module Layout not found.