### PR TITLE
feature: broadcast structured workspace changes

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -4,8 +4,8 @@ import * as EncodingType from '../EncodingType/EncodingType.js'
 import * as GetFileSystem from '../GetFileSystem/GetFileSystem.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 
-const notifyWorkspaceChanged = async (deletedUris = []) => {
-  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', deletedUris), Command.execute('Layout.refreshSourceControlBadgeCount')])
+const notifyWorkspaceChanged = async (changes = {}) => {
+  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', changes), Command.execute('Layout.refreshSourceControlBadgeCount')])
 }
 
 export const readFile = async (uri, encoding = EncodingType.Utf8) => {
@@ -27,14 +27,18 @@ export const remove = async (uri) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.remove(uri)
-  await notifyWorkspaceChanged([uri])
+  await notifyWorkspaceChanged({
+    deleted: [uri],
+  })
 }
 
 export const rename = async (oldUri, newUri) => {
   const protocol = GetProtocol.getProtocol(oldUri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.rename(oldUri, newUri)
-  await notifyWorkspaceChanged()
+  await notifyWorkspaceChanged({
+    renamed: [[oldUri, newUri]],
+  })
 }
 
 export const mkdir = async (uri) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -32,6 +32,7 @@ import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as Workspace from '../Workspace/Workspace.js'
+import type { WorkspaceRefresh } from '../WorkspaceChanges/WorkspaceChanges.ts'
 import { getPoints } from './LayoutPoints.ts'
 import type { LayoutState, LayoutStateResult, SideBarFocusModeLayoutStateSnapshot } from './LayoutState.ts'
 
@@ -1872,8 +1873,8 @@ export const setUpdateState = async (state, updateState) => {
   return callGlobalEvent(state, 'handleUpdateStateChange', updateState)
 }
 
-export const handleWorkspaceRefresh = async (state: LayoutState, deletedUris: readonly string[] = []) => {
-  return callGlobalEvent(state, 'handleWorkspaceRefresh', deletedUris)
+export const handleWorkspaceRefresh = async (state: LayoutState, refresh: WorkspaceRefresh = {}) => {
+  return callGlobalEvent(state, 'handleWorkspaceRefresh', refresh)
 }
 
 export const handleSettingsChanged = async (state: LayoutState) => {

--- a/packages/renderer-worker/src/parts/WorkspaceChanges/WorkspaceChanges.ts
+++ b/packages/renderer-worker/src/parts/WorkspaceChanges/WorkspaceChanges.ts
@@ -1,4 +1,4 @@
-export type UriRename = readonly [oldUri: string, newUri: string]
+type UriRename = readonly [oldUri: string, newUri: string]
 
 export interface WorkspaceChanges {
   readonly deleted?: readonly string[]

--- a/packages/renderer-worker/src/parts/WorkspaceChanges/WorkspaceChanges.ts
+++ b/packages/renderer-worker/src/parts/WorkspaceChanges/WorkspaceChanges.ts
@@ -1,0 +1,8 @@
+export type UriRename = readonly [oldUri: string, newUri: string]
+
+export interface WorkspaceChanges {
+  readonly deleted?: readonly string[]
+  readonly renamed?: readonly UriRename[]
+}
+
+export type WorkspaceRefresh = WorkspaceChanges | readonly string[]

--- a/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
+++ b/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
@@ -18,7 +18,9 @@ const refresh = async () => {
   const deleted = [...deletedUris]
   deletedUris.clear()
   await Promise.allSettled([
-    Command.execute('Layout.handleWorkspaceRefresh', deleted),
+    Command.execute('Layout.handleWorkspaceRefresh', {
+      deleted,
+    }),
     Command.execute('Layout.refreshSourceControlBadgeCount'),
   ])
 }

--- a/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
+++ b/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
@@ -28,6 +28,27 @@ test('remove notifies workspace views with the deleted uri', async () => {
   await FileSystem.remove('test://some-file.txt')
 
   expect(remove).toHaveBeenCalledWith('test://some-file.txt')
-  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', ['test://some-file.txt'])
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    deleted: ['test://some-file.txt'],
+  })
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
+})
+
+test('rename notifies workspace views with the old and new uris', async () => {
+  const rename = jest.fn()
+  FileSystemState.registerAll({
+    test() {
+      return {
+        rename,
+      }
+    },
+  })
+
+  await FileSystem.rename('test://old-folder', 'test://new-folder')
+
+  expect(rename).toHaveBeenCalledWith('test://old-folder', 'test://new-folder')
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    renamed: [['test://old-folder', 'test://new-folder']],
+  })
   expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -57,14 +57,16 @@ const createInstance = (uid, eventName, handler) => {
 
 test('handleWorkspaceRefresh runs global event handlers in parallel', async () => {
   const calls: string[] = []
-  const deletedUris = ['/workspace/deleted.ts']
+  const workspaceChanges = {
+    deleted: ['/workspace/deleted.ts'],
+  }
   const first = createDeferred()
   const second = createDeferred()
   ViewletStates.set(
     'first',
-    createInstance(1, 'handleWorkspaceRefresh', async (state, receivedDeletedUris) => {
+    createInstance(1, 'handleWorkspaceRefresh', async (state, receivedWorkspaceChanges) => {
       calls.push('first:start')
-      expect(receivedDeletedUris).toBe(deletedUris)
+      expect(receivedWorkspaceChanges).toBe(workspaceChanges)
       await first.promise
       calls.push('first:end')
       return {
@@ -75,9 +77,9 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   )
   ViewletStates.set(
     'second',
-    createInstance(2, 'handleWorkspaceRefresh', async (state, receivedDeletedUris) => {
+    createInstance(2, 'handleWorkspaceRefresh', async (state, receivedWorkspaceChanges) => {
       calls.push('second:start')
-      expect(receivedDeletedUris).toBe(deletedUris)
+      expect(receivedWorkspaceChanges).toBe(workspaceChanges)
       await second.promise
       calls.push('second:end')
       return {
@@ -88,7 +90,7 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   )
 
   const state = ViewletLayout.create(1)
-  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state, deletedUris)
+  const resultPromise = ViewletLayout.handleWorkspaceRefresh(state, workspaceChanges)
 
   expect(calls).toEqual(['first:start', 'second:start'])
 

--- a/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
+++ b/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
@@ -92,7 +92,9 @@ test('watcher events - debounce refresh and forward deleted uris', async () => {
   await jest.runAllTimersAsync()
 
   expect(Command.execute).toHaveBeenCalledTimes(2)
-  expect(Command.execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', ['file:///workspace/deleted.txt'])
+  expect(Command.execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    deleted: ['file:///workspace/deleted.txt'],
+  })
   expect(Command.execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
 


### PR DESCRIPTION
## Summary

- broadcast structured deleted and renamed paths through Layout.handleWorkspaceRefresh
- preserve rename pairs at the central filesystem boundary
- keep global workspace-change consumers decoupled from producers