### PR TITLE
feature: apply extension view scroll positions

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -12,6 +12,7 @@ interface ViewRenderResult {
   readonly dom?: readonly unknown[]
   readonly focusSelector?: string
   readonly patches?: readonly unknown[]
+  readonly scrollPosition?: readonly [selector: string, scrollTop: number]
   readonly title?: string
   readonly type: string
 }
@@ -63,6 +64,14 @@ const createContext = (state: ViewletExtensionViewState, savedState: unknown): u
   }
 }
 
+const getScrollPositionCommands = (state: ViewletExtensionViewState, result: ViewRenderResult): readonly (readonly unknown[])[] => {
+  if (!result.scrollPosition) {
+    return []
+  }
+  const [selector, scrollTop] = result.scrollPosition
+  return [['Viewlet.setProperty', state.uid, selector, 'scrollTop', scrollTop]]
+}
+
 const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRenderResult | undefined): ViewletExtensionViewState => {
   if (!result) {
     return {
@@ -74,7 +83,7 @@ const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRe
   }
   return {
     ...state,
-    commands: [],
+    commands: getScrollPositionCommands(state, result),
     dom: result.type === 'setDom' ? result.dom || [] : state.dom,
     error: undefined,
     focusSelector: typeof result.focusSelector === 'string' ? result.focusSelector : '',

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
@@ -172,6 +172,23 @@ test('handleClick stores patches without duplicate commands', async () => {
   expect(newState.patches).toBe(patches)
 })
 
+test('handleClick forwards rendered scroll position as a renderer process command', async () => {
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    patches: [],
+    scrollPosition: ['.Messages', 9_999_999],
+    type: 'setPatches',
+  })
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    kind: 'virtualDom',
+  }
+
+  const newState = await ViewletExtensionView.handleClick(state, 'connect')
+
+  expect(newState.commands).toEqual([['Viewlet.setProperty', 1, '.Messages', 'scrollTop', 9_999_999]])
+})
+
 test('loadContent stores rendered sidebar actions', async () => {
   // @ts-ignore
   ExtensionManagementWorker.invoke.mockImplementation(async (method) => {

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -59,6 +59,36 @@ test('extension view render supports functional events', () => {
   expect(ViewletExtensionViewRender.hasFunctionalEvents).toBe(true)
 })
 
+test('extension view applies scroll position after patches', () => {
+  const actionsDom: readonly unknown[] = []
+  const dom: readonly unknown[] = []
+  const oldState = {
+    actionsDom,
+    commands: [],
+    css: '',
+    cssId: '',
+    dom,
+    focusSelector: '',
+    kind: 'virtualDom',
+    patches: [],
+    title: 'Testing',
+    uid: 1,
+  }
+  const patches = [{ type: 1 }]
+  const newState = {
+    ...oldState,
+    commands: [['Viewlet.setProperty', 1, '.Messages', 'scrollTop', 9_999_999]],
+    patches,
+  }
+
+  const commands = ViewletManager.render(ViewletExtensionViewRender, oldState, newState, 1)
+
+  expect(commands).toEqual([
+    ['Viewlet.setPatches', 1, patches],
+    ['Viewlet.setProperty', 1, '.Messages', 'scrollTop', 9_999_999],
+  ])
+})
+
 test('concurrent side effect commands preserve completed state changes', async () => {
   const createDeferred = () => {
     let resolve: () => void = () => {}


### PR DESCRIPTION
Forwards optional extension-view scroll metadata to renderer-process after DOM patches, using the existing scoped element-property command.