### PR TITLE
fix: make locations view visible

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -56,3 +56,24 @@ test('bundleCss preserves the simple browser preview width', async () => {
     await rm(dir, { recursive: true, force: true })
   }
 }, 30_000)
+
+test('bundleCss preserves the locations flex growth', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletReferences.css'), 'utf8')
+
+    expect(css).toContain(`.Locations {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/static/css/parts/ViewletReferences.css
+++ b/static/css/parts/ViewletReferences.css
@@ -1,5 +1,6 @@
 .Locations {
   display: flex;
+  flex: 1;
   flex-direction: column;
 }
 


### PR DESCRIPTION
Summary:
- let the locations view grow to fill the available sidebar space
- preserve the layout rule in the bundled CSS regression coverage