### PR TITLE
feature: add running extensions row hover styles

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -77,3 +77,27 @@ test('bundleCss preserves the locations flex growth', async () => {
     await rm(dir, { recursive: true, force: true })
   }
 }, 30_000)
+
+test('bundleCss preserves the running extensions hover styles', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletRunningExtensions.css'), 'utf8')
+
+    expect(css).toContain(`.RunningExtension:where(:hover) {
+  background: var(--ListHoverBackground, color-mix(in srgb, var(--WorkbenchForeground) 8%, transparent));
+  color: var(--ListHoverForeground, var(--WorkbenchForeground));
+}`)
+    expect(css).toContain(`.RunningExtension:where(:hover) .RunningExtensionId,
+.RunningExtension:where(:hover) .RunningExtensionActivationTime {
+  color: inherit;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -15,6 +15,16 @@
   gap: 12px;
 }
 
+.RunningExtension:where(:hover) {
+  background: var(--ListHoverBackground, color-mix(in srgb, var(--WorkbenchForeground) 8%, transparent));
+  color: var(--ListHoverForeground, var(--WorkbenchForeground));
+}
+
+.RunningExtension:where(:hover) .RunningExtensionId,
+.RunningExtension:where(:hover) .RunningExtensionActivationTime {
+  color: inherit;
+}
+
 .RunningExtensionIcon {
   flex: none;
   height: 32px;


### PR DESCRIPTION
Adds a subtle theme-aware hover background to running extension rows and brightens the row metadata on hover.

Includes focused coverage for the bundled CSS output.