### PR TITLE
fix: use column layout for source control lists

### DIFF
--- a/static/css/parts/ViewletList.css
+++ b/static/css/parts/ViewletList.css
@@ -1,4 +1,6 @@
 .List {
+  display: flex;
+  flex-direction: column;
   position: relative;
   flex: 1;
 }

--- a/static/css/parts/ViewletSourceControl.css
+++ b/static/css/parts/ViewletSourceControl.css
@@ -33,6 +33,8 @@
 }
 
 .SourceControlItems {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   contain: strict;
 }


### PR DESCRIPTION
Summary:
- make the shared list container a flex column
- make source control items a flex column so entries stack vertically