### PR TITLE
fix: load source control view in background

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import * as Assert from '../Assert/Assert.ts'
 import * as Command from '../Command/Command.js'
+import * as ErrorHandling from '../ErrorHandling/ErrorHandling.js'
 import { CancelationError } from '../Errors/CancelationError.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as Id from '../Id/Id.js'
@@ -19,6 +20,28 @@ import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 export const state = {
   pendingModules: Object.create(null),
+}
+
+const runLoadContentLaterWithErrorHandling = async (loadContentLater, viewletState) => {
+  try {
+    await loadContentLater(viewletState)
+  } catch (error) {
+    try {
+      await ErrorHandling.handleError(error)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+}
+
+export const runLoadContentLater = (uid) => {
+  const instance = ViewletStates.getInstance(uid)
+  const loadContentLater = instance?.factory?.Commands?.loadContentLater
+  if (!loadContentLater || instance.loadContentLaterStarted) {
+    return
+  }
+  instance.loadContentLaterStarted = true
+  void runLoadContentLaterWithErrorHandling(loadContentLater, instance.state)
 }
 
 const ViewletState = {
@@ -645,10 +668,6 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       commands.push(...additionalExtraCommands)
     }
 
-    if (module.Commands && module.Commands['loadContentLater']) {
-      const commands = await module.Commands['loadContentLater'](newState)
-    }
-
     const instanceNow = ViewletStates.getInstance(viewletUid)
     viewletState = instanceNow.renderedState
     if (module.hasFunctionalRender && shouldRender) {
@@ -682,6 +701,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       commands.push(...extraCommands)
       updateDynamicFocusContext(commands)
       await RendererProcess.invoke(/* Viewlet.sendMultiple */ kSendMultiple, /* commands */ commands)
+      runLoadContentLater(viewletUid)
     } else if (!module.hasFunctionalEvents && shouldRender) {
       const allCommands = [
         ...commands,

--- a/packages/renderer-worker/src/parts/ViewletSecondarySideBar/ViewletSecondarySideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSecondarySideBar/ViewletSecondarySideBar.js
@@ -81,6 +81,7 @@ export const handleSecondarySideBarViewletChange = async (state, moduleId) => {
   )
 
   await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+  ViewletManager.runLoadContentLater(childUid)
 
   await savePromise
   return {

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -207,6 +207,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
       return state
     }
     await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+    ViewletManager.runLoadContentLater(childUid)
   }
 
   // TODO race condition (check if disposed after created)

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -51,7 +51,6 @@ export const loadContent = async (state, savedState) => {
     platform,
     assetDir,
   )
-  await SourceControlWorker.invoke('SourceControl.loadContent', state.uid, savedState)
   const diffResult = await SourceControlWorker.invoke('SourceControl.diff2', state.uid)
   const commands = await SourceControlWorker.invoke('SourceControl.render2', state.uid, diffResult)
   const actionsDom = await SourceControlWorker.invoke('SourceControl.renderActions2', state.uid)
@@ -62,7 +61,12 @@ export const loadContent = async (state, savedState) => {
     commands,
     actionsDom,
     badgeCount,
+    savedState,
   }
+}
+
+export const loadContentLater = async (state) => {
+  await Command.execute('Viewlet.executeViewletCommand', state.uid, 'loadContent', state.savedState)
 }
 
 export const dispose = (state) => {
@@ -120,8 +124,20 @@ export const handleMouseOver = async (state, index) => {
   }
 }
 
-export const handleWorkspaceChange = (state) => {
-  return loadContent(state)
+export const handleWorkspaceChange = async (state) => {
+  const loadingState = await loadContent(state)
+  await SourceControlWorker.invoke('SourceControl.loadContent', state.uid)
+  const diffResult = await SourceControlWorker.invoke('SourceControl.diff2', state.uid)
+  const commands = await SourceControlWorker.invoke('SourceControl.render2', state.uid, diffResult)
+  const actionsDom = await SourceControlWorker.invoke('SourceControl.renderActions2', state.uid)
+  const badgeCount = await SourceControlWorker.invoke('SourceControl.getBadgeCount', state.uid)
+  await Command.execute('Layout.setBadgeCount', ViewletModuleId.SourceControl, badgeCount)
+  return {
+    ...loadingState,
+    actionsDom,
+    badgeCount,
+    commands,
+  }
 }
 
 export const handleMouseOut = (state, index) => {

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
@@ -9,6 +9,7 @@ export const getCommands = async () => {
   for (const command of commands) {
     Commands[command] = WrapSourceControlCommand.wrapSourceControlCommand(command)
   }
+  Commands['loadContentLater'] = ViewletSourceControl.loadContentLater
   Commands['hotReload'] = ViewletSourceControl.hotReload
   Commands['getInfo'] = ({ uid }) => SourceControlWorker.invoke('SourceControl.getInfo', uid)
   return Commands

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCss.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCss.js
@@ -6,6 +6,7 @@ export const Css = [
   '/css/parts/InputBox.css',
   '/css/parts/Label.css',
   '/css/parts/MaskIcon.css',
+  '/css/parts/Progress.css',
   '/css/parts/SourceControlListItem.css',
   '/css/parts/SplitButton.css',
   '/css/parts/TreeItem.css',

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -35,6 +35,27 @@ const Command = await import('../src/parts/Command/Command.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const ViewletExtensionViewRender = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts')
 
+test('runLoadContentLater starts deferred loading once', async () => {
+  const loadContentLater = jest.fn(async (_state: unknown) => {})
+  const viewletState = { uid: 42 }
+  ViewletStates.set(42, {
+    factory: {
+      Commands: {
+        loadContentLater,
+      },
+    },
+    renderedState: viewletState,
+    state: viewletState,
+  })
+
+  ViewletManager.runLoadContentLater(42)
+  ViewletManager.runLoadContentLater(42)
+  await Promise.resolve()
+
+  expect(loadContentLater).toHaveBeenCalledTimes(1)
+  expect(loadContentLater).toHaveBeenCalledWith(viewletState)
+})
+
 test('render adds uid to setPatches command', () => {
   const patches = [{ type: 1 }]
   const mockModule = {

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -29,6 +29,7 @@ jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
 jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => {
   return {
     load: jest.fn(() => []),
+    runLoadContentLater: jest.fn(),
   }
 })
 
@@ -47,6 +48,7 @@ beforeEach(() => {
   RendererProcess.invoke.mockResolvedValue(undefined)
   SaveState.saveViewletState.mockResolvedValue(undefined)
   ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'Explorer', 2, true]])
+  ViewletManager.runLoadContentLater.mockReturnValue(undefined)
   GetExtensionViews.getExtensionView.mockResolvedValue(undefined)
 })
 
@@ -149,6 +151,7 @@ test('handleSideBarViewletChange uses child title', async () => {
   const newState = await ViewletSideBar.handleSideBarViewletChange(state, 'Explorer')
 
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.createFunctionalRoot', 'Explorer', 2, true]])
+  expect(ViewletManager.runLoadContentLater).toHaveBeenCalledWith(expect.any(Number))
   expect(newState).toMatchObject({
     currentViewletId: 'Explorer',
     title: 'workspace-name',

--- a/packages/renderer-worker/test/ViewletSideBarRace.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBarRace.test.ts
@@ -43,6 +43,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
     load: jest.fn(() => {
       throw new Error('not implemented')
     }),
+    runLoadContentLater: jest.fn(),
   }
 })
 

--- a/static/css/parts/Progress.css
+++ b/static/css/parts/Progress.css
@@ -1,5 +1,29 @@
+@keyframes progress {
+  from {
+    transform: translateX(0%) scaleX(1);
+  }
+
+  50% {
+    transform: translateX(2500%) scaleX(3);
+  }
+
+  to {
+    transform: translateX(4900%) scaleX(1);
+  }
+}
+
 .ProgressContainer {
   width: 100%;
   height: 2px;
   contain: strict;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.Progress {
+  width: 2%;
+  height: 100%;
+  animation: progress 4s infinite linear;
+  background-color: var(--ProgressBarBackground, #0e70c0);
+  transform-origin: left;
 }


### PR DESCRIPTION
## Summary
- render the source control loading shell before provider data is requested
- defer the expensive provider load until after the initial view commands are applied
- add the shared blue indeterminate progress bar styling to source control

Depends on lvce-editor/source-control-view#528 for the loading-state DOM.

## Verification
- renderer-worker: 961 passed, 242 skipped
- renderer-worker type-check passed
- changed files pass Prettier