### PR TITLE
feature: suppress no-op location messages

### DIFF
--- a/packages/renderer-worker/src/parts/Location/Location.js
+++ b/packages/renderer-worker/src/parts/Location/Location.js
@@ -1,15 +1,39 @@
+import { state } from '../LocationState/LocationState.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
-export const getPathName = () => {
-  return RendererProcess.invoke(/* Location.getPathName */ 'Location.getPathName')
+export const initialize = (href) => {
+  state.href = href
 }
 
-export const getHref = () => {
-  return RendererProcess.invoke(/* Location.getHref */ 'Location.getHref')
+export const getPathName = async () => {
+  const pathName = await RendererProcess.invoke(/* Location.getPathName */ 'Location.getPathName')
+  const { href } = state
+  if (href) {
+    const url = new URL(href)
+    url.pathname = pathName
+    state.href = url.href
+  }
+  return pathName
 }
 
-export const setPathName = (pathName) => {
-  return RendererProcess.invoke(/* Location.setPathName */ 'Location.setPathName', /* pathName */ pathName)
+export const getHref = async () => {
+  const href = await RendererProcess.invoke(/* Location.getHref */ 'Location.getHref')
+  state.href = href
+  return href
+}
+
+export const setPathName = async (pathName) => {
+  const { href } = state
+  if (!href) {
+    return RendererProcess.invoke(/* Location.setPathName */ 'Location.setPathName', /* pathName */ pathName)
+  }
+  const resolvedUrl = new URL(pathName, href)
+  const currentUrl = new URL(href)
+  if (resolvedUrl.pathname === currentUrl.pathname) {
+    return
+  }
+  await RendererProcess.invoke(/* Location.setPathName */ 'Location.setPathName', /* pathName */ pathName)
+  state.href = resolvedUrl.href
 }
 
 export const hydrate = () => {

--- a/packages/renderer-worker/src/parts/LocationState/LocationState.js
+++ b/packages/renderer-worker/src/parts/LocationState/LocationState.js
@@ -1,0 +1,3 @@
+export const state = {
+  href: '',
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -124,6 +124,7 @@ export const startup = async (platform, assetDir) => {
   LifeCycle.mark(LifeCyclePhase.One)
 
   const initData = await InitData.getInitData()
+  Location.initialize(initData.Location.href)
 
   IpcState.setConfig(initData.Config?.shouldLaunchMultipleWorkers)
 

--- a/packages/renderer-worker/test/Location.test.ts
+++ b/packages/renderer-worker/test/Location.test.ts
@@ -13,6 +13,7 @@ const RendererProcess = await import('../src/parts/RendererProcess/RendererProce
 
 afterEach(() => {
   jest.resetAllMocks()
+  Location.initialize('')
 })
 
 test('getPathName', async () => {
@@ -36,7 +37,58 @@ test('getHref', async () => {
 test('setPathName', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockImplementation(() => {})
+  Location.initialize('http://localhost:3000/test-path')
   await Location.setPathName('/')
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Location.setPathName', '/')
+})
+
+test('setPathName - does not invoke renderer process when resolved pathname is unchanged', async () => {
+  Location.initialize('http://localhost:3000/tests/activity-bar.html?test=activity-bar#test')
+
+  await Location.setPathName('')
+
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('setPathName - invokes renderer process only once for repeated pathname', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  Location.initialize('http://localhost:3000/')
+
+  await Location.setPathName('/github/lvce-editor/lvce-editor')
+  await Location.setPathName('/github/lvce-editor/lvce-editor')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Location.setPathName', '/github/lvce-editor/lvce-editor')
+})
+
+test('setPathName - resolves relative pathnames against the latest pathname', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  Location.initialize('http://localhost:3000/github/lvce-editor/lvce-editor?test=1#test')
+
+  await Location.setPathName('./vscode')
+  await Location.setPathName('/github/lvce-editor/vscode')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Location.setPathName', './vscode')
+})
+
+test('setPathName - preserves query and hash when the pathname is unchanged', async () => {
+  Location.initialize('http://localhost:3000/callback?code=123#auth')
+
+  await Location.setPathName('/callback')
+
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('setPathName - falls back to renderer process before initialization', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+
+  await Location.setPathName('/')
+
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Location.setPathName', '/')
 })


### PR DESCRIPTION
Caches the renderer location from init data and avoids renderer-process calls when a requested pathname already resolves to the current path. Keeps the cache synchronized after renderer reads and successful pathname changes, with focused regression coverage.