### PR TITLE
feature: implement title bar fullscreen command

### DIFF
--- a/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.ipc.js
+++ b/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.ipc.js
@@ -8,6 +8,7 @@ export const Commands = {
   minimize: ElectronWindow.minimize,
   openNew: ElectronWindow.openNew,
   toggleDevtools: ElectronWindow.toggleDevtools,
+  toggleFullScreen: ElectronWindow.toggleFullScreen,
   unmaximize: ElectronWindow.unmaximize,
   zoomIn: ElectronWindow.zoomIn,
   zoomOut: ElectronWindow.zoomOut,

--- a/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.js
+++ b/packages/renderer-worker/src/parts/ElectronWindow/ElectronWindow.js
@@ -22,6 +22,8 @@ export const openNew = forward('ElectronWindow.openNew')
 
 export const toggleDevtools = forward('ElectronWindow.toggleDevtools')
 
+export const toggleFullScreen = forward('ElectronWindow.toggleFullScreen')
+
 export const zoomIn = forward('ElectronWindow.zoomIn')
 
 export const zoomOut = forward('ElectronWindow.zoomOut')

--- a/packages/renderer-worker/src/parts/ToggleFullScreen/ToggleFullScreen.js
+++ b/packages/renderer-worker/src/parts/ToggleFullScreen/ToggleFullScreen.js
@@ -1,0 +1,11 @@
+import * as Command from '../Command/Command.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+
+export const toggleFullScreen = () => {
+  if (Platform.getPlatform() === PlatformType.Electron) {
+    return Command.execute('ElectronWindow.toggleFullScreen')
+  }
+  return RendererProcess.invoke('Window.toggleFullScreen')
+}

--- a/packages/renderer-worker/src/parts/Window/Window.ipc.js
+++ b/packages/renderer-worker/src/parts/Window/Window.ipc.js
@@ -1,4 +1,5 @@
 import * as Chrome from '../Chrome/Chrome.js'
+import * as ToggleFullScreen from '../ToggleFullScreen/ToggleFullScreen.js'
 
 export const name = 'Window'
 
@@ -8,6 +9,7 @@ export const Commands = {
   maximize: Chrome.maximize,
   minimize: Chrome.minimize,
   openNew: Chrome.openNew,
+  toggleFullScreen: ToggleFullScreen.toggleFullScreen,
   unmaximize: Chrome.unmaximize,
   zoomIn: Chrome.zoomIn,
   zoomOut: Chrome.zoomOut,

--- a/packages/renderer-worker/test/ToggleFullScreen.test.ts
+++ b/packages/renderer-worker/test/ToggleFullScreen.test.ts
@@ -1,0 +1,15 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const ToggleFullScreen = await import('../src/parts/ToggleFullScreen/ToggleFullScreen.js')
+
+test('toggleFullScreen - web', async () => {
+  await ToggleFullScreen.toggleFullScreen()
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Window.toggleFullScreen')
+})

--- a/packages/renderer-worker/test/ToggleFullScreenElectron.test.ts
+++ b/packages/renderer-worker/test/ToggleFullScreenElectron.test.ts
@@ -1,0 +1,20 @@
+import { expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: () => PlatformType.Electron,
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const ToggleFullScreen = await import('../src/parts/ToggleFullScreen/ToggleFullScreen.js')
+
+test('toggleFullScreen - electron', async () => {
+  await ToggleFullScreen.toggleFullScreen()
+
+  expect(Command.execute).toHaveBeenCalledTimes(1)
+  expect(Command.execute).toHaveBeenCalledWith('ElectronWindow.toggleFullScreen')
+})

--- a/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.ipc.ts
+++ b/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.ipc.ts
@@ -12,6 +12,7 @@ export const Commands = {
   openNewWithUri: ElectronWindow.openNewWithUri,
   reload: ElectronWindow.reload,
   toggleDevtools: ElectronWindow.toggleDevtools,
+  toggleFullScreen: ElectronWindow.toggleFullScreen,
   unmaximize: ElectronWindow.unmaximize,
   zoomIn: ElectronWindow.zoomIn,
   zoomOut: ElectronWindow.zoomOut,

--- a/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.ts
+++ b/packages/shared-process/src/parts/ElectronWindow/ElectronWindow.ts
@@ -22,6 +22,11 @@ export const toggleDevtools = (windowId: any): any => {
   return ParentIpc.invoke('ElectronWindow.executeWindowFunction', windowId, 'toggleDevtools')
 }
 
+export const toggleFullScreen = (windowId: any): any => {
+  Assert.number(windowId)
+  return ParentIpc.invoke('ElectronWindow.executeWindowFunction', windowId, 'toggleFullScreen')
+}
+
 export const maximize = (windowId: any): any => {
   Assert.number(windowId)
   return ParentIpc.invoke('ElectronWindow.executeWindowFunction', windowId, 'maximize')

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -86,6 +86,7 @@ export const getModuleId = (commandId: any): any => {
     case 'ElectronWindow.openNewWithUri':
     case 'ElectronWindow.reload':
     case 'ElectronWindow.toggleDevtools':
+    case 'ElectronWindow.toggleFullScreen':
     case 'ElectronWindow.unmaximize':
     case 'ElectronWindow.zoomIn':
     case 'ElectronWindow.zoomOut':

--- a/packages/shared-process/test/ElectronWindow.test.ts
+++ b/packages/shared-process/test/ElectronWindow.test.ts
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
   invoke: jest.fn(() => {}),
@@ -13,10 +13,20 @@ const AppWindow = await import('../src/parts/AppWindow/AppWindow.js')
 const ElectronWindow = await import('../src/parts/ElectronWindow/ElectronWindow.js')
 const ParentIpc = await import('../src/parts/MainProcess/MainProcess.js')
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 test('toggleDevtools', async () => {
   await ElectronWindow.toggleDevtools(1)
   expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
   expect(ParentIpc.invoke).toHaveBeenCalledWith('ElectronWindow.executeWindowFunction', 1, 'toggleDevtools')
+})
+
+test('toggleFullScreen', async () => {
+  await ElectronWindow.toggleFullScreen(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('ElectronWindow.executeWindowFunction', 1, 'toggleFullScreen')
 })
 
 test('openNewWithUri', async () => {


### PR DESCRIPTION
Wires View → Appearance → Full Screen through the renderer and shared-process bridges. Electron now toggles the native app window, while web builds retain the browser Fullscreen API.