### PR TITLE
fix: keep preview position while resizing

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1301,16 +1301,13 @@ const getNewStatePointerMovePanel = async (state: LayoutState, x: number, y: num
   }
 }
 
-const getNewStatePointerMovePreview = async (state: LayoutState, x: number, y: number): Promise<{ newState: LayoutState; commands: any[] }> => {
-  const windowHeight = state.windowHeight
+const getNewStatePointerMovePreview = async (state: LayoutState, x: number): Promise<{ newState: LayoutState; commands: any[] }> => {
   const windowWidth = state.windowWidth
   return {
     newState: {
       ...state,
       previewLeft: x,
-      previewTop: y,
       previewWidth: windowWidth - x,
-      previewHeight: windowHeight - y,
     },
     commands: [],
   }
@@ -1330,7 +1327,7 @@ const getNewStatePointerMove = async (
     case SashType.Panel:
       return getNewStatePointerMovePanel(state, x, y)
     case SashType.Preview:
-      return getNewStatePointerMovePreview(state, x, y)
+      return getNewStatePointerMovePreview(state, x)
     case SashType.ActivityBar:
       return getNewStatePointerMoveActivityBar(state, x, y)
     default:

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.js
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.js
@@ -219,6 +219,32 @@ test('showPreview replaces an open file preview with the simple browser', async 
   })
 })
 
+test('resizing the preview preserves its vertical position', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    previewHeight: 745,
+    previewId: 7,
+    previewLeft: 800,
+    previewTop: 35,
+    previewUri: 'simple-browser://',
+    previewViewletId: 'SimpleBrowser',
+    previewVisible: true,
+    previewWidth: 400,
+    sashId: 'Preview',
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const result = await ViewletLayout.handleSashPointerMove(state, 700, 400)
+
+  expect(result.newState).toMatchObject({
+    previewHeight: 745,
+    previewLeft: 700,
+    previewTop: 35,
+    previewWidth: 500,
+  })
+})
+
 test('hidePreview disables preview sash', async () => {
   const state = {
     ...ViewletLayout.create(1),


### PR DESCRIPTION
Fix preview-area resizing so the vertical sash only changes horizontal bounds. Preserve the simple browser's top position and height when the pointer moves vertically during a drag, with regression coverage.