### PR TITLE
fix: retry cli prompt test cleanup

### DIFF
--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -110,7 +110,7 @@ afterAll(async () => {
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve(undefined)))
   })
-  await rm(temporaryDirectory, { force: true, recursive: true })
+  await rm(temporaryDirectory, { force: true, maxRetries: 1, recursive: true, retryDelay: 100 })
   if (dbusPid) {
     process.kill(dbusPid)
   }


### PR DESCRIPTION
Retry removal of the CLI prompt test's temporary directory once so transient Windows file locks do not fail an otherwise successful test.