### PR TITLE
feature: support extension detail tab titles

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -420,6 +420,7 @@ export const commandMap = {
   'Viewlet.focus': lazy('Viewlet.focus'),
   'Viewlet.resize': lazy('Viewlet.resize'),
   'Viewlet.getAllStates': lazy('Viewlet.getAllStates'),
+  'Viewlet.getTitle': lazy('Viewlet.getTitle'),
   'Viewlet.openWidget': lazy('Viewlet.openWidget'),
   'Viewlet.send': lazy('Viewlet.send'),
   'ViewletDebugConsole.clear': lazy('ViewletDebugConsole.clear'),

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
@@ -8,6 +8,7 @@ export const Commands = {
   executeViewletCommand: Viewlet.executeViewletCommand,
   focus: Viewlet.focus,
   getAllStates: Viewlet.getAllStates,
+  getTitle: Viewlet.getTitle,
   openWidget: Viewlet.openWidget,
   send: Viewlet.send,
   dispose: Viewlet.dispose,

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -18,6 +18,14 @@ const getKeyBindingSetId = (instance, fallback) => {
   return instance.moduleId || fallback
 }
 
+export const getTitle = (id) => {
+  const instance = ViewletStates.getInstance(id)
+  if (!instance || typeof instance.factory.getTitle !== 'function') {
+    return undefined
+  }
+  return instance.factory.getTitle(instance.state.uid)
+}
+
 export const focus = async (id) => {
   const instance = ViewletStates.getInstance(id)
   if (!instance) {

--- a/packages/renderer-worker/src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ts
@@ -81,4 +81,8 @@ export const saveState = async (state) => {
   return savedState
 }
 
+export const getTitle = async (uid) => {
+  return ExtensionDetailViewWorker.invoke('ExtensionDetail.renderTitle', uid)
+}
+
 export const hasFunctionalResize = true

--- a/packages/renderer-worker/test/Viewlet.test.js
+++ b/packages/renderer-worker/test/Viewlet.test.js
@@ -65,6 +65,30 @@ test.skip('setState - shouldApplyNewState returns false', () => {
   // }
 })
 
+test('getTitle - no instance', () => {
+  expect(Viewlet.getTitle(2)).toBeUndefined()
+})
+
+test('getTitle - provider has no getTitle function', () => {
+  expect(Viewlet.getTitle(1)).toBeUndefined()
+})
+
+test('getTitle', async () => {
+  const getTitle = jest.fn(async (_uid = 0) => 'Test Title')
+  const state = { uid: 1 }
+  ViewletStates.set(1, {
+    state,
+    renderedState: state,
+    moduleId: 'Layout',
+    factory: {
+      getTitle,
+    },
+  })
+  await expect(Viewlet.getTitle(1)).resolves.toBe('Test Title')
+  expect(getTitle).toHaveBeenCalledTimes(1)
+  expect(getTitle).toHaveBeenCalledWith(1)
+})
+
 test('openWidget - once', async () => {
   // @ts-ignore
   ViewletManager.load.mockImplementation(() => {

--- a/packages/renderer-worker/test/ViewletExtensionDetail.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionDetail.test.js
@@ -22,6 +22,17 @@ jest.unstable_mockModule('../src/parts/ExtensionManagement/ExtensionManagement.j
   }
 })
 
+jest.unstable_mockModule('../src/parts/ExtensionDetailViewWorker/ExtensionDetailViewWorker.js', () => {
+  return {
+    invoke: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+    restart: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/ExtensionManagement/ExtensionManagement.js', () => {
   return {
     getExtension: jest.fn(() => {
@@ -38,6 +49,7 @@ class NodeError extends Error {
 }
 
 const ViewletExtensionDetail = await import('../src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ts')
+const ExtensionDetailViewWorker = await import('../src/parts/ExtensionDetailViewWorker/ExtensionDetailViewWorker.js')
 const ExtensionManagement = await import('../src/parts/ExtensionManagement/ExtensionManagement.js')
 const FileSystem = await import('../src/parts/FileSystem/FileSystem.js')
 
@@ -45,6 +57,14 @@ test('create', () => {
   // @ts-ignore
   const state = ViewletExtensionDetail.create()
   expect(state).toBeDefined()
+})
+
+test('getTitle', async () => {
+  // @ts-ignore
+  ExtensionDetailViewWorker.invoke.mockResolvedValue('Test Extension')
+  await expect(ViewletExtensionDetail.getTitle(42)).resolves.toBe('Test Extension')
+  expect(ExtensionDetailViewWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(ExtensionDetailViewWorker.invoke).toHaveBeenCalledWith('ExtensionDetail.renderTitle', 42)
 })
 
 test.skip('loadContent', async () => {


### PR DESCRIPTION
## Summary
- expose a generic `Viewlet.getTitle` renderer command for providers that support titles
- let the extension detail provider resolve its loaded extension name from the extension detail worker
- keep URI-derived titles as the fallback when a provider has no title

## Validation
- renderer worker focused tests: 8 passed
- renderer worker full suite: 229 suites / 862 tests passed
- renderer worker type-check
- repository lint
- `git diff --check`