### PR TITLE
fix: load diagnostics after editor render

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -1,3 +1,4 @@
+import * as Command from '../Command/Command.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as WrapEditorCommands from '../WrapEditorCommands/WrapEditorCommands.js'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
@@ -103,10 +104,15 @@ const handleUriChange = async (editor, editorUidOrNewUri, maybeNewUri) => {
   }
 }
 
+const loadContentLater = async (editor) => {
+  await Command.execute('Viewlet.executeViewletCommand', editor.uid, 'updateDiagnostics')
+}
+
 export const getCommands = async () => {
   const commandIds = await EditorWorker.invoke('Editor.getCommandIds')
   Object.assign(Commands, WrapEditorCommands.wrapEditorCommands(commandIds), WrapEditorCommands.wrapEditorCommands(subWidgetCommandIds), {
     handleUriChange,
+    loadContentLater,
     showOverlayMessage,
     hotReload,
   })

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -44,6 +44,14 @@ export const runLoadContentLater = (uid) => {
   void runLoadContentLaterWithErrorHandling(loadContentLater, instance.state)
 }
 
+export const runLoadContentLaterForCreatedViewlets = (commands) => {
+  for (const command of commands) {
+    if (command[0] === 'Viewlet.create' || command[0] === 'Viewlet.createFunctionalRoot') {
+      runLoadContentLater(command[2])
+    }
+  }
+}
+
 const ViewletState = {
   Default: 0,
   ModuleLoaded: 1,
@@ -109,6 +117,7 @@ const runFn = async (instance, id, key, fn, args) => {
     updateDynamicFocusContext(commands)
     ViewletStates.setRenderedState(id, newState)
     await RendererProcess.invoke(/* Viewlet.sendMultiple */ kSendMultiple, /* commands */ commands)
+    runLoadContentLaterForCreatedViewlets(commands)
   } else {
     return fn(instance.state, ...args)
   }
@@ -135,6 +144,7 @@ const runFnWithSideEffect = async (instance, id, key, fn, ...args) => {
   }
   updateDynamicFocusContext(commands)
   await RendererProcess.invoke(/* Viewlet.sendMultiple */ kSendMultiple, /* commands */ commands)
+  runLoadContentLaterForCreatedViewlets(commands)
 }
 
 // TODO maybe wrapViewletCommand should accept module instead of id string
@@ -703,7 +713,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       commands.push(...extraCommands)
       updateDynamicFocusContext(commands)
       await RendererProcess.invoke(/* Viewlet.sendMultiple */ kSendMultiple, /* commands */ commands)
-      runLoadContentLater(viewletUid)
+      runLoadContentLaterForCreatedViewlets(commands)
     } else if (!module.hasFunctionalEvents && shouldRender) {
       const allCommands = [
         ...commands,

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const commandExecute = jest.fn()
 const editorWorkerInvoke = jest.fn()
 const rendererProcessInvoke = jest.fn()
 
@@ -8,6 +9,10 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => {
     invoke: editorWorkerInvoke,
   }
 })
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: commandExecute,
+}))
 
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
   return {
@@ -43,8 +48,18 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
   expect(commands['FindWidget.close']).toBeDefined()
   expect(commands['ColorPicker.handleSliderPointerDown']).toBeDefined()
   expect(commands.handleUriChange).toBeDefined()
+  expect(commands.loadContentLater).toBeDefined()
   expect(commands.showOverlayMessage).toBeDefined()
   expect(commands.hotReload).toBeDefined()
+})
+
+test('loadContentLater requests diagnostics after the initial render', async () => {
+  editorWorkerInvoke.mockResolvedValue([])
+  const commands = await ViewletEditorTextCommands.getCommands()
+
+  await commands.loadContentLater({ uid: 42 })
+
+  expect(commandExecute).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'updateDiagnostics')
 })
 
 test('worker command wrapper invokes editor command, diff, and render', async () => {

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -54,7 +54,12 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
 })
 
 test('loadContentLater requests diagnostics after the initial render', async () => {
-  editorWorkerInvoke.mockResolvedValue([])
+  editorWorkerInvoke.mockImplementation((method) => {
+    if (method === 'Editor.getCommandIds') {
+      return []
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
   const commands = await ViewletEditorTextCommands.getCommands()
 
   await commands.loadContentLater({ uid: 42 })

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -56,6 +56,26 @@ test('runLoadContentLater starts deferred loading once', async () => {
   expect(loadContentLater).toHaveBeenCalledWith(viewletState)
 })
 
+test('runLoadContentLaterForCreatedViewlets starts deferred loading for newly rendered viewlets', async () => {
+  const loadContentLater = jest.fn(async (_state: unknown) => {})
+  const viewletState = { uid: 42 }
+  ViewletStates.set(42, {
+    factory: {
+      Commands: {
+        loadContentLater,
+      },
+    },
+    renderedState: viewletState,
+    state: viewletState,
+  })
+
+  ViewletManager.runLoadContentLaterForCreatedViewlets([['Viewlet.createFunctionalRoot', 'EditorText', 42, true]])
+  await Promise.resolve()
+
+  expect(loadContentLater).toHaveBeenCalledTimes(1)
+  expect(loadContentLater).toHaveBeenCalledWith(viewletState)
+})
+
 test('render adds uid to setPatches command', () => {
   const patches = [{ type: 1 }]
   const mockModule = {


### PR DESCRIPTION
Starts editor diagnostics through the deferred post-render lifecycle hook. The initial editor command batch is sent first, then diagnostics update and rerender the live editor when results arrive.