### PR TITLE
feature: simplify renderer process test rpc

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchTestWorker/LaunchTestWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchTestWorker/LaunchTestWorker.ts
@@ -3,7 +3,6 @@ import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
-import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as TestWorker from '../TestWorker/TestWorker.js'
 import * as TestWorkerUrl from '../TestWorkerUrl/TestWorkerUrl.js'
 
@@ -16,9 +15,7 @@ const createTestWorker = async (): Promise<any> => {
   })
   HandleIpc.handleIpc(ipc)
   TestWorker.set(ipc)
-  const { port1, port2 } = new MessageChannel()
-  await RendererProcess.invokeAndTransfer('TestWorkerRpc.initialize', port1)
-  await JsonRpc.invokeAndTransfer(ipc, 'RendererProcess.initialize', port2)
+  await JsonRpc.invoke(ipc, 'RendererProcess.initialize')
   return ipc
 }
 

--- a/packages/renderer-worker/test/LaunchTestWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchTestWorker.test.ts
@@ -26,13 +26,7 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
 
 jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => {
   return {
-    invokeAndTransfer: jest.fn(),
-  }
-})
-
-jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
-  return {
-    invokeAndTransfer: jest.fn(),
+    invoke: jest.fn(),
   }
 })
 
@@ -47,17 +41,14 @@ const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
 const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchTestWorker = await import('../src/parts/LaunchTestWorker/LaunchTestWorker.ts')
-const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const TestWorker = await import('../src/parts/TestWorker/TestWorker.js')
-const jsonRpcInvokeAndTransfer = jest.mocked(JsonRpc.invokeAndTransfer)
-const rendererProcessInvokeAndTransfer = jest.mocked(RendererProcess.invokeAndTransfer)
 
 beforeEach(() => {
   jest.resetAllMocks()
   LaunchTestWorker.reset()
 })
 
-test('launchTestWorker connects the test worker directly to the renderer process', async () => {
+test('launchTestWorker asks the test worker to initialize its renderer process rpc', async () => {
   const ipc = {
     send(): void {},
   }
@@ -76,12 +67,8 @@ test('launchTestWorker connects the test worker directly to the renderer process
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
   expect(TestWorker.set).toHaveBeenCalledWith(ipc)
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('TestWorkerRpc.initialize', expect.any(MessagePort))
-  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledTimes(1)
-  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'RendererProcess.initialize', expect.any(MessagePort))
-  expect(rendererProcessInvokeAndTransfer.mock.calls[0][1]).not.toBe(jsonRpcInvokeAndTransfer.mock.calls[0][2])
-  expect(rendererProcessInvokeAndTransfer.mock.invocationCallOrder[0]).toBeLessThan(jsonRpcInvokeAndTransfer.mock.invocationCallOrder[0])
+  expect(JsonRpc.invoke).toHaveBeenCalledTimes(1)
+  expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'RendererProcess.initialize')
   expect(result).toBe(ipc)
 })
 


### PR DESCRIPTION
Let test-worker own and lazily forward the direct renderer-process MessagePort through the existing generic HandleMessagePort path. Renderer-worker now only asks test-worker to initialize its renderer-process RPC.