### PR TITLE
fix: dispose viewlets without cleanup hook

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -128,7 +128,9 @@ export const dispose = async (id) => {
     if (!instance.factory) {
       throw new Error(`${id} is missing a factory function`)
     }
-    await instance.factory.dispose(instance.state)
+    if (instance.factory.dispose) {
+      await instance.factory.dispose(instance.state)
+    }
     await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     if (instance.factory.getKeyBindings) {
       KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, instanceUid))

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -160,6 +160,22 @@ test('dispose - waits for factory disposal before disposing the rendered viewlet
   expect(didDispose).toBe(true)
 })
 
+test('dispose - disposes the rendered viewlet when the factory has no dispose function', async () => {
+  ViewletStates.set(2, {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'ActivityBar',
+    factory: {},
+  })
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(async () => {})
+
+  await Viewlet.dispose(2)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.dispose', 2)
+  expect(ViewletStates.getInstance(2)).toBeUndefined()
+})
+
 test('openWidget - once', async () => {
   // @ts-ignore
   ViewletManager.load.mockImplementation(() => {


### PR DESCRIPTION
## Summary
- treat a viewlet factory cleanup hook as optional in the async disposal path
- preserve renderer disposal and state cleanup when no hook is provided
- add regression coverage for factories without `dispose`

## Verification
- `npm test -- --runInBand Viewlet.test.ts` (10 passed, 2 skipped)
- `npm run type-check`
- `git diff --check`

Required by lvce-editor/virtual-dom#522 after updating `@lvce-editor/server`.