### PR TITLE
fix: handle duplicate dynamic focus commands

### DIFF
--- a/packages/renderer-worker/src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js
+++ b/packages/renderer-worker/src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js
@@ -1,16 +1,17 @@
 import * as Focus from '../Focus/Focus.js'
 
 const updateDynamic = (commands, key, fn) => {
-  const keyIndex = commands.findIndex((command) => command[0] === key)
-  let args = []
-  if (keyIndex !== -1) {
-    const command = commands[keyIndex]
-    args = command.slice(2)
-    commands.splice(keyIndex, 1)
+  const matchingCommands = []
+  for (let i = commands.length - 1; i >= 0; i--) {
+    const command = commands[i]
+    if (command[0] === key) {
+      matchingCommands.push(command)
+      commands.splice(i, 1)
+    }
   }
   // TODO send focus changes to renderer process together with other message
-  if (args.length) {
-    fn(...args)
+  for (let i = matchingCommands.length - 1; i >= 0; i--) {
+    fn(...matchingCommands[i].slice(2))
   }
 }
 

--- a/packages/renderer-worker/test/UpdateDynamicFocusContext.test.ts
+++ b/packages/renderer-worker/test/UpdateDynamicFocusContext.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => {
+  return {
+    removeAdditionalFocus: jest.fn(),
+    setAdditionalFocus: jest.fn(),
+    setFocus: jest.fn(),
+  }
+})
+
+const Focus = await import('../src/parts/Focus/Focus.js')
+const UpdateDynamicFocusContext = await import('../src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js')
+const mockRemoveAdditionalFocus = jest.mocked(Focus.removeAdditionalFocus)
+const mockSetAdditionalFocus = jest.mocked(Focus.setAdditionalFocus)
+const mockSetFocus = jest.mocked(Focus.setFocus)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('removes and applies all dynamic focus commands', () => {
+  const commands = [
+    ['Viewlet.setFocusContext', 1, 10],
+    ['Viewlet.setDom2', 1, []],
+    ['Viewlet.setFocusContext', 1, 20],
+    ['Viewlet.setAdditionalFocus', 1, 30],
+    ['Viewlet.setAdditionalFocus', 1, 40],
+    ['Viewlet.unsetAdditionalFocus', 1, 50],
+    ['Viewlet.unsetAdditionalFocus', 1, 60],
+  ]
+
+  UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
+
+  expect(commands).toEqual([['Viewlet.setDom2', 1, []]])
+  expect(mockSetFocus.mock.calls).toEqual([[10], [20]])
+  expect(mockSetAdditionalFocus.mock.calls).toEqual([[30], [40]])
+  expect(mockRemoveAdditionalFocus.mock.calls).toEqual([[50], [60]])
+})


### PR DESCRIPTION
## Summary
- remove every dynamic focus command before sending renderer commands
- apply duplicate focus updates in their original order
- add a regression test covering duplicate set, add, and remove focus commands

## Why
The explorer-view 20x e2e matrix reproduced `unknown command Viewlet.setFocusContext` three times on Windows Chromium. `updateDynamic` only removed the first matching command, so a duplicate was forwarded to renderer-process, which has no handler for this internal command.

Diagnostic run: https://github.com/lvce-editor/explorer-view/actions/runs/29503010747
Diagnostic PR: https://github.com/lvce-editor/explorer-view/pull/1742

## Validation
- renderer-worker type-check
- UpdateDynamicFocusContext unit test
- prettier check