### PR TITLE
feature: add save changes prompt

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -47,6 +47,7 @@ export const commandMap = {
   'ColorTheme.setColorTheme': lazy('ColorTheme.setColorTheme'),
   'ConfirmPrompt.mock': lazy('ConfirmPrompt.mock'),
   'ConfirmPrompt.prompt': lazy('ConfirmPrompt.prompt'),
+  'ConfirmPrompt.promptSave': lazy('ConfirmPrompt.promptSave'),
   'ConfirmPrompt.showErrorMessage': lazy('ConfirmPrompt.showErrorMessage'),
   'ContentTracing.start': lazy('ContentTracing.start'),
   'ContentTracing.stop': lazy('ContentTracing.stop'),

--- a/packages/renderer-worker/src/parts/ConfirmPrompt/ConfirmPrompt.ipc.js
+++ b/packages/renderer-worker/src/parts/ConfirmPrompt/ConfirmPrompt.ipc.js
@@ -5,5 +5,6 @@ export const name = 'ConfirmPrompt'
 export const Commands = {
   mock: ConfirmPrompt.mock,
   prompt: ConfirmPrompt.prompt,
+  promptSave: ConfirmPrompt.promptSave,
   showErrorMessage: ConfirmPrompt.showErrorMessage,
 }

--- a/packages/renderer-worker/src/parts/ConfirmPrompt/ConfirmPrompt.js
+++ b/packages/renderer-worker/src/parts/ConfirmPrompt/ConfirmPrompt.js
@@ -5,6 +5,7 @@ import * as ConfirmPromptStrings from '../ConfirmPromptStrings/ConfirmPromptStri
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as TestWorker from '../TestWorker/TestWorker.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as SavePromptResult from '../SavePromptResult/SavePromptResult.js'
 
 let _mockId = 0
 
@@ -32,6 +33,37 @@ export const prompt = async (
     return ConfirmPromptElectron.prompt(message, confirmMessage, title, cancelMessage)
   }
   return ConfirmPromptWeb.prompt(message, confirmMessage, title)
+}
+
+const showMockSavePrompt = async (message, options) => {
+  const result = await showMockConfirmPrompt(message, options)
+  if (result === true) {
+    return SavePromptResult.Save
+  }
+  if (result === false) {
+    return SavePromptResult.Cancel
+  }
+  return result
+}
+
+export const promptSave = async (
+  message,
+  {
+    platform = Platform.getPlatform(),
+    title = 'Save Changes',
+    saveMessage = 'Save',
+    discardMessage = "Don't Save",
+    cancelMessage = ConfirmPromptStrings.cancel(),
+  } = {},
+) => {
+  const options = { cancelMessage, discardMessage, saveMessage, title }
+  if (_mockId) {
+    return showMockSavePrompt(message, options)
+  }
+  if (platform === PlatformType.Electron) {
+    return ConfirmPromptElectron.promptSave(message, options)
+  }
+  return ConfirmPromptWeb.promptSave(message)
 }
 
 export const showErrorMessage = ({ message, platform = Platform.getPlatform(), confirmMessage = ConfirmPromptStrings.ok(), title = '' }) => {

--- a/packages/renderer-worker/src/parts/ConfirmPromptElectron/ConfirmPromptElectron.js
+++ b/packages/renderer-worker/src/parts/ConfirmPromptElectron/ConfirmPromptElectron.js
@@ -1,5 +1,6 @@
 import * as ElectronDialog from '../ElectronDialog/ElectronDialog.js'
 import * as ElectronMessageBoxType from '../ElectronMessageBoxType/ElectronMessageBoxType.js'
+import * as SavePromptResult from '../SavePromptResult/SavePromptResult.js'
 
 export const prompt = async (message, confirmMessage, title, cancelMessage) => {
   const result = await ElectronDialog.showMessageBox({
@@ -21,4 +22,22 @@ export const promptError = async (message, confirmMessage, title) => {
     title,
   })
   return result === 0
+}
+
+export const promptSave = async (message, { cancelMessage, discardMessage, saveMessage, title }, showMessageBox = ElectronDialog.showMessageBox) => {
+  const result = await showMessageBox({
+    buttons: [cancelMessage, discardMessage, saveMessage],
+    cancelId: 0,
+    defaultId: 2,
+    message,
+    title,
+    type: ElectronMessageBoxType.Question,
+  })
+  if (result === 2) {
+    return SavePromptResult.Save
+  }
+  if (result === 1) {
+    return SavePromptResult.Discard
+  }
+  return SavePromptResult.Cancel
 }

--- a/packages/renderer-worker/src/parts/ConfirmPromptWeb/ConfirmPromptWeb.js
+++ b/packages/renderer-worker/src/parts/ConfirmPromptWeb/ConfirmPromptWeb.js
@@ -1,6 +1,16 @@
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as SavePromptResult from '../SavePromptResult/SavePromptResult.js'
 
 export const prompt = async (message, confirmMessage, title) => {
   const result = await RendererProcess.invoke('ConfirmPrompt.prompt', message)
   return result
+}
+
+export const promptSave = async (message, invoke = RendererProcess.invoke) => {
+  const shouldSave = await invoke('ConfirmPrompt.prompt', `${message}\n\nSelect OK to save, or Cancel for more options.`)
+  if (shouldSave) {
+    return SavePromptResult.Save
+  }
+  const shouldDiscard = await invoke('ConfirmPrompt.prompt', 'Discard your changes? Select OK to discard them, or Cancel to keep editing.')
+  return shouldDiscard ? SavePromptResult.Discard : SavePromptResult.Cancel
 }

--- a/packages/renderer-worker/src/parts/SavePromptResult/SavePromptResult.js
+++ b/packages/renderer-worker/src/parts/SavePromptResult/SavePromptResult.js
@@ -1,0 +1,3 @@
+export const Cancel = 'cancel'
+export const Discard = 'discard'
+export const Save = 'save'

--- a/packages/renderer-worker/test/ConfirmPromptElectronSave.test.ts
+++ b/packages/renderer-worker/test/ConfirmPromptElectronSave.test.ts
@@ -1,0 +1,29 @@
+import { expect, jest, test } from '@jest/globals'
+import { promptSave } from '../src/parts/ConfirmPromptElectron/ConfirmPromptElectron.js'
+
+const options = {
+  cancelMessage: 'Cancel',
+  discardMessage: "Don't Save",
+  saveMessage: 'Save',
+  title: 'Save Changes',
+}
+
+test.each([
+  [0, 'cancel'],
+  [1, 'discard'],
+  [2, 'save'],
+])('promptSave maps dialog result %s to %s', async (dialogResult, expected) => {
+  const showMessageBox = jest.fn<(options: unknown) => Promise<number>>(async () => dialogResult)
+
+  const result = await promptSave('Save changes to test.txt?', options, showMessageBox)
+
+  expect(result).toBe(expected)
+  expect(showMessageBox).toHaveBeenCalledWith({
+    buttons: ['Cancel', "Don't Save", 'Save'],
+    cancelId: 0,
+    defaultId: 2,
+    message: 'Save changes to test.txt?',
+    title: 'Save Changes',
+    type: 'question',
+  })
+})

--- a/packages/renderer-worker/test/ConfirmPromptWebSave.test.ts
+++ b/packages/renderer-worker/test/ConfirmPromptWebSave.test.ts
@@ -1,0 +1,29 @@
+import { expect, jest, test } from '@jest/globals'
+import { promptSave } from '../src/parts/ConfirmPromptWeb/ConfirmPromptWeb.js'
+
+test('promptSave returns save when the first confirmation is accepted', async () => {
+  const invoke = jest.fn<(method: string, message: string) => Promise<boolean>>(async () => true)
+
+  const result = await promptSave('Save changes to test.txt?', invoke)
+
+  expect(result).toBe('save')
+  expect(invoke).toHaveBeenCalledTimes(1)
+})
+
+test('promptSave returns discard when the discard confirmation is accepted', async () => {
+  const invoke = jest.fn<(method: string, message: string) => Promise<boolean>>().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+  const result = await promptSave('Save changes to test.txt?', invoke)
+
+  expect(result).toBe('discard')
+  expect(invoke).toHaveBeenCalledTimes(2)
+})
+
+test('promptSave returns cancel when both confirmations are canceled', async () => {
+  const invoke = jest.fn<(method: string, message: string) => Promise<boolean>>(async () => false)
+
+  const result = await promptSave('Save changes to test.txt?', invoke)
+
+  expect(result).toBe('cancel')
+  expect(invoke).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
## Summary
- add a close-specific save prompt that returns save, discard, or cancel
- use a native three-button dialog on Electron and a safe two-step confirmation on web
- support the existing test prompt mock and add focused coverage for every result

## Validation
- 6 focused renderer-worker tests
- renderer-worker type-check
- ESLint and Prettier checks on changed files
- full static application build