### PR TITLE
fix: support secondary side bar focus mode

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -39,6 +39,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
   if (source.sideBarFocusMode) {
     const contentTop = titleBarVisible ? titleBarHeight : 0
     const contentBottom = statusBarVisible ? windowHeight - statusBarHeight : windowHeight
+    const focusSecondarySideBar = source.sideBarFocusModeTarget === 'secondary'
     return {
       ...source,
       activityBarSashVisible: false,
@@ -49,13 +50,17 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
       panelVisible: false,
       previewSashVisible: false,
       previewVisible: false,
-      secondarySideBarVisible: false,
+      secondarySideBarHeight: Math.max(0, contentBottom - contentTop),
+      secondarySideBarLeft: 0,
+      secondarySideBarTop: contentTop,
+      secondarySideBarVisible: focusSecondarySideBar,
+      secondarySideBarWidth: focusSecondarySideBar ? windowWidth : secondarySideBarWidth,
       sideBarHeight: Math.max(0, contentBottom - contentTop),
       sideBarLeft: 0,
       sideBarSashVisible: false,
       sideBarTop: contentTop,
-      sideBarVisible: true,
-      sideBarWidth: windowWidth,
+      sideBarVisible: !focusSecondarySideBar,
+      sideBarWidth: focusSecondarySideBar ? sideBarWidth : windowWidth,
       statusBarTop: contentBottom,
       statusBarWidth: windowWidth,
       titleBarWidth: windowWidth,

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -7,6 +7,7 @@ export interface SideBarFocusModeLayoutStateSnapshot {
   readonly previewSashVisible: boolean
   readonly previewVisible: boolean
   readonly secondarySideBarVisible: boolean
+  readonly secondarySideBarWidth: number
   readonly sideBarSashVisible: boolean
   readonly sideBarVisible: boolean
   readonly sideBarWidth: number
@@ -80,6 +81,7 @@ export interface LayoutState {
   readonly sideBarView: string
   readonly sideBarFocusMode: boolean
   readonly sideBarFocusModeLayout: SideBarFocusModeLayoutStateSnapshot | undefined
+  readonly sideBarFocusModeTarget: 'primary' | 'secondary'
   readonly sideBarVisible: boolean
   readonly sideBarWidth: number
   readonly secondarySideBarHeight: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -127,6 +127,7 @@ export const create = (id: number): LayoutState => {
     sideBarSashVisible: false,
     sideBarFocusMode: false,
     sideBarFocusModeLayout: undefined,
+    sideBarFocusModeTarget: 'primary',
     sideBarVisible: false,
     secondarySideBarVisible: false,
     statusBarVisible: false,
@@ -354,6 +355,7 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
     sideBarSashVisible: true,
     sideBarFocusMode: false,
     sideBarFocusModeLayout: undefined,
+    sideBarFocusModeTarget: 'primary',
     sideBarView: savedView,
     secondarySideBarView: savedSecondaryView,
     workbenchVisible: true,
@@ -482,6 +484,7 @@ const getSideBarFocusModeLayoutSnapshot = (state: LayoutState): SideBarFocusMode
     previewSashVisible: state.previewSashVisible,
     previewVisible: state.previewVisible,
     secondarySideBarVisible: state.secondarySideBarVisible,
+    secondarySideBarWidth: state.secondarySideBarWidth,
     sideBarSashVisible: state.sideBarSashVisible,
     sideBarVisible: state.sideBarVisible,
     sideBarWidth: state.sideBarWidth,
@@ -492,8 +495,9 @@ export const getSideBarFocusMode = (state: LayoutState): boolean => {
   return state.sideBarFocusMode
 }
 
-export const enterSideBarFocusMode = async (state: LayoutState): Promise<LayoutStateResult> => {
-  if (state.sideBarFocusMode || !state.sideBarVisible) {
+export const enterSideBarFocusMode = async (state: LayoutState, target: 'primary' | 'secondary' = 'primary'): Promise<LayoutStateResult> => {
+  const targetVisible = target === 'secondary' ? state.secondarySideBarVisible : state.sideBarVisible
+  if (state.sideBarFocusMode || !targetVisible) {
     return {
       newState: state,
       commands: [],
@@ -503,6 +507,7 @@ export const enterSideBarFocusMode = async (state: LayoutState): Promise<LayoutS
     ...state,
     sideBarFocusMode: true,
     sideBarFocusModeLayout: getSideBarFocusModeLayoutSnapshot(state),
+    sideBarFocusModeTarget: target,
   })
   return {
     newState,
@@ -522,6 +527,7 @@ export const leaveSideBarFocusMode = async (state: LayoutState): Promise<LayoutS
     ...state.sideBarFocusModeLayout,
     sideBarFocusMode: false,
     sideBarFocusModeLayout: undefined,
+    sideBarFocusModeTarget: 'primary',
   })
   return {
     newState,

--- a/packages/renderer-worker/test/ViewletLayoutSideBarFocusMode.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBarFocusMode.test.ts
@@ -58,6 +58,28 @@ test('enterSideBarFocusMode gives the side bar the full content area', async () 
   )
 })
 
+test('enterSideBarFocusMode gives the secondary side bar the full content area', async () => {
+  const state = createState()
+  const result = await ViewletLayout.enterSideBarFocusMode(state, 'secondary')
+
+  expect(result.newState).toEqual(
+    expect.objectContaining({
+      activityBarVisible: false,
+      mainVisible: false,
+      panelVisible: false,
+      previewVisible: false,
+      secondarySideBarHeight: state.windowHeight - state.titleBarHeight - state.statusBarHeight,
+      secondarySideBarLeft: 0,
+      secondarySideBarTop: state.titleBarHeight,
+      secondarySideBarVisible: true,
+      secondarySideBarWidth: 1200,
+      sideBarFocusMode: true,
+      sideBarFocusModeTarget: 'secondary',
+      sideBarVisible: false,
+    }),
+  )
+})
+
 test('leaveSideBarFocusMode restores the previous layout', async () => {
   const state = createState()
   const focused = await ViewletLayout.enterSideBarFocusMode(state)
@@ -79,12 +101,38 @@ test('leaveSideBarFocusMode restores the previous layout', async () => {
   )
 })
 
+test('leaveSideBarFocusMode restores the secondary side bar width', async () => {
+  const state = createState()
+  const focused = await ViewletLayout.enterSideBarFocusMode(state, 'secondary')
+  const restored = await ViewletLayout.leaveSideBarFocusMode(focused.newState)
+
+  expect(restored.newState).toEqual(
+    expect.objectContaining({
+      secondarySideBarVisible: true,
+      secondarySideBarWidth: state.secondarySideBarWidth,
+      sideBarFocusMode: false,
+      sideBarFocusModeLayout: undefined,
+      sideBarFocusModeTarget: 'primary',
+      sideBarVisible: true,
+      sideBarWidth: state.sideBarWidth,
+    }),
+  )
+})
+
 test('focus mode follows window resizes', async () => {
   const focused = await ViewletLayout.enterSideBarFocusMode(createState())
   const resized = await ViewletLayout.handleResize(focused.newState, 900, 600)
 
   expect(resized.newState.sideBarWidth).toBe(900)
   expect(resized.newState.sideBarHeight).toBe(600 - resized.newState.titleBarHeight - resized.newState.statusBarHeight)
+})
+
+test('secondary side bar focus mode follows window resizes', async () => {
+  const focused = await ViewletLayout.enterSideBarFocusMode(createState(), 'secondary')
+  const resized = await ViewletLayout.handleResize(focused.newState, 900, 600)
+
+  expect(resized.newState.secondarySideBarWidth).toBe(900)
+  expect(resized.newState.secondarySideBarHeight).toBe(600 - resized.newState.titleBarHeight - resized.newState.statusBarHeight)
 })
 
 test('saveState preserves the normal side bar width while focused', async () => {
@@ -97,6 +145,20 @@ test('saveState preserves the normal side bar width while focused', async () => 
       panelVisible: true,
       previewVisible: true,
       secondarySideBarVisible: true,
+      sideBarWidth: state.sideBarWidth,
+    }),
+  )
+})
+
+test('saveState preserves the normal secondary side bar width while focused', async () => {
+  const state = createState()
+  const focused = await ViewletLayout.enterSideBarFocusMode(state, 'secondary')
+
+  expect(ViewletLayout.saveState(focused.newState)).toEqual(
+    expect.objectContaining({
+      secondarySideBarVisible: true,
+      secondarySideBarWidth: state.secondarySideBarWidth,
+      sideBarVisible: true,
       sideBarWidth: state.sideBarWidth,
     }),
   )
@@ -122,6 +184,18 @@ test('enterSideBarFocusMode is a no-op when the side bar is hidden', async () =>
   }
 
   expect(await ViewletLayout.enterSideBarFocusMode(state)).toEqual({
+    newState: state,
+    commands: [],
+  })
+})
+
+test('enterSideBarFocusMode is a no-op when the secondary side bar is hidden', async () => {
+  const state = {
+    ...createState(),
+    secondarySideBarVisible: false,
+  }
+
+  expect(await ViewletLayout.enterSideBarFocusMode(state, 'secondary')).toEqual({
     newState: state,
     commands: [],
   })


### PR DESCRIPTION
## Summary
- allow the side-bar focus command to target the secondary side bar
- give the targeted pane the full workbench content area
- restore and persist normal primary and secondary side-bar widths
- cover entry, exit, resize, persistence, and hidden-pane behavior

## Verification
- renderer worker: 244 suites passed, 922 tests
- renderer worker type-check
- Prettier and git diff checks