### PR TITLE
feature: enable xterm by default

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
@@ -14,7 +14,6 @@ const runCommand = async (KeyBoard, command) => {
 export const test = async ({ Command, KeyBoard, Locator, Settings, expect }) => {
   await Settings.update({
     'terminal.backend': 'mock',
-    'terminal.renderer': 'xterm',
   })
 
   await Command.execute('Layout.showPanel', 'Terminals')

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -38,7 +38,7 @@
   "simpleBrowser.suggestions": false,
 
   "terminal.backend": "real",
-  "terminal.renderer": "termterm",
+  "terminal.renderer": "xterm",
   "terminal.separateConnection": false,
 
   "window.titleBarStyle": "custom",


### PR DESCRIPTION
Use the xterm-backed terminal view when the terminal panel opens by default. Update the existing terminal e2e scenario to verify xterm is selected without a renderer preference override.