### PR TITLE
fix: normalize Windows language server URIs

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -1,6 +1,7 @@
 import { dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { LanguageServerConnection } from '../LanguageServerConnection/LanguageServerConnection.ts'
+import { normalizeLanguageServerDocumentUri } from '../NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
 
 interface TextDocument {
   readonly languageId: string
@@ -30,13 +31,6 @@ interface ConnectionState {
 }
 
 const connections = new Map<string, ConnectionState>()
-
-const normalizeDocumentUri = (uri: string): string => {
-  if (uri.startsWith('/')) {
-    return pathToFileURL(uri).href
-  }
-  return uri
-}
 
 const getRootUri = (documentUri: string): string => {
   if (documentUri.startsWith('file:')) {
@@ -70,7 +64,7 @@ const getConnection = (id: string, uri: string, argv: readonly string[], rootUri
 export const complete = async ({ argv, id, offset, textDocument, uri }: CompleteOptions): Promise<readonly unknown[]> => {
   const normalizedDocument = {
     ...textDocument,
-    uri: normalizeDocumentUri(textDocument.uri),
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
   }
   const rootUri = getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${rootUri}`, uri, argv, rootUri)
@@ -80,7 +74,7 @@ export const complete = async ({ argv, id, offset, textDocument, uri }: Complete
 export const diagnostic = async ({ argv, id, textDocument, uri }: DiagnosticOptions): Promise<readonly unknown[]> => {
   const normalizedDocument = {
     ...textDocument,
-    uri: normalizeDocumentUri(textDocument.uri),
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
   }
   const rootUri = getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${rootUri}`, uri, argv, rootUri)

--- a/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
+++ b/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
@@ -1,0 +1,10 @@
+import { pathToFileURL } from 'node:url'
+
+const windowsFileUriRegex = /^file:\/\/\/([a-z])(?::|%3a)(?=\/|$)/i
+
+export const normalizeLanguageServerDocumentUri = (uri: string): string => {
+  if (uri.startsWith('/')) {
+    return pathToFileURL(uri).href
+  }
+  return uri.replace(windowsFileUriRegex, (_, driveLetter: string) => `file:///${driveLetter.toLowerCase()}%3A`)
+}

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals'
+import { normalizeLanguageServerDocumentUri } from '../src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
+
+test('normalizes an absolute path', () => {
+  expect(normalizeLanguageServerDocumentUri('/tmp/README.md')).toBe('file:///tmp/README.md')
+})
+
+test('normalizes a Windows file URI', () => {
+  expect(normalizeLanguageServerDocumentUri('file:///D:/workspace/README.md')).toBe('file:///d%3A/workspace/README.md')
+})
+
+test('normalizes an encoded Windows file URI', () => {
+  expect(normalizeLanguageServerDocumentUri('file:///D%3A/workspace/README.md')).toBe('file:///d%3A/workspace/README.md')
+})
+
+test('preserves a normalized file URI', () => {
+  expect(normalizeLanguageServerDocumentUri('file:///tmp/README.md')).toBe('file:///tmp/README.md')
+})
+
+test('preserves a non-file URI', () => {
+  expect(normalizeLanguageServerDocumentUri('memfs:///workspace/README.md')).toBe('memfs:///workspace/README.md')
+})

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@jest/globals'
+import { pathToFileURL } from 'node:url'
 import { normalizeLanguageServerDocumentUri } from '../src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
 
 test('normalizes an absolute path', () => {
-  expect(normalizeLanguageServerDocumentUri('/tmp/README.md')).toBe('file:///tmp/README.md')
+  expect(normalizeLanguageServerDocumentUri('/tmp/README.md')).toBe(pathToFileURL('/tmp/README.md').href)
 })
 
 test('normalizes a Windows file URI', () => {


### PR DESCRIPTION
Canonicalizes Windows file URIs before synchronizing them with language servers. This keeps the didOpen URI identical to the URI produced by vscode-uri during pull diagnostics, fixing Markdown diagnostics returning an empty list on Windows.\n\nAdds focused normalization tests and was validated against the real Markdown language server with a file:///D:/ document URI.