### PR TITLE
feature: optimize renderer message traffic

### DIFF
--- a/packages/renderer-worker/src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js
+++ b/packages/renderer-worker/src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js
@@ -1,0 +1,99 @@
+const kDispose = 'Viewlet.dispose'
+const kPatchCss = 'Viewlet.patchCss'
+const kSetCss = 'Viewlet.setCss'
+const kSetPatches = 'Viewlet.setPatches'
+
+export const state = {
+  /** @type {Map<string | number, string>} */
+  cssTexts: new Map(),
+}
+
+const getJsonByteLength = (value) => {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength
+}
+
+const getCommonPrefixLength = (oldText, newText) => {
+  const limit = Math.min(oldText.length, newText.length)
+  let index = 0
+  while (index < limit && oldText[index] === newText[index]) {
+    index++
+  }
+  return index
+}
+
+const getCommonSuffixLength = (oldText, newText, prefixLength) => {
+  const limit = Math.min(oldText.length, newText.length) - prefixLength
+  let length = 0
+  while (length < limit && oldText[oldText.length - length - 1] === newText[newText.length - length - 1]) {
+    length++
+  }
+  return length
+}
+
+const normalizeSetCss = (command) => {
+  const id = command[1]
+  const newText = command[2]
+  if ((typeof id !== 'string' && typeof id !== 'number') || typeof newText !== 'string') {
+    return command
+  }
+  const oldText = state.cssTexts.get(id)
+  if (oldText === newText) {
+    return undefined
+  }
+  state.cssTexts.set(id, newText)
+  if (oldText === undefined) {
+    return command
+  }
+  const start = getCommonPrefixLength(oldText, newText)
+  const suffixLength = getCommonSuffixLength(oldText, newText, start)
+  const deleteCount = oldText.length - start - suffixLength
+  const replacement = newText.slice(start, newText.length - suffixLength)
+  const patchCommand = [kPatchCss, id, start, deleteCount, replacement]
+  if (getJsonByteLength(patchCommand) < getJsonByteLength(command)) {
+    return patchCommand
+  }
+  return command
+}
+
+const normalizeCommand = (command) => {
+  if (!Array.isArray(command)) {
+    return command
+  }
+  if (command[0] === kSetPatches && Array.isArray(command[2]) && command[2].length === 0) {
+    return undefined
+  }
+  if (command[0] === kSetCss) {
+    return normalizeSetCss(command)
+  }
+  if (command[0] === kDispose) {
+    state.cssTexts.delete(command[1])
+  }
+  return command
+}
+
+export const normalizeCommands = (commands) => {
+  const normalized = []
+  for (const command of commands) {
+    const normalizedCommand = normalizeCommand(command)
+    if (normalizedCommand) {
+      normalized.push(normalizedCommand)
+    }
+  }
+  return normalized
+}
+
+export const getCssText = (id) => {
+  return state.cssTexts.get(id)
+}
+
+export const setCssText = (id, text) => {
+  state.cssTexts.set(id, text)
+}
+
+export const removeCssText = (id) => {
+  state.cssTexts.delete(id)
+}
+
+export const reset = () => {
+  state.cssTexts.clear()
+}

--- a/packages/renderer-worker/src/parts/RendererFrameScheduler/RendererFrameScheduler.js
+++ b/packages/renderer-worker/src/parts/RendererFrameScheduler/RendererFrameScheduler.js
@@ -1,0 +1,134 @@
+import * as NormalizeRendererCommands from '../NormalizeRendererCommands/NormalizeRendererCommands.js'
+import * as RequestAnimationFrame from '../RequestAnimationFrame/RequestAnimationFrame.js'
+
+const kAddCssStyleSheet = 'Css.addCssStyleSheet'
+const kDispose = 'Viewlet.dispose'
+const kSendMultiple = 'Viewlet.sendMultiple'
+const kSetCss = 'Viewlet.setCss'
+const kSetPatches = 'Viewlet.setPatches'
+const minimumFrameDuration = 16
+
+export const state = {
+  frameCount: 0,
+  lastFrameTime: Number.NEGATIVE_INFINITY,
+  /** @type {{commands: any[], promise: Promise<any>} | undefined} */
+  pendingFrame: undefined,
+  /** @type {any} */
+  rpc: undefined,
+  tail: Promise.resolve(),
+}
+
+const enqueue = (operation) => {
+  const promise = state.tail.then(operation)
+  state.tail = promise.catch(() => {})
+  return promise
+}
+
+const waitForEligibleFrame = () => {
+  return new Promise((resolve) => {
+    const handleFrame = (timestamp) => {
+      if (timestamp - state.lastFrameTime < minimumFrameDuration) {
+        RequestAnimationFrame.requestAnimationFrame(handleFrame)
+        return
+      }
+      resolve(timestamp)
+    }
+    RequestAnimationFrame.requestAnimationFrame(handleFrame)
+  })
+}
+
+const invokeWithCacheRecovery = async (method, ...params) => {
+  try {
+    return await state.rpc.invoke(method, ...params)
+  } catch (error) {
+    NormalizeRendererCommands.reset()
+    throw error
+  }
+}
+
+const runFrame = async (frame) => {
+  const timestamp = await waitForEligibleFrame()
+  if (state.pendingFrame === frame) {
+    state.pendingFrame = undefined
+  }
+  const commands = NormalizeRendererCommands.normalizeCommands(frame.commands)
+  if (commands.length === 0) {
+    return
+  }
+  state.frameCount++
+  state.lastFrameTime = timestamp
+  return invokeWithCacheRecovery(kSendMultiple, commands)
+}
+
+const sealPendingFrame = () => {
+  state.pendingFrame = undefined
+}
+
+const invokeDirectRendererCommand = async (method, params) => {
+  const commands = NormalizeRendererCommands.normalizeCommands([[method, ...params]])
+  if (commands.length === 0) {
+    return
+  }
+  const [command] = commands
+  return invokeWithCacheRecovery(command[0], ...command.slice(1))
+}
+
+const invokeCssStyleSheet = async (id, text) => {
+  if (NormalizeRendererCommands.getCssText(id) === text) {
+    return
+  }
+  NormalizeRendererCommands.setCssText(id, text)
+  return invokeWithCacheRecovery(kAddCssStyleSheet, id, text)
+}
+
+export const reset = (rpc) => {
+  NormalizeRendererCommands.reset()
+  state.frameCount = 0
+  state.lastFrameTime = Number.NEGATIVE_INFINITY
+  state.pendingFrame = undefined
+  state.rpc = rpc
+  state.tail = Promise.resolve()
+}
+
+export const sendMultiple = (commands) => {
+  if (state.pendingFrame) {
+    state.pendingFrame.commands.push(...commands)
+    return state.pendingFrame.promise
+  }
+  /** @type {{commands: any[], promise: Promise<any>}} */
+  const frame = {
+    commands: [...commands],
+    promise: Promise.resolve(),
+  }
+  state.pendingFrame = frame
+  frame.promise = enqueue(() => runFrame(frame))
+  return frame.promise
+}
+
+export const invoke = (method, ...params) => {
+  if (method === kSendMultiple) {
+    return sendMultiple(params[0])
+  }
+  sealPendingFrame()
+  return enqueue(async () => {
+    if (method === kAddCssStyleSheet) {
+      return invokeCssStyleSheet(params[0], params[1])
+    }
+    if (method === kDispose || method === kSetCss || method === kSetPatches) {
+      return invokeDirectRendererCommand(method, params)
+    }
+    return invokeWithCacheRecovery(method, ...params)
+  })
+}
+
+export const invokeAndTransfer = (method, ...params) => {
+  sealPendingFrame()
+  return enqueue(async () => {
+    try {
+      return await state.rpc.invokeAndTransfer(method, ...params)
+    } catch (error) {
+      NormalizeRendererCommands.reset()
+      throw error
+    }
+  })
+}

--- a/packages/renderer-worker/src/parts/RendererProcess/RendererProcess.js
+++ b/packages/renderer-worker/src/parts/RendererProcess/RendererProcess.js
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { WebWorkerRpcClient2 } from '../../../../../static/js/lvce-editor-rpc.js'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.js'
+import * as RendererFrameScheduler from '../RendererFrameScheduler/RendererFrameScheduler.js'
 
 export const state = {
   pendingMessages: [],
@@ -23,6 +24,7 @@ export const listen = async () => {
   console.assert(state.pendingMessages.length === 0)
   const rpc = await getRpc()
   state.rpc = rpc
+  RendererFrameScheduler.reset(rpc)
 }
 
 /**
@@ -34,11 +36,11 @@ export const send = (message) => {
 }
 
 export const invoke = (method, ...params) => {
-  return state.rpc.invoke(method, ...params)
+  return RendererFrameScheduler.invoke(method, ...params)
 }
 
 export const invokeAndTransfer = (method, ...params) => {
-  return state.rpc.invokeAndTransfer(method, ...params)
+  return RendererFrameScheduler.invokeAndTransfer(method, ...params)
 }
 
 export const sendAndTransfer = (message, transferables) => {

--- a/packages/renderer-worker/test/NormalizeRendererCommands.test.ts
+++ b/packages/renderer-worker/test/NormalizeRendererCommands.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, expect, test } from '@jest/globals'
+
+const NormalizeRendererCommands = await import('../src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js')
+
+beforeEach(() => {
+  NormalizeRendererCommands.reset()
+})
+
+test('removes empty patches and preserves command order', () => {
+  const commands = [
+    ['Viewlet.send', 1, 'before'],
+    ['Viewlet.setPatches', 1, []],
+    ['Viewlet.send', 1, 'after'],
+  ]
+
+  expect(NormalizeRendererCommands.normalizeCommands(commands)).toEqual([
+    ['Viewlet.send', 1, 'before'],
+    ['Viewlet.send', 1, 'after'],
+  ])
+})
+
+test('requires an initial full stylesheet and suppresses duplicates', () => {
+  const command = ['Viewlet.setCss', 1, '.item { color: red; }']
+
+  expect(NormalizeRendererCommands.normalizeCommands([command])).toEqual([command])
+  expect(NormalizeRendererCommands.normalizeCommands([command])).toEqual([])
+})
+
+test('creates a smaller replacement patch', () => {
+  const prefix = 'a'.repeat(100)
+  const suffix = 'z'.repeat(100)
+  NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, `${prefix}old${suffix}`]])
+
+  expect(NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, `${prefix}new${suffix}`]])).toEqual([
+    ['Viewlet.patchCss', 1, 100, 3, 'new'],
+  ])
+})
+
+test('creates insertion and deletion patches', () => {
+  const prefix = 'a'.repeat(100)
+  const suffix = 'z'.repeat(100)
+  NormalizeRendererCommands.normalizeCommands([
+    ['Viewlet.setCss', 'one', `${prefix}${suffix}`],
+    ['Viewlet.setCss', 'two', `${prefix}middle${suffix}`],
+  ])
+
+  expect(
+    NormalizeRendererCommands.normalizeCommands([
+      ['Viewlet.setCss', 'one', `${prefix}middle${suffix}`],
+      ['Viewlet.setCss', 'two', `${prefix}${suffix}`],
+    ]),
+  ).toEqual([
+    ['Viewlet.patchCss', 'one', 100, 0, 'middle'],
+    ['Viewlet.patchCss', 'two', 100, 6, ''],
+  ])
+})
+
+test('retains a full replacement when a patch is not smaller', () => {
+  NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, 'a']])
+
+  expect(NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, 'b']])).toEqual([['Viewlet.setCss', 1, 'b']])
+})
+
+test('disposal clears stylesheet state', () => {
+  const command = ['Viewlet.setCss', 1, '.item {}']
+  NormalizeRendererCommands.normalizeCommands([command])
+
+  NormalizeRendererCommands.normalizeCommands([['Viewlet.dispose', 1]])
+
+  expect(NormalizeRendererCommands.normalizeCommands([command])).toEqual([command])
+})
+
+test('tracks stylesheets independently by id', () => {
+  const css = '.item {}'
+
+  expect(
+    NormalizeRendererCommands.normalizeCommands([
+      ['Viewlet.setCss', 1, css],
+      ['Viewlet.setCss', 2, css],
+    ]),
+  ).toEqual([
+    ['Viewlet.setCss', 1, css],
+    ['Viewlet.setCss', 2, css],
+  ])
+})

--- a/packages/renderer-worker/test/RendererFrameScheduler.test.ts
+++ b/packages/renderer-worker/test/RendererFrameScheduler.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const frameCallbacks: Array<(timestamp: number) => void> = []
+
+jest.unstable_mockModule('../src/parts/RequestAnimationFrame/RequestAnimationFrame.js', () => ({
+  requestAnimationFrame: jest.fn((callback: (timestamp: number) => void) => {
+    frameCallbacks.push(callback)
+  }),
+}))
+
+const NormalizeRendererCommands = await import('../src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js')
+const RendererFrameScheduler = await import('../src/parts/RendererFrameScheduler/RendererFrameScheduler.js')
+
+const rpc = {
+  invoke: jest.fn<(...args: any[]) => Promise<any>>(),
+  invokeAndTransfer: jest.fn<(...args: any[]) => Promise<any>>(),
+}
+
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const runAnimationFrame = async (timestamp: number) => {
+  const callback = frameCallbacks.shift()
+  expect(callback).toBeDefined()
+  callback!(timestamp)
+  await flushMicrotasks()
+}
+
+beforeEach(() => {
+  frameCallbacks.length = 0
+  jest.clearAllMocks()
+  rpc.invoke.mockResolvedValue(undefined)
+  rpc.invokeAndTransfer.mockResolvedValue(undefined)
+  RendererFrameScheduler.reset(rpc)
+})
+
+test('coalesces consecutive render batches in arrival order', async () => {
+  const first = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'first']])
+  const second = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'second']])
+  await flushMicrotasks()
+
+  expect(rpc.invoke).not.toHaveBeenCalled()
+  await runAnimationFrame(0)
+  await Promise.all([first, second])
+
+  expect(rpc.invoke).toHaveBeenCalledTimes(1)
+  expect(rpc.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.send', 1, 'first'],
+    ['Viewlet.send', 1, 'second'],
+  ])
+  expect(RendererFrameScheduler.state.frameCount).toBe(1)
+})
+
+test('does not send empty patches or an empty render batch', async () => {
+  const promise = RendererFrameScheduler.sendMultiple([['Viewlet.setPatches', 1, []]])
+  await flushMicrotasks()
+  await runAnimationFrame(0)
+  await promise
+
+  expect(rpc.invoke).not.toHaveBeenCalled()
+  expect(RendererFrameScheduler.state.frameCount).toBe(0)
+})
+
+test('uses direct RPCs as ordering barriers', async () => {
+  const first = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'first']])
+  const barrier = RendererFrameScheduler.invoke('Window.test')
+  const second = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'second']])
+  await flushMicrotasks()
+
+  await runAnimationFrame(0)
+  await first
+  await barrier
+  await flushMicrotasks()
+  await runAnimationFrame(16)
+  await second
+
+  expect(rpc.invoke.mock.calls).toEqual([
+    ['Viewlet.sendMultiple', [['Viewlet.send', 1, 'first']]],
+    ['Window.test'],
+    ['Viewlet.sendMultiple', [['Viewlet.send', 1, 'second']]],
+  ])
+})
+
+test('enforces 16ms spacing on high refresh displays', async () => {
+  const first = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'first']])
+  await flushMicrotasks()
+  await runAnimationFrame(0)
+  await first
+
+  const second = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'second']])
+  await flushMicrotasks()
+  await runAnimationFrame(8)
+
+  expect(rpc.invoke).toHaveBeenCalledTimes(1)
+  expect(frameCallbacks).toHaveLength(1)
+
+  await runAnimationFrame(16)
+  await second
+  expect(rpc.invoke).toHaveBeenCalledTimes(2)
+  expect(RendererFrameScheduler.state.frameCount).toBe(2)
+})
+
+test('resolves every caller only after its shared frame succeeds', async () => {
+  let firstResolved = false
+  let secondResolved = false
+  const first = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'first']]).then(() => {
+    firstResolved = true
+  })
+  const second = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'second']]).then(() => {
+    secondResolved = true
+  })
+  await flushMicrotasks()
+
+  expect(firstResolved).toBe(false)
+  expect(secondResolved).toBe(false)
+  await runAnimationFrame(0)
+  await Promise.all([first, second])
+  expect(firstResolved).toBe(true)
+  expect(secondResolved).toBe(true)
+})
+
+test('rejects a failed frame and resets CSS optimization state', async () => {
+  const error = new Error('renderer failed')
+  rpc.invoke.mockRejectedValueOnce(error)
+  const command = ['Viewlet.setCss', 1, '.item {}']
+  const first = RendererFrameScheduler.sendMultiple([command])
+  const second = RendererFrameScheduler.sendMultiple([command])
+  const resultsPromise = Promise.allSettled([first, second])
+  await flushMicrotasks()
+  await runAnimationFrame(0)
+
+  const results = await resultsPromise
+  expect(results).toEqual([
+    { reason: error, status: 'rejected' },
+    { reason: error, status: 'rejected' },
+  ])
+  expect(NormalizeRendererCommands.state.cssTexts.size).toBe(0)
+
+  const recovered = RendererFrameScheduler.sendMultiple([command])
+  await flushMicrotasks()
+  await runAnimationFrame(16)
+  await recovered
+  expect(rpc.invoke).toHaveBeenLastCalledWith('Viewlet.sendMultiple', [command])
+})
+
+test('does not send direct empty patches', async () => {
+  await RendererFrameScheduler.invoke('Viewlet.setPatches', 1, [])
+
+  expect(rpc.invoke).not.toHaveBeenCalled()
+})
+
+test('suppresses unchanged direct stylesheets', async () => {
+  await RendererFrameScheduler.invoke('Css.addCssStyleSheet', 'ContributedColorTheme', ':root {}')
+  await RendererFrameScheduler.invoke('Css.addCssStyleSheet', 'ContributedColorTheme', ':root {}')
+
+  expect(rpc.invoke).toHaveBeenCalledTimes(1)
+  expect(rpc.invoke).toHaveBeenCalledWith('Css.addCssStyleSheet', 'ContributedColorTheme', ':root {}')
+})
+
+test('recovers the direct stylesheet cache after an RPC failure', async () => {
+  const error = new Error('renderer failed')
+  rpc.invoke.mockRejectedValueOnce(error)
+  await expect(RendererFrameScheduler.invoke('Css.addCssStyleSheet', 'ContributedColorTheme', ':root {}')).rejects.toBe(error)
+
+  await RendererFrameScheduler.invoke('Css.addCssStyleSheet', 'ContributedColorTheme', ':root {}')
+
+  expect(rpc.invoke).toHaveBeenCalledTimes(2)
+})
+
+test('clears direct stylesheet state after disposal', async () => {
+  const command = ['Viewlet.setCss', 1, '.item {}']
+  const first = RendererFrameScheduler.sendMultiple([command])
+  await flushMicrotasks()
+  await runAnimationFrame(0)
+  await first
+
+  await RendererFrameScheduler.invoke('Viewlet.dispose', 1)
+
+  const second = RendererFrameScheduler.sendMultiple([command])
+  await flushMicrotasks()
+  await runAnimationFrame(16)
+  await second
+  expect(rpc.invoke).toHaveBeenLastCalledWith('Viewlet.sendMultiple', [command])
+})
+
+test('orders invokeAndTransfer after pending render work', async () => {
+  const render = RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'render']])
+  const transfer = RendererFrameScheduler.invokeAndTransfer('IpcParent.create', {})
+  await flushMicrotasks()
+  await runAnimationFrame(0)
+  await Promise.all([render, transfer])
+
+  expect(rpc.invoke).toHaveBeenCalledTimes(1)
+  expect(rpc.invokeAndTransfer).toHaveBeenCalledWith('IpcParent.create', {})
+  expect(rpc.invoke.mock.invocationCallOrder[0]).toBeLessThan(rpc.invokeAndTransfer.mock.invocationCallOrder[0])
+})


### PR DESCRIPTION
## Summary
- normalize renderer commands centrally, suppressing empty patches and duplicate CSS
- send smaller prefix/suffix CSS text edits through the released Viewlet.patchCss protocol
- coalesce render batches on 16 ms animation-frame boundaries while preserving RPC ordering barriers
- reset optimization state after disposal or renderer RPC failures

## Validation
- renderer-worker focused tests (18 tests)
- full renderer-worker suite (247 suites, 945 tests)
- root lint and all workspace type checks
- production static bundle