### PR TITLE
fix: preserve prompt auth errors

### DIFF
--- a/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
+++ b/packages/renderer-worker/src/parts/PromptMode/PromptMode.js
@@ -8,6 +8,7 @@ const promptWithValuePrefix = `${promptFlag}=`
 const allowReadFlag = '--allow-read'
 const allowWriteFlag = '--allow-write'
 const backendUrlFlag = '--backend-url'
+const unknownErrorCode = 'E_UNKNOWN'
 
 const parseFlagValue = (argv, flag) => {
   const prefix = `${flag}=`
@@ -99,11 +100,37 @@ const getErrorMessage = (error) => {
   return String(error)
 }
 
-export const run = async (promptOrOptions) => {
+const getErrorCode = (error) => {
+  if (!error || typeof error !== 'object') {
+    return unknownErrorCode
+  }
+  return typeof error.code === 'string' && error.code ? error.code : unknownErrorCode
+}
+
+const getAccessToken = (authState) => {
+  if (typeof authState?.authAccessToken === 'string') {
+    return authState.authAccessToken
+  }
+  return typeof authState?.accessToken === 'string' ? authState.accessToken : ''
+}
+
+const getCommandArguments = (prompt, fileSystemAccess, accessToken) => {
+  if (accessToken) {
+    return [prompt, undefined, fileSystemAccess, accessToken]
+  }
+  if (fileSystemAccess) {
+    return [prompt, undefined, fileSystemAccess]
+  }
+  return [prompt]
+}
+
+export const run = async (promptOrOptions, authState) => {
   const options = typeof promptOrOptions === 'string' ? { prompt: promptOrOptions } : promptOrOptions
   const prompt = options?.prompt
+  const accessToken = getAccessToken(authState)
   const id = PromptTrace.createId()
   const startedAt = new Date().toISOString()
+  let errorCode = ''
   let errorMessage = ''
   let fileSystemAccess
   let result
@@ -112,9 +139,8 @@ export const run = async (promptOrOptions) => {
       throw new TypeError('Prompt must be a non-empty string')
     }
     fileSystemAccess = getFileSystemAccess(options)
-    result = fileSystemAccess
-      ? await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', prompt, undefined, fileSystemAccess)
-      : await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', prompt)
+    const commandArguments = getCommandArguments(prompt, fileSystemAccess, accessToken)
+    result = await Command.execute('ExtensionHost.executeCommand', 'chat2.runPrompt', ...commandArguments)
     if (result?.status !== 'completed') {
       throw new Error(result?.error || 'Chat task failed without an error message')
     }
@@ -123,12 +149,14 @@ export const run = async (promptOrOptions) => {
       await Process.writeStdout(`${finalMessage}\n`)
     }
   } catch (error) {
+    errorCode = typeof result?.errorCode === 'string' && result.errorCode ? result.errorCode : getErrorCode(error)
     errorMessage = getErrorMessage(error)
     await Process.writeStderr(`${errorMessage}\n`)
   }
   try {
     const trace = PromptTrace.create({
       error: errorMessage,
+      errorCode,
       finishedAt: new Date().toISOString(),
       fileSystemAccess,
       id,
@@ -141,6 +169,7 @@ export const run = async (promptOrOptions) => {
       await Process.writeStderr(`Trace: ${tracePath}\n`)
     }
   } catch (error) {
+    errorCode ||= getErrorCode(error)
     errorMessage ||= getErrorMessage(error)
     await Process.writeStderr(`Failed to write agent trace: ${getErrorMessage(error)}\n`)
   }

--- a/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
+++ b/packages/renderer-worker/src/parts/PromptTrace/PromptTrace.js
@@ -5,10 +5,11 @@ const join = (separator, left, right) => {
   return left.endsWith(separator) ? `${left}${right}` : `${left}${separator}${right}`
 }
 
-export const create = ({ error, fileSystemAccess, finishedAt, id, prompt, result, startedAt }) => {
+export const create = ({ error, errorCode = '', fileSystemAccess, finishedAt, id, prompt, result, startedAt }) => {
   return {
     cwd: Workspace.getPath(),
     ...(error && { error }),
+    ...(error && errorCode && { errorCode }),
     finishedAt,
     id,
     messages: Array.isArray(result?.trace) ? result.trace : [],

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -169,7 +169,7 @@ export const startup = async (platform, assetDir) => {
   if (promptOptions !== undefined) {
     await HeadlessLayout.initialize(initData)
     await Command.execute('Layout.setAuthState', authState)
-    await PromptMode.run(promptOptions)
+    await PromptMode.run(promptOptions, authState)
     return
   }
 

--- a/packages/renderer-worker/test/PromptMode.test.ts
+++ b/packages/renderer-worker/test/PromptMode.test.ts
@@ -122,6 +122,28 @@ test('run - passes a read-only workspace sandbox to headless chat', async () => 
   expect(Exit.exit).toHaveBeenCalledWith(0)
 })
 
+test('run - passes the restored startup access token to headless chat', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValueOnce({
+    sessionId: 'session-1',
+    status: 'completed',
+    task: { events: [] },
+    trace: [],
+  })
+
+  await PromptMode.run('Fix the tests', { authAccessToken: 'access-token-1' })
+
+  expect(Command.execute).toHaveBeenCalledWith(
+    'ExtensionHost.executeCommand',
+    'chat2.runPrompt',
+    'Fix the tests',
+    undefined,
+    undefined,
+    'access-token-1',
+  )
+  expect(Exit.exit).toHaveBeenCalledWith(0)
+})
+
 test('run - makes workspace write access imply read access', async () => {
   // @ts-ignore
   Command.execute.mockResolvedValueOnce({
@@ -152,6 +174,7 @@ test('run - reports failures and exits unsuccessfully', async () => {
   // @ts-ignore
   Command.execute.mockResolvedValue({
     error: 'Model request failed',
+    errorCode: 'E_MODEL_REQUEST_FAILED',
     sessionId: 'session-1',
     status: 'failed',
     trace: [],
@@ -162,6 +185,12 @@ test('run - reports failures and exits unsuccessfully', async () => {
   expect(Process.writeStderr).toHaveBeenCalledWith('Model request failed\n')
   expect(Process.writeStderr).toHaveBeenCalledWith('Trace: /workspace/.agent-logs/trace-trace-1.json\n')
   expect(Process.writeStdout).not.toHaveBeenCalled()
+  expect(PromptTrace.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: 'Model request failed',
+      errorCode: 'E_MODEL_REQUEST_FAILED',
+    }),
+  )
   expect(Exit.exit).toHaveBeenCalledWith(1)
 })
 

--- a/packages/renderer-worker/test/PromptTrace.test.ts
+++ b/packages/renderer-worker/test/PromptTrace.test.ts
@@ -63,6 +63,35 @@ test('create - creates a Pi-inspired completed trace object', () => {
   })
 })
 
+test('create - includes a machine-readable code in failed traces', () => {
+  const trace = PromptTrace.create({
+    error: 'No token provided',
+    errorCode: 'E_NO_ACCESS_TOKEN_PROVIDED',
+    fileSystemAccess: undefined,
+    finishedAt: '2026-07-14T00:01:00.000Z',
+    id: 'trace-id',
+    prompt: 'Fix the tests',
+    result: undefined,
+    startedAt: '2026-07-14T00:00:00.000Z',
+  })
+
+  expect(trace).toEqual({
+    cwd: '/workspace',
+    error: 'No token provided',
+    errorCode: 'E_NO_ACCESS_TOKEN_PROVIDED',
+    finishedAt: '2026-07-14T00:01:00.000Z',
+    id: 'trace-id',
+    messages: [],
+    prompt: 'Fix the tests',
+    sessionId: '',
+    status: 'failed',
+    task: null,
+    timestamp: '2026-07-14T00:00:00.000Z',
+    type: 'agent-trace',
+    version: 1,
+  })
+})
+
 test('write - writes formatted JSON below the workspace', async () => {
   const trace = { cwd: '/workspace', id: 'trace-id' }
 


### PR DESCRIPTION
Pass restored startup authentication into CLI prompt execution and include machine-readable error codes in failed agent traces.