### PR TITLE
feature: preload test worker during startup

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchTestWorker/LaunchTestWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchTestWorker/LaunchTestWorker.ts
@@ -5,7 +5,7 @@ import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as TestWorker from '../TestWorker/TestWorker.js'
 import * as TestWorkerUrl from '../TestWorkerUrl/TestWorkerUrl.js'
 
-export const launchTestWorker = async () => {
+const createTestWorker = async () => {
   const configuredWorkerUrl = GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.testWorkerPath', TestWorkerUrl.testWorkerUrl)
   const ipc = await IpcParent.create({
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
@@ -15,4 +15,45 @@ export const launchTestWorker = async () => {
   HandleIpc.handleIpc(ipc)
   TestWorker.set(ipc)
   return ipc
+}
+
+let launchPromise: ReturnType<typeof createTestWorker> | undefined
+
+const getOrCreateLaunchPromise = () => {
+  if (!launchPromise) {
+    launchPromise = createTestWorker()
+  }
+  return launchPromise
+}
+
+const shouldPreloadTestWorker = (href: string, isPromptMode: boolean) => {
+  if (isPromptMode) {
+    return false
+  }
+  const url = new URL(href)
+  return url.pathname.includes('/tests/') && !url.searchParams.has('replayId')
+}
+
+export const preloadTestWorker = (href: string, isPromptMode: boolean) => {
+  if (!shouldPreloadTestWorker(href, isPromptMode)) {
+    return
+  }
+  const promise = getOrCreateLaunchPromise()
+  void promise.catch(() => {})
+}
+
+export const launchTestWorker = async () => {
+  const promise = getOrCreateLaunchPromise()
+  try {
+    return await promise
+  } catch (error) {
+    if (launchPromise === promise) {
+      launchPromise = undefined
+    }
+    throw error
+  }
+}
+
+export const reset = () => {
+  launchPromise = undefined
 }

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -16,6 +16,7 @@ import * as IpcState from '../IpcState/IpcState.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as Languages from '../Languages/Languages.js'
 import * as LaunchSharedProcess from '../LaunchSharedProcess/LaunchSharedProcess.js'
+import * as LaunchTestWorker from '../LaunchTestWorker/LaunchTestWorker.ts'
 import * as LifeCycle from '../LifeCycle/LifeCycle.js'
 import * as LifeCyclePhase from '../LifeCyclePhase/LifeCyclePhase.js'
 import * as Location from '../Location/Location.js'
@@ -149,6 +150,8 @@ export const startup = async (platform, assetDir) => {
     PreferencesState.set('layout.backendUrl', promptOptions.backendUrl)
   }
   Performance.mark(PerformanceMarkerType.DidLoadPreferences)
+
+  LaunchTestWorker.preloadTestWorker(initData.Location.href, promptOptions !== undefined)
 
   // TODO only load this if session replay is enabled in preferences
   if (promptOptions === undefined && Preferences.get('sessionReplay.enabled')) {

--- a/packages/renderer-worker/test/LaunchTestWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchTestWorker.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as IpcParentType from '../src/parts/IpcParentType/IpcParentType.js'
+
+jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => {
+  return {
+    getConfiguredWorkerUrl: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => {
+  return {
+    handleIpc: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
+  return {
+    create: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/TestWorker/TestWorker.js', () => {
+  return {
+    set: jest.fn(),
+  }
+})
+
+const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
+const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
+const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const LaunchTestWorker = await import('../src/parts/LaunchTestWorker/LaunchTestWorker.ts')
+const TestWorker = await import('../src/parts/TestWorker/TestWorker.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  LaunchTestWorker.reset()
+})
+
+test('preload starts the configured Test Worker once and execution reuses it', async () => {
+  const ipc = {
+    send() {},
+  }
+  let resolveWorker: (value: typeof ipc) => void = () => {}
+  const workerPromise = new Promise<typeof ipc>((resolve) => {
+    resolveWorker = resolve
+  })
+  // @ts-ignore
+  GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///configured-test-worker.js')
+  // @ts-ignore
+  IpcParent.create.mockReturnValue(workerPromise)
+
+  LaunchTestWorker.preloadTestWorker('http://localhost:3000/tests/activity-bar.html', false)
+  LaunchTestWorker.preloadTestWorker('http://localhost:3000/tests/activity-bar.html', false)
+  const executionPromise = LaunchTestWorker.launchTestWorker()
+
+  expect(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).toHaveBeenCalledTimes(1)
+  expect(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).toHaveBeenCalledWith(
+    'develop.testWorkerPath',
+    expect.stringContaining('/@lvce-editor/test-worker/dist/testWorkerMain.js'),
+  )
+  expect(IpcParent.create).toHaveBeenCalledTimes(1)
+  expect(IpcParent.create).toHaveBeenCalledWith({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Test Worker',
+    url: 'file:///configured-test-worker.js',
+  })
+
+  resolveWorker(ipc)
+  await expect(executionPromise).resolves.toBe(ipc)
+  await expect(LaunchTestWorker.launchTestWorker()).resolves.toBe(ipc)
+  expect(IpcParent.create).toHaveBeenCalledTimes(1)
+  expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(TestWorker.set).toHaveBeenCalledWith(ipc)
+})
+
+test.each([
+  ['normal workspace', 'http://localhost:3000/github/lvce-editor/lvce-editor', false],
+  ['prompt mode', 'http://localhost:3000/tests/activity-bar.html', true],
+  ['session replay', 'http://localhost:3000/tests/activity-bar.html?replayId=1', false],
+])('does not preload for %s', (_name, href, isPromptMode) => {
+  LaunchTestWorker.preloadTestWorker(href, isPromptMode)
+
+  expect(IpcParent.create).not.toHaveBeenCalled()
+})
+
+test('preload handles rejection, execution reports it, and a later retry relaunches', async () => {
+  const launchError = new Error('failed to launch Test Worker')
+  const ipc = {
+    send() {},
+  }
+  // @ts-ignore
+  GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///test-worker.js')
+  // @ts-ignore
+  IpcParent.create.mockRejectedValueOnce(launchError).mockResolvedValueOnce(ipc)
+
+  LaunchTestWorker.preloadTestWorker('http://localhost:3000/tests/activity-bar.html', false)
+  await Promise.resolve()
+
+  await expect(LaunchTestWorker.launchTestWorker()).rejects.toBe(launchError)
+  await expect(LaunchTestWorker.launchTestWorker()).resolves.toBe(ipc)
+  expect(IpcParent.create).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
Starts Test Worker download and initialization immediately after preferences hydrate for test URLs, while initial layout work continues. Memoizes the pending/ready worker so test execution reuses it, preserves configured development URLs, filters normal/prompt/replay startup, handles preload rejection, and allows retry after execution reports the original error.\n\nTests: LaunchTestWorker and ExecuteCurrentTest Jest suites (8 passed); renderer-worker type-check.