### PR TITLE
feature: add search editors

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-accessibility.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-accessibility.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-accessibility'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+  await Locator('#SideBar button[title="Open New Search Editor"]').click()
+
+  const tab = Locator('.MainTab')
+  await expect(tab).toHaveAttribute('aria-selected', 'true')
+
+  const input = Locator('#Main textarea[name="SearchValue"]')
+  await expect(input).toHaveAttribute('autocapitalize', 'off')
+  await expect(input).toHaveAttribute('autocorrect', 'off')
+  await expect(input).toHaveAttribute('spellcheck', 'false')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-close.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-close.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-close'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+  await Locator('#SideBar button[title="Open New Search Editor"]').click()
+
+  const tab = Locator('.MainTab')
+  await expect(tab).toHaveCount(1)
+  await tab.locator('.EditorTabCloseButton').click()
+
+  await expect(tab).toHaveCount(0)
+  await expect(Locator('#Main .Search')).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-independent-input.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-independent-input.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-independent-input'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+
+  const sideBarInput = Locator('#SideBar textarea[name="SearchValue"]')
+  await sideBarInput.click()
+  await sideBarInput.type('sidebar query')
+  await Locator('#SideBar button[title="Open New Search Editor"]').click()
+
+  const editorInput = Locator('#Main textarea[name="SearchValue"]')
+  await expect(editorInput).toHaveValue('')
+  await editorInput.click()
+  await editorInput.type('editor query')
+
+  await expect(editorInput).toHaveValue('editor query')
+  await expect(sideBarInput).toHaveValue('sidebar query')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-new-each-time.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-new-each-time.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-new-each-time'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+
+  const searchEditorButton = Locator('#SideBar button[title="Open New Search Editor"]')
+  await searchEditorButton.click()
+  await searchEditorButton.click()
+
+  const tabs = Locator('.MainTab')
+  await expect(tabs).toHaveCount(2)
+  await expect(tabs.nth(0).locator('.TabTitle')).toHaveText('Search')
+  await expect(tabs.nth(1).locator('.TabTitle')).toHaveText('Search')
+  await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'false')
+  await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-open.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-open.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-open'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+
+  const searchEditorButton = Locator('#SideBar button[title="Open New Search Editor"]')
+  await expect(searchEditorButton).toBeVisible()
+  await searchEditorButton.click()
+
+  const tabs = Locator('.MainTab')
+  await expect(tabs).toHaveCount(1)
+  await expect(tabs.locator('.TabTitle')).toHaveText('Search')
+  await expect(Locator('#Main .Search')).toBeVisible()
+  await expect(Locator('#Main textarea[name="SearchValue"]')).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-preserve-tab-state.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-preserve-tab-state.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-preserve-tab-state'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+
+  const searchEditorButton = Locator('#SideBar button[title="Open New Search Editor"]')
+  await searchEditorButton.click()
+  const editorInput = Locator('#Main textarea[name="SearchValue"]')
+  await editorInput.click()
+  await editorInput.type('first editor')
+
+  await searchEditorButton.click()
+  await editorInput.click()
+  await editorInput.type('second editor')
+
+  const tabs = Locator('.MainTab')
+  await tabs.nth(0).click()
+  await expect(editorInput).toHaveValue('first editor')
+
+  await tabs.nth(1).click()
+  await expect(editorInput).toHaveValue('second editor')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-restore-previous-editor.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-restore-previous-editor.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-restore-previous-editor'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Workspace }) => {
+  await Main.closeAllEditors()
+  const tmpDir = await FileSystem.getTmpDir()
+  const file = `${tmpDir}/example.txt`
+  await FileSystem.writeFile(file, 'example')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(file)
+
+  await Locator('.ActivityBarItem[title="Search"]').click()
+  await Locator('#SideBar button[title="Open New Search Editor"]').click()
+
+  const tabs = Locator('.MainTab')
+  await expect(tabs).toHaveCount(2)
+  await tabs.nth(1).locator('.EditorTabCloseButton').click()
+
+  await expect(tabs).toHaveCount(1)
+  await expect(tabs.nth(0).locator('.TabTitle')).toHaveText('example.txt')
+  await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true')
+  await expect(Locator('.Editor')).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -224,6 +224,7 @@ export const commandMap = {
   'Main.handleTabContextMenu': lazy('Main.handleTabContextMenu'),
   'Main.openBackgroundTab': lazy('Main.openBackgroundTab'),
   'Main.openKeyBindings': lazy('Main.openKeyBindings'),
+  'Main.openUri': lazy('Main.openUri'),
   'Main.reopenEditorWith': lazy('Main.reopenEditorWith'),
   'Main.save': lazy('Main.save'),
   'Markdown.getVirtualDom': lazy('Markdown.getVirtualDom'),

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -37,6 +37,9 @@ export const getModuleId = async (uri, opener) => {
   if (uri.startsWith('running-extensions://')) {
     return ViewletModuleId.RunningExtensions
   }
+  if (uri.startsWith('search-editor://')) {
+    return ViewletModuleId.Search
+  }
   if (uri.startsWith('simple-browser://')) {
     return ViewletModuleId.SimpleBrowser
   }

--- a/packages/renderer-worker/test/ViewletMap.test.ts
+++ b/packages/renderer-worker/test/ViewletMap.test.ts
@@ -36,6 +36,10 @@ test('running extensions', async () => {
   expect(await ViewletMap.getModuleId('running-extensions://')).toBe(ViewletModuleId.RunningExtensions)
 })
 
+test('search editor', async () => {
+  expect(await ViewletMap.getModuleId('search-editor://1/Search')).toBe(ViewletModuleId.Search)
+})
+
 test('inline diff uses the external diff editor', async () => {
   expect(await ViewletMap.getModuleId('inline-diff://data://before<->/test/file.ts')).toBe(ViewletModuleId.DiffEditor)
 })


### PR DESCRIPTION
Adds a main-area search editor opened from the Search sidebar, with a stable Search tab title, independent editor state, and focused e2e coverage.