### PR TITLE
feature: connect test worker to renderer process

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchTestWorker/LaunchTestWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchTestWorker/LaunchTestWorker.ts
@@ -2,31 +2,43 @@ import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfigured
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as TestWorker from '../TestWorker/TestWorker.js'
 import * as TestWorkerUrl from '../TestWorkerUrl/TestWorkerUrl.js'
 
-const createTestWorker = async () => {
+const createTestWorker = async (): Promise<any> => {
   const configuredWorkerUrl = GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.testWorkerPath', TestWorkerUrl.testWorkerUrl)
   const ipc = await IpcParent.create({
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
-    url: configuredWorkerUrl,
     name: 'Test Worker',
+    url: configuredWorkerUrl,
   })
   HandleIpc.handleIpc(ipc)
   TestWorker.set(ipc)
+  const { port1, port2 } = new MessageChannel()
+  await RendererProcess.invokeAndTransfer('TestWorkerRpc.initialize', port1)
+  await JsonRpc.invokeAndTransfer(ipc, 'RendererProcess.initialize', port2)
   return ipc
 }
 
-let launchPromise: ReturnType<typeof createTestWorker> | undefined
-
-const getOrCreateLaunchPromise = () => {
-  if (!launchPromise) {
-    launchPromise = createTestWorker()
-  }
-  return launchPromise
+const state: {
+  launchPromise: ReturnType<typeof createTestWorker> | undefined
+} = {
+  launchPromise: undefined,
 }
 
-const shouldPreloadTestWorker = (href: string, isPromptMode: boolean) => {
+const getOrCreateLaunchPromise = (): ReturnType<typeof createTestWorker> => {
+  const { launchPromise } = state
+  if (launchPromise) {
+    return launchPromise
+  }
+  const promise = createTestWorker()
+  state.launchPromise = promise
+  return promise
+}
+
+const shouldPreloadTestWorker = (href: string, isPromptMode: boolean): boolean => {
   if (isPromptMode) {
     return false
   }
@@ -34,7 +46,7 @@ const shouldPreloadTestWorker = (href: string, isPromptMode: boolean) => {
   return url.pathname.includes('/tests/') && !url.searchParams.has('replayId')
 }
 
-export const preloadTestWorker = (href: string, isPromptMode: boolean) => {
+export const preloadTestWorker = (href: string, isPromptMode: boolean): void => {
   if (!shouldPreloadTestWorker(href, isPromptMode)) {
     return
   }
@@ -42,18 +54,19 @@ export const preloadTestWorker = (href: string, isPromptMode: boolean) => {
   void promise.catch(() => {})
 }
 
-export const launchTestWorker = async () => {
+export const launchTestWorker = async (): Promise<any> => {
   const promise = getOrCreateLaunchPromise()
   try {
     return await promise
   } catch (error) {
+    const { launchPromise } = state
     if (launchPromise === promise) {
-      launchPromise = undefined
+      state.launchPromise = undefined
     }
     throw error
   }
 }
 
-export const reset = () => {
-  launchPromise = undefined
+export const reset = (): void => {
+  state.launchPromise = undefined
 }

--- a/packages/renderer-worker/test/LaunchTestWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchTestWorker.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Worker launch tests use ESM module mocks for transport dependencies. */
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as IpcParentType from '../src/parts/IpcParentType/IpcParentType.js'
 
@@ -23,6 +24,18 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => {
+  return {
+    invokeAndTransfer: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
+  return {
+    invokeAndTransfer: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/TestWorker/TestWorker.js', () => {
   return {
     set: jest.fn(),
@@ -32,22 +45,51 @@ jest.unstable_mockModule('../src/parts/TestWorker/TestWorker.js', () => {
 const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
 const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchTestWorker = await import('../src/parts/LaunchTestWorker/LaunchTestWorker.ts')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const TestWorker = await import('../src/parts/TestWorker/TestWorker.js')
+const jsonRpcInvokeAndTransfer = jest.mocked(JsonRpc.invokeAndTransfer)
+const rendererProcessInvokeAndTransfer = jest.mocked(RendererProcess.invokeAndTransfer)
 
 beforeEach(() => {
   jest.resetAllMocks()
   LaunchTestWorker.reset()
 })
 
+test('launchTestWorker connects the test worker directly to the renderer process', async () => {
+  const ipc = {
+    send(): void {},
+  }
+  // @ts-ignore
+  GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///test-worker.js')
+  // @ts-ignore
+  IpcParent.create.mockResolvedValue(ipc)
+
+  const result = await LaunchTestWorker.launchTestWorker()
+
+  expect(IpcParent.create).toHaveBeenCalledTimes(1)
+  expect(IpcParent.create).toHaveBeenCalledWith({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Test Worker',
+    url: 'file:///test-worker.js',
+  })
+  expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(TestWorker.set).toHaveBeenCalledWith(ipc)
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('TestWorkerRpc.initialize', expect.any(MessagePort))
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'RendererProcess.initialize', expect.any(MessagePort))
+  expect(rendererProcessInvokeAndTransfer.mock.calls[0][1]).not.toBe(jsonRpcInvokeAndTransfer.mock.calls[0][2])
+  expect(rendererProcessInvokeAndTransfer.mock.invocationCallOrder[0]).toBeLessThan(jsonRpcInvokeAndTransfer.mock.invocationCallOrder[0])
+  expect(result).toBe(ipc)
+})
+
 test('preload starts the configured Test Worker once and execution reuses it', async () => {
   const ipc = {
-    send() {},
+    send(): void {},
   }
-  let resolveWorker: (value: typeof ipc) => void = () => {}
-  const workerPromise = new Promise<typeof ipc>((resolve) => {
-    resolveWorker = resolve
-  })
+  const { promise: workerPromise, resolve: resolveWorker } = Promise.withResolvers<typeof ipc>()
   // @ts-ignore
   GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///configured-test-worker.js')
   // @ts-ignore
@@ -90,7 +132,7 @@ test.each([
 test('preload handles rejection, execution reports it, and a later retry relaunches', async () => {
   const launchError = new Error('failed to launch Test Worker')
   const ipc = {
-    send() {},
+    send(): void {},
   }
   // @ts-ignore
   GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///test-worker.js')


### PR DESCRIPTION
Creates a dedicated MessageChannel when test-worker launches and transfers one endpoint to test-worker and the other to renderer-process, allowing renderer-local test checks and actions to bypass renderer-worker. Keeps single- and multi-element condition checks one-shot.