### PR TITLE
feature: disable test layout restoration

### DIFF
--- a/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
+++ b/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
@@ -49,7 +49,7 @@ export const reset = async (state: LayoutState): Promise<LayoutStateResult> => {
     await Command.execute('Layout.moveSideBarRight')
   }
   if (!state.sideBarVisible || state.sideBarView !== ViewletModuleId.Explorer) {
-    await Command.execute('Layout.showSideBar', ViewletModuleId.Explorer)
+    await Command.execute('Layout.showSideBar', ViewletModuleId.Explorer, false)
   }
   const panelViewNeedsReset = state.panelView !== ViewletModuleId.Problems
   if (state.panelVisible || panelViewNeedsReset) {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -367,7 +367,7 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
   return newState
 }
 
-const show = async (state: LayoutState, module, currentViewletId) => {
+const show = async (state: LayoutState, module, currentViewletId, restore?: boolean) => {
   if (state.sideBarFocusMode && module !== LayoutModules.SideBar && module !== LayoutModules.StatusBar && module !== LayoutModules.TitleBar) {
     return {
       newState: state,
@@ -381,6 +381,8 @@ const show = async (state: LayoutState, module, currentViewletId) => {
       commands: [],
     }
   }
+  const { restore: defaultRestore } = state
+  const shouldRestore = restore ?? defaultRestore
   const intermediateState: LayoutState = getPoints({
     ...state,
     [kVisible]: true,
@@ -414,7 +416,8 @@ const show = async (state: LayoutState, module, currentViewletId) => {
     parentUid: uid,
     uid: childUid,
   }
-  const commands = await ViewletManager.load(viewlet, false, true, undefined)
+  const restoreState: any = shouldRestore ? undefined : { restore: false }
+  const commands = await ViewletManager.load(viewlet, false, shouldRestore, restoreState)
   if (commands) {
     // commands.push(['Viewlet.append', uid, childUid])
   }
@@ -536,11 +539,15 @@ export const leaveSideBarFocusMode = async (state: LayoutState): Promise<LayoutS
   }
 }
 
-export const showSideBar = async (state: LayoutState, moduleId = state.sideBarView): Promise<LayoutStateResult> => {
-  const sideBarView = moduleId || state.sideBarView || ViewletModuleId.Explorer
+export const showSideBar = async (state: LayoutState, moduleId?: string, restore?: boolean): Promise<LayoutStateResult> => {
+  const { restore: defaultRestore, sideBarView: currentSideBarView } = state
+  const shouldRestore = restore ?? defaultRestore
+  const sideBarView = moduleId || currentSideBarView || ViewletModuleId.Explorer
   if (state.sideBarVisible) {
     const switchResult =
-      state.sideBarView === sideBarView ? { newState: state, commands: [] } : await callGlobalEvent(state, 'handleSideBarViewletChange', sideBarView)
+      state.sideBarView === sideBarView
+        ? { newState: state, commands: [] }
+        : await callGlobalEvent(state, 'handleSideBarViewletChange', sideBarView, shouldRestore)
     const newState = {
       ...switchResult.newState,
       sideBarView,
@@ -553,7 +560,7 @@ export const showSideBar = async (state: LayoutState, moduleId = state.sideBarVi
     }
   }
   const sideBarState = sideBarView === state.sideBarView ? state : { ...state, sideBarView }
-  const { newState, commands } = await show(sideBarState, LayoutModules.SideBar, sideBarView)
+  const { newState, commands } = await show(sideBarState, LayoutModules.SideBar, sideBarView, shouldRestore)
   const activityBarCommands = await renderSideBarActivityBarCommands(newState.activityBarId, sideBarView, true)
   return {
     newState: {

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -126,7 +126,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   // TODO set it in layout
   const { currentViewletId } = state
   const requestId = state.currentViewletRequestId + 1
-  const savePromise = SaveState.saveViewletState(currentViewletId)
+  const savePromise = restore ? SaveState.saveViewletState(currentViewletId) : undefined
   state.currentViewletRequestId = requestId
   state.currentViewletId = moduleId
 

--- a/packages/renderer-worker/test/ResetLayout.test.ts
+++ b/packages/renderer-worker/test/ResetLayout.test.ts
@@ -61,7 +61,7 @@ test('reset restores the initial application state', async () => {
   expect(Command.execute).toHaveBeenNthCalledWith(12, 'Workspace.close')
   expect(Command.execute).toHaveBeenNthCalledWith(13, 'Layout.leaveSideBarFocusMode')
   expect(Command.execute).toHaveBeenNthCalledWith(14, 'Layout.moveSideBarRight')
-  expect(Command.execute).toHaveBeenNthCalledWith(15, 'Layout.showSideBar', 'Explorer')
+  expect(Command.execute).toHaveBeenNthCalledWith(15, 'Layout.showSideBar', 'Explorer', false)
   expect(Command.execute).toHaveBeenNthCalledWith(16, 'Layout.unmaximizePanel')
   expect(Command.execute).toHaveBeenNthCalledWith(17, 'Layout.showPanel', 'Problems')
   expect(Command.execute).toHaveBeenNthCalledWith(18, 'Layout.hidePanel')

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -128,6 +128,37 @@ test('showSideBar shows hidden side bar with requested viewlet', async () => {
   })
 })
 
+test('showSideBar disables restore when the layout disables restore', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'SideBar', 1, true]])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    restore: false,
+    sideBarView: 'Explorer',
+    sideBarVisible: false,
+    statusBarHeight: 20,
+    titleBarHeight: 0,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  await ViewletLayout.showSideBar(state, 'Explorer')
+
+  expect(viewletManagerLoadMock.mock.calls[0]).toEqual([
+    expect.objectContaining({
+      args: ['Explorer'],
+      id: 'SideBar',
+    }),
+    false,
+    false,
+    { restore: false },
+  ])
+})
+
 test('showSideBar switches visible side bar to requested viewlet', async () => {
   mockActivityBarRender()
   const state = {
@@ -153,6 +184,35 @@ test('showSideBar switches visible side bar to requested viewlet', async () => {
       sideBarVisible: true,
     },
   })
+})
+
+test('showSideBar propagates disabled restore when switching a visible side bar', async () => {
+  mockActivityBarRender()
+  const handleSideBarViewletChange = jest.fn((state: any, _moduleId: string, _restore: boolean) => state)
+  const sideBarState = {}
+  // @ts-ignore
+  ViewletStates.getAllInstances.mockReturnValue({
+    12: {
+      factory: {
+        Commands: {
+          handleSideBarViewletChange,
+        },
+      },
+      renderedState: sideBarState,
+      state: sideBarState,
+    },
+  })
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    restore: false,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  }
+
+  await ViewletLayout.showSideBar(state, 'SourceControl')
+
+  expect(handleSideBarViewletChange.mock.calls[0]).toEqual([sideBarState, 'SourceControl', false])
 })
 
 test('hideSideBar updates activity bar through shared sidebar render helper', async () => {

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -136,6 +136,7 @@ test('loadContent opens explorer when restore is disabled', async () => {
     false,
     { restore: false },
   )
+  expect(SaveState.saveViewletState).not.toHaveBeenCalled()
   expect(newState).toMatchObject({
     currentViewletId: 'Explorer',
   })


### PR DESCRIPTION
Propagates layout restore=false through generic show and visible Side Bar switches, skips outgoing Side Bar state saves on non-restoring resets, and keeps normal restoration unchanged. Adds focused reset, hidden-show, visible-switch, and child-load coverage.