### PR TITLE
fix: uninstall extensions via trash

### DIFF
--- a/packages/shared-process/src/parts/ExtensionUninstall/ExtensionUninstall.ts
+++ b/packages/shared-process/src/parts/ExtensionUninstall/ExtensionUninstall.ts
@@ -1,16 +1,26 @@
-import { rm } from 'node:fs/promises'
+import { access, rm } from 'node:fs/promises'
 import * as Path from '../Path/Path.ts'
 import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
+import * as Trash from '../Trash/Trash.ts'
 import { VError } from '../VError/VError.ts'
 
 export const uninstall = async (id: any): Promise<any> => {
+  const extensionsPath = PlatformPaths.getExtensionsPath()
+  const extensionPath = Path.join(extensionsPath, id)
   try {
-    const extensionsPath = PlatformPaths.getExtensionsPath()
-    await rm(Path.join(extensionsPath, id), { recursive: true })
+    await access(extensionPath)
   } catch (error) {
-    // if (error.code === 'ENOENT') {
-    //   return
-    // }
+    throw new VError(error, `Failed to uninstall extension "${id}"`)
+  }
+  try {
+    await Trash.trash(extensionPath)
+    return
+  } catch {
+    // Fall back to permanent deletion when the platform trash is unavailable.
+  }
+  try {
+    await rm(extensionPath, { recursive: true })
+  } catch (error) {
     throw new VError(error, `Failed to uninstall extension "${id}"`)
   }
 }

--- a/packages/shared-process/test/ExtensionUninstall.test.ts
+++ b/packages/shared-process/test/ExtensionUninstall.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { join } from 'node:path'
 
 jest.unstable_mockModule('node:fs/promises', () => ({
   access: jest.fn(),
@@ -17,6 +18,7 @@ const fs = await import('node:fs/promises')
 const ExtensionUninstall = await import('../src/parts/ExtensionUninstall/ExtensionUninstall.js')
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
 const Trash = await import('../src/parts/Trash/Trash.js')
+const extensionPath = join('/test/extensions', 'test-author.test-extension')
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -29,7 +31,7 @@ beforeEach(() => {
 test('moves extension to trash', async () => {
   await ExtensionUninstall.uninstall('test-author.test-extension')
 
-  expect(Trash.trash).toHaveBeenCalledWith('/test/extensions/test-author.test-extension')
+  expect(Trash.trash).toHaveBeenCalledWith(extensionPath)
   expect(fs.rm).not.toHaveBeenCalled()
 })
 
@@ -38,7 +40,7 @@ test('permanently deletes extension when moving to trash fails', async () => {
 
   await ExtensionUninstall.uninstall('test-author.test-extension')
 
-  expect(fs.rm).toHaveBeenCalledWith('/test/extensions/test-author.test-extension', {
+  expect(fs.rm).toHaveBeenCalledWith(extensionPath, {
     recursive: true,
   })
 })

--- a/packages/shared-process/test/ExtensionUninstall.test.ts
+++ b/packages/shared-process/test/ExtensionUninstall.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('node:fs/promises', () => ({
+  access: jest.fn(),
+  rm: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
+  getExtensionsPath: jest.fn(() => '/test/extensions'),
+}))
+
+jest.unstable_mockModule('../src/parts/Trash/Trash.js', () => ({
+  trash: jest.fn(),
+}))
+
+const fs = await import('node:fs/promises')
+const ExtensionUninstall = await import('../src/parts/ExtensionUninstall/ExtensionUninstall.js')
+const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
+const Trash = await import('../src/parts/Trash/Trash.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(fs.access).mockResolvedValue(undefined)
+  jest.mocked(fs.rm).mockResolvedValue(undefined)
+  jest.mocked(PlatformPaths.getExtensionsPath).mockReturnValue('/test/extensions')
+  jest.mocked(Trash.trash).mockResolvedValue(undefined)
+})
+
+test('moves extension to trash', async () => {
+  await ExtensionUninstall.uninstall('test-author.test-extension')
+
+  expect(Trash.trash).toHaveBeenCalledWith('/test/extensions/test-author.test-extension')
+  expect(fs.rm).not.toHaveBeenCalled()
+})
+
+test('permanently deletes extension when moving to trash fails', async () => {
+  jest.mocked(Trash.trash).mockRejectedValue(new Error('Trash is unavailable'))
+
+  await ExtensionUninstall.uninstall('test-author.test-extension')
+
+  expect(fs.rm).toHaveBeenCalledWith('/test/extensions/test-author.test-extension', {
+    recursive: true,
+  })
+})
+
+test('throws when moving to trash and permanent deletion fail', async () => {
+  jest.mocked(Trash.trash).mockRejectedValue(new Error('Trash is unavailable'))
+  jest.mocked(fs.rm).mockRejectedValue(new Error('Permission denied'))
+
+  await expect(ExtensionUninstall.uninstall('test-author.test-extension')).rejects.toThrow(
+    new Error('Failed to uninstall extension "test-author.test-extension": Permission denied'),
+  )
+})
+
+test('throws when extension does not exist', async () => {
+  jest.mocked(fs.access).mockRejectedValue(new Error('Extension does not exist'))
+
+  await expect(ExtensionUninstall.uninstall('test-author.test-extension')).rejects.toThrow(
+    new Error('Failed to uninstall extension "test-author.test-extension": Extension does not exist'),
+  )
+  expect(Trash.trash).not.toHaveBeenCalled()
+  expect(fs.rm).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Moves an installed extension directory to the platform trash first and falls back to permanent deletion when trash is unavailable. Preserves a clear uninstall error when neither removal method succeeds and adds regression coverage for every branch.