### PR TITLE
feature: update test-worker to version 17.2.3

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -67,7 +67,7 @@
         "@lvce-editor/status-bar-worker": "^3.4.1",
         "@lvce-editor/syntax-highlighting-worker": "^2.4.3",
         "@lvce-editor/terminal-worker": "^1.2.0",
-        "@lvce-editor/test-worker": "^17.2.2",
+        "@lvce-editor/test-worker": "^17.2.3",
         "@lvce-editor/text-measurement-worker": "^1.16.0",
         "@lvce-editor/text-search-worker": "^7.5.3",
         "@lvce-editor/title-bar-worker": "^4.9.1",
@@ -476,9 +476,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.2.2.tgz",
-      "integrity": "sha512-mewVNPyBxkz4SWB9MB7fi6FGmIS9GVU6aoPbj/s2/wn8l+31ZczthtZS70jCCURCk+qmN3NcprcoE7ZmIci5Mw==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.2.3.tgz",
+      "integrity": "sha512-f7cQyZNtNuSsBJnbMqw/pJn2gpcglpb59wZfgjvGFyBvr2aBmkf9ly+2ResAFSI9nuw+b33TBXRYWPsU070GIA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-measurement-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -99,7 +99,7 @@
     "@lvce-editor/status-bar-worker": "^3.4.1",
     "@lvce-editor/syntax-highlighting-worker": "^2.4.3",
     "@lvce-editor/terminal-worker": "^1.2.0",
-    "@lvce-editor/test-worker": "^17.2.2",
+    "@lvce-editor/test-worker": "^17.2.3",
     "@lvce-editor/text-measurement-worker": "^1.16.0",
     "@lvce-editor/text-search-worker": "^7.5.3",
     "@lvce-editor/title-bar-worker": "^4.9.1",


### PR DESCRIPTION
## Summary
- update `@lvce-editor/test-worker` to 17.2.3
- include the full-height Activity Bar reset used by reused-page e2e suites

## Verification
- lockfile resolves `@lvce-editor/test-worker` 17.2.3
- `git diff --check`

Required by lvce-editor/virtual-dom#522.