### PR TITLE
fix: update cli prompt websocket mock

### DIFF
--- a/packages/main-process/package-lock.json
+++ b/packages/main-process/package-lock.json
@@ -12,7 +12,8 @@
         "@lvce-editor/main-process": "^6.9.0"
       },
       "devDependencies": {
-        "electron": "43.1.0"
+        "electron": "43.1.0",
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=24"
@@ -175,6 +176,28 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -30,6 +30,7 @@
     "@lvce-editor/main-process": "^6.9.0"
   },
   "devDependencies": {
-    "electron": "43.1.0"
+    "electron": "43.1.0",
+    "ws": "^8.21.0"
   }
 }

--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -6,6 +6,7 @@ import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { WebSocketServer } from 'ws'
 
 const expectedOutput = 'Mock response'
 const electronExecutable = String(electronPath)
@@ -20,6 +21,7 @@ let dbusAddress = ''
 let dbusPid = 0
 let server
 let temporaryDirectory = ''
+let webSocketServer
 
 const startDbus = () => {
   if (process.platform !== 'linux') {
@@ -85,6 +87,13 @@ beforeAll(async () => {
   temporaryDirectory = await mkdtemp(join(tmpdir(), 'lvce-cli-prompt-'))
   startDbus()
   server = createServer(handleRequest)
+  webSocketServer = new WebSocketServer({ server })
+  webSocketServer.on('connection', (socket) => {
+    socket.once('message', () => {
+      socket.send(JSON.stringify({ delta: expectedOutput, type: 'response.output_text.delta' }))
+      socket.send(JSON.stringify({ response: { id: 'response-1' }, type: 'response.completed' }))
+    })
+  })
   await new Promise((resolve, reject) => {
     server.once('error', reject)
     server.listen(0, 'localhost', () => resolve(undefined))
@@ -97,6 +106,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  await new Promise((resolve) => webSocketServer.close(resolve))
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve(undefined)))
   })


### PR DESCRIPTION
Update the CLI prompt integration test backend to serve the current WebSocket response protocol. This fixes the tag release workflow, which was still mocking the previous HTTP/SSE transport.\n\nVerification:\n- npm test -- --runInBand CliPrompt.test.js\n- npm run type-check (packages/main-process)\n- npm run lint