### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ const disableConfiguredRules = (prefix) => {
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...config.recommendedTsconfig,
   ...config.recommendedActions,
   ...config.recommendedRegex,
@@ -32,6 +33,8 @@ export default [
       'prefer-destructuring': 'off',
       'prefer-const': 'off',
       'regex/hoist-regex': 'error',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
 ]


### PR DESCRIPTION
## Summary
- enable the recommended virtual DOM ESLint configuration for the renderer VDOM implementation
- exempt the non-rendering shared-process package from two generic state/object rules

## Validation
- npm run lint
- npm run type-check
- npm test (renderer 960 passed; shared-process 297 passed; build/static-server passed)
- packages/main-process: npm test (1 passed; isolated rerun avoids Lerna FORCE_COLOR stderr)