### PR TITLE
fix: show running extensions tab title

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
@@ -3,11 +3,13 @@ import * as Platform from '../Platform/Platform.js'
 import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
 import type { RunningExtensionsState } from './ViewletRunningExtensionsTypes.ts'
 
+const title = 'Running Extensions'
+
 export const create = (uid: number, uri: string, x: number, y: number, width: number, height: number): RunningExtensionsState => {
   return {
     commands: [],
     height,
-    title: 'Running Extensions',
+    title,
     uid,
     uri,
     width,
@@ -26,6 +28,10 @@ export const loadContent = async (state: RunningExtensionsState): Promise<Runnin
     ...state,
     commands,
   }
+}
+
+export const getTitle = (): string => {
+  return title
 }
 
 export const menus = []

--- a/packages/renderer-worker/test/ViewletRunningExtensions.test.ts
+++ b/packages/renderer-worker/test/ViewletRunningExtensions.test.ts
@@ -42,6 +42,7 @@ test('provides the side bar name and title', () => {
   const state = ViewletRunningExtensions.create(1, 'RunningExtensions', 10, 20, 800, 600)
 
   expect(ViewletRunningExtensionsName.name).toBe('RunningExtensions')
+  expect(ViewletRunningExtensions.getTitle()).toBe('Running Extensions')
   expect(ViewletRunningExtensionsRenderTitle.renderTitle.apply(state, state)).toBe('Running Extensions')
 })
 


### PR DESCRIPTION
Summary:
- expose the Running Extensions provider title to main-area tabs
- cover the title adapter with a renderer-worker regression test