### PR TITLE
fix: load auth worker on demand

### DIFF
--- a/packages/renderer-worker/src/parts/ShouldInitializeAuth/ShouldInitializeAuth.ts
+++ b/packages/renderer-worker/src/parts/ShouldInitializeAuth/ShouldInitializeAuth.ts
@@ -1,0 +1,3 @@
+export const shouldInitializeAuth = (hasAuthCallback: boolean, isPromptMode: boolean): boolean => {
+  return hasAuthCallback || isPromptMode
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1809,6 +1809,12 @@ export const setAuthState = async (state: LayoutState, authState): Promise<Layou
   }
 }
 
+export const refreshAuthState = async (state: LayoutState): Promise<LayoutStateResult> => {
+  const href = await Location.getHref()
+  const authState = await AuthWorker.initialize(state.backendUrl, state.platform, href)
+  return setAuthState(state, authState)
+}
+
 export const signIn = async (state: LayoutState): Promise<LayoutStateResult> => {
   const { platform, backendUrl } = state
   const authState = await AuthWorker.signIn(backendUrl, platform)

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -67,6 +67,7 @@ export const CommandsWithSideEffects = {
   openSideBarViewlet: ViewletLayout.openSideBarView,
   openSecondarySideBarViewlet: ViewletLayout.openSecondarySideBarView,
   openPanelViewlet: ViewletLayout.openPanelView,
+  refreshAuthState: ViewletLayout.refreshAuthState,
   setBadgeCount: ViewletLayout.setBadgeCount,
   setAuthState: ViewletLayout.setAuthState,
   setExplicitBounds: ViewletLayout.setExplicitBounds,

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -30,6 +30,7 @@ import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as SaveState from '../SaveState/SaveState.js'
 import * as SessionReplay from '../SessionReplay/SessionReplay.js'
+import { shouldInitializeAuth } from '../ShouldInitializeAuth/ShouldInitializeAuth.ts'
 import * as StartupAuth from '../StartupAuth/StartupAuth.js'
 import * as UnhandledErrorHandling from '../UnhandledErrorHandling/UnhandledErrorHandling.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
@@ -154,11 +155,13 @@ export const startup = async (platform, assetDir) => {
     Performance.mark(PerformanceMarkerType.DidLoadSessionReplay)
   }
 
-  let authState
-  if (HasCodeQueryParam.hasCodeQueryParam(initData.Location.href)) {
+  const hasAuthCallback = HasCodeQueryParam.hasCodeQueryParam(initData.Location.href)
+  if (hasAuthCallback) {
     await CleanAuthCallbackUrl.cleanAuthCallbackUrl(initData.Location.href)
   }
-  authState = await StartupAuth.initializeAuth(platform, initData.Location.href)
+  const authState = shouldInitializeAuth(hasAuthCallback, promptOptions !== undefined)
+    ? await StartupAuth.initializeAuth(platform, initData.Location.href)
+    : undefined
 
   LifeCycle.mark(LifeCyclePhase.Twelve)
 
@@ -213,7 +216,9 @@ export const startup = async (platform, assetDir) => {
   // commands.push(...placeholderCommands)
   commands.push(['Viewlet.appendToBody', layout.uid])
   await RendererProcess.invoke('Viewlet.executeCommands', commands)
-  await Command.execute('Layout.setAuthState', authState)
+  if (authState) {
+    await Command.execute('Layout.setAuthState', authState)
+  }
   // await Layout.hydrate(initData)
   Performance.mark(PerformanceMarkerType.DidShowLayout)
 

--- a/packages/renderer-worker/test/ShouldInitializeAuth.test.ts
+++ b/packages/renderer-worker/test/ShouldInitializeAuth.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { shouldInitializeAuth } from '../src/parts/ShouldInitializeAuth/ShouldInitializeAuth.ts'
+
+test('does not initialize auth during ordinary startup', () => {
+  expect(shouldInitializeAuth(false, false)).toBe(false)
+})
+
+test('initializes auth for an auth callback', () => {
+  expect(shouldInitializeAuth(true, false)).toBe(true)
+})
+
+test('initializes auth in prompt mode', () => {
+  expect(shouldInitializeAuth(false, true)).toBe(true)
+})

--- a/packages/renderer-worker/test/ViewletLayoutAuth.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutAuth.test.ts
@@ -52,10 +52,19 @@ jest.unstable_mockModule('../src/parts/ChatViewWorker/ChatViewWorker.js', () => 
   }
 })
 
+jest.unstable_mockModule('../src/parts/Location/Location.js', () => {
+  return {
+    getHref: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
 const Command = await import('../src/parts/Command/Command.js')
 const AuthWorker = await import('../src/parts/AuthWorker/AuthWorker.js')
 const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityBarWorker.js')
 const ChatViewWorker = await import('../src/parts/ChatViewWorker/ChatViewWorker.js')
+const Location = await import('../src/parts/Location/Location.js')
 const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
 
 beforeEach(() => {
@@ -214,6 +223,43 @@ test('setAuthState fans auth changes out to activity bar and chat when visible',
     userUsedTokens: 42,
   })
   expect(Array.isArray(result.commands)).toBe(true)
+})
+
+test('refreshAuthState initializes auth on demand and merges the result', async () => {
+  // @ts-ignore
+  Location.getHref.mockResolvedValue('https://app.example/')
+  // @ts-ignore
+  AuthWorker.initialize.mockResolvedValue({
+    authAccessToken: 'token-1',
+    authErrorMessage: '',
+    userName: 'Test User',
+    userState: 'loggedIn',
+    userSubscriptionPlan: 'pro',
+    userUsedTokens: 42,
+  })
+  const state = {
+    ...ViewletLayout.create(1),
+    backendUrl: 'https://example.com/',
+    platform: 1,
+  }
+
+  const result = await ViewletLayout.refreshAuthState(state)
+
+  expect(Location.getHref).toHaveBeenCalledTimes(1)
+  expect(AuthWorker.initialize).toHaveBeenCalledTimes(1)
+  expect(AuthWorker.initialize).toHaveBeenCalledWith('https://example.com/', 1, 'https://app.example/')
+  expect(result).toEqual({
+    commands: [],
+    newState: {
+      ...state,
+      authAccessToken: 'token-1',
+      authErrorMessage: '',
+      userName: 'Test User',
+      userState: 'loggedIn',
+      userSubscriptionPlan: 'pro',
+      userUsedTokens: 42,
+    },
+  })
 })
 
 test('signIn merges auth worker state into layout state', async () => {


### PR DESCRIPTION
Skips auth-worker initialization during ordinary startup and refreshes account state when the Activity Bar Account menu opens. OAuth callbacks and prompt mode continue to initialize auth immediately.