### PR TITLE
fix: close quick pick with escape

### DIFF
--- a/packages/renderer-worker/src/parts/GetQuickPickKeyBindings/GetQuickPickKeyBindings.ts
+++ b/packages/renderer-worker/src/parts/GetQuickPickKeyBindings/GetQuickPickKeyBindings.ts
@@ -1,0 +1,13 @@
+import * as WhenExpression from '../WhenExpression/WhenExpression.js'
+
+interface KeyBinding {
+  readonly when?: number
+}
+
+const isQuickPickKeyBinding = (keyBinding: KeyBinding): boolean => {
+  return keyBinding.when === WhenExpression.FocusQuickPickInput
+}
+
+export const getQuickPickKeyBindings = (keyBindings: readonly KeyBinding[]): readonly KeyBinding[] => {
+  return keyBindings.filter(isQuickPickKeyBinding)
+}

--- a/packages/renderer-worker/src/parts/Viewlet/ViewletElectron.js
+++ b/packages/renderer-worker/src/parts/Viewlet/ViewletElectron.js
@@ -1,6 +1,7 @@
 import * as ElectronBrowserView from '../ElectronBrowserView/ElectronBrowserView.js'
 import * as ElectronBrowserViewQuickPick from '../ElectronBrowserViewQuickPick/ElectronBrowserViewQuickPick.js'
 import * as ElectronWindow from '../ElectronWindow/ElectronWindow.js'
+import * as GetQuickPickKeyBindings from '../GetQuickPickKeyBindings/GetQuickPickKeyBindings.ts'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
@@ -13,14 +14,6 @@ import * as JsonRpcVersion from '../JsonRpcVersion/JsonRpcVersion.js'
 
 export const state = {
   isQuickPickOpen: false,
-}
-
-const isQuickPickKeyBinding = (keyBinding) => {
-  return keyBinding.when === 'focus.quickPickInput'
-}
-
-const getQuickPickKeyBindings = (keyBindings) => {
-  return keyBindings.filter(isQuickPickKeyBinding)
 }
 
 export const isQuickPickOpen = () => {
@@ -39,7 +32,7 @@ export const openElectronQuickPick = async (...args) => {
   const y = 50
   // @ts-ignore
   const keyBindings = await KeyBindings.getKeyBindings()
-  const quickPickKeyBindings = getQuickPickKeyBindings(keyBindings)
+  const quickPickKeyBindings = GetQuickPickKeyBindings.getQuickPickKeyBindings(keyBindings)
   await ElectronBrowserViewQuickPick.createBrowserViewQuickPick(x, y, width, height)
   const ipc = await IpcParent.create({
     method: IpcParentType.ElectronMessagePort,

--- a/packages/renderer-worker/test/GetQuickPickKeyBindings.test.ts
+++ b/packages/renderer-worker/test/GetQuickPickKeyBindings.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jest/globals'
+import * as GetQuickPickKeyBindings from '../src/parts/GetQuickPickKeyBindings/GetQuickPickKeyBindings.ts'
+import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
+import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.js'
+
+test('returns quick pick keybindings using the numeric focus context', () => {
+  const keyBindings = [
+    {
+      command: 'QuickPick.close',
+      key: KeyCode.Escape,
+      when: WhenExpression.FocusQuickPickInput,
+    },
+    {
+      command: 'Main.closeAllEditors',
+      key: KeyCode.Escape,
+      when: WhenExpression.FocusEditor,
+    },
+  ]
+
+  expect(GetQuickPickKeyBindings.getQuickPickKeyBindings(keyBindings)).toEqual([keyBindings[0]])
+})


### PR DESCRIPTION
Forward Quick Pick keybindings to the Electron Quick Pick using the current numeric focus context so Escape closes the picker again.