### PR TITLE
feature: speed up e2e layout resets

### DIFF
--- a/packages/renderer-worker/src/parts/RendererFrameScheduler/RendererFrameScheduler.js
+++ b/packages/renderer-worker/src/parts/RendererFrameScheduler/RendererFrameScheduler.js
@@ -1,3 +1,4 @@
+import * as IsTest from '../IsTest/IsTest.js'
 import * as NormalizeRendererCommands from '../NormalizeRendererCommands/NormalizeRendererCommands.js'
 import * as RequestAnimationFrame from '../RequestAnimationFrame/RequestAnimationFrame.js'
 import * as Timestamp from '../Timestamp/Timestamp.js'
@@ -26,6 +27,9 @@ const enqueue = (operation) => {
 }
 
 const waitForEligibleFrame = () => {
+  if (IsTest.isTest()) {
+    return Promise.resolve(Timestamp.now())
+  }
   return new Promise((resolve) => {
     const handleFrame = (timestamp) => {
       if (timestamp - state.lastFrameTime < minimumFrameDuration) {

--- a/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
+++ b/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
@@ -1,5 +1,5 @@
-import * as Command from '../Command/Command.js'
 import type { LayoutState, LayoutStateResult } from '../ViewletLayout/LayoutState.ts'
+import * as Command from '../Command/Command.js'
 import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
@@ -7,47 +7,71 @@ const defaultColorTheme = 'slime'
 const defaultTitleTemplate = '${folderName}'
 
 const closeWidgets = async (): Promise<void> => {
-  await Command.execute('Viewlet.closeWidget', ViewletModuleId.QuickPick)
-  await Command.execute('Viewlet.closeWidget', ViewletModuleId.About)
-  await Command.execute('Viewlet.closeWidget', ViewletModuleId.Dialog)
-  await Command.execute('Viewlet.closeWidget', ViewletModuleId.Confirm)
+  await Promise.all([
+    Command.execute('Viewlet.closeWidget', ViewletModuleId.QuickPick),
+    Command.execute('Viewlet.closeWidget', ViewletModuleId.About),
+    Command.execute('Viewlet.closeWidget', ViewletModuleId.Dialog),
+    Command.execute('Viewlet.closeWidget', ViewletModuleId.Confirm),
+  ])
+}
+
+const resetTitleBar = async (titleBarWidth: number): Promise<void> => {
+  await Command.execute('TitleBar.closeMenu')
+  await Command.execute('TitleBar.setTitleTemplate', defaultTitleTemplate)
+  await Command.execute('TitleBar.setWidth', titleBarWidth)
+}
+
+const resetWorkspace = async (): Promise<void> => {
+  await Command.execute('Main.closeAllEditors')
+  const workspacePath = await Command.execute('Workspace.getPath')
+  if (workspacePath) {
+    await Command.execute('Workspace.close')
+  }
+}
+
+const resetSideBar = async (sideBarFocusMode: boolean, sideBarLocation: number, sideBarView: string, sideBarVisible: boolean): Promise<void> => {
+  if (sideBarFocusMode) {
+    await Command.execute('Layout.leaveSideBarFocusMode')
+  }
+  if (sideBarLocation !== SideBarLocationType.Right) {
+    await Command.execute('Layout.moveSideBarRight')
+  }
+  if (!sideBarVisible || sideBarView !== ViewletModuleId.Explorer) {
+    await Command.execute('Layout.showSideBar', ViewletModuleId.Explorer, false)
+  }
+}
+
+const resetPanel = async (panelMaximized: boolean, panelView: string, panelVisible: boolean): Promise<void> => {
+  const panelViewNeedsReset = panelView !== ViewletModuleId.Problems
+  if (!panelVisible && !panelViewNeedsReset) {
+    return
+  }
+  if (panelMaximized) {
+    await Command.execute('Layout.unmaximizePanel')
+  }
+  if (panelViewNeedsReset) {
+    await Command.execute('Layout.showPanel', ViewletModuleId.Problems)
+  }
+  await Command.execute('Layout.hidePanel')
 }
 
 const resetActivityBar = async (): Promise<void> => {
   await Command.execute('ActivityBar.reset')
 }
 
-export const reset = async (state: LayoutState): Promise<LayoutStateResult> => {
-  await Command.execute('Menu.hide', false)
-  await Command.execute('TitleBar.closeMenu')
-  await Command.execute('TitleBar.setTitleTemplate', defaultTitleTemplate)
-  await Command.execute('TitleBar.setWidth', state.titleBarWidth)
-  await closeWidgets()
-  await Command.execute('ColorTheme.setColorTheme', defaultColorTheme)
-  await Command.execute('Main.closeAllEditors')
-  const workspacePath = await Command.execute('Workspace.getPath')
-  if (workspacePath) {
-    await Command.execute('Workspace.close')
-  }
-  if (state.sideBarFocusMode) {
-    await Command.execute('Layout.leaveSideBarFocusMode')
-  }
-  if (state.sideBarLocation !== SideBarLocationType.Right) {
-    await Command.execute('Layout.moveSideBarRight')
-  }
-  if (!state.sideBarVisible || state.sideBarView !== ViewletModuleId.Explorer) {
-    await Command.execute('Layout.showSideBar', ViewletModuleId.Explorer, false)
-  }
-  const panelViewNeedsReset = state.panelView !== ViewletModuleId.Problems
-  if (state.panelVisible || panelViewNeedsReset) {
-    if (state.panelMaximized) {
-      await Command.execute('Layout.unmaximizePanel')
-    }
-    if (panelViewNeedsReset) {
-      await Command.execute('Layout.showPanel', ViewletModuleId.Problems)
-    }
-    await Command.execute('Layout.hidePanel')
-  }
+export const reset = async (state: Readonly<LayoutState>): Promise<LayoutStateResult> => {
+  const { panelMaximized, panelView, panelVisible, sideBarFocusMode, sideBarLocation, sideBarView, sideBarVisible, titleBarWidth } = state
+  await Promise.all([
+    Command.execute('Menu.hide', false),
+    resetTitleBar(titleBarWidth),
+    closeWidgets(),
+    Command.execute('ColorTheme.setColorTheme', defaultColorTheme),
+    resetWorkspace(),
+  ])
+  await Promise.all([
+    resetSideBar(sideBarFocusMode, sideBarLocation, sideBarView, sideBarVisible),
+    resetPanel(panelMaximized, panelView, panelVisible),
+  ])
   await resetActivityBar()
   return {
     commands: [],

--- a/packages/renderer-worker/test/RendererFrameScheduler.test.ts
+++ b/packages/renderer-worker/test/RendererFrameScheduler.test.ts
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../src/parts/Timestamp/Timestamp.js', () => ({
 }))
 
 const NormalizeRendererCommands = await import('../src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js')
+const IsTest = await import('../src/parts/IsTest/IsTest.js')
 const RendererFrameScheduler = await import('../src/parts/RendererFrameScheduler/RendererFrameScheduler.js')
 
 const rpc = {
@@ -38,10 +39,20 @@ const runAnimationFrame = async (timestamp: number) => {
 beforeEach(() => {
   frameCallbacks.length = 0
   currentTime = 0
+  IsTest.state.isTest = false
   jest.clearAllMocks()
   rpc.invoke.mockResolvedValue(undefined)
   rpc.invokeAndTransfer.mockResolvedValue(undefined)
   RendererFrameScheduler.reset(rpc)
+})
+
+test('sends render batches without waiting for an animation frame in tests', async () => {
+  IsTest.state.isTest = true
+
+  await RendererFrameScheduler.sendMultiple([['Viewlet.send', 1, 'test']])
+
+  expect(frameCallbacks).toHaveLength(0)
+  expect(rpc.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.send', 1, 'test']])
 })
 
 test('coalesces consecutive render batches in arrival order', async () => {

--- a/packages/renderer-worker/test/ResetLayout.test.ts
+++ b/packages/renderer-worker/test/ResetLayout.test.ts
@@ -20,11 +20,11 @@ beforeEach(() => {
 
 test('reset restores the initial application state', async () => {
   const state = {
-    panelVisible: true,
     panelMaximized: true,
     panelView: 'Output',
-    sideBarLocation: SideBarLocationType.Left,
+    panelVisible: true,
     sideBarFocusMode: true,
+    sideBarLocation: SideBarLocationType.Left,
     sideBarView: 'Search',
     sideBarVisible: false,
     titleBarWidth: 1024,
@@ -36,25 +36,25 @@ test('reset restores the initial application state', async () => {
   })
 
   expect(Command.execute).toHaveBeenCalledTimes(19)
-  expect(Command.execute).toHaveBeenNthCalledWith(1, 'Menu.hide', false)
-  expect(Command.execute).toHaveBeenNthCalledWith(2, 'TitleBar.closeMenu')
-  expect(Command.execute).toHaveBeenNthCalledWith(3, 'TitleBar.setTitleTemplate', '${folderName}')
-  expect(Command.execute).toHaveBeenNthCalledWith(4, 'TitleBar.setWidth', 1024)
-  expect(Command.execute).toHaveBeenNthCalledWith(5, 'Viewlet.closeWidget', 'QuickPick')
-  expect(Command.execute).toHaveBeenNthCalledWith(6, 'Viewlet.closeWidget', 'About')
-  expect(Command.execute).toHaveBeenNthCalledWith(7, 'Viewlet.closeWidget', 'Dialog')
-  expect(Command.execute).toHaveBeenNthCalledWith(8, 'Viewlet.closeWidget', 'Confirm')
-  expect(Command.execute).toHaveBeenNthCalledWith(9, 'ColorTheme.setColorTheme', 'slime')
-  expect(Command.execute).toHaveBeenNthCalledWith(10, 'Main.closeAllEditors')
-  expect(Command.execute).toHaveBeenNthCalledWith(11, 'Workspace.getPath')
-  expect(Command.execute).toHaveBeenNthCalledWith(12, 'Workspace.close')
-  expect(Command.execute).toHaveBeenNthCalledWith(13, 'Layout.leaveSideBarFocusMode')
-  expect(Command.execute).toHaveBeenNthCalledWith(14, 'Layout.moveSideBarRight')
-  expect(Command.execute).toHaveBeenNthCalledWith(15, 'Layout.showSideBar', 'Explorer', false)
-  expect(Command.execute).toHaveBeenNthCalledWith(16, 'Layout.unmaximizePanel')
-  expect(Command.execute).toHaveBeenNthCalledWith(17, 'Layout.showPanel', 'Problems')
-  expect(Command.execute).toHaveBeenNthCalledWith(18, 'Layout.hidePanel')
-  expect(Command.execute).toHaveBeenNthCalledWith(19, 'ActivityBar.reset')
+  expect(Command.execute).toHaveBeenCalledWith('Menu.hide', false)
+  expect(Command.execute).toHaveBeenCalledWith('TitleBar.closeMenu')
+  expect(Command.execute).toHaveBeenCalledWith('TitleBar.setTitleTemplate', '${folderName}')
+  expect(Command.execute).toHaveBeenCalledWith('TitleBar.setWidth', 1024)
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'QuickPick')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'About')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'Dialog')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'Confirm')
+  expect(Command.execute).toHaveBeenCalledWith('ColorTheme.setColorTheme', 'slime')
+  expect(Command.execute).toHaveBeenCalledWith('Main.closeAllEditors')
+  expect(Command.execute).toHaveBeenCalledWith('Workspace.getPath')
+  expect(Command.execute).toHaveBeenCalledWith('Workspace.close')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.leaveSideBarFocusMode')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.moveSideBarRight')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.showSideBar', 'Explorer', false)
+  expect(Command.execute).toHaveBeenCalledWith('Layout.unmaximizePanel')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.showPanel', 'Problems')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.hidePanel')
+  expect(Command.execute).toHaveBeenLastCalledWith('ActivityBar.reset')
 })
 
 test('reset leaves an initial layout in place', async () => {
@@ -62,8 +62,8 @@ test('reset leaves an initial layout in place', async () => {
     panelMaximized: false,
     panelView: 'Problems',
     panelVisible: false,
-    sideBarLocation: SideBarLocationType.Right,
     sideBarFocusMode: false,
+    sideBarLocation: SideBarLocationType.Right,
     sideBarView: 'Explorer',
     sideBarVisible: true,
     titleBarWidth: 1024,
@@ -81,4 +81,45 @@ test('reset leaves an initial layout in place', async () => {
   expect(Command.execute).not.toHaveBeenCalledWith('Layout.showPanel', 'Problems')
   expect(Command.execute).not.toHaveBeenCalledWith('Layout.hidePanel')
   expect(Command.execute).toHaveBeenLastCalledWith('ActivityBar.reset')
+})
+
+test('resets independent components in parallel', async () => {
+  const state = {
+    panelMaximized: false,
+    panelView: 'Problems',
+    panelVisible: false,
+    sideBarFocusMode: false,
+    sideBarLocation: SideBarLocationType.Right,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+    titleBarWidth: 1024,
+  } as any
+  const resolvers: Array<() => void> = []
+  const parallelCommands = new Set(['Menu.hide', 'TitleBar.closeMenu', 'ColorTheme.setColorTheme', 'Main.closeAllEditors'])
+  jest.spyOn(Command, 'execute').mockImplementation((command) => {
+    if (parallelCommands.has(command)) {
+      return new Promise<void>((resolve) => {
+        resolvers.push(resolve)
+      })
+    }
+    return undefined
+  })
+
+  const resetPromise = ResetLayout.reset(state)
+  await Promise.resolve()
+
+  expect(Command.execute).toHaveBeenCalledWith('Menu.hide', false)
+  expect(Command.execute).toHaveBeenCalledWith('TitleBar.closeMenu')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'QuickPick')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'About')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'Dialog')
+  expect(Command.execute).toHaveBeenCalledWith('Viewlet.closeWidget', 'Confirm')
+  expect(Command.execute).toHaveBeenCalledWith('ColorTheme.setColorTheme', 'slime')
+  expect(Command.execute).toHaveBeenCalledWith('Main.closeAllEditors')
+  expect(Command.execute).not.toHaveBeenCalledWith('ActivityBar.reset')
+
+  for (const resolve of resolvers) {
+    resolve()
+  }
+  await resetPromise
 })


### PR DESCRIPTION
## Summary

- bypass the animation-frame scheduler while the renderer is running tests
- reset independent layout components concurrently
- keep dependent title bar, workspace, sidebar, panel, and activity bar operations ordered
- add coverage for test-mode frame delivery and parallel reset startup

The existing diff/render2 flow is intentionally unchanged.