### PR TITLE
fix: dispose process explorer when view closes

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.js
@@ -39,7 +39,9 @@ export const loadContent = async (state, savedState) => {
   }
 }
 
-export const dispose = () => {}
+export const dispose = async (state) => {
+  await ProcessExplorerWorker.invoke('ProcessExplorer.dispose', state.uid)
+}
 
 export const hotReload = async (state) => {
   if (state.isHotReloading) {

--- a/packages/renderer-worker/test/ViewletProcessExplorer.test.ts
+++ b/packages/renderer-worker/test/ViewletProcessExplorer.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn()
+
+jest.unstable_mockModule('../src/parts/ProcessExplorerWorker/ProcessExplorerWorker.js', () => ({
+  invoke,
+}))
+
+const ViewletProcessExplorer = await import('../src/parts/ViewletProcessExplorer/ViewletProcessExplorer.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('dispose - disposes process explorer worker state', async () => {
+  const state = {
+    uid: 7,
+  }
+
+  await ViewletProcessExplorer.dispose(state)
+
+  expect(invoke).toHaveBeenCalledWith('ProcessExplorer.dispose', 7)
+})


### PR DESCRIPTION
## Summary
- invoke `ProcessExplorer.dispose` with the view UID when the Process Explorer view closes
- let the process-explorer worker clear the instance's auto-refresh interval and state through its existing dispose path
- add renderer-worker regression coverage for the lifecycle call

## Validation
- renderer-worker: 250 suites passed, 958 tests passed (26 suites / 242 tests skipped)
- `npm run lint`
- `npm run type-check`
- `npm run build:static:ignore-icon-theme`
- `npm run build:server`
- `npm run test-static-export`
- targeted Prettier check