### PR TITLE
fix: close all editors command

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.main-close-all-editors-command.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-close-all-editors-command.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-close-all-editors-command'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, QuickPick, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file-1.txt`, 'content 1')
+  await FileSystem.writeFile(`${tmpDir}/file-2.txt`, 'content 2')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/file-1.txt`)
+  await Main.openUri(`${tmpDir}/file-2.txt`)
+
+  const tabs = Locator('.MainTab')
+  await expect(tabs).toHaveCount(2)
+
+  await QuickPick.open()
+  await QuickPick.setValue('>Close all Editors')
+  await QuickPick.selectItem('Main: Close all Editors')
+
+  await expect(tabs).toHaveCount(0)
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -326,7 +326,7 @@ export const getQuickPickMenuEntries = () => {
       label: 'Main: Close Editor',
     },
     {
-      id: 'Main.CloseAllEditors',
+      id: 'Main.closeAllEditors',
       label: 'Main: Close all Editors',
     },
     {

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -67,3 +67,12 @@ test('getQuickPickMenuEntries includes simple browser preview command', () => {
     args: ['simple-browser://'],
   })
 })
+
+test('getQuickPickMenuEntries includes close all editors command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Main.closeAllEditors',
+    label: 'Main: Close all Editors',
+  })
+})


### PR DESCRIPTION
## Summary
- use the registered lowercase close-all-editors command ID in the command palette
- add a unit regression for the contributed command entry
- add an end-to-end regression that opens two files and closes both through Quick Pick

## Validation
- focused renderer-worker unit tests (6 passed)
- renderer-worker and extension-host-worker-tests type checks
- ESLint and Prettier checks on changed files
- static application build
- browser regression passed against the generated test page