### PR TITLE
fix: refresh source control badge after workspace change

### DIFF
--- a/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
+++ b/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
@@ -63,6 +63,7 @@ export const watchWorkspace = async (workspaceUri) => {
 
 const handleWorkspaceChange = async () => {
   await watchWorkspace(Workspace.getWorkspaceUri())
+  await Command.execute('Layout.refreshSourceControlBadgeCount')
 }
 
 export const hydrate = async () => {

--- a/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
+++ b/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
@@ -60,7 +60,7 @@ test('watchWorkspace - replaces the previous watcher', async () => {
   })
 })
 
-test('workspace change - watches the new workspace uri', async () => {
+test('workspace change - watches the new workspace uri and refreshes the source control badge count', async () => {
   await WorkspaceFileWatcher.hydrate()
   getWorkspaceUri.mockReturnValue('file:///other')
   const handleWorkspaceChange = GlobalEventBus.state.listenerMap['workspace.change'][0]
@@ -71,6 +71,7 @@ test('workspace change - watches the new workspace uri', async () => {
     exclude: ['.git', 'node_modules'],
     roots: ['file:///other'],
   })
+  expect(Command.execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
 
 test('watcher events - debounce refresh and forward deleted uris', async () => {


### PR DESCRIPTION
Refreshes the cached source-control activity-bar badge whenever the workspace root changes, so counts from the previous workspace are cleared or replaced. Adds focused regression coverage for the workspace-change listener.