### PR TITLE
feature: validate renderer process chunks

### DIFF
--- a/packages/build/src/parts/BundleWorkers/BundleWorkers.ts
+++ b/packages/build/src/parts/BundleWorkers/BundleWorkers.ts
@@ -6,6 +6,7 @@ import * as Copy from '../Copy/Copy.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Logger from '../Logger/Logger.ts'
 import * as Path from '../Path/Path.ts'
+import * as ValidateRendererProcessArtifacts from '../ValidateRendererProcessArtifacts/ValidateRendererProcessArtifacts.ts'
 
 const workersJsonPath = 'packages/renderer-worker/src/parts/Workers/Workers.json'
 
@@ -57,6 +58,9 @@ export const bundleWorkers = async ({ commitHash, platform, assetDir, version, d
     from: rendererProcessCachePath,
     to: `${toRoot}/packages/renderer-process`,
     ignore: ['static'],
+  })
+  ValidateRendererProcessArtifacts.validateRendererProcessArtifacts({
+    rendererProcessPath: `${toRoot}/packages/renderer-process`,
   })
   const rendererWorkerCachePath = await BundleRendererWorkerCached.bundleRendererWorkerCached({
     commitHash,

--- a/packages/build/src/parts/ValidateRendererProcessArtifacts/ValidateRendererProcessArtifacts.ts
+++ b/packages/build/src/parts/ValidateRendererProcessArtifacts/ValidateRendererProcessArtifacts.ts
@@ -1,0 +1,14 @@
+import { existsSync } from 'node:fs'
+import * as Path from '../Path/Path.ts'
+
+const artifactNames = ['rendererProcessMain.js', 'xterm.js']
+
+export const validateRendererProcessArtifacts = ({ rendererProcessPath }) => {
+  const distPath = Path.join(Path.absolute(rendererProcessPath), 'dist')
+  for (const artifactName of artifactNames) {
+    const artifactPath = Path.join(distPath, artifactName)
+    if (!existsSync(artifactPath)) {
+      throw new Error(`renderer process artifact not found: ${artifactPath}`)
+    }
+  }
+}

--- a/packages/build/test/ValidateRendererProcessArtifacts.test.ts
+++ b/packages/build/test/ValidateRendererProcessArtifacts.test.ts
@@ -1,0 +1,32 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { validateRendererProcessArtifacts } from '../src/parts/ValidateRendererProcessArtifacts/ValidateRendererProcessArtifacts.ts'
+
+test('validates renderer process main and xterm artifacts', async () => {
+  const rendererProcessPath = join(tmpdir(), `lvce-renderer-process-${process.pid}`)
+  const distPath = join(rendererProcessPath, 'dist')
+  try {
+    await mkdir(distPath, { recursive: true })
+    await writeFile(join(distPath, 'rendererProcessMain.js'), '')
+    await writeFile(join(distPath, 'xterm.js'), '')
+
+    expect(() => validateRendererProcessArtifacts({ rendererProcessPath })).not.toThrow()
+  } finally {
+    await rm(rendererProcessPath, { recursive: true, force: true })
+  }
+})
+
+test('throws when the xterm artifact is missing', async () => {
+  const rendererProcessPath = join(tmpdir(), `lvce-renderer-process-missing-${process.pid}`)
+  const distPath = join(rendererProcessPath, 'dist')
+  try {
+    await mkdir(distPath, { recursive: true })
+    await writeFile(join(distPath, 'rendererProcessMain.js'), '')
+
+    expect(() => validateRendererProcessArtifacts({ rendererProcessPath })).toThrow('renderer process artifact not found')
+  } finally {
+    await rm(rendererProcessPath, { recursive: true, force: true })
+  }
+})

--- a/packages/shared-process/src/parts/ExportStatic/ExportStatic.ts
+++ b/packages/shared-process/src/parts/ExportStatic/ExportStatic.ts
@@ -126,6 +126,16 @@ const copyStaticFiles = async (root: any, serverStaticPath: any): Promise<any> =
   await FileSystem.copy(serverStaticPath, Path.join(root, 'dist'))
 }
 
+export const validateRendererProcessArtifacts = ({ commitHash, root }: any): any => {
+  const rendererProcessDistPath = Path.join(root, 'dist', commitHash, 'packages', 'renderer-process', 'dist')
+  for (const artifactName of ['rendererProcessMain.js', 'xterm.js']) {
+    const artifactPath = Path.join(rendererProcessDistPath, artifactName)
+    if (!existsSync(artifactPath)) {
+      throw new Error(`renderer process artifact not found: ${artifactPath}`)
+    }
+  }
+}
+
 const applyOverridesRendererProcess = async ({ commitHash, pathPrefix, root }: any): Promise<any> => {
   await replace(
     Path.join(root, 'dist', commitHash, 'packages', 'renderer-process', 'dist', 'rendererProcessMain.js'),
@@ -720,6 +730,7 @@ export const exportStatic = async ({
   console.time('copyStaticFiles')
   await copyStaticFiles(root, serverStaticPath)
   console.timeEnd('copyStaticFiles')
+  validateRendererProcessArtifacts({ commitHash, root })
 
   console.time('applyOverrides')
   await applyOverrides({

--- a/packages/shared-process/test/ExportStatic.test.ts
+++ b/packages/shared-process/test/ExportStatic.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@jest/globals'
-import { mergeExtensionManifests, transpileFile } from '../src/parts/ExportStatic/ExportStatic.js'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mergeExtensionManifests, transpileFile, validateRendererProcessArtifacts } from '../src/parts/ExportStatic/ExportStatic.js'
 
 test('transpileFile removes typescript annotations', () => {
   const content = `const value: number = 1
@@ -43,4 +46,33 @@ test('mergeExtensionManifests appends local extension when id is new', () => {
   }
 
   expect(mergeExtensionManifests([builtinExtension], [localExtension])).toEqual([builtinExtension, localExtension])
+})
+
+test('validateRendererProcessArtifacts accepts copied renderer process chunks', async () => {
+  const root = join(tmpdir(), `lvce-static-export-${process.pid}`)
+  const commitHash = 'abcdefg'
+  const rendererProcessDistPath = join(root, 'dist', commitHash, 'packages', 'renderer-process', 'dist')
+  try {
+    await mkdir(rendererProcessDistPath, { recursive: true })
+    await writeFile(join(rendererProcessDistPath, 'rendererProcessMain.js'), '')
+    await writeFile(join(rendererProcessDistPath, 'xterm.js'), '')
+
+    expect(() => validateRendererProcessArtifacts({ commitHash, root })).not.toThrow()
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})
+
+test('validateRendererProcessArtifacts rejects a missing xterm chunk', async () => {
+  const root = join(tmpdir(), `lvce-static-export-missing-${process.pid}`)
+  const commitHash = 'abcdefg'
+  const rendererProcessDistPath = join(root, 'dist', commitHash, 'packages', 'renderer-process', 'dist')
+  try {
+    await mkdir(rendererProcessDistPath, { recursive: true })
+    await writeFile(join(rendererProcessDistPath, 'rendererProcessMain.js'), '')
+
+    expect(() => validateRendererProcessArtifacts({ commitHash, root })).toThrow('renderer process artifact not found')
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
 })


### PR DESCRIPTION
Validates that rendererProcessMain.js and its lazy xterm.js sibling are preserved by server, Electron, and static-export packaging.

Adds focused coverage for both the build and shared-process export boundaries.