### PR TITLE
feature: disable custom worker paths via cli

### DIFF
--- a/packages/shared-process/src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.ts
+++ b/packages/shared-process/src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.ts
@@ -1,3 +1,4 @@
+import * as ApplyCustomWorkerPathCliOverride from '../ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts'
 import * as GetCustomPathsConfig from '../GetCustomPathsConfig/GetCustomPathsConfig.ts'
 import * as Platform from '../Platform/Platform.ts'
 import * as Preferences from '../Preferences/Preferences.ts'
@@ -6,7 +7,7 @@ export const addCustomPathsToIndexHtml = async (content: any): Promise<any> => {
   if (Platform.isProduction) {
     return content
   }
-  const preferences = await Preferences.getUserPreferences()
+  const preferences = ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(await Preferences.getUserPreferences())
   const config = GetCustomPathsConfig.getCustomPathsConfig(preferences)
   let newContent = content
   if (config.rendererProcessPath) {

--- a/packages/shared-process/src/parts/ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts
+++ b/packages/shared-process/src/parts/ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts
@@ -1,0 +1,23 @@
+import * as Process from '../Process/Process.ts'
+
+const disableCustomWorkerPathsFlag = '--disable-custom-worker-paths'
+
+const workerPathSettingsWithoutWorkerInName = new Set(['develop.languageModelsViewPath', 'develop.runningExtensionsViewPath'])
+
+const isCustomWorkerPathSetting = (key: string): boolean => {
+  const isDevelopmentSetting = key.startsWith('develop.') || key.startsWith('developer.')
+  return isDevelopmentSetting && (key.endsWith('WorkerPath') || workerPathSettingsWithoutWorkerInName.has(key))
+}
+
+export const applyCustomWorkerPathCliOverride = (preferences: Record<string, any>): Record<string, any> => {
+  if (!Process.argv.includes(disableCustomWorkerPathsFlag)) {
+    return preferences
+  }
+  const filteredPreferences = { ...preferences }
+  for (const key of Object.keys(filteredPreferences)) {
+    if (isCustomWorkerPathSetting(key)) {
+      delete filteredPreferences[key]
+    }
+  }
+  return filteredPreferences
+}

--- a/packages/shared-process/src/parts/Preferences/Preferences.ts
+++ b/packages/shared-process/src/parts/Preferences/Preferences.ts
@@ -1,3 +1,4 @@
+import * as ApplyCustomWorkerPathCliOverride from '../ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import * as JsoncFile from '../JsoncFile/JsoncFile.ts'
 import * as Logger from '../Logger/Logger.ts'
@@ -81,7 +82,7 @@ export const getAll = async (): Promise<any> => {
     // } catch {
     //   // ignore
     // }
-    return preferences
+    return ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(preferences)
   } catch (error) {
     throw new VError(error, 'Failed to get all preferences')
   }

--- a/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
+++ b/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, jest, test } from '@jest/globals'
+import * as GetRemoteUrl from '../src/parts/GetRemoteUrl/GetRemoteUrl.js'
 
 jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
   isProduction: false,
@@ -29,11 +30,12 @@ test('addCustomPathsToIndexHtml - excludes custom worker paths when disabled fro
   })
   const content =
     '<title>Test</title><script src="/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js"></script>'
+  const rendererProcessUrl = GetRemoteUrl.getRemoteUrl('/test/renderer-process')
 
   const result = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(content)
 
-  expect(result).toContain('<script src="/remote/test/renderer-process"></script>')
-  expect(result).toContain('"rendererProcessPath": "/remote/test/renderer-process"')
+  expect(result).toContain(`<script src="${rendererProcessUrl}"></script>`)
+  expect(result).toContain(`"rendererProcessPath": "${rendererProcessUrl}"`)
   expect(result).not.toContain('editorWorkerUrl')
   expect(result).not.toContain('extensionHostWorkerUrl')
 })

--- a/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
+++ b/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 
 test('addCustomPathsToIndexHtml - excludes custom worker paths when disabled from the command line', async () => {
   process.argv = [...originalArgv, '--disable-custom-worker-paths']
-  Preferences.getUserPreferences.mockResolvedValue({
+  jest.mocked(Preferences.getUserPreferences).mockResolvedValue({
     'develop.editorWorkerPath': '/test/editor-worker',
     'develop.extensionHostWorkerPath': '/test/extension-host-worker',
     'develop.rendererProcessPath': '/test/renderer-process',

--- a/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
+++ b/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  isProduction: false,
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  getUserPreferences: jest.fn(() => {
+    throw new Error('not implemented')
+  }),
+}))
+
+const AddCustomPathsToIndexHtml = await import('../src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+
+const originalArgv = process.argv
+
+afterEach(() => {
+  jest.resetAllMocks()
+  process.argv = originalArgv
+})
+
+test('addCustomPathsToIndexHtml - excludes custom worker paths when disabled from the command line', async () => {
+  process.argv = [...originalArgv, '--disable-custom-worker-paths']
+  Preferences.getUserPreferences.mockResolvedValue({
+    'develop.editorWorkerPath': '/test/editor-worker',
+    'develop.extensionHostWorkerPath': '/test/extension-host-worker',
+    'develop.rendererProcessPath': '/test/renderer-process',
+  })
+  const content =
+    '<title>Test</title><script src="/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js"></script>'
+
+  const result = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(content)
+
+  expect(result).toContain('<script src="/remote/test/renderer-process"></script>')
+  expect(result).toContain('"rendererProcessPath": "/remote/test/renderer-process"')
+  expect(result).not.toContain('editorWorkerUrl')
+  expect(result).not.toContain('extensionHostWorkerUrl')
+})

--- a/packages/shared-process/test/ApplyCustomWorkerPathCliOverride.test.ts
+++ b/packages/shared-process/test/ApplyCustomWorkerPathCliOverride.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, expect, test } from '@jest/globals'
+import * as ApplyCustomWorkerPathCliOverride from '../src/parts/ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.js'
+
+const originalArgv = process.argv
+
+afterEach(() => {
+  process.argv = originalArgv
+})
+
+test('applyCustomWorkerPathCliOverride - keeps custom worker paths by default', () => {
+  const preferences = {
+    'develop.editorWorkerPath': '/test/editor-worker',
+  }
+
+  expect(ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(preferences)).toBe(preferences)
+})
+
+test('applyCustomWorkerPathCliOverride - removes custom worker paths when disabled from the command line', () => {
+  process.argv = [...originalArgv, '--disable-custom-worker-paths']
+  const preferences = {
+    'develop.editorWorkerPath': '/test/editor-worker',
+    'developer.syntaxHighlightingWorkerPath': '/test/syntax-highlighting-worker',
+    'develop.languageModelsViewPath': '/test/language-models-view-worker',
+    'develop.runningExtensionsViewPath': '/test/running-extensions-view-worker',
+    'develop.rendererProcessPath': '/test/renderer-process',
+    'workbench.colorTheme': 'test-theme',
+  }
+
+  expect(ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(preferences)).toEqual({
+    'develop.rendererProcessPath': '/test/renderer-process',
+    'workbench.colorTheme': 'test-theme',
+  })
+})

--- a/packages/shared-process/test/ApplyCustomWorkerPathCliOverride.test.ts
+++ b/packages/shared-process/test/ApplyCustomWorkerPathCliOverride.test.ts
@@ -19,10 +19,10 @@ test('applyCustomWorkerPathCliOverride - removes custom worker paths when disabl
   process.argv = [...originalArgv, '--disable-custom-worker-paths']
   const preferences = {
     'develop.editorWorkerPath': '/test/editor-worker',
-    'developer.syntaxHighlightingWorkerPath': '/test/syntax-highlighting-worker',
     'develop.languageModelsViewPath': '/test/language-models-view-worker',
-    'develop.runningExtensionsViewPath': '/test/running-extensions-view-worker',
     'develop.rendererProcessPath': '/test/renderer-process',
+    'develop.runningExtensionsViewPath': '/test/running-extensions-view-worker',
+    'developer.syntaxHighlightingWorkerPath': '/test/syntax-highlighting-worker',
     'workbench.colorTheme': 'test-theme',
   }
 


### PR DESCRIPTION
Adds a `--disable-custom-worker-paths` flag that ignores custom worker paths from settings for a single launch while preserving configured process paths. Includes focused coverage for regular preferences and early worker bootstrap configuration.