### PR TITLE
fix: update virtual dom worker

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -506,9 +506,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/virtual-dom-worker": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.7.0.tgz",
-      "integrity": "sha512-G7q+muSVZ9emunvpzv7N/0CINW3FhIPDGXGO6pisPb3cbQ3ENZf9/ndjVZ9pFk2/hB/GQnyG3zqVvVPml20olg==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.7.1.tgz",
+      "integrity": "sha512-eOTz8FuoQsoP4XCuvGbT4yb0UuZpUfsvrqf0Df1I3aFpp1aOZH8NxEXzEcfKQ0rhKzIf96A5dQpmA77Xb/rFvw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/constants": "^5.19.0"


### PR DESCRIPTION
## Summary
- update @lvce-editor/virtual-dom-worker lockfile entry to 11.7.1
- pulls in the pointer listener cleanup from lvce-editor/virtual-dom#502

## Verification
- npm ci
- npm run type-check (packages/renderer-worker)
- npm test -- --coverage=false (packages/renderer-worker)
- npm run lint