### PR TITLE
fix: resolve server config json path

### DIFF
--- a/packages/shared-process/src/parts/GetConfigJsonPath/GetConfigJsonPath.ts
+++ b/packages/shared-process/src/parts/GetConfigJsonPath/GetConfigJsonPath.ts
@@ -1,0 +1,19 @@
+import { pathToFileURL } from 'node:url'
+import * as Path from '../Path/Path.ts'
+
+interface GetConfigJsonPathOptions {
+  readonly getStaticPath: () => string
+  readonly isBuiltServer: boolean
+  readonly isProduction: boolean
+  readonly root: string
+}
+
+export const getConfigJsonPath = ({ getStaticPath, isBuiltServer, isProduction, root }: GetConfigJsonPathOptions): string => {
+  if (!isProduction) {
+    return pathToFileURL(Path.join(root, 'static', 'config.json')).toString()
+  }
+  if (isBuiltServer) {
+    return pathToFileURL(Path.join(getStaticPath(), '..', 'config.json')).toString()
+  }
+  return pathToFileURL(Path.join(root, 'config.json')).toString()
+}

--- a/packages/shared-process/src/parts/PlatformPaths/PlatformPaths.ts
+++ b/packages/shared-process/src/parts/PlatformPaths/PlatformPaths.ts
@@ -2,11 +2,14 @@ import { homedir, tmpdir } from 'node:os'
 import { isAbsolute, join, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { xdgCache, xdgConfig, xdgData, xdgState } from 'xdg-basedir'
+import * as GetConfigJsonPath from '../GetConfigJsonPath/GetConfigJsonPath.ts'
 import * as GetResolvedTestPath from '../GetResolvedTestPath/GetResolvedTestPath.ts'
+import * as IsBuiltServer from '../IsBuiltServer/IsBuiltServer.ts'
 import * as Path from '../Path/Path.ts'
 import * as Platform from '../Platform/Platform.ts'
 import * as Process from '../Process/Process.ts'
 import * as Root from '../Root/Root.ts'
+import * as StaticPath from '../StaticPath/StaticPath.ts'
 
 const { env } = process
 
@@ -143,10 +146,12 @@ export const getConfigDir = (): any => {
 }
 
 export const getConfigJsonPath = (): any => {
-  if (Platform.isProduction) {
-    return pathToFileURL(Path.join(Root.root, 'config.json')).toString()
-  }
-  return pathToFileURL(Path.join(Root.root, 'static', 'config.json')).toString()
+  return GetConfigJsonPath.getConfigJsonPath({
+    getStaticPath: StaticPath.getStaticPath,
+    isBuiltServer: IsBuiltServer.isBuiltServer,
+    isProduction: Platform.isProduction,
+    root: Root.root,
+  })
 }
 
 export const getDataDir = (): any => {

--- a/packages/shared-process/test/GetConfigJsonPath.test.ts
+++ b/packages/shared-process/test/GetConfigJsonPath.test.ts
@@ -1,0 +1,41 @@
+import { expect, jest, test } from '@jest/globals'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import * as GetConfigJsonPath from '../src/parts/GetConfigJsonPath/GetConfigJsonPath.js'
+
+test('development', () => {
+  const getStaticPath = jest.fn<() => string>()
+  const result = GetConfigJsonPath.getConfigJsonPath({
+    getStaticPath,
+    isBuiltServer: false,
+    isProduction: false,
+    root: '/test/app',
+  })
+  expect(result).toBe(pathToFileURL('/test/app/static/config.json').toString())
+  expect(getStaticPath).not.toHaveBeenCalled()
+})
+
+test('electron production', () => {
+  const getStaticPath = jest.fn<() => string>()
+  const result = GetConfigJsonPath.getConfigJsonPath({
+    getStaticPath,
+    isBuiltServer: false,
+    isProduction: true,
+    root: '/test/app',
+  })
+  expect(result).toBe(pathToFileURL('/test/app/config.json').toString())
+  expect(getStaticPath).not.toHaveBeenCalled()
+})
+
+test('server production', () => {
+  const staticPath = join('/test', 'node_modules', '@lvce-editor', 'static-server', 'static')
+  const getStaticPath = jest.fn(() => staticPath)
+  const result = GetConfigJsonPath.getConfigJsonPath({
+    getStaticPath,
+    isBuiltServer: true,
+    isProduction: true,
+    root: '/test/node_modules/@lvce-editor/shared-process',
+  })
+  expect(result).toBe(pathToFileURL('/test/node_modules/@lvce-editor/static-server/config.json').toString())
+  expect(getStaticPath).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Fix the shared-process config JSON URI for production servers by resolving the file from the packaged static-server. Preserve the existing development and production Electron paths, with regression coverage for all three layouts.