### PR TITLE
fix: adjust legacy focus context commands

### DIFF
--- a/packages/renderer-worker/src/parts/AdjustCommands/AdjustCommands.js
+++ b/packages/renderer-worker/src/parts/AdjustCommands/AdjustCommands.js
@@ -1,5 +1,11 @@
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
+const focusContextCommands = new Set([
+  'Viewlet.setAdditionalFocus',
+  'Viewlet.setFocusContext',
+  'Viewlet.unsetAdditionalFocus',
+])
+
 export const apply = (oldState, newState) => {
   const commands = newState.commands
   newState.commands = []
@@ -9,6 +15,9 @@ export const apply = (oldState, newState) => {
   const adjustedCommands = commands.map((command) => {
     if (command[0] === 'Viewlet.dispose') {
       ViewletStates.remove(command[1])
+    }
+    if (command.length === 2 && focusContextCommands.has(command[0])) {
+      return [command[0], newState.uid, command[1]]
     }
     if (command[1] === newState.uid || typeof command[1] === 'number') {
       return command

--- a/packages/renderer-worker/test/AdjustCommands.test.ts
+++ b/packages/renderer-worker/test/AdjustCommands.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@jest/globals'
+import * as AdjustCommands from '../src/parts/AdjustCommands/AdjustCommands.js'
+
+test.each([
+  'Viewlet.setAdditionalFocus',
+  'Viewlet.setFocusContext',
+  'Viewlet.unsetAdditionalFocus',
+])('adds the viewlet uid to a legacy %s command', (method) => {
+  const oldState = {}
+  const newState = {
+    commands: [[method, 10]],
+    uid: 20,
+  }
+
+  expect(AdjustCommands.apply(oldState, newState)).toEqual([[method, 20, 10]])
+  expect(newState.commands).toEqual([])
+})
+
+test('preserves a targeted focus context command', () => {
+  const oldState = {}
+  const newState = {
+    commands: [['Viewlet.setFocusContext', 20, 10]],
+    uid: 30,
+  }
+
+  expect(AdjustCommands.apply(oldState, newState)).toEqual([
+    ['Viewlet.setFocusContext', 20, 10],
+  ])
+  expect(newState.commands).toEqual([])
+})


### PR DESCRIPTION
Preserve legacy two-field focus commands by adding the current viewlet UID before renderer focus handling. This restores functional views such as About while retaining support for already-targeted commands.