### PR TITLE
Style extension activation reason

### DIFF
--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -32,6 +32,7 @@
 }
 
 .RunningExtensionId,
+.RunningExtensionActivationReason,
 .RunningExtensionActivationTime,
 .RunningExtensionsEmpty {
   color: var(--DescriptionForeground, rgba(156, 162, 160, 0.7));


### PR DESCRIPTION
Style the new running-extension activation reason as secondary metadata alongside the existing extension id and activation time.