### PR TITLE
fix: dispose editor worker state

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -12,6 +12,7 @@ import * as Id from '../Id/Id.js'
 import * as Languages from '../Languages/Languages.js'
 import * as Platform from '../Platform/Platform.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as Tokenizer from '../Tokenizer/Tokenizer.js'
 import * as TokenizerMap from '../TokenizerMap/TokenizerMap.js'
 import * as UnquoteString from '../UnquoteString/UnquoteString.js'
@@ -273,8 +274,10 @@ export const resize = async (state, dimensions) => {
   return rerender(newState)
 }
 
-export const dispose = (state) => {
+export const dispose = async (state) => {
   Tokenizer.removeConnectedEditor(state.id)
+  const commands = await EditorWorker.invoke('Editor.dispose', state.id)
+  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
 }
 
 export const hasFunctionalRender = true

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const editorWorkerInvoke = jest.fn()
+const rendererProcessInvoke = jest.fn()
+const tokenizerRemoveConnectedEditor = jest.fn()
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -20,7 +22,27 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: rendererProcessInvoke,
+}))
+
+jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
+  getTokenizer: jest.fn(),
+  removeConnectedEditor: tokenizerRemoveConnectedEditor,
+}))
+
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+
+test('dispose', async () => {
+  const commands = [['Viewlet.dispose', 2]]
+  editorWorkerInvoke.mockImplementation(() => commands)
+
+  await ViewletEditorText.dispose({ id: 1 })
+
+  expect(tokenizerRemoveConnectedEditor).toHaveBeenCalledWith(1)
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.dispose', 1)
+  expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.sendMultiple', commands)
+})
 
 test('resize - increase height', async () => {
   editorWorkerInvoke.mockImplementation((method) => {


### PR DESCRIPTION
Dispose editor-worker state whenever a text editor viewlet closes, then forward the returned renderer commands so functional widgets such as the color picker are removed.

Includes a focused renderer-worker regression test for tokenizer cleanup, editor disposal, and command forwarding.