### PR TITLE
fix: update activity bar items on window resize

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-window-resize.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-window-resize.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.activity-bar-window-resize'
+
+export const test: Test = async ({ Command, Locator, expect }) => {
+  const additionalViews = Locator('.ActivityBarItem[title="Additional Views"]')
+  const search = Locator('.ActivityBarItem[title="Search"]')
+
+  await Command.execute('Layout.handleResize', 800, 180)
+
+  await expect(additionalViews).toBeVisible()
+  await expect(search).toHaveCount(0)
+
+  await Command.execute('Layout.handleResize', 800, 720)
+
+  await expect(additionalViews).toHaveCount(0)
+  await expect(search).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/ViewletActivityBar/ViewletActivityBarRenderVirtualDom.js
+++ b/packages/renderer-worker/src/parts/ViewletActivityBar/ViewletActivityBarRenderVirtualDom.js
@@ -7,6 +7,8 @@ export const hasFunctionalRootRender = true
 
 export const hasFunctionalEvents = true
 
+export const hasFunctionalResize = true
+
 const renderItems = {
   isEqual(oldState, newState) {
     return JSON.stringify(oldState.commands) === JSON.stringify(newState.commands)

--- a/packages/renderer-worker/test/ViewletActivityBarRenderVirtualDom.test.js
+++ b/packages/renderer-worker/test/ViewletActivityBarRenderVirtualDom.test.js
@@ -1,0 +1,6 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletActivityBarRenderVirtualDom from '../src/parts/ViewletActivityBar/ViewletActivityBarRenderVirtualDom.js'
+
+test('supports functional resize commands', () => {
+  expect(ViewletActivityBarRenderVirtualDom.hasFunctionalResize).toBe(true)
+})


### PR DESCRIPTION
- declare functional resize support for the worker-backed activity bar so layout resizes invoke its resize command
- cover shrinking and restoring the activity bar with unit and end-to-end regression tests