### PR TITLE
fix: improve explorer ignored file contrast

### DIFF
--- a/static/css/parts/Label.css
+++ b/static/css/parts/Label.css
@@ -19,5 +19,5 @@
 }
 
 .LabelCut {
-  opacity: 0.5;
+  opacity: 0.7;
 }


### PR DESCRIPTION
## Summary

- increase the shared dimmed Explorer label opacity from 50% to 70%
- keep ignored and cut-file highlighting intact while making the text easier to read across themes

## Validation

- `npx prettier --check static/css/parts/Label.css`
- `npm run build:static:ignore-icon-theme`