### PR TITLE
Dispatch live settings changes to viewlets

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -512,6 +512,7 @@ export const commandMap = {
   'Layout.handleSashPointerDown': lazy('Layout.handleSashPointerDown'),
   'Layout.handleSashPointerMove': lazy('Layout.handleSashPointerMove'),
   'Layout.handleSashPointerUp': lazy('Layout.handleSashPointerUp'),
+  'Layout.handleSettingsChanged': lazy('Layout.handleSettingsChanged'),
   'Layout.handleWorkspaceRefresh': lazy('Layout.handleWorkspaceRefresh'),
   'Layout.refreshSourceControlBadgeCount': lazy('Layout.refreshSourceControlBadgeCount'),
   'Layout.reset': lazy('Layout.reset'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1742,6 +1742,10 @@ const callGlobalEvent = async (state: LayoutState, eventName, ...args): Promise<
       const commands = ViewletManager.render(value.factory, value.renderedState, newState)
       // @ts-ignore
       allCommands.push(...commands)
+      // @ts-ignore
+      value.state = newState
+      // @ts-ignore
+      value.renderedState = newState
     }
   }
   return {
@@ -1845,6 +1849,11 @@ export const setUpdateState = async (state, updateState) => {
 
 export const handleWorkspaceRefresh = async (state: LayoutState, deletedUris: readonly string[] = []) => {
   return callGlobalEvent(state, 'handleWorkspaceRefresh', deletedUris)
+}
+
+export const handleSettingsChanged = async (state: LayoutState) => {
+  await Preferences.hydrate()
+  return callGlobalEvent(state, 'handleSettingsChanged')
 }
 
 export const refreshSourceControlBadgeCount = async (state: LayoutState): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -40,6 +40,7 @@ export const CommandsWithSideEffects = {
   handleSashPreviewPointerDown: ViewletLayout.handleSashPreviewPointerDown,
   handleSashPointerMove: ViewletLayout.handleSashPointerMove,
   handleSashPointerUp: ViewletLayout.handleSashPointerUp,
+  handleSettingsChanged: ViewletLayout.handleSettingsChanged,
   handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
   refreshSourceControlBadgeCount: ViewletLayout.refreshSourceControlBadgeCount,
   reset: ResetLayout.reset,

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -1,5 +1,15 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const hydratePreferences = jest.fn()
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => {
+  return {
+    get: jest.fn(),
+    hydrate: hydratePreferences,
+    update: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => {
   return {
     render: jest.fn((factory, renderedState, newState) => {
@@ -113,6 +123,36 @@ test('handleColorThemeChanged forwards the color theme id to viewlets', async ()
 
   expect(handler).toHaveBeenCalledWith({ uid: 1 }, 'slime')
   expect(ViewletManager.render).toHaveBeenCalledTimes(1)
+  expect(result).toEqual({
+    commands: [['render.1']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
+test('handleSettingsChanged hydrates preferences and updates viewlet state', async () => {
+  const calls: string[] = []
+  hydratePreferences.mockImplementation(async () => {
+    calls.push('hydrate')
+  })
+  const handler = jest.fn((state: { uid: number }) => {
+    calls.push('handleSettingsChanged')
+    return {
+      ...state,
+      lineNumbers: false,
+    }
+  })
+  ViewletStates.set('editor', createInstance(1, 'handleSettingsChanged', handler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleSettingsChanged(state)
+
+  expect(calls).toEqual(['hydrate', 'handleSettingsChanged'])
+  expect(ViewletStates.getInstance('editor').state).toEqual({
+    lineNumbers: false,
+    uid: 1,
+  })
   expect(result).toEqual({
     commands: [['render.1']],
     newState: {


### PR DESCRIPTION
Adds a layout settings-change event that rehydrates preferences, updates loaded viewlet state, and rerenders components that implement handleSettingsChanged.