### PR TITLE
feature: support language server diagnostics

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -4,4 +4,5 @@ export const name = 'LanguageServer'
 
 export const Commands = {
   complete: LanguageServer.complete,
+  diagnostic: LanguageServer.diagnostic,
 }

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -16,6 +16,13 @@ export interface CompleteOptions {
   readonly uri: string
 }
 
+export interface DiagnosticOptions {
+  readonly argv: readonly string[]
+  readonly id: string
+  readonly textDocument: TextDocument
+  readonly uri: string
+}
+
 interface ConnectionState {
   readonly argv: readonly string[]
   readonly connection: LanguageServerConnection
@@ -68,6 +75,16 @@ export const complete = async ({ argv, id, offset, textDocument, uri }: Complete
   const rootUri = getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${rootUri}`, uri, argv, rootUri)
   return connection.complete(normalizedDocument, offset)
+}
+
+export const diagnostic = async ({ argv, id, textDocument, uri }: DiagnosticOptions): Promise<readonly unknown[]> => {
+  const normalizedDocument = {
+    ...textDocument,
+    uri: normalizeDocumentUri(textDocument.uri),
+  }
+  const rootUri = getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${rootUri}`, uri, argv, rootUri)
+  return connection.diagnostic(normalizedDocument)
 }
 
 export const disposeAll = (): void => {

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -144,6 +144,21 @@ export class LanguageServerConnection {
     return []
   }
 
+  async diagnostic(textDocument: TextDocument): Promise<readonly unknown[]> {
+    await this.ready
+    this.configureMarkdown(textDocument.languageId)
+    this.syncDocument(textDocument)
+    const result = await this.sendRequest('textDocument/diagnostic', {
+      textDocument: {
+        uri: textDocument.uri,
+      },
+    })
+    if (result && typeof result === 'object' && Array.isArray((result as { readonly items?: unknown }).items)) {
+      return (result as { readonly items: readonly unknown[] }).items
+    }
+    return []
+  }
+
   private configureMarkdown(languageId: string): void {
     if (languageId !== 'markdown' || this.markdownConfigured) {
       return
@@ -166,7 +181,24 @@ export class LanguageServerConnection {
             },
           },
           validate: {
-            enabled: false,
+            duplicateLinkDefinitions: {
+              enabled: 'warning',
+            },
+            enabled: true,
+            fileLinks: {
+              enabled: 'warning',
+              markdownFragmentLinks: 'inherit',
+            },
+            fragmentLinks: {
+              enabled: 'warning',
+            },
+            ignoredLinks: [],
+            referenceLinks: {
+              enabled: 'warning',
+            },
+            unusedLinkDefinitions: {
+              enabled: 'warning',
+            },
           },
         },
       },
@@ -181,6 +213,10 @@ export class LanguageServerConnection {
             completionItem: {
               snippetSupport: true,
             },
+          },
+          diagnostic: {
+            dynamicRegistration: false,
+            relatedDocumentSupport: false,
           },
           synchronization: {
             didSave: true,

--- a/packages/shared-process/src/parts/MarkdownLanguageServerRequest/MarkdownLanguageServerRequest.ts
+++ b/packages/shared-process/src/parts/MarkdownLanguageServerRequest/MarkdownLanguageServerRequest.ts
@@ -27,6 +27,8 @@ export const isMarkdownLanguageServerRequest = (method: string): boolean => {
     method === 'markdown/fs/readFile' ||
     method === 'markdown/fs/readDirectory' ||
     method === 'markdown/fs/stat' ||
+    method === 'markdown/fs/watcher/create' ||
+    method === 'markdown/fs/watcher/delete' ||
     method === 'markdown/findMarkdownFilesInWorkspace'
   )
 }
@@ -92,6 +94,9 @@ export const executeMarkdownLanguageServerRequest = async (
   }
   if (method === 'markdown/findMarkdownFilesInWorkspace') {
     return findMarkdownFiles(getWorkspacePath(context.rootUri, context.rootUri))
+  }
+  if (method === 'markdown/fs/watcher/create' || method === 'markdown/fs/watcher/delete') {
+    return null
   }
   if (!params.uri) {
     throw new Error(`Markdown file request is missing a uri`)

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -248,6 +248,7 @@ export const getModuleId = (commandId: any): any => {
     case 'IsAutoUpdateSupported.isAutoUpdateSupported':
       return ModuleId.IsAutoUpdateSupported
     case 'LanguageServer.complete':
+    case 'LanguageServer.diagnostic':
       return ModuleId.LanguageServer
     case 'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage':
       return ModuleId.ListProcessesWithMemoryUsage

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { complete, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
+import { complete, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
 
@@ -48,4 +48,28 @@ test('complete starts a JavaScript language server', async () => {
   }
 
   await expect(complete(options)).resolves.toEqual([{ insertText: 'fixtureCompletion', kind: 6, label: 'fixtureCompletion:con' }])
+})
+
+test('diagnostic starts a stdio language server and synchronizes documents', async () => {
+  const options = {
+    argv: [serverScript],
+    id: 'sample.fixture',
+    textDocument: {
+      languageId: 'markdown',
+      text: '[link][missing]',
+      uri: '/tmp/README.md',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+
+  await expect(diagnostic(options)).resolves.toEqual([
+    {
+      message: 'fixtureDiagnostic:[link][missing]',
+      range: {
+        end: { character: 3, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+      severity: 2,
+    },
+  ])
 })

--- a/packages/shared-process/test/MarkdownLanguageServerRequest.test.ts
+++ b/packages/shared-process/test/MarkdownLanguageServerRequest.test.ts
@@ -14,7 +14,14 @@ const context = {
 
 test('recognizes Markdown language server requests', () => {
   expect(isMarkdownLanguageServerRequest('markdown/parse')).toBe(true)
+  expect(isMarkdownLanguageServerRequest('markdown/fs/watcher/create')).toBe(true)
+  expect(isMarkdownLanguageServerRequest('markdown/fs/watcher/delete')).toBe(true)
   expect(isMarkdownLanguageServerRequest('workspace/configuration')).toBe(false)
+})
+
+test('acknowledges Markdown file watcher requests', async () => {
+  await expect(executeMarkdownLanguageServerRequest('markdown/fs/watcher/create', {}, context)).resolves.toBeNull()
+  await expect(executeMarkdownLanguageServerRequest('markdown/fs/watcher/delete', {}, context)).resolves.toBeNull()
 })
 
 test('parses the current in-memory Markdown document', async () => {

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -31,6 +31,27 @@ const handleMessage = (message) => {
         items: [{ insertText: 'fixtureCompletion', kind: 6, label: `fixtureCompletion:${text}` }],
       },
     })
+    return
+  }
+  if (message.method === 'textDocument/diagnostic') {
+    const text = documents.get(message.params.textDocument.uri)
+    send({
+      id: message.id,
+      jsonrpc: '2.0',
+      result: {
+        items: [
+          {
+            message: `fixtureDiagnostic:${text}`,
+            range: {
+              end: { character: 3, line: 0 },
+              start: { character: 0, line: 0 },
+            },
+            severity: 2,
+          },
+        ],
+        kind: 'full',
+      },
+    })
   }
 }
 


### PR DESCRIPTION
Adds pull-diagnostic requests to native language-server connections, including Markdown validation and file-watcher protocol support.