### PR TITLE
feature: deduplicate keybinding identifiers

### DIFF
--- a/packages/renderer-worker/src/parts/IsEqualUint32Array/IsEqualUint32Array.js
+++ b/packages/renderer-worker/src/parts/IsEqualUint32Array/IsEqualUint32Array.js
@@ -1,0 +1,11 @@
+export const isEqualUint32Array = (a, b) => {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
@@ -1,5 +1,6 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as Context from '../Context/Context.js'
+import { isEqualUint32Array } from '../IsEqualUint32Array/IsEqualUint32Array.js'
 import * as Logger from '../Logger/Logger.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
@@ -46,10 +47,14 @@ const getAvailableKeyBindings = (keyBindings) => {
 }
 
 export const update = () => {
-  const matchingKeyBindings = getMatchingKeyBindings(state.keyBindingSets)
+  const { keyBindingIdentifiers: oldKeyBindingIdentifiers, keyBindingSets } = state
+  const matchingKeyBindings = getMatchingKeyBindings(keyBindingSets)
   const keyBindingIdentifiers = getAvailableKeyBindings(matchingKeyBindings)
-  RendererProcess.invoke('KeyBindings.setIdentifiers', keyBindingIdentifiers)
   state.matchingKeyBindings = matchingKeyBindings
+  if (isEqualUint32Array(oldKeyBindingIdentifiers, keyBindingIdentifiers)) {
+    return
+  }
+  RendererProcess.invoke('KeyBindings.setIdentifiers', keyBindingIdentifiers)
   state.keyBindingIdentifiers = keyBindingIdentifiers
 }
 

--- a/packages/renderer-worker/test/IsEqualUint32Array.test.ts
+++ b/packages/renderer-worker/test/IsEqualUint32Array.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@jest/globals'
+import { isEqualUint32Array } from '../src/parts/IsEqualUint32Array/IsEqualUint32Array.js'
+
+test('returns true for equal arrays', () => {
+  expect(isEqualUint32Array(new Uint32Array([1, 2]), new Uint32Array([1, 2]))).toBe(true)
+})
+
+test('returns false for different lengths', () => {
+  expect(isEqualUint32Array(new Uint32Array([1]), new Uint32Array([1, 2]))).toBe(false)
+})
+
+test('returns false for different values', () => {
+  expect(isEqualUint32Array(new Uint32Array([1, 2]), new Uint32Array([1, 3]))).toBe(false)
+})
+
+test('returns false for reordered values', () => {
+  expect(isEqualUint32Array(new Uint32Array([1, 2]), new Uint32Array([2, 1]))).toBe(false)
+})

--- a/packages/renderer-worker/test/KeyBindings.test.ts
+++ b/packages/renderer-worker/test/KeyBindings.test.ts
@@ -33,6 +33,74 @@ beforeEach(() => {
   KeyBindingsState.state.matchingKeyBindings = []
 })
 
+test('update does not send equal empty identifiers', () => {
+  KeyBindingsState.update()
+
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+  expect(KeyBindingsState.state.keyBindingIdentifiers).toEqual(new Uint32Array())
+  expect(KeyBindingsState.state.matchingKeyBindings).toEqual([])
+})
+
+test('update refreshes matching keybindings without sending equal identifiers', () => {
+  const previousKeyBinding = {
+    key: 1,
+    command: 'test.previous',
+  }
+  const currentKeyBinding = {
+    key: 1,
+    command: 'test.current',
+  }
+  KeyBindingsState.state.keyBindingIdentifiers = new Uint32Array([1])
+  KeyBindingsState.state.matchingKeyBindings = [previousKeyBinding]
+  KeyBindingsState.state.keyBindingSets.Editor = [currentKeyBinding]
+
+  KeyBindingsState.update()
+
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+  expect(KeyBindingsState.state.keyBindingIdentifiers).toEqual(new Uint32Array([1]))
+  expect(KeyBindingsState.state.matchingKeyBindings).toEqual([currentKeyBinding])
+  expect(KeyBindingsState.getKeyBinding(1)).toBe(currentKeyBinding)
+})
+
+test.each([
+  {
+    name: 'added',
+    previous: [],
+    keyBindings: [{ key: 1, command: 'test.one' }],
+    expected: [1],
+  },
+  {
+    name: 'removed',
+    previous: [1],
+    keyBindings: [],
+    expected: [],
+  },
+  {
+    name: 'changed',
+    previous: [1],
+    keyBindings: [{ key: 2, command: 'test.two' }],
+    expected: [2],
+  },
+  {
+    name: 'reordered',
+    previous: [1, 2],
+    keyBindings: [
+      { key: 2, command: 'test.two' },
+      { key: 1, command: 'test.one' },
+    ],
+    expected: [2, 1],
+  },
+])('update sends $name identifiers', ({ previous, keyBindings, expected }) => {
+  KeyBindingsState.state.keyBindingIdentifiers = new Uint32Array(previous)
+  KeyBindingsState.state.keyBindingSets.Editor = keyBindings
+
+  KeyBindingsState.update()
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('KeyBindings.setIdentifiers', new Uint32Array(expected))
+  expect(KeyBindingsState.state.keyBindingIdentifiers).toEqual(new Uint32Array(expected))
+})
+
 test('addKeyBindings increments refcount when keybinding set is already registered', () => {
   const keyBindings = [
     {


### PR DESCRIPTION
Avoids sending KeyBindings.setIdentifiers when the ordered Uint32Array is unchanged while still refreshing matching keybinding objects used for command lookup. Adds typed-array equality and regression coverage for empty, equal, added, removed, changed, and reordered identifiers.