### PR TITLE
fix: send complete viewlet stylesheets

### DIFF
--- a/packages/renderer-worker/src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js
+++ b/packages/renderer-worker/src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js
@@ -1,33 +1,10 @@
 const kDispose = 'Viewlet.dispose'
-const kPatchCss = 'Viewlet.patchCss'
 const kSetCss = 'Viewlet.setCss'
 const kSetPatches = 'Viewlet.setPatches'
 
 export const state = {
   /** @type {Map<string | number, string>} */
   cssTexts: new Map(),
-}
-
-const getJsonByteLength = (value) => {
-  return new TextEncoder().encode(JSON.stringify(value)).byteLength
-}
-
-const getCommonPrefixLength = (oldText, newText) => {
-  const limit = Math.min(oldText.length, newText.length)
-  let index = 0
-  while (index < limit && oldText[index] === newText[index]) {
-    index++
-  }
-  return index
-}
-
-const getCommonSuffixLength = (oldText, newText, prefixLength) => {
-  const limit = Math.min(oldText.length, newText.length) - prefixLength
-  let length = 0
-  while (length < limit && oldText[oldText.length - length - 1] === newText[newText.length - length - 1]) {
-    length++
-  }
-  return length
 }
 
 const normalizeSetCss = (command) => {
@@ -41,17 +18,6 @@ const normalizeSetCss = (command) => {
     return undefined
   }
   state.cssTexts.set(id, newText)
-  if (oldText === undefined) {
-    return command
-  }
-  const start = getCommonPrefixLength(oldText, newText)
-  const suffixLength = getCommonSuffixLength(oldText, newText, start)
-  const deleteCount = oldText.length - start - suffixLength
-  const replacement = newText.slice(start, newText.length - suffixLength)
-  const patchCommand = [kPatchCss, id, start, deleteCount, replacement]
-  if (getJsonByteLength(patchCommand) < getJsonByteLength(command)) {
-    return patchCommand
-  }
   return command
 }
 

--- a/packages/renderer-worker/test/NormalizeRendererCommands.test.ts
+++ b/packages/renderer-worker/test/NormalizeRendererCommands.test.ts
@@ -26,39 +26,13 @@ test('requires an initial full stylesheet and suppresses duplicates', () => {
   expect(NormalizeRendererCommands.normalizeCommands([command])).toEqual([])
 })
 
-test('creates a smaller replacement patch', () => {
+test('sends the full stylesheet when it changes', () => {
   const prefix = 'a'.repeat(100)
   const suffix = 'z'.repeat(100)
   NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, `${prefix}old${suffix}`]])
+  const command = ['Viewlet.setCss', 1, `${prefix}new${suffix}`]
 
-  expect(NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, `${prefix}new${suffix}`]])).toEqual([
-    ['Viewlet.patchCss', 1, 100, 3, 'new'],
-  ])
-})
-
-test('creates insertion and deletion patches', () => {
-  const prefix = 'a'.repeat(100)
-  const suffix = 'z'.repeat(100)
-  NormalizeRendererCommands.normalizeCommands([
-    ['Viewlet.setCss', 'one', `${prefix}${suffix}`],
-    ['Viewlet.setCss', 'two', `${prefix}middle${suffix}`],
-  ])
-
-  expect(
-    NormalizeRendererCommands.normalizeCommands([
-      ['Viewlet.setCss', 'one', `${prefix}middle${suffix}`],
-      ['Viewlet.setCss', 'two', `${prefix}${suffix}`],
-    ]),
-  ).toEqual([
-    ['Viewlet.patchCss', 'one', 100, 0, 'middle'],
-    ['Viewlet.patchCss', 'two', 100, 6, ''],
-  ])
-})
-
-test('retains a full replacement when a patch is not smaller', () => {
-  NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, 'a']])
-
-  expect(NormalizeRendererCommands.normalizeCommands([['Viewlet.setCss', 1, 'b']])).toEqual([['Viewlet.setCss', 1, 'b']])
+  expect(NormalizeRendererCommands.normalizeCommands([command])).toEqual([command])
 })
 
 test('disposal clears stylesheet state', () => {


### PR DESCRIPTION
## Summary

- keep suppressing duplicate stylesheet updates
- send the complete stylesheet when viewlet CSS changes so cached CSS cannot diverge and corrupt Explorer indentation