### PR TITLE
fix: remove condition check retries

### DIFF
--- a/packages/renderer-worker/src/parts/TestFrameWork/TestFrameWork.js
+++ b/packages/renderer-worker/src/parts/TestFrameWork/TestFrameWork.js
@@ -1,32 +1,11 @@
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
-const defaultTimeout = 1000
-const interval = 50
-
-const delay = (ms) => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms)
-  })
-}
-
-const checkCondition = async (method, locator, fnName, options) => {
-  const timeout = options?.timeout ?? defaultTimeout
-  const deadline = Date.now() + timeout
-  while (true) {
-    const result = await RendererProcess.invoke(method, locator, fnName, options)
-    if (!result?.error || Date.now() >= deadline) {
-      return result
-    }
-    await delay(interval)
-  }
-}
-
 export const checkSingleElementCondition = (locator, fnName, options) => {
-  return checkCondition('TestFrameWork.checkSingleElementCondition', locator, fnName, options)
+  return RendererProcess.invoke('TestFrameWork.checkSingleElementCondition', locator, fnName, options)
 }
 
 export const checkMultiElementCondition = (locator, fnName, options) => {
-  return checkCondition('TestFrameWork.checkMultiElementCondition', locator, fnName, options)
+  return RendererProcess.invoke('TestFrameWork.checkMultiElementCondition', locator, fnName, options)
 }
 
 export const showOverlay = (...args) => {

--- a/packages/renderer-worker/test/TestFrameWork.test.ts
+++ b/packages/renderer-worker/test/TestFrameWork.test.ts
@@ -10,23 +10,31 @@ const RendererProcess = await import('../src/parts/RendererProcess/RendererProce
 const TestFrameWork = await import('../src/parts/TestFrameWork/TestFrameWork.js')
 
 beforeEach(() => {
-  jest.clearAllMocks()
+  jest.resetAllMocks()
 })
 
-test('checkSingleElementCondition retries until condition passes', async () => {
+test('checkSingleElementCondition checks once and returns the first result', async () => {
+  const locator = { selector: '.Test' }
+  const options = { text: 'Hello' }
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValueOnce({ error: true })
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValueOnce({ error: false })
 
-  await expect(TestFrameWork.checkSingleElementCondition({ selector: '.Test' }, 'toBeVisible', { timeout: 100 })).resolves.toEqual({ error: false })
-  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
+  await expect(TestFrameWork.checkSingleElementCondition(locator, 'toHaveText', options)).resolves.toEqual({ error: true })
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('TestFrameWork.checkSingleElementCondition', locator, 'toHaveText', options)
 })
 
-test('checkSingleElementCondition returns last failed result after timeout', async () => {
+test('checkMultiElementCondition checks once and returns the first result', async () => {
+  const locator = { selector: '.Test' }
+  const options = { count: 2 }
   // @ts-ignore
-  RendererProcess.invoke.mockResolvedValue({ error: true })
+  RendererProcess.invoke.mockResolvedValueOnce({ error: true })
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValueOnce({ error: false })
 
-  await expect(TestFrameWork.checkSingleElementCondition({ selector: '.Test' }, 'toBeVisible', { timeout: 0 })).resolves.toEqual({ error: true })
+  await expect(TestFrameWork.checkMultiElementCondition(locator, 'toHaveCount', options)).resolves.toEqual({ error: true })
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('TestFrameWork.checkMultiElementCondition', locator, 'toHaveCount', options)
 })


### PR DESCRIPTION
Restore renderer-worker condition assertions to a single DOM check so awaited commands remain responsible for synchronization. Add regression coverage for single- and multi-element condition calls.