### PR TITLE
fix: preserve extension view keybindings

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionViewContext/ExtensionViewContext.js
+++ b/packages/renderer-worker/src/parts/ExtensionViewContext/ExtensionViewContext.js
@@ -29,6 +29,10 @@ const addAllContexts = () => {
   }
 }
 
+export const restore = () => {
+  addAllContexts()
+}
+
 export const handleViewContextChange = (uid, viewId, context) => {
   const oldKeys = getAllKeys()
   removeKeys(oldKeys)

--- a/packages/renderer-worker/src/parts/Focus/Focus.js
+++ b/packages/renderer-worker/src/parts/Focus/Focus.js
@@ -1,6 +1,7 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as Browser from '../Browser/Browser.js'
 import * as Context from '../Context/Context.js'
+import * as ExtensionViewContext from '../ExtensionViewContext/ExtensionViewContext.js'
 import * as FocusState from '../FocusState/FocusState.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 import * as WhenExpression from '../WhenExpression/WhenExpression.js'
@@ -15,6 +16,7 @@ import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 export const setFocus = (focusKey, additionalFocusKey, uid, viewletModuleId) => {
   Assert.number(focusKey)
   Context.reset()
+  ExtensionViewContext.restore()
   FocusState.set(focusKey)
   Context.set(FocusState.get(), true)
   if (additionalFocusKey) {

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -13,6 +13,7 @@ import * as IconTheme from '../IconTheme/IconTheme.js'
 import * as Id from '../Id/Id.js'
 import * as InitData from '../InitData/InitData.js'
 import * as IpcState from '../IpcState/IpcState.js'
+import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as Languages from '../Languages/Languages.js'
 import * as LaunchSharedProcess from '../LaunchSharedProcess/LaunchSharedProcess.js'
 import * as LifeCycle from '../LifeCycle/LifeCycle.js'
@@ -175,6 +176,7 @@ export const startup = async (platform, assetDir) => {
   const isTestRun = Workspace.isTest() || initData.Location.href.includes('/tests/')
 
   await Focus.hydrate()
+  await KeyBindings.hydrate()
 
   LifeCycle.mark(LifeCyclePhase.Three)
 

--- a/packages/renderer-worker/test/Focus.test.ts
+++ b/packages/renderer-worker/test/Focus.test.ts
@@ -1,3 +1,40 @@
-import { test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 
-test.skip('', () => {})
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
+const Context = await import('../src/parts/Context/Context.js')
+const ExtensionViewContext = await import('../src/parts/ExtensionViewContext/ExtensionViewContext.js')
+const Focus = await import('../src/parts/Focus/Focus.js')
+const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
+
+test('setFocus preserves extension view context keybindings', () => {
+  const keyBindings = [
+    {
+      command: 'ExtensionHost.executeCommand',
+      key: 3,
+      when: 'chat2.composerFocus',
+    },
+  ]
+  KeyBindingsState.setKeyBindings('extensions', keyBindings)
+  ExtensionViewContext.handleViewContextChange(1, 'chat2.views.chat', {
+    'chat2.composerFocus': true,
+  })
+
+  Focus.setFocus(WhenExpression.FocusExplorer)
+
+  expect(Context.get('chat2.composerFocus')).toBe(true)
+  expect(RendererProcess.invoke).toHaveBeenLastCalledWith('KeyBindings.setIdentifiers', new Uint32Array([3]))
+
+  ExtensionViewContext.handleViewContextChange(1, 'chat2.views.chat', {
+    'chat2.composerFocus': false,
+  })
+
+  expect(Context.get('chat2.composerFocus')).toBeUndefined()
+  expect(RendererProcess.invoke).toHaveBeenLastCalledWith('KeyBindings.setIdentifiers', new Uint32Array())
+})

--- a/packages/renderer-worker/test/KeyBindings.test.ts
+++ b/packages/renderer-worker/test/KeyBindings.test.ts
@@ -12,6 +12,14 @@ jest.unstable_mockModule('../src/parts/Logger/Logger.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/ExtensionKeyBindings/ExtensionKeyBindings.js', () => {
+  return {
+    getKeyBindings: jest.fn(() => []),
+  }
+})
+
+const ExtensionKeyBindings = await import('../src/parts/ExtensionKeyBindings/ExtensionKeyBindings.js')
+const KeyBindings = await import('../src/parts/KeyBindings/KeyBindings.js')
 const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
 const Logger = await import('../src/parts/Logger/Logger.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
@@ -65,4 +73,19 @@ test('removeKeyBindings unregisters keybinding set after last reference is remov
   expect(KeyBindingsState.state.keyBindingSetCounts.Editor).toBeUndefined()
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
   expect(RendererProcess.invoke).toHaveBeenLastCalledWith('KeyBindings.setIdentifiers', new Uint32Array())
+})
+
+test('hydrate registers extension keybindings', async () => {
+  const keyBindings = [
+    {
+      command: 'ExtensionHost.executeCommand',
+      key: 3,
+      when: 'chat2.composerFocus',
+    },
+  ]
+  jest.mocked(ExtensionKeyBindings.getKeyBindings).mockResolvedValue(keyBindings)
+
+  await KeyBindings.hydrate()
+
+  expect(KeyBindingsState.state.keyBindingSets.extensions).toBe(keyBindings)
 })


### PR DESCRIPTION
## Summary

- hydrate extension-contributed keybindings during workbench startup
- restore extension view context keys after focus context resets
- cover extension keybinding hydration and focus preservation

## Validation

- renderer-worker full test suite: 234 suites passed, 877 tests passed
- renderer-worker type-check
- chat-view-2 focused and full e2e against the patched renderer bundle

The package-local xo command currently reports pre-existing repository-wide style failures in untouched files.