### PR TITLE
feature: add preview close button

### DIFF
--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -164,6 +164,24 @@ const getPreviewDom = (previewId: number) => {
   }
 }
 
+const getPreviewCloseButtonDom = () => {
+  return [
+    {
+      ariaLabel: 'Close Preview',
+      childCount: 1,
+      className: 'IconButton PreviewCloseButton',
+      onClick: DomEventListenerFunctions.HandleClickClose,
+      title: 'Close Preview',
+      type: VirtualDomElements.Button,
+    },
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconClose',
+      type: VirtualDomElements.Div,
+    },
+  ]
+}
+
 const getContentAreaVirtualDomLeft = (state: LayoutState) => {
   const {
     activityBarVisible,
@@ -212,6 +230,8 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
 
   if (previewVisible) {
     children.push(getPreviewDom(previewId))
+    children.push(...getPreviewCloseButtonDom())
+    delta--
   }
 
   return [
@@ -264,6 +284,8 @@ const getContentAreaVirtualDomRight = (state: LayoutState) => {
   }
   if (previewVisible) {
     children.push(getPreviewDom(previewId))
+    children.push(...getPreviewCloseButtonDom())
+    delta--
   }
 
   return [

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
@@ -193,6 +193,10 @@ const renderCss = {
 export const renderEventListeners = () => {
   return [
     {
+      name: DomEventListenersFunctions.HandleClickClose,
+      params: ['hidePreview'],
+    },
+    {
       name: DomEventListenersFunctions.HandleContextMenu,
       params: ['handleContextMenu'],
     },

--- a/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
@@ -29,6 +29,7 @@ test('getLayoutVirtualDom renders sashes with tabIndex -1', () => {
   // @ts-ignore
   const dom = getLayoutVirtualDom(state)
   const sashes = dom.filter((node) => node.className?.includes('Sash'))
+  const previewCloseButton = dom.find((node) => node.className?.includes('PreviewCloseButton'))
 
   expect(sashes).toHaveLength(4)
   expect(sashes).toEqual(
@@ -55,4 +56,40 @@ test('getLayoutVirtualDom renders sashes with tabIndex -1', () => {
       }),
     ]),
   )
+  expect(previewCloseButton).toEqual(
+    expect.objectContaining({
+      ariaLabel: 'Close Preview',
+      onClick: DomEventListenerFunctions.HandleClickClose,
+      title: 'Close Preview',
+    }),
+  )
+})
+
+test('getLayoutVirtualDom does not render the preview close button when preview is hidden', () => {
+  const state = {
+    activityBarVisible: false,
+    mainVisible: true,
+    mainId: 1,
+    panelSashVisible: false,
+    panelVisible: false,
+    panelId: -1,
+    previewSashVisible: false,
+    previewVisible: false,
+    previewId: -1,
+    secondarySideBarVisible: false,
+    secondarySideBarId: -1,
+    sideBarLocation: SideBarLocationType.Left,
+    sideBarSashVisible: false,
+    sideBarVisible: false,
+    sideBarId: -1,
+    statusBarVisible: false,
+    statusBarId: -1,
+    titleBarVisible: false,
+    titleBarId: -1,
+  }
+
+  // @ts-ignore
+  const dom = getLayoutVirtualDom(state)
+
+  expect(dom.some((node) => node.className?.includes('PreviewCloseButton'))).toBe(false)
 })

--- a/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
@@ -125,3 +125,13 @@ test('renderEventListeners registers context menu handler', () => {
     }),
   )
 })
+
+test('renderEventListeners registers preview close handler', () => {
+  const listeners = ViewletLayoutRender2.renderEventListeners()
+  const closeListener = listeners.find((listener) => listener.name === 'handleClickClose')
+
+  expect(closeListener).toEqual({
+    name: 'handleClickClose',
+    params: ['hidePreview'],
+  })
+})

--- a/static/css/parts/ViewletLayout.css
+++ b/static/css/parts/ViewletLayout.css
@@ -12,7 +12,17 @@
   flex: 1;
   display: flex;
   contain: strict;
+  position: relative;
   /* flex-direction: column; */
+}
+
+.PreviewCloseButton {
+  background: var(--TitleBarBackground, rgb(40, 46, 47));
+  color: var(--TitleBarForeground, #c5c5c5);
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  z-index: 1;
 }
 
 .ActivityBar {

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -10,10 +10,12 @@
 }
 
 .SimpleBrowserHeader {
+  box-sizing: border-box;
   height: 30px;
   width: 100%;
   contain: strict;
   display: flex;
+  padding-right: 30px;
 }
 
 .SimpleBrowserHeader .InputBox {


### PR DESCRIPTION
## Summary
- show an accessible close button at the top-right of the shared preview area
- route it through the existing `hidePreview` layout command
- reserve toolbar space when Simple Browser occupies the preview slot

## Validation
- focused renderer layout tests: 8 passed
- renderer-worker type-check
- Prettier check for all touched TypeScript and CSS files