### PR TITLE
fix: refresh explorer for external file changes

### DIFF
--- a/packages/renderer-worker/src/parts/FileWatcher/FileWatcher.js
+++ b/packages/renderer-worker/src/parts/FileWatcher/FileWatcher.js
@@ -4,6 +4,7 @@ import * as TestWorker from '../TestWorker/TestWorker.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 
 const map = Object.create(null)
+const ids = new WeakMap()
 
 export const handleEvent = async (id, event) => {
   const eventTarget = map[id]
@@ -29,9 +30,21 @@ export const handleEvent = async (id, event) => {
 
 export const watch = async (options) => {
   const id = Id.create()
-  map[id] = new EventTarget()
+  const target = new EventTarget()
+  map[id] = target
+  ids.set(target, id)
   await SharedProcess.invoke('FileWatcher.watch', id, options)
-  return map[id]
+  return target
+}
+
+export const dispose = async (target) => {
+  const id = ids.get(target)
+  if (id === undefined) {
+    return
+  }
+  ids.delete(target)
+  delete map[id]
+  await SharedProcess.invoke('FileWatcher.dispose', id)
 }
 
 const map2 = Object.create(null)

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -40,6 +40,7 @@ import * as ViewletModuleInternal from '../ViewletModuleInternal/ViewletModuleIn
 import * as ViewletModuleMap from '../ViewletModuleMap/ViewletModuleMap.js'
 import * as WatchFilesForHotReload from '../WatchFilesForHotReload/WatchFilesForHotReload.js'
 import * as Workspace from '../Workspace/Workspace.js'
+import * as WorkspaceFileWatcher from '../WorkspaceFileWatcher/WorkspaceFileWatcher.js'
 
 const actions = [
   async () => {
@@ -250,7 +251,11 @@ export const startup = async (platform, assetDir) => {
   await Location.hydrate()
   Performance.mark(PerformanceMarkerType.DidLoadLocation)
 
-  const watcherPromises = Promise.all([DevelopFileWatcher.hydrate(), WatchFilesForHotReload.watchFilesForHotReload()])
+  const watcherPromises = Promise.all([
+    DevelopFileWatcher.hydrate(),
+    WatchFilesForHotReload.watchFilesForHotReload(),
+    WorkspaceFileWatcher.hydrate(),
+  ])
 
   Performance.measure(PerformanceMarkerType.OpenWorkspace, PerformanceMarkerType.WillOpenWorkspace, PerformanceMarkerType.DidOpenWorkspace)
   Performance.measure(PerformanceMarkerType.LoadMain, PerformanceMarkerType.WillLoadMain, PerformanceMarkerType.DidLoadMain)

--- a/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
+++ b/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
@@ -1,0 +1,79 @@
+import * as Command from '../Command/Command.js'
+import * as FileWatcher from '../FileWatcher/FileWatcher.js'
+import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
+import * as Workspace from '../Workspace/Workspace.js'
+
+const RefreshDelay = 100
+
+let watcher
+let refreshTimeout
+const deletedUris = new Set()
+
+const isDeleteEvent = (eventName) => {
+  return eventName === 'unlink' || eventName === 'unlinkDir'
+}
+
+const refresh = async () => {
+  refreshTimeout = undefined
+  const deleted = [...deletedUris]
+  deletedUris.clear()
+  await Promise.allSettled([
+    Command.execute('Layout.handleWorkspaceRefresh', deleted),
+    Command.execute('Layout.refreshSourceControlBadgeCount'),
+  ])
+}
+
+const scheduleRefresh = (event) => {
+  if (isDeleteEvent(event.eventName)) {
+    deletedUris.add(event.uri)
+  }
+  if (refreshTimeout !== undefined) {
+    clearTimeout(refreshTimeout)
+  }
+  refreshTimeout = setTimeout(refresh, RefreshDelay)
+}
+
+const disposeWatcher = async () => {
+  if (!watcher) {
+    return
+  }
+  const oldWatcher = watcher
+  watcher = undefined
+  oldWatcher.removeEventListener('watcher-event', handleEvent)
+  await FileWatcher.dispose(oldWatcher)
+}
+
+const handleEvent = (event) => {
+  scheduleRefresh(event.detail)
+}
+
+export const watchWorkspace = async (workspaceUri) => {
+  await disposeWatcher()
+  if (!workspaceUri || !workspaceUri.startsWith('file://')) {
+    return
+  }
+  watcher = await FileWatcher.watch({
+    exclude: ['.git', 'node_modules'],
+    roots: [workspaceUri],
+  })
+  watcher.addEventListener('watcher-event', handleEvent)
+}
+
+const handleWorkspaceChange = async () => {
+  await watchWorkspace(Workspace.getWorkspaceUri())
+}
+
+export const hydrate = async () => {
+  GlobalEventBus.addListener('workspace.change', handleWorkspaceChange)
+  await watchWorkspace(Workspace.getWorkspaceUri())
+}
+
+export const dispose = async () => {
+  GlobalEventBus.removeListener('workspace.change', handleWorkspaceChange)
+  if (refreshTimeout !== undefined) {
+    clearTimeout(refreshTimeout)
+    refreshTimeout = undefined
+  }
+  deletedUris.clear()
+  await disposeWatcher()
+}

--- a/packages/renderer-worker/test/FileWatcher.test.ts
+++ b/packages/renderer-worker/test/FileWatcher.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Id/Id.js', () => ({
+  create: jest.fn(() => 123),
+}))
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const FileWatcher = await import('../src/parts/FileWatcher/FileWatcher.js')
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('dispose - disposes watcher and ignores later events', async () => {
+  const listener = jest.fn()
+  const watcher = await FileWatcher.watch({
+    exclude: [],
+    roots: ['file:///workspace'],
+  })
+  watcher.addEventListener('watcher-event', listener)
+
+  await FileWatcher.dispose(watcher)
+  await FileWatcher.handleEvent(123, {
+    eventName: 'add',
+    uri: 'file:///workspace/new.txt',
+  })
+
+  expect(SharedProcess.invoke).toHaveBeenNthCalledWith(1, 'FileWatcher.watch', 123, {
+    exclude: [],
+    roots: ['file:///workspace'],
+  })
+  expect(SharedProcess.invoke).toHaveBeenNthCalledWith(2, 'FileWatcher.dispose', 123)
+  expect(listener).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
+++ b/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+
+const addEventListener = jest.fn()
+const removeEventListener = jest.fn()
+const watcher = {
+  addEventListener,
+  removeEventListener,
+}
+const getWorkspaceUri = jest.fn(() => 'file:///workspace')
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/FileWatcher/FileWatcher.js', () => ({
+  dispose: jest.fn(),
+  watch: jest.fn(() => watcher),
+}))
+
+jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
+  getWorkspaceUri,
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const FileWatcher = await import('../src/parts/FileWatcher/FileWatcher.js')
+const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+const WorkspaceFileWatcher = await import('../src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js')
+
+beforeEach(async () => {
+  jest.useFakeTimers()
+  await WorkspaceFileWatcher.dispose()
+  GlobalEventBus.state.listenerMap = Object.create(null)
+  jest.clearAllMocks()
+  getWorkspaceUri.mockReturnValue('file:///workspace')
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('hydrate - watches the current file workspace', async () => {
+  await WorkspaceFileWatcher.hydrate()
+
+  expect(FileWatcher.watch).toHaveBeenCalledWith({
+    exclude: ['.git', 'node_modules'],
+    roots: ['file:///workspace'],
+  })
+  expect(addEventListener).toHaveBeenCalledWith('watcher-event', expect.any(Function))
+})
+
+test('watchWorkspace - replaces the previous watcher', async () => {
+  await WorkspaceFileWatcher.watchWorkspace('file:///workspace')
+  await WorkspaceFileWatcher.watchWorkspace('file:///other')
+
+  expect(removeEventListener).toHaveBeenCalledWith('watcher-event', expect.any(Function))
+  expect(FileWatcher.dispose).toHaveBeenCalledWith(watcher)
+  expect(FileWatcher.watch).toHaveBeenLastCalledWith({
+    exclude: ['.git', 'node_modules'],
+    roots: ['file:///other'],
+  })
+})
+
+test('workspace change - watches the new workspace uri', async () => {
+  await WorkspaceFileWatcher.hydrate()
+  getWorkspaceUri.mockReturnValue('file:///other')
+  const handleWorkspaceChange = GlobalEventBus.state.listenerMap['workspace.change'][0]
+
+  await handleWorkspaceChange('/other')
+
+  expect(FileWatcher.watch).toHaveBeenLastCalledWith({
+    exclude: ['.git', 'node_modules'],
+    roots: ['file:///other'],
+  })
+})
+
+test('watcher events - debounce refresh and forward deleted uris', async () => {
+  await WorkspaceFileWatcher.watchWorkspace('file:///workspace')
+  const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
+
+  handleEvent({
+    detail: {
+      eventName: 'add',
+      uri: 'file:///workspace/new.txt',
+    },
+  })
+  handleEvent({
+    detail: {
+      eventName: 'unlink',
+      uri: 'file:///workspace/deleted.txt',
+    },
+  })
+  await jest.runAllTimersAsync()
+
+  expect(Command.execute).toHaveBeenCalledTimes(2)
+  expect(Command.execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', ['file:///workspace/deleted.txt'])
+  expect(Command.execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
+})
+
+test('watchWorkspace - skips non-file workspaces', async () => {
+  await WorkspaceFileWatcher.watchWorkspace('github://owner/repository')
+
+  expect(FileWatcher.watch).not.toHaveBeenCalled()
+})

--- a/packages/shared-process/src/parts/FileWatcher/FileWatcher.ipc.ts
+++ b/packages/shared-process/src/parts/FileWatcher/FileWatcher.ipc.ts
@@ -3,6 +3,7 @@ import * as FileWatcher from '../FileWatcher/FileWatcher.ts'
 export const name = 'FileWatcher'
 
 export const Commands = {
+  dispose: FileWatcher.dispose,
   handleChange: FileWatcher.handleChange,
   watch: FileWatcher.watch,
   watchFile2: FileWatcher.watchFile2,

--- a/packages/shared-process/src/parts/FileWatcher/FileWatcher.ts
+++ b/packages/shared-process/src/parts/FileWatcher/FileWatcher.ts
@@ -10,14 +10,30 @@ const handleEvents = (id: any, ipc: any, event: any): any => {
 // TODO remove ipc and dispose file watcher when socket / messageport closes
 const internalIdMap = Object.create(null)
 
+const addCloseListener = (ipc: any, listener: any): void => {
+  if (ipc.addEventListener) {
+    ipc.addEventListener('close', listener)
+  } else {
+    ipc.on('close', listener)
+  }
+}
+
+const removeCloseListener = (ipc: any, listener: any): void => {
+  if (ipc.removeEventListener) {
+    ipc.removeEventListener('close', listener)
+  } else {
+    ipc.off('close', listener)
+  }
+}
+
 export const watch = async (ipc: any, id: any, { exclude, roots }: any): Promise<any> => {
   const internalId = Id.create()
   const handleClose = async (): Promise<void> => {
-    ipc.off('close', handleClose)
+    removeCloseListener(ipc, handleClose)
     delete internalIdMap[internalId]
     await disposeFileWatcher(internalId)
   }
-  ipc.on('close', handleClose)
+  addCloseListener(ipc, handleClose)
   internalIdMap[internalId] = { handleClose, id, ipc }
   return FileWatcherProcess.invoke('FileWatcher.watchFolders', {
     exclude,
@@ -37,7 +53,7 @@ const disposeFileWatcher = async (internalId: any): Promise<any> => {
 export const dispose = async (ipc: any, id: any): Promise<void> => {
   for (const [internalId, ref] of Object.entries(internalIdMap)) {
     if ((ref as any).id === id && (ref as any).ipc === ipc) {
-      ipc.off('close', (ref as any).handleClose)
+      removeCloseListener(ipc, (ref as any).handleClose)
       delete internalIdMap[internalId]
       await disposeFileWatcher(Number(internalId))
       return
@@ -48,11 +64,11 @@ export const dispose = async (ipc: any, id: any): Promise<void> => {
 export const watchFile2 = async (ipc: any, id: any, uri: any): Promise<any> => {
   const internalId = Id.create()
   const handleClose = async (): Promise<any> => {
-    ipc.off('close', handleClose)
+    removeCloseListener(ipc, handleClose)
     delete internalIdMap[internalId]
     await disposeFileWatcher(internalId)
   }
-  ipc.on('close', handleClose)
+  addCloseListener(ipc, handleClose)
   internalIdMap[internalId] = { handleClose, id, ipc }
   // TODO promise never resolves, should resolve as soon as watcher has been set up
   await FileWatcherProcess.invoke('FileWatcher.watchFile2', internalId, uri)

--- a/packages/shared-process/src/parts/FileWatcher/FileWatcher.ts
+++ b/packages/shared-process/src/parts/FileWatcher/FileWatcher.ts
@@ -12,7 +12,13 @@ const internalIdMap = Object.create(null)
 
 export const watch = async (ipc: any, id: any, { exclude, roots }: any): Promise<any> => {
   const internalId = Id.create()
-  internalIdMap[internalId] = { id, ipc }
+  const handleClose = async (): Promise<void> => {
+    ipc.off('close', handleClose)
+    delete internalIdMap[internalId]
+    await disposeFileWatcher(internalId)
+  }
+  ipc.on('close', handleClose)
+  internalIdMap[internalId] = { handleClose, id, ipc }
   return FileWatcherProcess.invoke('FileWatcher.watchFolders', {
     exclude,
     id: internalId,
@@ -28,19 +34,34 @@ const disposeFileWatcher = async (internalId: any): Promise<any> => {
   }
 }
 
+export const dispose = async (ipc: any, id: any): Promise<void> => {
+  for (const [internalId, ref] of Object.entries(internalIdMap)) {
+    if ((ref as any).id === id && (ref as any).ipc === ipc) {
+      ipc.off('close', (ref as any).handleClose)
+      delete internalIdMap[internalId]
+      await disposeFileWatcher(Number(internalId))
+      return
+    }
+  }
+}
+
 export const watchFile2 = async (ipc: any, id: any, uri: any): Promise<any> => {
   const internalId = Id.create()
   const handleClose = async (): Promise<any> => {
     ipc.off('close', handleClose)
+    delete internalIdMap[internalId]
     await disposeFileWatcher(internalId)
   }
   ipc.on('close', handleClose)
-  internalIdMap[internalId] = { id, ipc }
+  internalIdMap[internalId] = { handleClose, id, ipc }
   // TODO promise never resolves, should resolve as soon as watcher has been set up
   await FileWatcherProcess.invoke('FileWatcher.watchFile2', internalId, uri)
 }
 
 export const handleChange = (event: any): any => {
   const ref = internalIdMap[event.id]
+  if (!ref) {
+    return
+  }
   handleEvents(ref.id, ref.ipc, event)
 }

--- a/packages/shared-process/src/parts/RequiresSocket/RequiresSocket.ts
+++ b/packages/shared-process/src/parts/RequiresSocket/RequiresSocket.ts
@@ -15,6 +15,7 @@ const METHODS_THAT_REQUIRE_SOCKET = new Set([
   'HandleMessagePortForExtensionHostHelperProcess.handleMessagePortForExtensionHostHelperProcess',
   'ElectronBrowserView.createBrowserView',
   'ElectronWebContentsView.createWebContentsView',
+  'FileWatcher.dispose',
   'FileWatcher.watch',
   'FileWatcher.watchFile2',
 ])

--- a/packages/shared-process/test/FileWatcher.test.ts
+++ b/packages/shared-process/test/FileWatcher.test.ts
@@ -14,6 +14,14 @@ jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
 
 const FileWatcher = await import('../src/parts/FileWatcher/FileWatcher.js')
 const FileWatcherProcess = await import('../src/parts/FileWatcherProcess/FileWatcherProcess.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+
+const createIpc = (): any => {
+  return {
+    off: jest.fn(),
+    on: jest.fn(),
+  }
+}
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -32,7 +40,7 @@ test.each([
 ])('watch - returns file watcher process result %#', async (result) => {
   // @ts-ignore
   FileWatcherProcess.invoke.mockResolvedValue(result)
-  const ipc = {}
+  const ipc = createIpc()
   const options = {
     exclude: ['node_modules'],
     roots: ['file:///workspace'],
@@ -46,4 +54,48 @@ test.each([
     id: 123,
     roots: options.roots,
   })
+})
+
+test('dispose - disposes matching folder watcher', async () => {
+  const ipc = createIpc()
+  await FileWatcher.watch(ipc, 1, {
+    exclude: [],
+    roots: ['file:///workspace'],
+  })
+
+  await FileWatcher.dispose(ipc, 1)
+
+  expect(ipc.off).toHaveBeenCalledWith('close', expect.any(Function))
+  expect(FileWatcherProcess.invoke).toHaveBeenLastCalledWith('FileWatcher.dispose', 123)
+})
+
+test('watch - disposes folder watcher when ipc closes', async () => {
+  const ipc = createIpc()
+  await FileWatcher.watch(ipc, 1, {
+    exclude: [],
+    roots: ['file:///workspace'],
+  })
+  const handleClose = ipc.on.mock.calls[0][1] as () => Promise<void>
+
+  await handleClose()
+
+  expect(ipc.off).toHaveBeenCalledWith('close', handleClose)
+  expect(FileWatcherProcess.invoke).toHaveBeenLastCalledWith('FileWatcher.dispose', 123)
+})
+
+test('handleChange - ignores events after disposal', async () => {
+  const ipc = createIpc()
+  await FileWatcher.watch(ipc, 1, {
+    exclude: [],
+    roots: ['file:///workspace'],
+  })
+  await FileWatcher.dispose(ipc, 1)
+
+  FileWatcher.handleChange({
+    eventName: 'add',
+    id: 123,
+    uri: 'file:///workspace/new.txt',
+  })
+
+  expect(JsonRpc.send).not.toHaveBeenCalled()
 })

--- a/packages/shared-process/test/FileWatcher.test.ts
+++ b/packages/shared-process/test/FileWatcher.test.ts
@@ -18,8 +18,8 @@ const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 
 const createIpc = (): any => {
   return {
-    off: jest.fn(),
-    on: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
   }
 }
 
@@ -65,7 +65,7 @@ test('dispose - disposes matching folder watcher', async () => {
 
   await FileWatcher.dispose(ipc, 1)
 
-  expect(ipc.off).toHaveBeenCalledWith('close', expect.any(Function))
+  expect(ipc.removeEventListener).toHaveBeenCalledWith('close', expect.any(Function))
   expect(FileWatcherProcess.invoke).toHaveBeenLastCalledWith('FileWatcher.dispose', 123)
 })
 
@@ -75,12 +75,28 @@ test('watch - disposes folder watcher when ipc closes', async () => {
     exclude: [],
     roots: ['file:///workspace'],
   })
-  const handleClose = ipc.on.mock.calls[0][1] as () => Promise<void>
+  const handleClose = ipc.addEventListener.mock.calls[0][1] as () => Promise<void>
 
   await handleClose()
 
-  expect(ipc.off).toHaveBeenCalledWith('close', handleClose)
+  expect(ipc.removeEventListener).toHaveBeenCalledWith('close', handleClose)
   expect(FileWatcherProcess.invoke).toHaveBeenLastCalledWith('FileWatcher.dispose', 123)
+})
+
+test('watch - supports node event emitter ipc', async () => {
+  const ipc = {
+    off: jest.fn(),
+    on: jest.fn(),
+  }
+
+  await FileWatcher.watch(ipc, 1, {
+    exclude: [],
+    roots: ['file:///workspace'],
+  })
+  await FileWatcher.dispose(ipc, 1)
+
+  expect(ipc.on).toHaveBeenCalledWith('close', expect.any(Function))
+  expect(ipc.off).toHaveBeenCalledWith('close', expect.any(Function))
 })
 
 test('handleChange - ignores events after disposal', async () => {


### PR DESCRIPTION
Watch file workspaces and debounce external filesystem events into the existing workspace refresh path. Dispose watchers on workspace/transport changes and preserve deleted URIs for editor cleanup.

Includes renderer/shared-process regression coverage for watcher creation, workspace switching, event debouncing, deletion forwarding, disposal, and both MessagePort/EventEmitter transports.

Producer dependencies:
- lvce-editor/file-watcher-process#132
- lvce-editor/file-watcher-process#133
- lvce-editor/file-watcher-process#134
- bot dependency update #12762

Validation:
- full renderer-worker suite: 242 suites / 910 tests passed
- full shared-process suite: 82 suites / 294 tests passed
- focused type checks and lint passed
- static build passed
- live Electron test confirmed external file creation, folder creation, and deletion update Explorer without manual refresh and without browser errors