### PR TITLE
feature: update chat view 2 to 1.7.2

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -20,7 +20,7 @@
   {
     "name": "builtin.chat-view-2",
     "repository": "github.com/lvce-editor/chat-view-2",
-    "version": "1.7.0",
+    "version": "1.7.2",
     "created": "2026-07-14"
   },
   {


### PR DESCRIPTION
Updates the built-in Chat 2 extension to v1.7.2.

This release adds end-to-end Linux desktop application launch, screenshot saving, multimodal screenshot feedback, and corrected X11 window-relative clicks.