### PR TITLE
fix: preserve renamed editor uri

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.explorer-rename-open-file-updates-tab-title.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-rename-open-file-updates-tab-title.ts
@@ -1,0 +1,33 @@
+export const name = 'viewlet.explorer-rename-open-file-updates-tab-title'
+
+export const test = async ({ Editor, expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const originalUri = `${tmpDir}/original.txt`
+  const renamedUri = `${tmpDir}/renamed.txt`
+  await FileSystem.writeFile(originalUri, 'content')
+  await Workspace.setPath(tmpDir)
+  await Explorer.handleClick(0)
+
+  const originalTab = Locator('.MainTab[title$="original.txt"]')
+  const renamedTab = Locator('.MainTab[title$="renamed.txt"]')
+  await expect(originalTab).toBeVisible()
+
+  await Explorer.focusIndex(0)
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('renamed.txt')
+  await Explorer.acceptEdit()
+
+  await expect(originalTab).toBeHidden()
+  await expect(renamedTab).toBeVisible()
+
+  await Editor.setCursor(0, 7)
+  await Editor.type('Z')
+  await Main.save()
+
+  await FileSystem.shouldHaveFile(renamedUri, 'contentZ')
+  const entries = await FileSystem.readDir(tmpDir)
+  const names = entries.map((entry) => entry.name)
+  if (names.length !== 1 || names[0] !== 'renamed.txt') {
+    throw new Error(`Expected only renamed.txt after saving the renamed editor, got ${JSON.stringify(names)}`)
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -94,9 +94,19 @@ const hotReload = async (state, editor, ...args) => {
   return state
 }
 
+const handleUriChange = async (editor, editorUidOrNewUri, maybeNewUri) => {
+  const newUri = maybeNewUri ?? editorUidOrNewUri
+  await EditorWorker.invoke('Editor.handleUriChange', editor.uid, newUri)
+  return {
+    ...editor,
+    uri: newUri,
+  }
+}
+
 export const getCommands = async () => {
   const commandIds = await EditorWorker.invoke('Editor.getCommandIds')
   Object.assign(Commands, WrapEditorCommands.wrapEditorCommands(commandIds), WrapEditorCommands.wrapEditorCommands(subWidgetCommandIds), {
+    handleUriChange,
     showOverlayMessage,
     hotReload,
   })

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -42,6 +42,7 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
   expect(commands.type).toBeDefined()
   expect(commands['FindWidget.close']).toBeDefined()
   expect(commands['ColorPicker.handleSliderPointerDown']).toBeDefined()
+  expect(commands.handleUriChange).toBeDefined()
   expect(commands.showOverlayMessage).toBeDefined()
   expect(commands.hotReload).toBeDefined()
 })
@@ -76,5 +77,32 @@ test('worker command wrapper invokes editor command, diff, and render', async ()
   expect(result).toEqual({
     ...editor,
     commands: [['Viewlet.send', 42, 'setDeltaY', 0]],
+  })
+})
+
+test('handleUriChange skips the duplicated viewlet uid and updates the renderer editor uri', async () => {
+  const editor = {
+    uid: 42,
+    uri: '/test/original.txt',
+  }
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.getCommandIds':
+        return ['handleUriChange']
+      case 'Editor.handleUriChange':
+        return undefined
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const commands = await ViewletEditorTextCommands.getCommands()
+  const result = await commands.handleUriChange(editor, 42, '/test/renamed.txt')
+
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(1, 'Editor.getCommandIds')
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.handleUriChange', 42, '/test/renamed.txt')
+  expect(result).toEqual({
+    ...editor,
+    uri: '/test/renamed.txt',
   })
 })


### PR DESCRIPTION
## Summary
- handle URI changes through a dedicated renderer editor command so the viewlet UID is not forwarded as the new URI
- keep the renderer editor state URI synchronized with the editor worker
- add an app-level E2E covering Explorer rename, tab retargeting, edit/save, and prevention of old-file recreation

## Testing
- npm test -- ViewletEditorTextCommands.test.ts --runInBand (packages/renderer-worker)
- npm run type-check
- prettier check for changed files
- npm run build:static
- isolated Chromium E2E: viewlet.explorer-rename-open-file-updates-tab-title