### PR TITLE
fix: expose status bar visibility

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -491,6 +491,7 @@ export const commandMap = {
   'Layout.getActiveSideBarView': lazy('Layout.getActiveSideBarView'),
   'Layout.getActiveSecondarySideBarView': lazy('Layout.getActiveSecondarySideBarView'),
   'Layout.getSecondarySideBarVisible': lazy('Layout.getSecondarySideBarVisible'),
+  'Layout.getStatusBarVisible': lazy('Layout.getStatusBarVisible'),
   'Layout.getSideBarFocusMode': lazy('Layout.getSideBarFocusMode'),
   'Layout.getAssetDir': lazy('Layout.getAssetDir'),
   'Layout.getAuthState': lazy('Layout.getAuthState'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1923,6 +1923,10 @@ export const getSecondarySideBarVisible = (state: LayoutState): boolean => {
   return state.secondarySideBarVisible
 }
 
+export const getStatusBarVisible = (state: LayoutState): boolean => {
+  return state.statusBarVisible
+}
+
 export const getSideBarPosition = (state: LayoutState) => {
   return state.sideBarLocation
 }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -9,6 +9,7 @@ export const Commands = {
   getActivePanelView: ViewletLayout.getActivePanelView,
   getSideBarVisible: ViewletLayout.getSideBarVisible,
   getSecondarySideBarVisible: ViewletLayout.getSecondarySideBarVisible,
+  getStatusBarVisible: ViewletLayout.getStatusBarVisible,
   getSideBarPosition: ViewletLayout.getSideBarPosition,
   getSideBarFocusMode: ViewletLayout.getSideBarFocusMode,
   getCommit: ViewletLayout.getCommit,

--- a/packages/renderer-worker/test/ViewletLayoutStatusBarVisible.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutStatusBarVisible.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletLayout from '../src/parts/ViewletLayout/ViewletLayout.ts'
+
+test('getStatusBarVisible returns the status bar visibility', () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    statusBarVisible: false,
+  }
+
+  expect(ViewletLayout.getStatusBarVisible(state)).toBe(false)
+})


### PR DESCRIPTION
Expose the renderer layout's status bar visibility so worker callers can avoid dispatching commands to a hidden status bar.