### PR TITLE
fix: allow extension changelog GitHub requests

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -222,7 +222,7 @@
     "productionPath": "/packages/extension-detail-view-worker/dist/extensionDetailViewWorkerMain.js",
     "settingName": "develop.extensionDetailViewWorkerPath",
     "hotReloadCommand": "ExtensionDetail.hotReload",
-    "contentSecurityPolicy": ["default-src 'none'"]
+    "contentSecurityPolicy": ["default-src 'none'", "connect-src https://api.github.com"]
   },
   {
     "id": "extensionHostSubWorker",

--- a/packages/static-server/test/ContentSecurityPolicyExtensionDetailViewWorker.test.ts
+++ b/packages/static-server/test/ContentSecurityPolicyExtensionDetailViewWorker.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import * as GetHeaders from '../src/parts/GetHeaders/GetHeaders.ts'
+
+test('extension detail view worker allows GitHub API connections', () => {
+  const headers = GetHeaders.getHeaders({
+    absolutePath: '/test/extensionDetailViewWorkerMain.js',
+    etag: 'test-etag',
+    isImmutable: false,
+    isForElectronProduction: false,
+    applicationName: 'lvce',
+  })
+
+  expect(headers['Content-Security-Policy']).toContain('connect-src https://api.github.com')
+})


### PR DESCRIPTION
Allow the extension detail worker to connect to the GitHub API so repository release notes can load in the Changelog tab. Add a static-server regression test for the worker response policy.