### PR TITLE
feature: omit empty listener registration for new roots

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -978,12 +978,11 @@ export const createPanelViewlet = async (
   }
   const eventsIndex = commands.findIndex((command) => command[0] === 'Viewlet.registerEventListeners')
   const events = eventsIndex === -1 ? [] : commands[eventsIndex][2]
-  commands.push(
-    ['Viewlet.createFunctionalRoot', viewletModuleId, actionsUid, true],
-    ['Viewlet.registerEventListeners', actionsUid, events],
-    ['Viewlet.setDom2', actionsUid, actionsDom],
-    ['Viewlet.setUid', actionsUid, editorUid],
-  )
+  commands.push(['Viewlet.createFunctionalRoot', viewletModuleId, actionsUid, true])
+  if (events.length > 0) {
+    commands.push(['Viewlet.registerEventListeners', actionsUid, events])
+  }
+  commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, editorUid])
   return {
     newState: state,
     commands,

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -559,10 +559,12 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     if (module.renderEventListeners) {
       // TODO reuse event listeners between components
       const eventListeners = await module.renderEventListeners(newState)
-      if (shouldRenderEvents === false) {
-        commands.push(['Viewlet.registerEventListeners', viewletUid, eventListeners])
-      } else {
-        await RendererProcess.invoke('Viewlet.registerEventListeners', viewletUid, eventListeners)
+      if (eventListeners.length > 0) {
+        if (shouldRenderEvents === false) {
+          commands.push(['Viewlet.registerEventListeners', viewletUid, eventListeners])
+        } else {
+          await RendererProcess.invoke('Viewlet.registerEventListeners', viewletUid, eventListeners)
+        }
       }
     }
     if ((viewlet.visible === undefined || viewlet.visible === true) && module.show) {

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -194,12 +194,11 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     if (titleAreaHeight > 0 && actionsDom.length > 0) {
       const events = eventsIndex >= 0 ? commands[eventsIndex][2] : []
       actionsUid = Id.create()
-      commands.push(
-        ['Viewlet.createFunctionalRoot', moduleId, actionsUid, true],
-        ['Viewlet.registerEventListeners', actionsUid, events],
-        ['Viewlet.setDom2', actionsUid, actionsDom],
-        ['Viewlet.setUid', actionsUid, childUid],
-      )
+      commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true])
+      if (events.length > 0) {
+        commands.push(['Viewlet.registerEventListeners', actionsUid, events])
+      }
+      commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid])
     }
     if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
       Viewlet.disposeFunctional(childUid)

--- a/packages/renderer-worker/test/AdjustCommands.test.ts
+++ b/packages/renderer-worker/test/AdjustCommands.test.ts
@@ -28,3 +28,16 @@ test('preserves a targeted focus context command', () => {
   ])
   expect(newState.commands).toEqual([])
 })
+
+test('preserves an explicit empty event listener registration for an existing root', () => {
+  const oldState = {}
+  const newState = {
+    commands: [['Viewlet.registerEventListeners', 20, []]],
+    uid: 30,
+  }
+
+  expect(AdjustCommands.apply(oldState, newState)).toEqual([
+    ['Viewlet.registerEventListeners', 20, []],
+  ])
+  expect(newState.commands).toEqual([])
+})

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -306,6 +306,38 @@ test('createPanelViewlet creates a linked actions root for child-contributed act
   })
 })
 
+test('createPanelViewlet omits empty event listener registration for its new actions root', async () => {
+  const state = ViewletLayout.create(1)
+  const actionsDom = [{ type: 'Button', childCount: 0 }]
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([
+    ['Viewlet.create', 'Output', 11],
+    ['Viewlet.send', -1, 'setActionsDom', actionsDom, 11],
+  ])
+
+  const result = await ViewletLayout.createPanelViewlet(
+    state,
+    'Output',
+    11,
+    22,
+    33,
+    {
+      x: 0,
+      y: 35,
+      width: 400,
+      height: 200,
+    },
+    '',
+  )
+
+  expect(result.commands).toEqual([
+    ['Viewlet.create', 'Output', 11],
+    ['Viewlet.createFunctionalRoot', 'Output', 33, true],
+    ['Viewlet.setDom2', 33, actionsDom],
+    ['Viewlet.setUid', 33, 11],
+  ])
+})
+
 test('toggleSideBarView hides the current side bar view when the same item is clicked', async () => {
   mockActivityBarRender()
   const state = {

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -76,6 +76,93 @@ test('render adds uid to setPatches command', () => {
   expect(commands).toEqual([['Viewlet.setPatches', 42, patches]])
 })
 
+test('load omits empty event listener registration for a new root', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const mockModule = {
+    create: jest.fn(() => ({ uid: 9 })),
+    hasFunctionalEvents: true,
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state) => state),
+    render: [],
+    renderEventListeners: jest.fn(() => []),
+  }
+
+  const viewlet = {
+    disposed: false,
+    getModule: async () => mockModule,
+    id: 'EmptyListenerTest',
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid: 9,
+    uri: '',
+  }
+  const commands = await ViewletManager.load(viewlet)
+
+  expect(commands).toEqual([['Viewlet.createFunctionalRoot', 'EmptyListenerTest', 9, true]])
+})
+
+test('load does not invoke the renderer for empty event listeners on a new root', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const mockModule = {
+    create: jest.fn(() => ({ uid: 10 })),
+    hasFunctionalEvents: true,
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state) => state),
+    render: [],
+    renderEventListeners: jest.fn(() => []),
+  }
+
+  const viewlet = {
+    disposed: false,
+    getModule: async () => mockModule,
+    id: 'DirectEmptyListenerTest',
+    show: false,
+    type: 0,
+    uid: 10,
+    uri: '',
+  }
+  await ViewletManager.load(viewlet)
+
+  expect(RendererProcess.invoke).not.toHaveBeenCalledWith('Viewlet.registerEventListeners', 10, [])
+})
+
+test('load retains non-empty event listener registration for a new root', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const eventListeners = [{ name: 'click', params: ['handleClick'] }]
+  const mockModule = {
+    create: jest.fn(() => ({ uid: 11 })),
+    hasFunctionalEvents: true,
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state) => state),
+    render: [],
+    renderEventListeners: jest.fn(() => eventListeners),
+  }
+
+  const viewlet = {
+    disposed: false,
+    getModule: async () => mockModule,
+    id: 'NonEmptyListenerTest',
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid: 11,
+    uri: '',
+  }
+  const commands = await ViewletManager.load(viewlet)
+
+  expect(commands).toEqual([
+    ['Viewlet.registerEventListeners', 11, eventListeners],
+    ['Viewlet.createFunctionalRoot', 'NonEmptyListenerTest', 11, true],
+  ])
+})
+
 test('extension view render supports functional events', () => {
   expect(ViewletExtensionViewRender.hasFunctionalEvents).toBe(true)
 })

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -190,6 +190,25 @@ test('handleSideBarViewletChange gives an opted-out extension view the full side
   })
 })
 
+test('handleSideBarViewletChange omits empty listener registration for its new actions root', async () => {
+  const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
+  ViewletManager.load.mockResolvedValue([
+    ['Viewlet.createFunctionalRoot', 'Explorer', 2, true],
+    ['Viewlet.send', 1, 'setActionsDom', ['explorer-actions']],
+  ])
+
+  const newState = await ViewletSideBar.handleSideBarViewletChange(state, 'Explorer')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.createFunctionalRoot', 'Explorer', 2, true],
+    ['Viewlet.createFunctionalRoot', 'Explorer', newState.actionsUid, true],
+    ['Viewlet.setDom2', newState.actionsUid, ['explorer-actions']],
+    ['Viewlet.setUid', newState.actionsUid, newState.childUid],
+  ])
+  expect(RendererProcess.invoke.mock.calls[0][1]).not.toContainEqual(['Viewlet.registerEventListeners', expect.any(Number), []])
+  expect(newState.actionsUid).not.toBe(-1)
+})
+
 test('setTitle', () => {
   const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
 


### PR DESCRIPTION
Suppresses empty event-listener registration only while constructing fresh functional roots. Existing-root empty registrations remain intact so callers can still explicitly clear listeners. Adds coverage for ViewletManager, Side Bar and panel action roots, ordering/UID aliasing, and explicit clearing.\n\nTests: renderer-worker focused Jest suites (39 passed, 12 existing skips); renderer-worker type-check.