### PR TITLE
fix: pass platform to activity bar worker

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletActivityBar/ViewletActivityBar.ts
+++ b/packages/renderer-worker/src/parts/ViewletActivityBar/ViewletActivityBar.ts
@@ -31,7 +31,7 @@ export const create = (id, uri, x, y, width, height): ActivityBarState => {
 
 export const loadContent = async (state: ActivityBarState): Promise<ActivityBarState> => {
   const savedState = {}
-  await ActivityBarWorker.invoke('ActivityBar.create', state.uid, '', state.x, state.y, state.width, state.height, null, null, -1, state.platform)
+  await ActivityBarWorker.invoke('ActivityBar.create', state.uid, '', state.x, state.y, state.width, state.height, null, null, state.platform)
   await ActivityBarWorker.invoke('ActivityBar.loadContent', state.uid, savedState)
   const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', state.uid)
   const commands = await ActivityBarWorker.invoke('ActivityBar.render2', state.uid, diffResult)
@@ -51,7 +51,7 @@ export const hotReload = async (state) => {
   // there could still be pending promises when the worker is disposed
   const savedState = await ActivityBarWorker.invoke('ActivityBar.saveState', state.uid)
   await ActivityBarWorker.restart('ActivityBar.terminate')
-  await ActivityBarWorker.invoke('ActivityBar.create', state.uid, '', state.x, state.y, state.width, state.height, null, null, -1, state.platform)
+  await ActivityBarWorker.invoke('ActivityBar.create', state.uid, '', state.x, state.y, state.width, state.height, null, null, state.platform)
   await ActivityBarWorker.invoke('ActivityBar.loadContent', state.uid, savedState)
   const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', state.uid)
   const commands = await ActivityBarWorker.invoke('ActivityBar.render2', state.uid, diffResult)

--- a/packages/renderer-worker/test/ViewletActivityBar.test.ts
+++ b/packages/renderer-worker/test/ViewletActivityBar.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => PlatformType.Web),
+}))
+
+jest.unstable_mockModule('../src/parts/ActivityBarWorker/ActivityBarWorker.js', () => ({
+  invoke: jest.fn(async (command: string) => {
+    if (command === 'ActivityBar.diff2') {
+      return []
+    }
+    if (command === 'ActivityBar.render2') {
+      return []
+    }
+    return undefined
+  }),
+  restart: jest.fn(),
+}))
+
+const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityBarWorker.js')
+const ViewletActivityBar = await import('../src/parts/ViewletActivityBar/ViewletActivityBar.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('loadContent passes the web platform to the activity bar worker', async () => {
+  const state = ViewletActivityBar.create(1, '', 2, 3, 48, 600)
+
+  await ViewletActivityBar.loadContent(state)
+
+  expect(ActivityBarWorker.invoke).toHaveBeenNthCalledWith(1, 'ActivityBar.create', 1, '', 2, 3, 48, 600, null, null, PlatformType.Web)
+})
+
+test('hotReload preserves the web platform when recreating the activity bar', async () => {
+  const state = {
+    ...ViewletActivityBar.create(1, '', 2, 3, 48, 600),
+    isHotReloading: false,
+  }
+
+  await ViewletActivityBar.hotReload(state)
+
+  expect(ActivityBarWorker.invoke).toHaveBeenNthCalledWith(2, 'ActivityBar.create', 1, '', 2, 3, 48, 600, null, null, PlatformType.Web)
+})


### PR DESCRIPTION
Pass the actual renderer platform when creating and hot-reloading the activity bar worker. This keeps static web builds on web extension discovery so contributed views such as Trello appear in the activity bar.