### PR TITLE
fix: spawn JavaScript language servers with Node

### DIFF
--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { basename } from 'node:path'
+import { basename, extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { LanguageServerMessageParser } from '../LanguageServerMessageParser/LanguageServerMessageParser.ts'
 import {
@@ -41,6 +41,21 @@ export interface LanguageServerConnectionOptions {
   readonly uri: string
 }
 
+const getSpawnOptions = (uri: string, argv: readonly string[]): { readonly args: readonly string[]; readonly command: string } => {
+  const executablePath = fileURLToPath(uri)
+  const extension = extname(executablePath).toLowerCase()
+  if (extension === '.js' || extension === '.mjs' || extension === '.cjs') {
+    return {
+      args: [executablePath, ...argv],
+      command: process.execPath,
+    }
+  }
+  return {
+    args: argv,
+    command: executablePath,
+  }
+}
+
 const getPosition = (text: string, offset: number): { readonly character: number; readonly line: number } => {
   const safeOffset = Math.max(0, Math.min(offset, text.length))
   const before = text.slice(0, safeOffset)
@@ -73,7 +88,8 @@ export class LanguageServerConnection {
 
   constructor({ argv, rootUri, uri }: LanguageServerConnectionOptions) {
     this.rootUri = rootUri
-    this.child = spawn(fileURLToPath(uri), [...argv], {
+    const { args, command } = getSpawnOptions(uri, argv)
+    this.child = spawn(command, [...args], {
       stdio: ['pipe', 'pipe', 'pipe'],
     })
     this.child.stdout.on('data', (chunk: Buffer) => {

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -33,3 +33,19 @@ test('complete starts a stdio language server and synchronizes documents', async
     }),
   ).resolves.toEqual([{ insertText: 'fixtureCompletion', kind: 6, label: 'fixtureCompletion:console' }])
 })
+
+test('complete starts a JavaScript language server', async () => {
+  const options = {
+    argv: [],
+    id: 'sample.javascript-fixture',
+    offset: 3,
+    textDocument: {
+      languageId: 'typescript',
+      text: 'con',
+      uri: '/tmp/sample.ts',
+    },
+    uri: pathToFileURL(serverScript).href,
+  }
+
+  await expect(complete(options)).resolves.toEqual([{ insertText: 'fixtureCompletion', kind: 6, label: 'fixtureCompletion:con' }])
+})


### PR DESCRIPTION
## Summary\n\n- run JavaScript language server entrypoints through the current Node executable\n- preserve direct spawning for native language server executables\n- add an integration test using a non-executable JavaScript server fixture\n\n## Verification\n\n- `npm test -- --runInBand LanguageServer.test.ts` in `packages/shared-process`\n- `npm run type-check` in `packages/shared-process`\n- `npm run lint -- --max-warnings=0`