### PR TITLE
feature: expose worker heap snapshots

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -81,6 +81,7 @@ export const commandMap = {
   'Developer.showMemoryUsage': lazy('Developer.showMemoryUsage'),
   'Developer.showStartupPerformance': lazy('Developer.showStartupPerformance'),
   'Developer.startupPerformance': lazy('Developer.startupPerformance'),
+  'Developer.takeWorkerHeapSnapshot': lazy('Developer.takeWorkerHeapSnapshot'),
   'Developer.toggleDeveloperTools': lazy('Developer.toggleDeveloperTools'),
   'Dialog.close': lazy('Dialog.close'),
   'Dialog.handleClick': lazy('Dialog.handleClick'),

--- a/packages/renderer-worker/src/parts/Developer/Developer.ipc.js
+++ b/packages/renderer-worker/src/parts/Developer/Developer.ipc.js
@@ -35,5 +35,6 @@ export const Commands = {
   showMemoryUsage: Developer.showMemoryUsage,
   showStartupPerformance: Developer.showStartupPerformance,
   startupPerformance: Developer.showStartupPerformance,
+  takeWorkerHeapSnapshot: Developer.takeWorkerHeapSnapshot,
   toggleDeveloperTools: Devtools.toggleDeveloperTools,
 }

--- a/packages/renderer-worker/src/parts/Developer/Developer.js
+++ b/packages/renderer-worker/src/parts/Developer/Developer.js
@@ -192,6 +192,21 @@ export const createSharedProcessProfile = async () => {
   await SharedProcess.invoke(/* Developer.createProfile */ 'Developer.createProfile')
 }
 
+export const takeWorkerHeapSnapshot = async (windowId, workerName) => {
+  try {
+    const uri = await ElectronDeveloper.takeWorkerHeapSnapshot(windowId, workerName)
+    return {
+      ok: true,
+      uri,
+    }
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      ok: false,
+    }
+  }
+}
+
 export const reloadIconTheme = async (platform, assetDir) => {
   await IconTheme.hydrate(platform, assetDir)
 }

--- a/packages/renderer-worker/src/parts/ElectronDeveloper/ElectronDeveloper.js
+++ b/packages/renderer-worker/src/parts/ElectronDeveloper/ElectronDeveloper.js
@@ -3,3 +3,7 @@ import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 export const getPerformanceEntries = () => {
   return SharedProcess.invoke('ElectronDeveloper.getPerformanceEntries')
 }
+
+export const takeWorkerHeapSnapshot = (windowId, workerName) => {
+  return SharedProcess.invoke('ElectronDeveloper.takeWorkerHeapSnapshot', windowId, workerName)
+}

--- a/packages/renderer-worker/test/Developer.test.ts
+++ b/packages/renderer-worker/test/Developer.test.ts
@@ -344,6 +344,37 @@ test.skip('monitorPerformance', async () => {
   delete globalThis.performance
 })
 
+test('takeWorkerHeapSnapshot returns the snapshot uri', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue('/home/test/Downloads/sample.heapsnapshot')
+
+  await expect(Developer.takeWorkerHeapSnapshot(7, 'Sample Extension Worker')).resolves.toEqual({
+    ok: true,
+    uri: '/home/test/Downloads/sample.heapsnapshot',
+  })
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('ElectronDeveloper.takeWorkerHeapSnapshot', 7, 'Sample Extension Worker')
+})
+
+test('takeWorkerHeapSnapshot returns an error result', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockRejectedValue(new Error('Worker not found: Sample Extension Worker'))
+
+  await expect(Developer.takeWorkerHeapSnapshot(7, 'Sample Extension Worker')).resolves.toEqual({
+    error: 'Worker not found: Sample Extension Worker',
+    ok: false,
+  })
+})
+
+test('takeWorkerHeapSnapshot handles non-error failures', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockRejectedValue('Snapshot failed')
+
+  await expect(Developer.takeWorkerHeapSnapshot(7, 'Sample Extension Worker')).resolves.toEqual({
+    error: 'Snapshot failed',
+    ok: false,
+  })
+})
+
 // TODO test createSharedProcessHeapSnapshot error
 
 test('createSharedProcessHeapSnapshot', async () => {

--- a/packages/shared-process/src/parts/ElectronDeveloper/ElectronDeveloper.ipc.ts
+++ b/packages/shared-process/src/parts/ElectronDeveloper/ElectronDeveloper.ipc.ts
@@ -4,4 +4,5 @@ export const name = 'ElectronDeveloper'
 
 export const Commands = {
   getPerformanceEntries: ElectronDeveloper.getPerformanceEntries,
+  takeWorkerHeapSnapshot: ElectronDeveloper.takeWorkerHeapSnapshot,
 }

--- a/packages/shared-process/src/parts/ElectronDeveloper/ElectronDeveloper.ts
+++ b/packages/shared-process/src/parts/ElectronDeveloper/ElectronDeveloper.ts
@@ -3,3 +3,7 @@ import * as ParentIpc from '../MainProcess/MainProcess.ts'
 export const getPerformanceEntries = (): any => {
   return ParentIpc.invoke('ElectronDeveloper.getPerformanceEntries')
 }
+
+export const takeWorkerHeapSnapshot = (windowId: number, workerName: string): Promise<string> => {
+  return ParentIpc.invoke('ElectronDeveloper.takeWorkerHeapSnapshot', windowId, workerName)
+}

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -52,6 +52,7 @@ export const getModuleId = (commandId: any): any => {
     case 'ElectronContextMenu.openContextMenu':
       return ModuleId.ElectronContextMenu
     case 'ElectronDeveloper.getPerformanceEntries':
+    case 'ElectronDeveloper.takeWorkerHeapSnapshot':
       return ModuleId.ElectronDeveloper
     case 'ElectronDialog.showMessageBox':
     case 'ElectronDialog.showOpenDialog':

--- a/packages/shared-process/test/ElectronDeveloper.test.ts
+++ b/packages/shared-process/test/ElectronDeveloper.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+const ElectronDeveloper = await import('../src/parts/ElectronDeveloper/ElectronDeveloper.ts')
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('takeWorkerHeapSnapshot', async () => {
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue('/home/test/Downloads/sample.heapsnapshot')
+
+  await expect(ElectronDeveloper.takeWorkerHeapSnapshot(7, 'Sample Extension Worker')).resolves.toBe(
+    '/home/test/Downloads/sample.heapsnapshot',
+  )
+  expect(MainProcess.invoke).toHaveBeenCalledWith('ElectronDeveloper.takeWorkerHeapSnapshot', 7, 'Sample Extension Worker')
+})

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -5,3 +5,7 @@ import * as ModuleMap from '../src/parts/ModuleMap/ModuleMap.js'
 test('getModuleId - Platform.getConfigJsonPath', () => {
   expect(ModuleMap.getModuleId('Platform.getConfigJsonPath')).toBe(ModuleId.Platform)
 })
+
+test('getModuleId - ElectronDeveloper.takeWorkerHeapSnapshot', () => {
+  expect(ModuleMap.getModuleId('ElectronDeveloper.takeWorkerHeapSnapshot')).toBe(ModuleId.ElectronDeveloper)
+})


### PR DESCRIPTION
Expose the released Electron worker heap-snapshot command through shared process and renderer worker. Return a stable success/error result for callers.