### PR TITLE
chore: update eslint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^16.5.0",
+        "@lvce-editor/eslint-config": "^17.0.3",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.0.1",
         "eslint": "^10.7.0",
@@ -3033,9 +3033,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.5.0.tgz",
-      "integrity": "sha512-jRVb67XrN9MnhpR9tPbkN5R3N9hb+u95Oj2GWNNtHDDMqmm0RnQkj44SUxkDsLXwjguqG6Kxj6WkqX7XKuAN0w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
+      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3045,14 +3045,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.5.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.5.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.5.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.5.0",
-        "@lvce-editor/eslint-plugin-regex": "16.5.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.5.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.5.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.5.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
+        "@lvce-editor/eslint-plugin-regex": "17.0.3",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -3067,9 +3067,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.5.0.tgz",
-      "integrity": "sha512-cxFhq3mzv4dCQi0HcGf1HibTNAcifkF9HAM2v9QGHVyzHicF23SEAVXbpPzZYQ8y1U6xB9hlzppXNuPDcLUxFA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
+      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3077,16 +3077,16 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.5.0.tgz",
-      "integrity": "sha512-lPTC+X6msmkRVfYzFGyWJzK4Dm4t7woQQtVTkosTnEeg8SCYTyAqbt7cc6Bt0NhrLtSnZocZiZT6gYbJ6877PA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
+      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.5.0.tgz",
-      "integrity": "sha512-nw9mndMNxY0GNYHR9XJDo2Ed8D6VJExTzPonYz2L1Q3qpleA3OEhDKezAGQpwPPeWSz030TtBxGzvV+HbnLFPQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
+      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3095,9 +3095,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.5.0.tgz",
-      "integrity": "sha512-50iv6im3U/W8JsS2dvgWhwNeiWfAMCh2kc9EgsmHQ5zdXmjcUmlkDU2rAKQriQsi3U3uZdWpFBCz6khdNAeq5w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
+      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3118,23 +3118,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.5.0.tgz",
-      "integrity": "sha512-qQkSzwQG3V4w3B7HSyOjdgutK2UiUSQJo5mIJ8MxeO9X/B+4WmzrPmMkKcTzEmCZPnwkEXzuGGhbpjAmTOvCTQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
+      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.5.0.tgz",
-      "integrity": "sha512-30OYviUIhK+2bsvl7UHXohPj4hPqR5XAayYsiSwfDRZGaqga7CVW7Zo89hKdE6lDIT1GrqE3OlpW1YzD6w5V1w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
+      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.5.0.tgz",
-      "integrity": "sha512-CYfNvMPO2VEhlmUVhdGiAbrJFuuzFy//ZqSlqoG3gCLSw2De5W4lVaWunLyuSnIs+kI9eFvwoQbT+LUSRpIaiQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
+      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3142,9 +3142,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.5.0.tgz",
-      "integrity": "sha512-x2ReJ0CfNxXF/1BfsdUVOZTf/8kaWjRS8HEsDnfLQ7dzvpdMOGFQBUc0STO/tUmY1TOK9SMlMIUnbNNwH0OEyQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
+      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^16.5.0",
+    "@lvce-editor/eslint-config": "^17.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.1",
     "eslint": "^10.7.0",


### PR DESCRIPTION
Updates the shared ESLint config to 17.0.3, including the virtual DOM node-hoisting rule. The existing source already satisfies the updated lint rules.