### PR TITLE
fix: avoid extension cache invalidation loop

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -148,6 +148,7 @@ export const commandMap = {
   'ExtensionManagement.getExtensions': lazy('ExtensionManagement.getExtensions'),
   'ExtensionManagement.getExtensionsEtag': lazy('ExtensionManagement.getExtensionsEtag'),
   'ExtensionManagement.getRunningExtensions': lazy('ExtensionManagement.getRunningExtensions'),
+  'ExtensionManagement.handleExtensionsCacheInvalidated': lazy('ExtensionManagement.handleExtensionsCacheInvalidated'),
   'ExtensionManagement.handleExtensionStatusUpdate': lazy('ExtensionManagement.handleExtensionStatusUpdate'),
   'ExtensionManagement.handleViewContextChange': lazy('ExtensionManagement.handleViewContextChange'),
   'ExtensionManagement.invalidateExtensionsCache': lazy('ExtensionManagement.invalidateExtensionsCache'),

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.ipc.js
@@ -10,9 +10,10 @@ export const Commands = {
   getExtensions: ExtensionManagement.getAllExtensions,
   getExtensionsEtag: ExtensionManagement.getExtensionsEtag,
   getRunningExtensions: ExtensionManagement.getRunningExtensions,
+  handleExtensionsCacheInvalidated: ExtensionManagement.handleExtensionsCacheInvalidated,
   handleExtensionStatusUpdate: ExtensionManagement.handleExtensionStatusUpdate,
   handleViewContextChange: ExtensionManagement.handleViewContextChange,
   showViewContextMenu: ExtensionManagement.showViewContextMenu,
   uninstall: ExtensionManagement.uninstall,
-  invalidateExtensionsCache: ExtensionManagement.invalidateExtensionsCache,
+  invalidateExtensionsCache: ExtensionManagement.handleExtensionsCacheInvalidated,
 }

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -16,9 +16,16 @@ export const handleExtensionStatusUpdate = async () => {
   // TODO inform all viewlets
 }
 
-export const invalidateExtensionsCache = async () => {
+export const doInvalidateExtensionsCache = async () => {
   try {
     await ExtensionManagementWorker.invoke('Extensions.invalidateExtensionsCache')
+  } catch {
+    // ignore
+  }
+}
+
+export const handleExtensionsCacheInvalidated = async () => {
+  try {
     await Command.execute('KeyBindings.hydrate')
     await Command.execute('Layout.handleExtensionsChanged')
   } catch {
@@ -39,12 +46,12 @@ export const showViewContextMenu = async (uid, viewId, menuId, x, y) => {
 
 export const install = async (id) => {
   await InstallExtension.install(id)
-  invalidateExtensionsCache()
+  doInvalidateExtensionsCache()
 }
 
 export const uninstall = async (id) => {
   await SharedProcess.invoke(/* ExtensionManagement.uninstall */ 'ExtensionManagement.uninstall', /* id */ id)
-  invalidateExtensionsCache()
+  doInvalidateExtensionsCache()
 }
 
 export const disable = async (id) => {
@@ -54,7 +61,7 @@ export const disable = async (id) => {
     } else {
       await SharedProcess.invoke(/* ExtensionManagement.disable */ 'ExtensionManagement.disable', /* id */ id)
     }
-    await invalidateExtensionsCache()
+    await doInvalidateExtensionsCache()
     return undefined
   } catch (error) {
     return error
@@ -68,7 +75,7 @@ export const enable = async (id) => {
     } else {
       await SharedProcess.invoke(/* ExtensionManagement.enable */ 'ExtensionManagement.enable', /* id */ id)
     }
-    await invalidateExtensionsCache()
+    await doInvalidateExtensionsCache()
     return undefined
   } catch (error) {
     return error

--- a/packages/renderer-worker/test/ExtensionManagement.test.js
+++ b/packages/renderer-worker/test/ExtensionManagement.test.js
@@ -31,9 +31,45 @@ jest.unstable_mockModule('../src/parts/ContextMenu/ContextMenu.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
 const ExtensionManagement = await import('../src/parts/ExtensionManagement/ExtensionManagement.js')
+const ExtensionManagementIpc = await import('../src/parts/ExtensionManagement/ExtensionManagement.ipc.js')
+const Command = await import('../src/parts/Command/Command.js')
 const ContextMenu = await import('../src/parts/ContextMenu/ContextMenu.js')
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+
+test('doInvalidateExtensionsCache asks the extension management worker to invalidate', async () => {
+  await ExtensionManagement.doInvalidateExtensionsCache()
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.invalidateExtensionsCache')
+  expect(Command.execute).not.toHaveBeenCalled()
+})
+
+test('handleExtensionsCacheInvalidated refreshes renderer state without invalidating again', async () => {
+  await ExtensionManagement.handleExtensionsCacheInvalidated()
+
+  expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'KeyBindings.hydrate')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'Layout.handleExtensionsChanged')
+})
+
+test('cache invalidation commands handle notifications without invalidating again', () => {
+  expect(ExtensionManagementIpc.Commands.handleExtensionsCacheInvalidated).toBe(ExtensionManagement.handleExtensionsCacheInvalidated)
+  expect(ExtensionManagementIpc.Commands.invalidateExtensionsCache).toBe(ExtensionManagement.handleExtensionsCacheInvalidated)
+})
 
 test.skip('install', async () => {
   // @ts-ignore


### PR DESCRIPTION
## Summary

Split renderer cache invalidation into an initiating path and a notification handler, preventing recursive calls between renderer-worker and extension-management-worker while keeping legacy notifications safe.