### PR TITLE
fix: show pretty paths in tab titles

### DIFF
--- a/packages/renderer-worker/src/parts/GetTabDom/GetTabDom.js
+++ b/packages/renderer-worker/src/parts/GetTabDom/GetTabDom.js
@@ -18,7 +18,7 @@ const getIconDom = (icon) => {
 }
 
 export const getTabDom = (tab) => {
-  const { icon, tabWidth, uri, flags, uid, isActive, fixedWidth, label } = tab
+  const { icon, tabWidth, uri, flags, uid, isActive, fixedWidth, label, title } = tab
   let tabClassName = ClassNames.MainTab
   if (isActive) {
     tabClassName += ' ' + ClassNames.MainTabSelected
@@ -34,7 +34,7 @@ export const getTabDom = (tab) => {
     draggable: true,
     width: actualTabWidth,
     ariaSelected: isActive,
-    title: uri,
+    title,
     childCount: 2,
     'data-dragUid': uid,
   }

--- a/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
+++ b/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
@@ -10,14 +10,25 @@ const getDisplayUri = (uri) => {
   return separatorIndex === -1 ? uri : uri.slice(separatorIndex + 3)
 }
 
+const getDisplayPath = (uri) => {
+  if (!uri.startsWith('file://')) {
+    return uri
+  }
+  try {
+    return decodeURIComponent(new URL(uri).pathname)
+  } catch {
+    return uri
+  }
+}
+
 export const getTitle = (uri) => {
   if (!uri) {
     return ''
   }
-  uri = getDisplayUri(uri)
+  uri = getDisplayPath(getDisplayUri(uri))
   const homeDir = Workspace.getHomeDir()
   // TODO tree shake this out in web
-  if (homeDir && uri.startsWith(homeDir)) {
+  if (homeDir && (uri === homeDir || uri.startsWith(`${homeDir}/`))) {
     return `~${uri.slice(homeDir.length)}`
   }
   return uri

--- a/packages/renderer-worker/test/GetTabDom.test.ts
+++ b/packages/renderer-worker/test/GetTabDom.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@jest/globals'
+import * as GetTabDom from '../src/parts/GetTabDom/GetTabDom.js'
+
+test('uses the pretty path as title', () => {
+  const dom = GetTabDom.getTabDom({
+    fixedWidth: 0,
+    flags: 0,
+    icon: '',
+    isActive: true,
+    label: 'file.txt',
+    tabWidth: 100,
+    title: '~/Documents/file.txt',
+    uid: 1,
+    uri: 'file:///home/test/Documents/file.txt',
+  })
+
+  expect(dom[0].title).toBe('~/Documents/file.txt')
+})

--- a/packages/renderer-worker/test/PathDisplay.test.ts
+++ b/packages/renderer-worker/test/PathDisplay.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 import * as PathDisplay from '../src/parts/PathDisplay/PathDisplay.js'
+import * as Workspace from '../src/parts/Workspace/Workspace.js'
 
 test('getLabel - process explorer', () => {
   expect(PathDisplay.getLabel('process-explorer://')).toBe('Process Explorer')
@@ -27,4 +28,10 @@ test('getLabel - inline diff editor', () => {
 
 test('getTitle - diff editor', () => {
   expect(PathDisplay.getTitle('diff://data://const value = 1<->/workspace/src/example.ts')).toBe('/workspace/src/example.ts')
+})
+
+test('getTitle - file uri in home directory', () => {
+  Workspace.state.homeDir = '/home/test'
+
+  expect(PathDisplay.getTitle('file:///home/test/Documents/my%20file.txt')).toBe('~/Documents/my file.txt')
 })


### PR DESCRIPTION
Show decoded filesystem paths in editor tab tooltips, shorten the home directory to `~`, and render the computed pretty title instead of the raw file URI.