### PR TITLE
fix: handle missing server socket

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -269,6 +269,9 @@ const handleSocketError = (error) => {
 
 const sendHandleSharedProcess = async (request, socket, method, ...params) => {
   request.on('error', handleRequestError)
+  if (!socket) {
+    return
+  }
   socket.on('error', handleSocketUpgradeError)
   const sharedProcess = await getOrCreateSharedProcess()
   sharedProcess.send(


### PR DESCRIPTION
Summary:
- guard the shared-process request path when Node does not provide a socket
- avoid registering handlers or launching the shared process for an absent socket