### PR TITLE
fix: enable activity bar keyboard navigation

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-keyboard-navigation.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-keyboard-navigation.ts
@@ -1,8 +1,6 @@
 export const name = 'viewlet.activity-bar-keyboard-navigation'
 
-export const skip = 1
-
-export const test = async ({ ActivityBar, Locator, expect }) => {
+export const test = async ({ ActivityBar, KeyBoard, Locator, expect }) => {
   // act
   await ActivityBar.focus()
 
@@ -13,53 +11,46 @@ export const test = async ({ ActivityBar, Locator, expect }) => {
   await expect(sideBarHeaderTitle).toHaveText('Explorer')
 
   // act
-  await ActivityBar.focusNext()
+  await KeyBoard.press('ArrowDown')
 
   // assert
   const activityBarItemSearch = Locator('.ActivityBarItem[title="Search"]')
   await expect(activityBarItemSearch).toHaveClass('FocusOutline')
 
   // act
-  await ActivityBar.selectCurrent()
+  await KeyBoard.press('ArrowUp')
 
   // assert
-  await expect(sideBarHeaderTitle).toHaveText('Search')
-  // TODO search input should be focused
+  await expect(activityBarItemExplorer).toHaveClass('FocusOutline')
 
   // act
-  await ActivityBar.focusLast()
+  await KeyBoard.press('End')
 
   // assert
   const activityBarItemSettings = Locator('.ActivityBarItem[title="Settings"]')
   await expect(activityBarItemSettings).toHaveClass('FocusOutline')
 
   // act
-  await ActivityBar.selectCurrent()
-
-  // assert
-  const menu = Locator(`#Menu-0`)
-  await expect(menu).toBeFocused()
-
-  // TODO close menu with escape
-
-  // act
-  await ActivityBar.focusPrevious()
-
-  // assert
-  const activityBarItemExtensions = Locator('.ActivityBarItem[title="Extensions"]')
-  await expect(activityBarItemExtensions).toHaveClass('FocusOutline')
-
-  // act
-  await ActivityBar.focusFirst()
+  await KeyBoard.press('Home')
 
   // assert
   await expect(activityBarItemExplorer).toHaveClass('FocusOutline')
 
   // act
-  await ActivityBar.selectCurrent()
+  await KeyBoard.press('ArrowDown')
+  await KeyBoard.press('Enter')
 
   // assert
-  await expect(sideBarHeaderTitle).toHaveText('Explorer')
+  await expect(sideBarHeaderTitle).toHaveText('Search')
 
-  // TODO explorer should be focused
+  // act
+  await ActivityBar.focus()
+  await expect(activityBarItemSearch).toHaveClass('FocusOutline')
+  await KeyBoard.press('End')
+  await expect(activityBarItemSettings).toHaveClass('FocusOutline')
+  await KeyBoard.press('Space')
+
+  // assert
+  const menu = Locator('#Menu-0')
+  await expect(menu).toBeFocused()
 }

--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-keyboard-navigation.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-keyboard-navigation.ts
@@ -1,8 +1,9 @@
 export const name = 'viewlet.activity-bar-keyboard-navigation'
 
-export const test = async ({ ActivityBar, KeyBoard, Locator, expect }) => {
+export const test = async ({ KeyBoard, Locator, expect }) => {
   // act
-  await ActivityBar.focus()
+  const activityBar = Locator('#ActivityBar')
+  await activityBar.click()
 
   // assert
   const activityBarItemExplorer = Locator('.ActivityBarItem[title="Explorer"]')
@@ -44,7 +45,7 @@ export const test = async ({ ActivityBar, KeyBoard, Locator, expect }) => {
   await expect(sideBarHeaderTitle).toHaveText('Search')
 
   // act
-  await ActivityBar.focus()
+  await activityBar.click()
   await expect(activityBarItemSearch).toHaveClass('FocusOutline')
   await KeyBoard.press('End')
   await expect(activityBarItemSettings).toHaveClass('FocusOutline')

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/about-view": "^7.8.0",
-        "@lvce-editor/activity-bar-worker": "^7.10.0",
+        "@lvce-editor/activity-bar-worker": "^7.10.1",
         "@lvce-editor/auth-worker": "^3.5.1",
         "@lvce-editor/chat-coordinator-worker": "^5.2.0",
         "@lvce-editor/chat-debug-view": "^11.7.0",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/activity-bar-worker": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/activity-bar-worker/-/activity-bar-worker-7.10.0.tgz",
-      "integrity": "sha512-BKbbwiVTeJTUEVmZaARA5xDhQ2ErsHftYtvxwMz956vOAg2xdWeXm+bMJEvPttGpwC3K6TTsTq1w6M81CIqk8Q==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/activity-bar-worker/-/activity-bar-worker-7.10.1.tgz",
+      "integrity": "sha512-lZ7rgTj9snkxPWmyfeC9eTBj///LyXeSNJdZPL9O9ipcpABfZvClHaE1eAvtHGNr5SS7lLKjX4av+w/rXOociA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/auth-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@lvce-editor/about-view": "^7.8.0",
-    "@lvce-editor/activity-bar-worker": "^7.10.0",
+    "@lvce-editor/activity-bar-worker": "^7.10.1",
     "@lvce-editor/auth-worker": "^3.5.1",
     "@lvce-editor/chat-coordinator-worker": "^5.2.0",
     "@lvce-editor/chat-debug-view": "^11.7.0",

--- a/packages/renderer-worker/src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts
@@ -1,7 +1,12 @@
 import * as ActivityBarWorker from '../ActivityBarWorker/ActivityBarWorker.js'
+import * as Focus from '../Focus/Focus.js'
+import * as FocusKey from '../FocusKey/FocusKey.js'
 
 export const wrapActivityBarCommand = (key: string) => {
   const fn = async (state, ...args) => {
+    if (key === 'handleFocus') {
+      Focus.setFocus(FocusKey.ActivityBar)
+    }
     await ActivityBarWorker.invoke(`ActivityBar.${key}`, state.uid, ...args)
     const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', state.uid)
     if (diffResult.length === 0) {

--- a/packages/renderer-worker/test/WrapActivityBarCommand.test.ts
+++ b/packages/renderer-worker/test/WrapActivityBarCommand.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ActivityBarWorker/ActivityBarWorker.js', () => ({
+  invoke: jest.fn(async (command: string) => {
+    if (command === 'ActivityBar.diff2' || command === 'ActivityBar.render2') {
+      return []
+    }
+    return undefined
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => ({
+  setFocus: jest.fn(),
+}))
+
+const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityBarWorker.js')
+const Focus = await import('../src/parts/Focus/Focus.js')
+const FocusKey = await import('../src/parts/FocusKey/FocusKey.js')
+const { wrapActivityBarCommand } = await import('../src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('handleFocus sets the activity bar keyboard context', async () => {
+  const state = { uid: 7 }
+
+  await wrapActivityBarCommand('handleFocus')(state)
+
+  expect(Focus.setFocus).toHaveBeenCalledWith(FocusKey.ActivityBar)
+  expect(ActivityBarWorker.invoke).toHaveBeenNthCalledWith(1, 'ActivityBar.handleFocus', 7)
+})
+
+test('other activity bar commands do not change the keyboard context', async () => {
+  const state = { uid: 7 }
+
+  await wrapActivityBarCommand('focusNext')(state)
+
+  expect(Focus.setFocus).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- restore the renderer focus context when the Activity Bar receives DOM focus
- update to @lvce-editor/activity-bar-worker 7.10.1, which restores visible-item navigation and keyboard activation
- unskip and convert the Activity Bar keyboard E2E to physical ArrowUp/ArrowDown/Home/End/Enter/Space input
- add renderer regression coverage for the focus-context integration

Companion package PR: https://github.com/lvce-editor/activity-bar-worker/pull/468
Published package: https://github.com/lvce-editor/activity-bar-worker/releases/tag/v7.10.1

## Verification
- renderer-worker: 244 suites passed, 917 tests passed (26 suites/242 tests skipped by the existing suite configuration)
- renderer-worker type-check
- extension-host-worker-tests type-check
- Prettier and git diff checks
- Electron/CDP physical-key regression: Arrow navigation, Home/End, Enter activation, and Space menu activation all passed

The renderer package's XO invocation reports the repository's existing incompatible style/config baseline (including existing directory naming and semicolon rules); no XO cleanup is included in this focused fix.