### PR TITLE
fix: improve ayu keybindings contrast

### DIFF
--- a/static/css/parts/ViewletKeyBindings.css
+++ b/static/css/parts/ViewletKeyBindings.css
@@ -1,5 +1,5 @@
 :root {
-  --KeyBindingsEditorColor: #e1e2de;
+  --KeyBindingsEditorColor: var(--WorkbenchForeground, #e1e2de);
 }
 
 .KeyBindings {


### PR DESCRIPTION
Uses the active workbench foreground for the keybindings editor so Ayu no longer renders pale text on its light background.