### PR TITLE
performance: preserve activity bar state during reset

### DIFF
--- a/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
+++ b/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
@@ -2,7 +2,6 @@ import * as Command from '../Command/Command.js'
 import type { LayoutState, LayoutStateResult } from '../ViewletLayout/LayoutState.ts'
 import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
-import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 const defaultColorTheme = 'slime'
 const defaultTitleTemplate = '${folderName}'
@@ -14,20 +13,8 @@ const closeWidgets = async (): Promise<void> => {
   await Command.execute('Viewlet.closeWidget', ViewletModuleId.Confirm)
 }
 
-const getActivityBarBounds = (): { readonly height: number; readonly width: number; readonly x: number; readonly y: number } => {
-  const state: LayoutState = ViewletStates.getState(ViewletModuleId.Layout)
-  return {
-    height: state.activityBarHeight,
-    width: state.activityBarWidth,
-    x: state.activityBarLeft,
-    y: state.activityBarTop,
-  }
-}
-
 const resetActivityBar = async (): Promise<void> => {
-  const { height, width, x, y } = getActivityBarBounds()
-  await Command.execute('ActivityBar.create', '', x, y, width, height, null, null, -1)
-  await Command.execute('ActivityBar.loadContent', {})
+  await Command.execute('ActivityBar.reset')
 }
 
 export const reset = async (state: LayoutState): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/test/ResetLayout.test.ts
+++ b/packages/renderer-worker/test/ResetLayout.test.ts
@@ -5,13 +5,8 @@ jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
   execute: jest.fn(),
 }))
 
-jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({
-  getState: jest.fn(),
-}))
-
 const Command = await import('../src/parts/Command/Command.js')
 const ResetLayout = await import('../src/parts/ResetLayout/ResetLayout.ts')
-const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -20,12 +15,6 @@ beforeEach(() => {
       return '/test'
     }
     return undefined
-  })
-  jest.spyOn(ViewletStates, 'getState').mockReturnValue({
-    activityBarHeight: 718,
-    activityBarLeft: 976,
-    activityBarTop: 30,
-    activityBarWidth: 48,
   })
 })
 
@@ -46,7 +35,7 @@ test('reset restores the initial application state', async () => {
     newState: state,
   })
 
-  expect(Command.execute).toHaveBeenCalledTimes(20)
+  expect(Command.execute).toHaveBeenCalledTimes(19)
   expect(Command.execute).toHaveBeenNthCalledWith(1, 'Menu.hide', false)
   expect(Command.execute).toHaveBeenNthCalledWith(2, 'TitleBar.closeMenu')
   expect(Command.execute).toHaveBeenNthCalledWith(3, 'TitleBar.setTitleTemplate', '${folderName}')
@@ -65,8 +54,7 @@ test('reset restores the initial application state', async () => {
   expect(Command.execute).toHaveBeenNthCalledWith(16, 'Layout.unmaximizePanel')
   expect(Command.execute).toHaveBeenNthCalledWith(17, 'Layout.showPanel', 'Problems')
   expect(Command.execute).toHaveBeenNthCalledWith(18, 'Layout.hidePanel')
-  expect(Command.execute).toHaveBeenNthCalledWith(19, 'ActivityBar.create', '', 976, 30, 48, 718, null, null, -1)
-  expect(Command.execute).toHaveBeenNthCalledWith(20, 'ActivityBar.loadContent', {})
+  expect(Command.execute).toHaveBeenNthCalledWith(19, 'ActivityBar.reset')
 })
 
 test('reset leaves an initial layout in place', async () => {
@@ -92,5 +80,5 @@ test('reset leaves an initial layout in place', async () => {
   expect(Command.execute).not.toHaveBeenCalledWith('Layout.unmaximizePanel')
   expect(Command.execute).not.toHaveBeenCalledWith('Layout.showPanel', 'Problems')
   expect(Command.execute).not.toHaveBeenCalledWith('Layout.hidePanel')
-  expect(Command.execute).toHaveBeenLastCalledWith('ActivityBar.loadContent', {})
+  expect(Command.execute).toHaveBeenLastCalledWith('ActivityBar.reset')
 })


### PR DESCRIPTION
## Summary
- replace the reset-time `ActivityBar.create` plus `ActivityBar.loadContent` sequence with `ActivityBar.reset`
- let activity-bar-worker preserve the existing rendered state as the virtual-DOM diff base
- remove the renderer-worker dependency on layout state solely for Activity Bar bounds

Depends on activity-bar-worker 7.12.0, already merged in #12872.

## Validation
- `npm run lint`
- `npm run type-check`
- `npx lerna run test --since origin/main` (renderer-worker: 254 suites passed, 26 skipped; 999 tests passed, 242 skipped)
- `npm run build:static`
- `npm run build:server`
- `npm run test-static-export`
- activity-bar-worker unit/type/lint/build checks and 90 Activity Bar E2E tests passed in lvce-editor/activity-bar-worker#472