### PR TITLE
fix: allow wider sidebar with preview

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -4,8 +4,9 @@ import * as LayoutKeys from '../LayoutKeys/LayoutKeys.js'
 import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
 import type { LayoutState } from './LayoutState.ts'
 
+const mainMinWidth = 100
+
 export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocationType.Right): LayoutState => {
-  const mainMinWidth = 300
   const activityBarVisible = source[LayoutKeys.ActivityBarVisible]
   const panelVisible = source[LayoutKeys.PanelVisible]
   const sideBarVisible = source[LayoutKeys.SideBarVisible]
@@ -99,7 +100,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
 
     // Calculate sidebar width for left section
     const maxSideBarWidth = Math.max(0, availableWidth - 48 - mainMinWidth)
-    const adjustedSideBarWidth = previewVisible ? Math.min(newSideBarWidth, maxSideBarWidth * 0.3) : Math.min(newSideBarWidth, maxSideBarWidth)
+    const adjustedSideBarWidth = Math.min(newSideBarWidth, maxSideBarWidth)
     let p7 = p8 - adjustedSideBarWidth
     if (sideBarVisible && p7 < 0) {
       p7 = 0

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -35,6 +35,8 @@ import * as Workspace from '../Workspace/Workspace.js'
 import { getPoints } from './LayoutPoints.ts'
 import type { LayoutState, LayoutStateResult, SideBarFocusModeLayoutStateSnapshot } from './LayoutState.ts'
 
+const mainMinWidth = 100
+
 const getInitialBackendUrl = () => {
   return Preferences.get('layout.backendUrl') || Product.getBackendUrl()
 }
@@ -1148,7 +1150,6 @@ export const handleSashPointerUp = (state: LayoutState, sashId: string) => {
 
 const getNewStatePointerMoveSideBar = async (state: LayoutState, x: number, y: number): Promise<{ newState: LayoutState; commands: any[] }> => {
   const { activityBarWidth, previewWidth, sideBarLocation, sideBarMinWidth, windowWidth } = state
-  const mainMinWidth = 300
   const newSideBarWidth = sideBarLocation === SideBarLocationType.Left ? x - activityBarWidth : windowWidth - activityBarWidth - x - previewWidth
   const availableWidth = Math.max(0, windowWidth - previewWidth)
   const sideBarMaxWidthForMain = Math.max(0, availableWidth - activityBarWidth - mainMinWidth)
@@ -1185,7 +1186,6 @@ const getNewStatePointerMoveSideBar = async (state: LayoutState, x: number, y: n
 
 const getNewStatePointerMoveSecondarySideBar = async (state: LayoutState, x: number): Promise<{ newState: LayoutState; commands: any[] }> => {
   const { sideBarLocation, secondarySideBarMinWidth, sideBarLeft, sideBarWidth, windowWidth, previewVisible, previewLeft } = state
-  const mainMinWidth = 300
   const secondarySideBarRight = previewVisible ? previewLeft : windowWidth
   const mainLeft = sideBarLocation === SideBarLocationType.Left ? sideBarLeft + sideBarWidth : 0
   const maxSecondarySideBarWidth = Math.max(0, secondarySideBarRight - mainLeft - mainMinWidth)
@@ -1221,7 +1221,6 @@ const getNewStatePointerMoveSecondarySideBar = async (state: LayoutState, x: num
 const getNewStatePointerMoveActivityBar = async (state: LayoutState, x: number, y: number): Promise<{ newState: LayoutState; commands: any[] }> => {
   const windowWidth = state[LayoutKeys.WindowWidth]
   const previewMinWidth = 200 // TODO: make configurable
-  const mainMinWidth = 100 // TODO: make configurable
   const newPreviewWidth = windowWidth - x
 
   if (newPreviewWidth < previewMinWidth / 2) {

--- a/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
@@ -124,7 +124,7 @@ test('setExplicitBounds enables explicit bounds and resizes layout', async () =>
     windowHeight: 320,
     mainLeft: 0,
     mainTop: 35,
-    mainWidth: 300,
+    mainWidth: 262,
     mainHeight: 265,
   })
   expect(result.commands).toEqual([['Viewlet.setBounds', 88, 432, 35, 48, 265]])

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -41,6 +41,7 @@ const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityB
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const LayoutPoints = await import('../src/parts/ViewletLayout/LayoutPoints.ts')
 const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
@@ -298,5 +299,54 @@ test('toggleSideBarView preserves resized preview width when showing the side ba
     previewWidth: 320,
     sideBarView: 'SourceControl',
     sideBarVisible: true,
+  })
+})
+
+test('layout allows the side bar to grow when the preview uses half the window', () => {
+  const state = LayoutPoints.getPoints({
+    ...ViewletLayout.create(1),
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    previewMinWidth: 100,
+    previewVisible: true,
+    previewWidth: 900,
+    sideBarMaxWidth: 9_999_999,
+    sideBarMinWidth: 170,
+    sideBarVisible: true,
+    sideBarWidth: 700,
+    windowHeight: 800,
+    windowWidth: 1800,
+  })
+
+  expect(state).toMatchObject({
+    mainWidth: 152,
+    previewWidth: 900,
+    sideBarWidth: 700,
+  })
+})
+
+test('resizing the side bar preserves a 100px main area', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    previewMinWidth: 100,
+    previewVisible: true,
+    previewWidth: 600,
+    sashId: 'SideBar',
+    sideBarMaxWidth: 9_999_999,
+    sideBarMinWidth: 170,
+    sideBarVisible: true,
+    sideBarWidth: 240,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const result = await ViewletLayout.handleSashPointerMove(state, 0, 400)
+
+  expect(result.newState).toMatchObject({
+    mainWidth: 100,
+    previewWidth: 600,
+    sideBarWidth: 452,
   })
 })


### PR DESCRIPTION
Allows the sidebar to grow across the available editor-side space when a preview is open. Keeps at least 100px of the main area visible and adds regression coverage for 50/50 preview layouts and sash resizing.