### PR TITLE
feature: expose builtin extensions path

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -280,6 +280,7 @@ export const commandMap = {
   'PersistentFileHandle.removeHandle': lazy('PersistentFileHandle.removeHandle'),
   'PlatformPaths.getCachePath': lazy('PlatformPaths.getCachePath'),
   'PlatformPaths.getCacheUri': lazy('PlatformPaths.getCacheUri'),
+  'PlatformPaths.getBuiltinExtensionsPath': lazy('PlatformPaths.getBuiltinExtensionsPath'),
   'PlatformPaths.getDisabledExtensionsJsonPath': lazy('PlatformPaths.getDisabledExtensionsJsonPath'),
   'PlatformPaths.getLogsDir': lazy('PlatformPaths.getLogsDir'),
   'PlatformPaths.getConfigJsonPath': lazy('PlatformPaths.getConfigJsonPath'),

--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.ipc.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.ipc.js
@@ -3,6 +3,7 @@ import * as PlatformPaths from './PlatformPaths.js'
 export const name = 'PlatformPaths'
 
 export const Commands = {
+  getBuiltinExtensionsPath: PlatformPaths.getBuiltinExtensionsPath,
   getLogsDir: PlatformPaths.getLogsDir,
   getTmpDir: PlatformPaths.getTmpDir,
   getCachePath: PlatformPaths.getCachePath,

--- a/packages/renderer-worker/test/PlatformPaths.test.ts
+++ b/packages/renderer-worker/test/PlatformPaths.test.ts
@@ -16,6 +16,23 @@ const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js'
 
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
 
+const PlatformPathsIpc = await import('../src/parts/PlatformPaths/PlatformPaths.ipc.js')
+
+test('exposes getBuiltinExtensionsPath over ipc', () => {
+  expect(PlatformPathsIpc.Commands.getBuiltinExtensionsPath).toBe(PlatformPaths.getBuiltinExtensionsPath)
+})
+
+test('getBuiltinExtensionsPath', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockImplementation((method) => {
+    if (method === 'Platform.getBuiltinExtensionsPath') {
+      return '/test/extensions'
+    }
+    throw new Error('unexpected message')
+  })
+  expect(await PlatformPaths.getBuiltinExtensionsPath()).toBe('/test/extensions')
+})
+
 test('getLogsDir', async () => {
   // @ts-ignore
   SharedProcess.invoke.mockImplementation((method, ...params) => {


### PR DESCRIPTION
Exposes the physical built-in extensions path to the extension management worker through the renderer command map.