### PR TITLE
feature: add references mask icon

### DIFF
--- a/static/css/parts/MaskIcon.css
+++ b/static/css/parts/MaskIcon.css
@@ -70,6 +70,11 @@
   mask-image: url(/icons/search.svg);
 }
 
+.MaskIconReferences,
+.IconReferences {
+  mask-image: url(/icons/references.svg);
+}
+
 .MaskIconAccount,
 .IconAccount {
   mask-image: url(/icons/account.svg);


### PR DESCRIPTION
Adds the shared References codicon mask used by the on-demand References activity bar item.