### PR TITLE
fix: use pointer cursor for running extensions

### DIFF
--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -11,6 +11,7 @@
 
 .RunningExtension {
   align-items: center;
+  cursor: pointer;
   display: flex;
   gap: 12px;
 }


### PR DESCRIPTION
Sets the pointer cursor on running extension rows so their interactive behavior is visually clear.