### PR TITLE
fix: pass deleted uris to workspace refresh

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -4,8 +4,8 @@ import * as EncodingType from '../EncodingType/EncodingType.js'
 import * as GetFileSystem from '../GetFileSystem/GetFileSystem.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 
-const notifyWorkspaceChanged = async () => {
-  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh'), Command.execute('Layout.refreshSourceControlBadgeCount')])
+const notifyWorkspaceChanged = async (deletedUris = []) => {
+  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', deletedUris), Command.execute('Layout.refreshSourceControlBadgeCount')])
 }
 
 export const readFile = async (uri, encoding = EncodingType.Utf8) => {
@@ -27,7 +27,7 @@ export const remove = async (uri) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.remove(uri)
-  await notifyWorkspaceChanged()
+  await notifyWorkspaceChanged([uri])
 }
 
 export const rename = async (oldUri, newUri) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1843,13 +1843,18 @@ export const setUpdateState = async (state, updateState) => {
   return callGlobalEvent(state, 'handleUpdateStateChange', updateState)
 }
 
-export const handleWorkspaceRefresh = async (state: LayoutState) => {
-  return callGlobalEvent(state, 'handleWorkspaceRefresh')
+export const handleWorkspaceRefresh = async (state: LayoutState, deletedUris: readonly string[] = []) => {
+  return callGlobalEvent(state, 'handleWorkspaceRefresh', deletedUris)
 }
 
 export const refreshSourceControlBadgeCount = async (state: LayoutState): Promise<LayoutStateResult> => {
   try {
-    const badgeCount = await SourceControlWorker.invoke('SourceControl.getWorkspaceBadgeCount', Workspace.state.workspacePath, assetDir, Platform.platform)
+    const badgeCount = await SourceControlWorker.invoke(
+      'SourceControl.getWorkspaceBadgeCount',
+      Workspace.state.workspacePath,
+      assetDir,
+      Platform.platform,
+    )
     return setBadgeCount(state, ViewletModuleId.SourceControl, badgeCount)
   } catch {
     return {

--- a/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
+++ b/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const execute = jest.fn()
+const remove = jest.fn()
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute,
+  }
+})
+
+const FileSystem = await import('../src/parts/FileSystem/FileSystem.js')
+const FileSystemState = await import('../src/parts/FileSystemState/FileSystemState.js')
+
+FileSystemState.registerAll({
+  test() {
+    return {
+      remove,
+    }
+  },
+})
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('remove notifies workspace views with the deleted uri', async () => {
+  await FileSystem.remove('test://some-file.txt')
+
+  expect(remove).toHaveBeenCalledWith('test://some-file.txt')
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', ['test://some-file.txt'])
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
+})

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -47,12 +47,14 @@ const createInstance = (uid, eventName, handler) => {
 
 test('handleWorkspaceRefresh runs global event handlers in parallel', async () => {
   const calls: string[] = []
+  const deletedUris = ['/workspace/deleted.ts']
   const first = createDeferred()
   const second = createDeferred()
   ViewletStates.set(
     'first',
-    createInstance(1, 'handleWorkspaceRefresh', async (state) => {
+    createInstance(1, 'handleWorkspaceRefresh', async (state, receivedDeletedUris) => {
       calls.push('first:start')
+      expect(receivedDeletedUris).toBe(deletedUris)
       await first.promise
       calls.push('first:end')
       return {
@@ -63,8 +65,9 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   )
   ViewletStates.set(
     'second',
-    createInstance(2, 'handleWorkspaceRefresh', async (state) => {
+    createInstance(2, 'handleWorkspaceRefresh', async (state, receivedDeletedUris) => {
       calls.push('second:start')
+      expect(receivedDeletedUris).toBe(deletedUris)
       await second.promise
       calls.push('second:end')
       return {
@@ -75,7 +78,7 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   )
 
   const state = ViewletLayout.create(1)
-  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state)
+  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state, deletedUris)
 
   expect(calls).toEqual(['first:start', 'second:start'])
 


### PR DESCRIPTION
Pass deleted file URIs through the renderer workspace refresh event so main-area-worker can close matching text editor tabs without making a nested renderer RPC. Adds focused coverage for file removal notifications and layout event fanout.