### PR TITLE
fix: await editor viewlet disposal

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -128,7 +128,7 @@ export const dispose = async (id) => {
     if (!instance.factory) {
       throw new Error(`${id} is missing a factory function`)
     }
-    instance.factory.dispose(instance.state)
+    await instance.factory.dispose(instance.state)
     await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     if (instance.factory.getKeyBindings) {
       KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, instanceUid))

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -89,6 +89,38 @@ test('getTitle', async () => {
   expect(getTitle).toHaveBeenCalledWith(1)
 })
 
+test('dispose - waits for factory disposal before disposing the rendered viewlet', async () => {
+  let resolveDispose = () => {}
+  const disposePromise = new Promise<void>((resolve) => {
+    resolveDispose = resolve
+  })
+  const factoryDispose = jest.fn((_state: unknown) => disposePromise)
+  ViewletStates.set(2, {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'SimpleBrowser',
+    factory: { dispose: factoryDispose },
+  })
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(async () => {})
+
+  let didDispose = false
+  const viewletDisposePromise = Viewlet.dispose(2).then(() => {
+    didDispose = true
+  })
+
+  await Promise.resolve()
+  expect(factoryDispose).toHaveBeenCalledWith({ uid: 2 })
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+  expect(didDispose).toBe(false)
+
+  resolveDispose()
+  await viewletDisposePromise
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.dispose', 2)
+  expect(didDispose).toBe(true)
+})
+
 test('openWidget - once', async () => {
   // @ts-ignore
   ViewletManager.load.mockImplementation(() => {


### PR DESCRIPTION
## Summary
- await asynchronous viewlet factory disposal before removing the rendered viewlet
- add a regression test that proves renderer disposal does not race ahead
- mirrors the already-merged renderer-worker lifecycle fix from lvce-editor/renderer-worker#111

## Validation
- renderer-worker: 893 passed, 242 skipped
- renderer-worker type-check
- Prettier check for changed files

## Note
- the package-local `npm run lint` currently invokes an unpinned XO configuration and reports 89,638 baseline errors across the package; the changed files pass the repository formatter.