### PR TITLE
fix: open extension previews as documents

### DIFF
--- a/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
+++ b/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
@@ -29,8 +29,10 @@ export interface ExtensionView {
   readonly iframe?: ExtensionViewIframe
   readonly kind?: string
   readonly name?: string
+  readonly selector?: readonly string[]
   readonly showSideBarHeader?: boolean
   readonly title: string
+  readonly type?: string
 }
 
 interface ManifestView {
@@ -100,7 +102,15 @@ export const getExtensionViews = async (): Promise<readonly ExtensionView[]> => 
   return mergeCss(views, extensions)
 }
 
-export const getExtensionView = async (id: string): Promise<ExtensionView | undefined> => {
+export const findExtensionView = (views: readonly ExtensionView[], idOrUri: string): ExtensionView | undefined => {
+  const exactMatch = views.find((view) => view.id === idOrUri)
+  if (exactMatch) {
+    return exactMatch
+  }
+  return views.find((view) => view.type === 'preview' && view.selector?.some((selector) => idOrUri.endsWith(selector)))
+}
+
+export const getExtensionView = async (idOrUri: string): Promise<ExtensionView | undefined> => {
   const views = await getExtensionViews()
-  return views.find((view) => view.id === id)
+  return findExtensionView(views, idOrUri)
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -58,7 +58,8 @@ const createContext = (state: ViewletExtensionViewState, savedState: unknown): u
   return {
     state: savedState,
     uid: state.uid,
-    viewId: state.uri,
+    uri: state.uri,
+    viewId: state.viewId,
   }
 }
 
@@ -92,7 +93,7 @@ const getActionsDom = async (state: ViewletExtensionViewState): Promise<readonly
   }
   const actions = (await ExtensionManagementWorker.invoke(
     'Extensions.getViewActions',
-    state.uri,
+    state.viewId,
     state.uid,
     assetDir,
     getPlatform(),
@@ -139,6 +140,7 @@ export const create = (
     title: '',
     uid: id,
     uri,
+    viewId: uri,
     width,
     x,
     y,
@@ -154,19 +156,23 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
   const css = await loadCss(view)
   const cssId = css ? getCssId(view) : ''
   const eventListeners = view.eventListeners || []
+  const stateWithViewId = {
+    ...state,
+    viewId: view.id,
+  }
   if (view.kind === 'virtualDom') {
     const result = await ExtensionManagementWorker.invoke(
       'Extensions.createViewInstance',
-      state.uri,
+      view.id,
       state.uid,
-      createContext(state, savedState),
+      createContext(stateWithViewId, savedState),
       assetDir,
       getPlatform(),
     )
     const createResult = result as CreateViewInstanceResult
     if (createResult.ok === false) {
       return {
-        ...state,
+        ...stateWithViewId,
         actionsDom: [],
         commands: [],
         css,
@@ -180,7 +186,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
     }
     const renderResult = createResult.ok === true ? createResult.result : (result as ViewRenderResult)
     const initialState = {
-      ...state,
+      ...stateWithViewId,
       title,
     }
     const newState = {
@@ -199,7 +205,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
     throw new Error(`view ${state.uri} is missing iframe contribution`)
   }
   return {
-    ...state,
+    ...stateWithViewId,
     actionsDom: [],
     css,
     cssId,
@@ -226,7 +232,7 @@ const dispatchEvent = async (state: ViewletExtensionViewState, event: unknown): 
   if (state.kind !== 'virtualDom') {
     return state
   }
-  const result = await ExtensionManagementWorker.invoke('Extensions.dispatchViewEvent', state.uri, state.uid, event, assetDir, getPlatform())
+  const result = await ExtensionManagementWorker.invoke('Extensions.dispatchViewEvent', state.viewId, state.uid, event, assetDir, getPlatform())
   const newState = renderVirtualDomResult(state, result as ViewRenderResult | undefined)
   return {
     ...newState,
@@ -251,7 +257,7 @@ export const rerender = async (state: ViewletExtensionViewState): Promise<Viewle
   if (state.kind !== 'virtualDom') {
     return state
   }
-  const result = await ExtensionManagementWorker.invoke('Extensions.renderViewInstance', state.uri, state.uid, assetDir, getPlatform())
+  const result = await ExtensionManagementWorker.invoke('Extensions.renderViewInstance', state.viewId, state.uid, assetDir, getPlatform())
   const newState = renderVirtualDomResult(state, result as ViewRenderResult)
   return {
     ...newState,
@@ -310,12 +316,12 @@ export const dispose = async (state: ViewletExtensionViewState): Promise<void> =
   if (state.kind !== 'virtualDom') {
     return
   }
-  await ExtensionManagementWorker.invoke('Extensions.disposeViewInstance', state.uri, state.uid, assetDir, getPlatform())
+  await ExtensionManagementWorker.invoke('Extensions.disposeViewInstance', state.viewId, state.uid, assetDir, getPlatform())
 }
 
 export const saveState = async (state: ViewletExtensionViewState): Promise<unknown> => {
   if (state.kind !== 'virtualDom') {
     return undefined
   }
-  return ExtensionManagementWorker.invoke('Extensions.saveViewInstanceState', state.uri, state.uid, assetDir, getPlatform())
+  return ExtensionManagementWorker.invoke('Extensions.saveViewInstanceState', state.viewId, state.uid, assetDir, getPlatform())
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts
@@ -14,7 +14,8 @@ const getMenuEntries = async (uid: number, props: ContextMenuProps = {}): Promis
   if (!state || typeof state.uri !== 'string' || typeof props.menuId !== 'string') {
     return []
   }
-  return ExtensionManagementWorker.invoke('Extensions.getViewMenuEntries', state.uri, uid, props.menuId, assetDir, getPlatform()) as Promise<
+  const viewId = typeof state.viewId === 'string' ? state.viewId : state.uri
+  return ExtensionManagementWorker.invoke('Extensions.getViewMenuEntries', viewId, uid, props.menuId, assetDir, getPlatform()) as Promise<
     readonly unknown[]
   >
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -18,6 +18,7 @@ export interface ViewletExtensionViewState {
   readonly title: string
   readonly uid: number
   readonly uri: string
+  readonly viewId: string
   readonly width: number
   readonly x: number
   readonly y: number

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -1,5 +1,6 @@
 import * as Path from '../Path/Path.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
 import * as GetWebViews from '../GetWebViews/GetWebViews.ts'
 
 // TODO move this all to extensions
@@ -68,6 +69,11 @@ export const getModuleId = async (uri, opener) => {
   }
   if (uri.endsWith('.css') || uri.endsWith('.json') || uri.endsWith('.js') || uri.endsWith('.ts')) {
     return ViewletModuleId.EditorText
+  }
+
+  const extensionViews = await GetExtensionViews.getExtensionViews()
+  if ((opener && GetExtensionViews.findExtensionView(extensionViews, opener)) || GetExtensionViews.findExtensionView(extensionViews, uri)) {
+    return ViewletModuleId.ExtensionView
   }
 
   // TODO only request webviews once

--- a/packages/renderer-worker/test/GetExtensionViews.test.js
+++ b/packages/renderer-worker/test/GetExtensionViews.test.js
@@ -1,0 +1,32 @@
+import { expect, test } from '@jest/globals'
+import { findExtensionView } from '../src/parts/GetExtensionViews/GetExtensionViews.ts'
+
+const views = [
+  {
+    extensionId: 'builtin.media-preview',
+    icon: '',
+    id: 'builtin.media-preview',
+    selector: ['.png', '.jpg'],
+    title: 'Media Preview',
+    type: 'preview',
+  },
+  {
+    extensionId: 'sample.extension',
+    icon: '',
+    id: 'sample.views.testing',
+    selector: ['.test'],
+    title: 'Testing',
+  },
+]
+
+test('findExtensionView finds a view by id', () => {
+  expect(findExtensionView(views, 'sample.views.testing')?.id).toBe('sample.views.testing')
+})
+
+test('findExtensionView finds preview views by document selector', () => {
+  expect(findExtensionView(views, 'file:///workspace/image.png')?.id).toBe('builtin.media-preview')
+})
+
+test('findExtensionView does not use sidebar view selectors for documents', () => {
+  expect(findExtensionView(views, 'file:///workspace/file.test')).toBeUndefined()
+})

--- a/packages/renderer-worker/test/ViewletExtensionView.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionView.test.js
@@ -34,6 +34,7 @@ const createState = () => {
     title: 'Testing',
     uid: 1,
     uri: 'sample.views.testing',
+    viewId: 'sample.views.testing',
     width: 100,
     x: 0,
     y: 0,

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.js
@@ -122,6 +122,28 @@ test('loadContent stores virtual dom without duplicate commands', async () => {
   expect(newState.patches).toEqual([])
 })
 
+test('loadContent opens a document view with its contributed id and resource uri', async () => {
+  const state = ViewletExtensionView.create(1, 'file:///workspace/image.png', 0, 0, 100, 100)
+
+  const newState = await ViewletExtensionView.loadContent(state, undefined)
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith(
+    'Extensions.createViewInstance',
+    'sample.views.testing',
+    1,
+    {
+      state: undefined,
+      uid: 1,
+      uri: 'file:///workspace/image.png',
+      viewId: 'sample.views.testing',
+    },
+    '',
+    4,
+  )
+  expect(newState.uri).toBe('file:///workspace/image.png')
+  expect(newState.viewId).toBe('sample.views.testing')
+})
+
 test('renderEventListeners includes extension view listeners', () => {
   const state = {
     ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),

--- a/packages/renderer-worker/test/ViewletMap.test.js
+++ b/packages/renderer-worker/test/ViewletMap.test.js
@@ -1,6 +1,12 @@
-import { expect, test } from '@jest/globals'
-import * as ViewletMap from '../src/parts/ViewletMap/ViewletMap.js'
-import * as ViewletModuleId from '../src/parts/ViewletModuleId/ViewletModuleId.js'
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => ({
+  findExtensionView: jest.fn(() => undefined),
+  getExtensionViews: jest.fn(async () => []),
+}))
+
+const ViewletMap = await import('../src/parts/ViewletMap/ViewletMap.js')
+const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
 
 test('audio - ogg', async () => {
   expect(await ViewletMap.getModuleId('/test/file.ogg')).toBe(ViewletModuleId.Audio)

--- a/packages/renderer-worker/test/ViewletMapExtensionViews.test.js
+++ b/packages/renderer-worker/test/ViewletMapExtensionViews.test.js
@@ -1,0 +1,57 @@
+import { expect, jest, test } from '@jest/globals'
+
+const state = {
+  views: /** @type {any[]} */ ([]),
+}
+
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => ({
+  findExtensionView(views, idOrUri) {
+    return (
+      views.find((view) => view.id === idOrUri) ||
+      views.find((view) => view.type === 'preview' && view.selector?.some((selector) => idOrUri.endsWith(selector)))
+    )
+  },
+  getExtensionViews: jest.fn(async () => state.views),
+}))
+
+jest.unstable_mockModule('../src/parts/GetWebViews/GetWebViews.ts', () => ({
+  getWebViews: jest.fn(async () => []),
+}))
+
+const ViewletMap = await import('../src/parts/ViewletMap/ViewletMap.js')
+const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
+
+test('image documents use a matching preview extension view', async () => {
+  state.views = [
+    {
+      id: 'builtin.media-preview',
+      selector: ['.png', '.jpg'],
+      type: 'preview',
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/image.png')).resolves.toBe(ViewletModuleId.ExtensionView)
+})
+
+test('sidebar view selectors do not claim documents', async () => {
+  state.views = [
+    {
+      id: 'sample.views.testing',
+      selector: ['.test'],
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/file.test')).resolves.toBe(ViewletModuleId.EditorText)
+})
+
+test('an explicit extension view opener uses the extension view renderer', async () => {
+  state.views = [
+    {
+      id: 'builtin.media-preview',
+      selector: ['.png'],
+      type: 'preview',
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/file.unknown', 'builtin.media-preview')).resolves.toBe(ViewletModuleId.ExtensionView)
+})


### PR DESCRIPTION
Route matching extension preview selectors to the main-area extension view renderer and pass the opened document URI to the view instance.