### PR TITLE
fix: explain external account sign in

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1823,10 +1823,24 @@ export const refreshAuthState = async (state: LayoutState): Promise<LayoutStateR
   return setAuthState(state, authState)
 }
 
+const showAuthNotification = async (type: string, message: string): Promise<void> => {
+  try {
+    await Command.execute('Notification.create', type, message)
+  } catch {
+    // Authentication should continue when notifications are unavailable.
+  }
+}
+
 export const signIn = async (state: LayoutState): Promise<LayoutStateResult> => {
   const { platform, backendUrl } = state
+  if (platform === PlatformType.Electron) {
+    await showAuthNotification('info', 'Continue signing in in your browser. If it did not open, check your system default browser settings.')
+  }
   const authState = await AuthWorker.signIn(backendUrl, platform)
   const newState = mergeAuthState(state, authState)
+  if (newState.authErrorMessage) {
+    await showAuthNotification('error', newState.authErrorMessage)
+  }
   return {
     newState,
     commands: await getAuthFanoutCommands(newState),

--- a/packages/renderer-worker/test/ViewletLayoutAuth.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutAuth.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
 
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
   return {
@@ -295,6 +296,57 @@ test('signIn merges auth worker state into layout state', async () => {
       userUsedTokens: 42,
     },
   })
+})
+
+test('signIn immediately explains the external browser flow on Electron', async () => {
+  const authResult = Promise.withResolvers<any>()
+  // @ts-ignore
+  AuthWorker.signIn.mockReturnValue(authResult.promise)
+  // @ts-ignore
+  Command.execute.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletLayout.create(1),
+    backendUrl: 'https://example.com/',
+    platform: PlatformType.Electron,
+  }
+
+  const signInPromise = ViewletLayout.signIn(state)
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(Command.execute).toHaveBeenCalledTimes(1)
+  expect(Command.execute).toHaveBeenCalledWith(
+    'Notification.create',
+    'info',
+    'Continue signing in in your browser. If it did not open, check your system default browser settings.',
+  )
+  expect(AuthWorker.signIn).toHaveBeenCalledWith('https://example.com/', PlatformType.Electron)
+
+  authResult.resolve({
+    authErrorMessage: '',
+    userState: 'loggedOut',
+  })
+  await signInPromise
+})
+
+test('signIn shows an auth worker error', async () => {
+  // @ts-ignore
+  AuthWorker.signIn.mockResolvedValue({
+    authErrorMessage: 'Could not open the browser.',
+    userState: 'loggedOut',
+  })
+  // @ts-ignore
+  Command.execute.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletLayout.create(1),
+    backendUrl: 'https://example.com/',
+    platform: PlatformType.Web,
+  }
+
+  await ViewletLayout.signIn(state)
+
+  expect(Command.execute).toHaveBeenCalledTimes(1)
+  expect(Command.execute).toHaveBeenCalledWith('Notification.create', 'error', 'Could not open the browser.')
 })
 
 test('signOut merges logged out auth state into layout state', async () => {


### PR DESCRIPTION
## Summary
- show immediate guidance when Electron starts account sign-in in the system browser
- tell users to check their default browser settings when no browser appears
- surface auth-worker errors instead of silently storing them
- add regression tests for the pending Electron flow and auth errors

## Root cause
The existing Electron flow correctly asks the OS to open the OIDC URL, but the layout waits for the localhost OAuth callback before returning. If the OS browser handler stalls or is misconfigured, LVCE shows no state change or explanation and the action looks inert.

## Validation
- live Electron reproduction before the fix: OS MIME helper invoked, no browser appeared, no LVCE feedback
- live Electron verification after the fix: guidance notification appears immediately while the OAuth callback remains pending
- focused ViewletLayoutAuth suite: 12 passing
- full renderer-worker suite: 243 suites and 915 tests passing
- renderer-worker type-check
- Prettier check for changed files
- git diff --check

The renderer-worker package xo command currently fails on the unchanged baseline with more than 90,000 configuration/style errors, including directory naming and semicolon rules across existing files.