### PR TITLE
fix: detect readonly explorer folders

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemDisk.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemDisk.js
@@ -90,8 +90,9 @@ export const getPathSeparator = () => {
   return FileSystemWorker.invoke('FileSystem.getPathSeparator')
 }
 
-export const isReadonly = () => {
-  return false
+export const isReadonly = (path) => {
+  path = toUri(path)
+  return FileSystemWorker.invoke('FileSystem.isReadonly', /* path */ path)
 }
 
 export const getRealPath = (path) => {

--- a/packages/renderer-worker/test/FileSystemDiskReadonly.test.ts
+++ b/packages/renderer-worker/test/FileSystemDiskReadonly.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn<(method: string, ...params: readonly unknown[]) => Promise<boolean>>()
+
+jest.unstable_mockModule('../src/parts/FileSystemWorker/FileSystemWorker.js', () => ({
+  invoke,
+}))
+
+const FileSystemDisk = await import('../src/parts/FileSystem/FileSystemDisk.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('isReadonly checks the disk file system', async () => {
+  invoke.mockResolvedValue(true)
+
+  expect(await FileSystemDisk.isReadonly('/usr/lib/lvce/resources/app/playground')).toBe(true)
+  expect(invoke).toHaveBeenCalledWith('FileSystem.isReadonly', 'file:///usr/lib/lvce/resources/app/playground')
+})
+
+test('isReadonly preserves file uris', async () => {
+  invoke.mockResolvedValue(false)
+
+  expect(await FileSystemDisk.isReadonly('file:///home/test')).toBe(false)
+  expect(invoke).toHaveBeenCalledWith('FileSystem.isReadonly', 'file:///home/test')
+})


### PR DESCRIPTION
## Summary
- ask the desktop file-system process whether the opened Explorer folder is writable
- preserve existing file URI handling
- add focused renderer tests for writable and read-only results

## Validation
- renderer FileSystemDiskReadonly tests (2 passed)
- renderer-worker type-check
- Prettier check

Depends on the merged file-system-process 5.5.1 and explorer-view 7.9.2 updates.