### PR TITLE
fix: restore renderer interactions

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.diff-editor-inline.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.diff-editor-inline.ts
@@ -1,0 +1,14 @@
+export const name = 'viewlet.diff-editor-inline'
+
+export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/file.ts`
+  await FileSystem.writeFile(filePath, 'const value = 2')
+  await Workspace.setPath(tmpDir)
+
+  await Main.openUri(`inline-diff://data://const value = 1<->${filePath}`)
+
+  const diffEditor = Locator('.Viewlet.DiffEditor')
+  await expect(diffEditor).toBeVisible()
+  await expect(Locator('.MainTab')).toHaveText('file.ts (Working Tree)')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.diff-editor-insertion-at-start-and-end.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.diff-editor-insertion-at-start-and-end.ts
@@ -17,8 +17,8 @@ d`,
   await Main.openUri(`diff://${tmpDir}/file-1.txt<->${tmpDir}/file-2.txt`)
 
   // assert
-  const contentLeft = Locator('.DiffEditorContentLeft')
-  const contentRight = Locator('.DiffEditorContentRight')
+  const contentLeft = Locator('.DiffEditorContentLeft .DiffEditorRows')
+  const contentRight = Locator('.DiffEditorContentRight .DiffEditorRows')
   await expect(contentLeft).toHaveText('c')
   await expect(contentRight).toHaveText('abcd')
 }

--- a/packages/extension-host-worker-tests/src/viewlet.diff-editor-insertion.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.diff-editor-insertion.ts
@@ -11,8 +11,8 @@ export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => 
   await Main.openUri(`diff://${tmpDir}/file-1.txt<->${tmpDir}/file-2.txt`)
 
   // assert
-  const contentLeft = Locator('.DiffEditorContentLeft')
-  const contentRight = Locator('.DiffEditorContentRight')
+  const contentLeft = Locator('.DiffEditorContentLeft .DiffEditorRows')
+  const contentRight = Locator('.DiffEditorContentRight .DiffEditorRows')
   await expect(contentLeft).toHaveText('')
   await expect(contentRight).toHaveText('def')
   const rowLeft = contentLeft.locator('.EditorRow')

--- a/packages/extension-host-worker-tests/src/viewlet.diff-editor-scrolling.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.diff-editor-scrolling.ts
@@ -1,32 +1,36 @@
-const getContent = () => {
-  let content = ''
-  for (let i = 97; i < 160; i++) {
-    content += String.fromCharCode(i) + '\n'
+const getContent = (bottomLine: string) => {
+  const lines: string[] = []
+  for (let index = 1; index <= 1800; index++) {
+    lines.push(`shared line ${index}`)
   }
-  return content
+  lines.push(bottomLine)
+  return lines.join('\n')
 }
 
-export const name = 'sample.diff-editor-insertion'
+export const name = 'viewlet.diff-editor-scrolling'
 
-export const skip = true
-
-export const test = async () => {
-  // arrange
+export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => {
   const tmpDir = await FileSystem.getTmpDir()
-  await FileSystem.writeFile(`${tmpDir}/file-1.txt`, ``)
-  await FileSystem.writeFile(`${tmpDir}/file-2.txt`, getContent())
+  await FileSystem.writeFile(`${tmpDir}/file-1.txt`, getContent('bottom change before'))
+  await FileSystem.writeFile(`${tmpDir}/file-2.txt`, getContent('bottom change after'))
   await Workspace.setPath(tmpDir)
 
-  // act
   await Main.openUri(`diff://${tmpDir}/file-1.txt<->${tmpDir}/file-2.txt`)
 
-  // assert
-  const contentLeft = Locator('.DiffEditorContentLeft')
+  const line1 = Locator('.DiffEditorContentLeft .DiffEditorLineNumber', {
+    hasText: '1',
+  })
+  await expect(line1).toBeVisible()
+
   const contentRight = Locator('.DiffEditorContentRight')
-  // await expect(contentLeft).toHaveText('')
-  // await expect(contentRight).toHaveText('def')
-  // const rowLeft = contentLeft.locator('.EditorRow')
-  // await expect(rowLeft).toHaveClass('Deletion')
-  // const rowRight = contentRight.locator('.EditorRow')
-  // await expect(rowRight).toHaveClass('Insertion')
+  await contentRight.dispatchEvent('wheel', {
+    bubbles: true,
+    deltaMode: 0,
+    deltaY: 9_999_999,
+  } as unknown as string)
+
+  const line1800 = Locator('.DiffEditorContentLeft .DiffEditorLineNumber', {
+    hasText: '1800',
+  })
+  await expect(line1800).toBeVisible()
 }

--- a/packages/extension-host-worker-tests/src/viewlet.diff-editor-syntax-highlighting.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.diff-editor-syntax-highlighting.ts
@@ -1,0 +1,15 @@
+export const name = 'viewlet.diff-editor-syntax-highlighting'
+
+export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/file.ts`
+  await FileSystem.writeFile(filePath, 'const rightValue = 2')
+  await Workspace.setPath(tmpDir)
+
+  await Main.openUri(`diff://data://const leftValue = 1<->${filePath}`)
+
+  await expect(Locator('.DiffEditorContentLeft .Token.Keyword')).toHaveText('const')
+  await expect(Locator('.DiffEditorContentLeft .Token.Numeric')).toHaveText('1')
+  await expect(Locator('.DiffEditorContentRight .Token.Keyword')).toHaveText('const')
+  await expect(Locator('.DiffEditorContentRight .Token.Numeric')).toHaveText('2')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.diff-editor.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.diff-editor.ts
@@ -11,8 +11,8 @@ export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => 
   await Main.openUri(`diff://${tmpDir}/file-1.txt<->${tmpDir}/file-2.txt`)
 
   // assert
-  const contentLeft = Locator('.DiffEditorContentLeft')
-  const contentRight = Locator('.DiffEditorContentRight')
+  const contentLeft = Locator('.DiffEditorContentLeft .DiffEditorRows')
+  const contentRight = Locator('.DiffEditorContentRight .DiffEditorRows')
   await expect(contentLeft).toHaveText('abc')
   await expect(contentRight).toHaveText('def')
 }

--- a/packages/extension-host-worker-tests/src/viewlet.explorer-preview-replacement.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-preview-replacement.ts
@@ -1,0 +1,15 @@
+export const name = 'viewlet.explorer-preview-replacement'
+
+export const test = async ({ Editor, Explorer, FileSystem, Locator, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/first.txt`, 'first content')
+  await FileSystem.writeFile(`${tmpDir}/second.txt`, 'second content')
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.handleClick(0)
+  await Editor.shouldHaveText('first content')
+
+  await Explorer.handleClick(1)
+  await Editor.shouldHaveText('second content')
+  await expect(Locator('.EditorContainer > .Viewlet.Editor')).toHaveCount(1)
+}

--- a/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
+++ b/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
@@ -2,10 +2,19 @@ import * as Icon from '../Icon/Icon.js'
 import * as IconTheme from '../IconTheme/IconTheme.js'
 import * as Workspace from '../Workspace/Workspace.js'
 
+const getDisplayUri = (uri) => {
+  if (!uri.startsWith('diff://') && !uri.startsWith('inline-diff://')) {
+    return uri
+  }
+  const separatorIndex = uri.indexOf('<->')
+  return separatorIndex === -1 ? uri : uri.slice(separatorIndex + 3)
+}
+
 export const getTitle = (uri) => {
   if (!uri) {
     return ''
   }
+  uri = getDisplayUri(uri)
   const homeDir = Workspace.getHomeDir()
   // TODO tree shake this out in web
   if (homeDir && uri.startsWith(homeDir)) {
@@ -30,7 +39,7 @@ export const getLabel = (uri) => {
   if (uri.startsWith('running-extensions://')) {
     return 'Running Extensions'
   }
-  return Workspace.pathBaseName(uri)
+  return Workspace.pathBaseName(getDisplayUri(uri))
 }
 
 /**
@@ -51,7 +60,7 @@ export const getFileIcon = (uri) => {
   if (uri.startsWith('running-extensions://')) {
     return `MaskIcon${Icon.Extensions}`
   }
-  const baseName = Workspace.pathBaseName(uri)
+  const baseName = Workspace.pathBaseName(getDisplayUri(uri))
   const icon = IconTheme.getFileIcon({ name: baseName })
   return icon
 }

--- a/packages/renderer-worker/src/parts/ViewletDiffEditor2/ViewletDiffEditor2.js
+++ b/packages/renderer-worker/src/parts/ViewletDiffEditor2/ViewletDiffEditor2.js
@@ -34,6 +34,9 @@ export const loadContent = async (state, savedState) => {
     state.assetDir,
   )
   await DiffViewWorker.invoke('DiffView.loadContent', state.uid, savedState)
+  if (state.uri.startsWith('inline-diff://')) {
+    await DiffViewWorker.invoke('DiffView.setDiffMode', state.uid, 'inline')
+  }
   const diffResult = await DiffViewWorker.invoke('DiffView.diff2', state.uid)
   const commands = await DiffViewWorker.invoke('DiffView.render2', state.uid, diffResult)
   return {

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -50,7 +50,7 @@ export const getModuleId = async (uri, opener) => {
     return ViewletModuleId.DiffEditor
   }
   if (uri.startsWith('inline-diff://')) {
-    return ViewletModuleId.InlineDiffEditor
+    return ViewletModuleId.DiffEditor
   }
   if (uri.startsWith('browser-view-overview://')) {
     return ViewletModuleId.BrowserViewOverview

--- a/packages/renderer-worker/test/PathDisplay.test.ts
+++ b/packages/renderer-worker/test/PathDisplay.test.ts
@@ -16,3 +16,15 @@ test('getLabel - running extensions', () => {
 test('getFileIcon - running extensions', () => {
   expect(PathDisplay.getFileIcon('running-extensions://')).toBe('MaskIconExtensions')
 })
+
+test('getLabel - diff editor', () => {
+  expect(PathDisplay.getLabel('diff://data://const value = 1<->/workspace/src/example.ts')).toBe('example.ts')
+})
+
+test('getLabel - inline diff editor', () => {
+  expect(PathDisplay.getLabel('inline-diff://data://const value = 1<->/workspace/src/example.ts')).toBe('example.ts')
+})
+
+test('getTitle - diff editor', () => {
+  expect(PathDisplay.getTitle('diff://data://const value = 1<->/workspace/src/example.ts')).toBe('/workspace/src/example.ts')
+})

--- a/packages/renderer-worker/test/ViewletDiffEditor2.test.ts
+++ b/packages/renderer-worker/test/ViewletDiffEditor2.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn() as any
+
+jest.unstable_mockModule('../src/parts/DiffViewWorker/DiffViewWorker.js', () => ({
+  invoke,
+}))
+
+const ViewletDiffEditor2 = await import('../src/parts/ViewletDiffEditor2/ViewletDiffEditor2.js')
+
+beforeEach(() => {
+  invoke.mockReset()
+  invoke.mockResolvedValue([])
+})
+
+test('loadContent enables inline mode for inline diff uris', async () => {
+  const state = {
+    uid: 1,
+    uri: 'inline-diff://data://before<->/workspace/file.ts',
+  }
+
+  await ViewletDiffEditor2.loadContent(state, undefined)
+
+  expect(invoke).toHaveBeenCalledWith('DiffView.setDiffMode', 1, 'inline')
+})
+
+test('loadContent keeps side-by-side mode for regular diff uris', async () => {
+  const state = {
+    uid: 1,
+    uri: 'diff://data://before<->/workspace/file.ts',
+  }
+
+  await ViewletDiffEditor2.loadContent(state, undefined)
+
+  expect(invoke).not.toHaveBeenCalledWith('DiffView.setDiffMode', 1, 'inline')
+})

--- a/packages/renderer-worker/test/ViewletMap.test.ts
+++ b/packages/renderer-worker/test/ViewletMap.test.ts
@@ -35,3 +35,7 @@ test('process explorer', async () => {
 test('running extensions', async () => {
   expect(await ViewletMap.getModuleId('running-extensions://')).toBe(ViewletModuleId.RunningExtensions)
 })
+
+test('inline diff uses the external diff editor', async () => {
+  expect(await ViewletMap.getModuleId('inline-diff://data://before<->/test/file.ts')).toBe(ViewletModuleId.DiffEditor)
+})


### PR DESCRIPTION
## Summary

- route `inline-diff://` editors through the external Diff View worker and explicitly select inline mode
- derive diff tab labels, titles, and file icons from the destination file instead of the full encoded comparison URI
- add integrated coverage for inline-diff routing, previous-side syntax highlighting, wheel scrolling, and replacing one Explorer preview editor with another
- update diff assertions to target text rows independently of the new line-number gutters

This completes the application-side wiring for:

- `@lvce-editor/diff-view` 3.27.1
- `@lvce-editor/syntax-highlighting-worker` 2.4.3
- `@lvce-editor/renderer-process` 30.10.1 (including `@lvce-editor/virtual-dom` 11.7.3)
- `@lvce-editor/status-bar-worker` 3.4.1
- `@lvce-editor/extension-host-worker` 8.53.1

## Validation

- renderer-worker focused tests: 3 suites, 17 tests
- renderer-worker full tests: 248 suites, 954 tests
- root lint and type-check
- integrated browser tests for standard, insertion, deletion, inline, syntax-highlighted, and 1,801-line scrolling diffs
- `viewlet.explorer-preview-replacement` integrated browser test
- manual integrated checks for activity-bar view switching, Git status quick pick, title-menu dismissal, diff editor interaction/theme/title behavior, README scrolling, and sequential file opening
