### PR TITLE
fix: resolve web config path locally

### DIFF
--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
@@ -24,7 +24,10 @@ export const getDisabledExtensionsJsonPath = () => {
   return SharedProcess.invoke(/* Platform.getDisabledExtensionsJsonPath */ 'Platform.getDisabledExtensionsJsonPath')
 }
 
-export const getConfigJsonPath = () => {
+export const getConfigJsonPath = (platform = Platform.getPlatform(), assetDir = AssetDir.assetDir) => {
+  if (platform === PlatformType.Web) {
+    return `${assetDir}/config.json`
+  }
   return SharedProcess.invoke(/* Platform.getConfigJsonPath */ 'Platform.getConfigJsonPath')
 }
 

--- a/packages/renderer-worker/test/PlatformPaths.test.ts
+++ b/packages/renderer-worker/test/PlatformPaths.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -72,7 +73,12 @@ test('getUserSettingsPath', async () => {
   expect(await PlatformPaths.getUserSettingsPath()).toBe('~/.config/app/settings.json')
 })
 
-test('getConfigJsonPath', async () => {
+test('getConfigJsonPath - web', async () => {
+  expect(await PlatformPaths.getConfigJsonPath(PlatformType.Web, '/test/commit-hash')).toBe('/test/commit-hash/config.json')
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('getConfigJsonPath - electron', async () => {
   // @ts-ignore
   SharedProcess.invoke.mockImplementation((method, ...params) => {
     switch (method) {
@@ -82,7 +88,7 @@ test('getConfigJsonPath', async () => {
         throw new Error('unexpected message')
     }
   })
-  expect(await PlatformPaths.getConfigJsonPath()).toBe('file:///test/config.json')
+  expect(await PlatformPaths.getConfigJsonPath(PlatformType.Electron)).toBe('file:///test/config.json')
   expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getConfigJsonPath')
 })
 


### PR DESCRIPTION
Resolve the web config JSON URL from the renderer asset directory so opening About no longer attempts to contact the unavailable shared process. Preserve the existing shared-process lookup for Electron and remote platforms.