### PR TITLE
fix: dispatch active editor changes through layout

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -502,6 +502,7 @@ export const commandMap = {
   'Layout.getModuleId': lazy('Layout.getModuleId'),
   'Layout.getPlatform': lazy('Layout.getPlatform'),
   'Layout.getUserInfo': lazy('Layout.getUserInfo'),
+  'Layout.handleActiveEditorChange': lazy('Layout.handleActiveEditorChange'),
   'Layout.handleBadgeCountChange': lazy('Layout.handleBadgeCountChange'),
   'Layout.handleBlur': lazy('Layout.handleBlur'),
   'Layout.handleColorThemeChanged': lazy('Layout.handleColorThemeChanged'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1883,6 +1883,10 @@ export const handleWorkspaceRefresh = async (state: LayoutState, refresh: Worksp
   return callGlobalEvent(state, 'handleWorkspaceRefresh', refresh)
 }
 
+export const handleActiveEditorChange = async (state: LayoutState, activeUri: string) => {
+  return callGlobalEvent(state, 'handleActiveEditorChange', activeUri)
+}
+
 export const handleSettingsChanged = async (state: LayoutState) => {
   await Preferences.hydrate()
   return callGlobalEvent(state, 'handleSettingsChanged')

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -25,6 +25,7 @@ export const Commands = {
 
 export const CommandsWithSideEffects = {
   attachViewlet: ViewletLayout.attachViewlet,
+  handleActiveEditorChange: ViewletLayout.handleActiveEditorChange,
   handleBadgeCountChange: ViewletLayout.handleBadgeCountChange,
   handleColorThemeChanged: ViewletLayout.handleColorThemeChanged,
   handleExtensionsChanged: ViewletLayout.handleExtensionsChanged,

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -133,6 +133,42 @@ test('handleColorThemeChanged forwards the color theme id to viewlets', async ()
   })
 })
 
+test('handleActiveEditorChange forwards the active uri to loaded viewlets', async () => {
+  const handler = jest.fn((state: { uid: number }, activeUri: string) => {
+    return {
+      ...state,
+      activeUri,
+    }
+  })
+  ViewletStates.set('problems', createInstance(1, 'handleActiveEditorChange', handler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleActiveEditorChange(state, 'file:///test.ts')
+
+  expect(handler).toHaveBeenCalledWith({ uid: 1 }, 'file:///test.ts')
+  expect(ViewletManager.render).toHaveBeenCalledTimes(1)
+  expect(result).toEqual({
+    commands: [['render.1']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
+test('handleActiveEditorChange ignores viewlets that are not loaded', async () => {
+  const state = ViewletLayout.create(1)
+
+  const result = await ViewletLayout.handleActiveEditorChange(state, 'file:///test.ts')
+
+  expect(ViewletManager.render).not.toHaveBeenCalled()
+  expect(result).toEqual({
+    commands: [],
+    newState: {
+      ...state,
+    },
+  })
+})
+
 test('handleSettingsChanged hydrates preferences and updates viewlet state', async () => {
   const calls: string[] = []
   hydratePreferences.mockImplementation(async () => {


### PR DESCRIPTION
Dispatch active editor changes through the layout global-event fan-out. Only loaded viewlets with a matching handler are notified, so unopened views are skipped.