### PR TITLE
fix: focus selected side bar view

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -428,6 +428,15 @@ const getLazyImport = (module, fnName) => {
   return undefined
 }
 
+const hasFn = (module, fnName) => {
+  return Boolean(
+    module.Commands?.[fnName] ||
+    module.CommandsWithSideEffects?.[fnName] ||
+    module.LazyCommands?.[fnName] ||
+    module.CommandsWithSideEffectsLazy?.[fnName],
+  )
+}
+
 const getFn = async (module, fnName) => {
   if (module.Commands && module.Commands[fnName]) {
     return module.Commands[fnName]
@@ -445,6 +454,22 @@ const getFn = async (module, fnName) => {
     throw new Error(`Command not found ${module.name}.${fnName}`)
   }
   return lazyFn
+}
+
+export const getFocusCommands = async (id) => {
+  const instance = ViewletStates.getInstance(id)
+  if (!instance || !hasFn(instance.factory, 'focus')) {
+    return []
+  }
+  const focus = await getFn(instance.factory, 'focus')
+  const oldState = instance.state
+  const newState = await focus(oldState)
+  if (oldState === newState) {
+    return []
+  }
+  const commands = ViewletManager.render(instance.factory, instance.renderedState, newState)
+  ViewletStates.setRenderedState(id, newState)
+  return commands
 }
 
 export const executeViewletCommand = async (uid, fnName, ...args) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -622,7 +622,12 @@ export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<L
   if (state.sideBarVisible && state.sideBarView === sideBarView) {
     return hideSideBar(state)
   }
-  return showSideBar(state, sideBarView)
+  const result = await showSideBar(state, sideBarView)
+  const focusCommands = await Viewlet.getFocusCommands(sideBarView)
+  return {
+    newState: result.newState,
+    commands: [...result.commands, ...focusCommands],
+  }
 }
 
 export const showSecondarySideBar = (state: LayoutState) => {

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -26,6 +26,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
     load: jest.fn(() => {
       throw new Error('not implemented')
     }),
+    render: jest.fn(() => []),
   }
 })
 jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
@@ -87,6 +88,44 @@ test('getTitle', async () => {
   await expect(Viewlet.getTitle(1)).resolves.toBe('Test Title')
   expect(getTitle).toHaveBeenCalledTimes(1)
   expect(getTitle).toHaveBeenCalledWith(1)
+})
+
+test('getFocusCommands returns focus render commands without sending them', async () => {
+  const oldState = { uid: 2 }
+  const newState = { focus: 1, uid: 2 }
+  const focus = jest.fn(async (_state: typeof oldState) => newState)
+  ViewletStates.set('Search', {
+    state: oldState,
+    renderedState: oldState,
+    moduleId: 'Search',
+    factory: {
+      Commands: { focus },
+    },
+  })
+  // @ts-ignore
+  ViewletManager.render.mockReturnValue([['Viewlet.focusElementByName', 2, 'SearchValue']])
+
+  const commands = await Viewlet.getFocusCommands('Search')
+
+  expect(focus).toHaveBeenCalledWith(oldState)
+  expect(ViewletManager.render).toHaveBeenCalledWith(expect.anything(), oldState, newState)
+  expect(commands).toEqual([['Viewlet.focusElementByName', 2, 'SearchValue']])
+  expect(ViewletStates.getState('Search')).toBe(newState)
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('getFocusCommands returns no commands when the view has no focus command', async () => {
+  ViewletStates.set('CustomView', {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'CustomView',
+    factory: {
+      Commands: {},
+    },
+  })
+
+  await expect(Viewlet.getFocusCommands('CustomView')).resolves.toEqual([])
+  expect(ViewletManager.render).not.toHaveBeenCalled()
 })
 
 test('dispose - waits for factory disposal before disposing the rendered viewlet', async () => {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -25,6 +25,7 @@ jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
 jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
   return {
     disposeFunctional: jest.fn(() => []),
+    getFocusCommands: jest.fn(() => []),
     resize: jest.fn(() => []),
   }
 })
@@ -54,6 +55,8 @@ beforeEach(() => {
   SaveState.saveViewletState.mockResolvedValue(undefined)
   // @ts-ignore
   Viewlet.disposeFunctional.mockReturnValue([])
+  // @ts-ignore
+  Viewlet.getFocusCommands.mockResolvedValue([])
   // @ts-ignore
   Viewlet.resize.mockResolvedValue([])
   // @ts-ignore
@@ -300,6 +303,23 @@ test('toggleSideBarView preserves resized preview width when showing the side ba
     sideBarView: 'SourceControl',
     sideBarVisible: true,
   })
+})
+
+test('toggleSideBarView appends focus commands after showing the requested view', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusElementByName', 12, 'SearchValue']])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  }
+
+  const result = await ViewletLayout.toggleSideBarView(state, 'Search')
+
+  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Search')
+  expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusElementByName', 12, 'SearchValue']])
 })
 
 test('layout allows the side bar to grow when the preview uses half the window', () => {


### PR DESCRIPTION
Focus the selected sidebar view after an Activity Bar switch so Search receives DOM and keybinding focus immediately.