### PR TITLE
fix: serialize editor render updates

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.editor-package-lock-scrolling.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-package-lock-scrolling.ts
@@ -1,0 +1,53 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-package-lock-scrolling'
+
+const createPackageLock = (): string => {
+  const packages = Object.fromEntries(
+    Array.from({ length: 100 }, (_, index) => [
+      `node_modules/package-${String(index).padStart(3, '0')}`,
+      {
+        integrity: `sha512-package-${index}`,
+        license: 'MIT',
+        resolved: `https://registry.npmjs.org/package-${index}/-/package-${index}-${index}.0.0.tgz`,
+        version: `${index}.0.0`,
+      },
+    ]),
+  )
+  return JSON.stringify(
+    {
+      lockfileVersion: 3,
+      name: 'package-lock-scroll',
+      packages,
+      requires: true,
+      version: '0.0.0-dev',
+    },
+    null,
+    2,
+  )
+}
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/package-lock.json`
+  await FileSystem.writeFile(filePath, createPackageLock())
+  await Workspace.setPath(tmpDir)
+  await Main.closeAllEditors()
+  await Main.openUri(filePath)
+
+  await Promise.all(Array.from({ length: 10 }, () => Command.execute('Editor.handleWheel', 0, 0, 56)))
+
+  const rows = Locator('.EditorRow')
+  const packageRow = rows.nth(0)
+  const integrityRow = rows.nth(1)
+  const licenseRow = rows.nth(2)
+  const resolvedRow = rows.nth(3)
+  const versionRow = rows.nth(4)
+  const closingRow = rows.nth(5)
+  await expect(packageRow).toHaveText('    "node_modules/package-004": {')
+  await expect(integrityRow).toHaveText('      "integrity": "sha512-package-4",')
+  await expect(licenseRow).toHaveText('      "license": "MIT",')
+  await expect(resolvedRow).toHaveText('      "resolved": "https://registry.npmjs.org/package-4/-/package-4-4.0.0.tgz",')
+  await expect(versionRow).toHaveText('      "version": "4.0.0"')
+  await expect(closingRow).toHaveText('    },')
+}

--- a/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
+++ b/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
@@ -1,5 +1,7 @@
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 
+const queues = new Map()
+
 export const wrapEditorCommand = (id) => {
   return async (...args) => {
     if (args.length === 0) {
@@ -8,13 +10,26 @@ export const wrapEditorCommand = (id) => {
     const editor = args[0]
     const restArgs = args.slice(1)
     const fullId = id.includes('.') ? id : `Editor.${id}`
+    const previous = queues.get(editor.uid)
+    const { promise: next, resolve } = Promise.withResolvers()
+    queues.set(editor.uid, next)
 
-    await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
-    const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
-    const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
-    return {
-      ...editor,
-      commands,
+    if (previous) {
+      await previous
+    }
+    try {
+      await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
+      const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
+      const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
+      return {
+        ...editor,
+        commands,
+      }
+    } finally {
+      resolve(undefined)
+      if (queues.get(editor.uid) === next) {
+        queues.delete(editor.uid)
+      }
     }
   }
 }

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -80,6 +80,46 @@ test('worker command wrapper invokes editor command, diff, and render', async ()
   })
 })
 
+test('worker command wrapper serializes command, diff, and render per editor', async () => {
+  const editor = {
+    commands: [],
+    uid: 42,
+  }
+  const { promise: firstCommand, resolve: resolveFirstCommand } = Promise.withResolvers<void>()
+  let diffCount = 0
+  editorWorkerInvoke.mockImplementation(async (method, uid, argument) => {
+    switch (method) {
+      case 'Editor.diff2':
+        return [++diffCount]
+      case 'Editor.getCommandIds':
+        return ['handleWheel']
+      case 'Editor.handleWheel':
+        return argument === 'first' ? firstCommand : undefined
+      case 'Editor.render2':
+        return [[method, uid, argument]]
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const commands = await ViewletEditorTextCommands.getCommands()
+  const first = commands.handleWheel(editor, 'first')
+  const second = commands.handleWheel(editor, 'second')
+
+  await Promise.resolve()
+  expect(editorWorkerInvoke).toHaveBeenCalledTimes(2)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.handleWheel', 42, 'first')
+
+  resolveFirstCommand()
+  await Promise.all([first, second])
+
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(3, 'Editor.diff2', 42)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(4, 'Editor.render2', 42, [1])
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(5, 'Editor.handleWheel', 42, 'second')
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(6, 'Editor.diff2', 42)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(7, 'Editor.render2', 42, [2])
+})
+
 test('handleUriChange skips the duplicated viewlet uid and updates the renderer editor uri', async () => {
   const editor = {
     uid: 42,


### PR DESCRIPTION
Serializes each editor command with its diff and render so rapid wheel updates cannot compute patches against a future DOM state. Adds unit coverage for overlapping editor commands and an app-level package-lock scrolling regression.