### PR TITLE
fix: notify views when color theme changes

### DIFF
--- a/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Command from '../Command/Command.js'
 import * as Css from '../Css/Css.js'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.js'
 import * as GetColorThemeCss from '../GetColorThemeCss/GetColorThemeCss.js'
@@ -50,6 +51,7 @@ export const setColorTheme = async (colorThemeId) => {
   }
   // TODO should preferences throw errors or should it call handleError directly?
   await Preferences.set('workbench.colorTheme', colorThemeId)
+  await Command.execute('Layout.handleColorThemeChanged', colorThemeId)
   return undefined
 }
 

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -502,6 +502,7 @@ export const commandMap = {
   'Layout.getUserInfo': lazy('Layout.getUserInfo'),
   'Layout.handleBadgeCountChange': lazy('Layout.handleBadgeCountChange'),
   'Layout.handleBlur': lazy('Layout.handleBlur'),
+  'Layout.handleColorThemeChanged': lazy('Layout.handleColorThemeChanged'),
   'Layout.handleContextMenu': lazy('Layout.handleContextMenu'),
   'Layout.handleExtensionsChanged': lazy('Layout.handleExtensionsChanged'),
   'Layout.handleFocus': lazy('Layout.handleFocus'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1894,6 +1894,10 @@ export const handleExtensionsChanged = async (state: LayoutState) => {
   return callGlobalEvent(state, 'handleExtensionsChanged')
 }
 
+export const handleColorThemeChanged = async (state: LayoutState, colorThemeId: string) => {
+  return callGlobalEvent(state, 'handleColorThemeChanged', colorThemeId)
+}
+
 export const getActiveSideBarView = (state: LayoutState) => {
   return state.sideBarView
 }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -25,6 +25,7 @@ export const Commands = {
 export const CommandsWithSideEffects = {
   attachViewlet: ViewletLayout.attachViewlet,
   handleBadgeCountChange: ViewletLayout.handleBadgeCountChange,
+  handleColorThemeChanged: ViewletLayout.handleColorThemeChanged,
   handleExtensionsChanged: ViewletLayout.handleExtensionsChanged,
   handleBlur: ViewletLayout.handleBlur,
   handleContextMenu: ViewletLayout.handleContextMenu,

--- a/packages/renderer-worker/test/ColorTheme.test.ts
+++ b/packages/renderer-worker/test/ColorTheme.test.ts
@@ -2,11 +2,16 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 beforeEach(() => {
   jest.clearAllMocks()
+  IsTest.state.isTest = true
   for (const key in Preferences.state) {
     delete Preferences.state[key]
   }
   ColorTheme.state.watchedTheme = ''
 })
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
 
 jest.unstable_mockModule('../src/parts/Css/Css.js', () => ({
   addCssStyleSheet: jest.fn(),
@@ -26,9 +31,11 @@ jest.unstable_mockModule('../src/parts/GetColorThemeCss/GetColorThemeCss.js', ()
 }))
 
 const ColorTheme = await import('../src/parts/ColorTheme/ColorTheme.js')
+const Command = await import('../src/parts/Command/Command.js')
 const Css = await import('../src/parts/Css/Css.js')
 const ErrorHandling = await import('../src/parts/ErrorHandling/ErrorHandling.js')
 const GetColorThemeCss = await import('../src/parts/GetColorThemeCss/GetColorThemeCss.js')
+const IsTest = await import('../src/parts/IsTest/IsTest.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
 test('reload applies slime when no color theme is selected', async () => {
@@ -47,4 +54,17 @@ test('hydrate falls back to slime when the selected color theme cannot be loaded
   expect(GetColorThemeCss.getColorThemeCss).toHaveBeenNthCalledWith(2, 'slime')
   expect(ErrorHandling.handleError).toHaveBeenCalledTimes(1)
   expect(Css.addCssStyleSheet).toHaveBeenCalledWith('ContributedColorTheme', ':root { --theme-id: "slime"; }')
+})
+
+test('setColorTheme notifies viewlets when the color theme changes', async () => {
+  await ColorTheme.setColorTheme('cobalt2')
+
+  expect(Preferences.state['workbench.colorTheme']).toBe('cobalt2')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.handleColorThemeChanged', 'cobalt2')
+})
+
+test('setColorTheme does not notify viewlets when applying the color theme fails', async () => {
+  await ColorTheme.setColorTheme('missing-theme')
+
+  expect(Command.execute).not.toHaveBeenCalled()
 })

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -29,14 +29,14 @@ const createDeferred = () => {
   }
 }
 
-const createInstance = (uid, handler) => {
+const createInstance = (uid, eventName, handler) => {
   const state = {
     uid,
   }
   return {
     factory: {
       Commands: {
-        handleWorkspaceRefresh: handler,
+        [eventName]: handler,
       },
     },
     moduleId: `Test${uid}`,
@@ -51,7 +51,7 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   const second = createDeferred()
   ViewletStates.set(
     'first',
-    createInstance(1, async (state) => {
+    createInstance(1, 'handleWorkspaceRefresh', async (state) => {
       calls.push('first:start')
       await first.promise
       calls.push('first:end')
@@ -63,7 +63,7 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   )
   ViewletStates.set(
     'second',
-    createInstance(2, async (state) => {
+    createInstance(2, 'handleWorkspaceRefresh', async (state) => {
       calls.push('second:start')
       await second.promise
       calls.push('second:end')
@@ -90,6 +90,28 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   expect(ViewletManager.render).toHaveBeenCalledTimes(2)
   expect(result).toEqual({
     commands: [['render.1'], ['render.2']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
+test('handleColorThemeChanged forwards the color theme id to viewlets', async () => {
+  const handler = jest.fn((state: { uid: number }, colorThemeId: string) => {
+    return {
+      ...state,
+      colorThemeId,
+    }
+  })
+  ViewletStates.set('extension-detail', createInstance(1, 'handleColorThemeChanged', handler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleColorThemeChanged(state, 'slime')
+
+  expect(handler).toHaveBeenCalledWith({ uid: 1 }, 'slime')
+  expect(ViewletManager.render).toHaveBeenCalledTimes(1)
+  expect(result).toEqual({
+    commands: [['render.1']],
     newState: {
       ...state,
     },


### PR DESCRIPTION
Broadcasts successful color theme changes to active viewlets through the layout global-event path. Adds renderer coverage for the notification and event forwarding.