### PR TITLE
fix: return status bar visibility queries

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -65,6 +65,7 @@ const runFn = async (instance, id, key, fn, args) => {
       key === 'getProductNameLong' ||
       key === 'getSideBarPosition' ||
       key === 'getSideBarVisible' ||
+      key === 'getStatusBarVisible' ||
       key === 'getUserInfo' ||
       key === 'getPayload' ||
       key === 'getResponse' ||

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -184,6 +184,39 @@ test('concurrent side effect commands preserve completed state changes', async (
   })
 })
 
+test('functional getStatusBarVisible command returns its boolean value', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const mockModule = {
+    Commands: {
+      getStatusBarVisible: (state) => state.statusBarVisible,
+    },
+    create: jest.fn(() => ({
+      statusBarVisible: false,
+      uid: 8,
+    })),
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state) => state),
+    render: [],
+  }
+  const getModule = async () => mockModule
+  const viewlet = {
+    disposed: false,
+    focus: false,
+    getModule,
+    id: 'StatusBarQueryTest',
+    show: false,
+    type: 0,
+    uid: 8,
+    uri: '',
+  }
+
+  await ViewletManager.load(viewlet)
+
+  await expect(Command.execute('StatusBarQueryTest.getStatusBarVisible')).resolves.toBe(false)
+})
+
 test('extension view render sends a dynamic title to its parent', () => {
   const dom = []
   const oldState = {


### PR DESCRIPTION
## Summary
- treat Layout.getStatusBarVisible as a functional query result
- prevent boolean visibility values from being validated as viewlet state
- add a regression test through the command wrapper

## Validation
- renderer-worker ViewletManager tests: 10 passed
- renderer-worker type-check passed
- package-local XO lint is currently unusable on the baseline (90,082 pre-existing style errors)