### PR TITLE
test: cover compact test locator forwarding

### DIFF
--- a/packages/renderer-worker/test/TestFrameWork.test.ts
+++ b/packages/renderer-worker/test/TestFrameWork.test.ts
@@ -14,7 +14,12 @@ beforeEach(() => {
 })
 
 test('checkSingleElementCondition checks once and returns the first result', async () => {
-  const locator = { selector: '.Test' }
+  const locator = [
+    {
+      selector: '.Test',
+      type: 'css',
+    },
+  ]
   const options = { text: 'Hello' }
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValueOnce({ error: true })
@@ -27,7 +32,16 @@ test('checkSingleElementCondition checks once and returns the first result', asy
 })
 
 test('checkMultiElementCondition checks once and returns the first result', async () => {
-  const locator = { selector: '.Test' }
+  const locator = [
+    {
+      selector: '.Test',
+      type: 'css',
+    },
+    {
+      text: 'Save',
+      type: 'has-text',
+    },
+  ]
   const options = { count: 2 }
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValueOnce({ error: true })
@@ -37,4 +51,22 @@ test('checkMultiElementCondition checks once and returns the first result', asyn
   await expect(TestFrameWork.checkMultiElementCondition(locator, 'toHaveCount', options)).resolves.toEqual({ error: true })
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
   expect(RendererProcess.invoke).toHaveBeenCalledWith('TestFrameWork.checkMultiElementCondition', locator, 'toHaveCount', options)
+})
+
+test('checkSingleElementCondition continues to forward a legacy locator', async () => {
+  const locator = {
+    _parsed: [
+      {
+        selector: '.Test',
+        type: 'css',
+      },
+    ],
+    _selector: '.Test',
+  }
+  const options = { text: 'Hello' }
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue({ error: false })
+
+  await expect(TestFrameWork.checkSingleElementCondition(locator, 'toHaveText', options)).resolves.toEqual({ error: false })
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('TestFrameWork.checkSingleElementCondition', locator, 'toHaveText', options)
 })


### PR DESCRIPTION
Locks in renderer-worker's shape-agnostic forwarding for compact parsed-selector arrays on both single- and multi-element conditions, while retaining legacy-locator coverage. No production change is needed because the forwarding layer already treats locators as opaque.\n\nTests: renderer-worker TestFrameWork Jest suite (3 passed); renderer-worker type-check.