### PR TITLE
fix: report manual update check results

### DIFF
--- a/packages/renderer-worker/src/parts/AutoUpdater/AutoUpdater.js
+++ b/packages/renderer-worker/src/parts/AutoUpdater/AutoUpdater.js
@@ -1,6 +1,40 @@
+import * as GetLatestVersion from '../GetLatestVersion/GetLatestVersion.js'
+import * as Notification from '../Notification/Notification.js'
 import * as UpdateWorker from '../UpdateWorker/UpdateWorker.js'
 
-export const checkForUpdates = async (updateSetting) => {
+const getErrorMessage = (error) => {
+  if (error && error.message) {
+    return error.message
+  }
+  return `${error}`
+}
+
+export const checkForUpdatesWithDependencies = async (updateSetting, silent, dependencies) => {
   const repository = 'lvce-editor/lvce-editor'
-  await UpdateWorker.invoke('Update.checkForUpdates', updateSetting, repository)
+  if (silent) {
+    await dependencies.startUpdate(updateSetting, repository)
+    return
+  }
+  await dependencies.notify('info', 'Checking for updates...')
+  try {
+    const latest = await dependencies.getLatestVersion()
+    if (!latest) {
+      await dependencies.notify('info', 'You are using the latest version.')
+      return
+    }
+    await dependencies.notify('info', `Update ${latest.version} is available.`)
+    await dependencies.startUpdate(updateSetting, repository)
+  } catch (error) {
+    await dependencies.notify('error', `Failed to check for updates: ${getErrorMessage(error)}`)
+  }
+}
+
+export const checkForUpdates = async (updateSetting, silent = Boolean(updateSetting)) => {
+  await checkForUpdatesWithDependencies(updateSetting, silent, {
+    getLatestVersion: GetLatestVersion.getLatestVersion,
+    notify: Notification.create,
+    startUpdate: async (setting, repository) => {
+      await UpdateWorker.invoke('Update.checkForUpdates', setting, repository)
+    },
+  })
 }

--- a/packages/renderer-worker/test/AutoUpdater.test.ts
+++ b/packages/renderer-worker/test/AutoUpdater.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as AutoUpdater from '../src/parts/AutoUpdater/AutoUpdater.js'
+
+const dependencies = {
+  getLatestVersion: jest.fn<() => Promise<{ readonly version: string } | undefined>>(),
+  notify: jest.fn<(type: string, message: string) => Promise<void>>(),
+  startUpdate: jest.fn<(updateSetting: string | undefined, repository: string) => Promise<void>>(),
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('reports when the current version is up to date', async () => {
+  dependencies.getLatestVersion.mockResolvedValue(undefined)
+
+  await AutoUpdater.checkForUpdatesWithDependencies(undefined, false, dependencies)
+
+  expect(dependencies.notify).toHaveBeenNthCalledWith(1, 'info', 'Checking for updates...')
+  expect(dependencies.notify).toHaveBeenNthCalledWith(2, 'info', 'You are using the latest version.')
+  expect(dependencies.startUpdate).not.toHaveBeenCalled()
+})
+
+test('reports an available update and starts the updater', async () => {
+  dependencies.getLatestVersion.mockResolvedValue({
+    version: '1.2.3',
+  })
+
+  await AutoUpdater.checkForUpdatesWithDependencies(undefined, false, dependencies)
+
+  expect(dependencies.notify).toHaveBeenNthCalledWith(1, 'info', 'Checking for updates...')
+  expect(dependencies.notify).toHaveBeenNthCalledWith(2, 'info', 'Update 1.2.3 is available.')
+  expect(dependencies.startUpdate).toHaveBeenCalledWith(undefined, 'lvce-editor/lvce-editor')
+})
+
+test('reports update check errors', async () => {
+  dependencies.getLatestVersion.mockRejectedValue(new Error('network unavailable'))
+
+  await AutoUpdater.checkForUpdatesWithDependencies(undefined, false, dependencies)
+
+  expect(dependencies.notify).toHaveBeenNthCalledWith(1, 'info', 'Checking for updates...')
+  expect(dependencies.notify).toHaveBeenNthCalledWith(2, 'error', 'Failed to check for updates: network unavailable')
+  expect(dependencies.startUpdate).not.toHaveBeenCalled()
+})
+
+test('keeps automatic update checks silent', async () => {
+  await AutoUpdater.checkForUpdatesWithDependencies('start', true, dependencies)
+
+  expect(dependencies.getLatestVersion).not.toHaveBeenCalled()
+  expect(dependencies.notify).not.toHaveBeenCalled()
+  expect(dependencies.startUpdate).toHaveBeenCalledWith('start', 'lvce-editor/lvce-editor')
+})


### PR DESCRIPTION
## Summary
- report progress when a manual update check starts
- report whether the app is current or an update is available
- surface update lookup failures while keeping startup checks silent

## Tests
- focused AutoUpdater unit tests
- renderer-worker type-check
- targeted lint and formatting