### PR TITLE
feature: apply isolated extension content security policies

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
@@ -1,14 +1,19 @@
+import * as ContentSecurityPolicy from '../ContentSecurityPolicy/ContentSecurityPolicy.js'
 import * as Id from '../Id/Id.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as RendererProcessIpcParentType from '../RendererProcessIpcParentType/RendererProcessIpcParentType.js'
 
-export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, workerName = '') => {
+export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, workerName = '', contentSecurityPolicy = '') => {
   const suffix = extensionId ? `: ${extensionId}` : ''
   const fallbackName = Platform.getPlatform() === PlatformType.Electron ? `Extension API (Electron)${suffix}` : `Extension API${suffix}`
   const name = workerName || fallbackName
   const id = Id.create()
+  if (contentSecurityPolicy) {
+    const pathName = new URL(url, 'http://localhost').pathname
+    await ContentSecurityPolicy.set(pathName, contentSecurityPolicy)
+  }
   await RendererProcess.invokeAndTransfer('IpcParent.create', {
     method: RendererProcessIpcParentType.ModuleWorkerWithMessagePort,
     name,

--- a/packages/renderer-worker/test/ContentSecurityPolicy.test.ts
+++ b/packages/renderer-worker/test/ContentSecurityPolicy.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+const state = {
+  platform: PlatformType.Remote,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  state.platform = PlatformType.Remote
+})
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
+  return {
+    getPlatform: jest.fn(() => state.platform),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
+  return {
+    invoke: jest.fn(),
+  }
+})
+
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const ContentSecurityPolicy = await import('../src/parts/ContentSecurityPolicy/ContentSecurityPolicy.js')
+
+test('sets the content security policy on the remote server', async () => {
+  await ContentSecurityPolicy.set('/remote/extensions/sample/main.js', `default-src 'none';`)
+
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('ContentSecurityPolicy.set', '/remote/extensions/sample/main.js', `default-src 'none';`)
+})
+
+test('sets the content security policy in Electron', async () => {
+  state.platform = PlatformType.Electron
+
+  await ContentSecurityPolicy.set('/extensions/sample/main.js', `default-src 'none';`)
+
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('ContentSecurityPolicy.set', '/extensions/sample/main.js', `default-src 'none';`)
+})
+
+test('does not set a dynamic content security policy for static web assets', async () => {
+  state.platform = PlatformType.Web
+
+  await ContentSecurityPolicy.set('/extensions/sample/main.js', `default-src 'none';`)
+
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
@@ -12,6 +12,12 @@ jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/ContentSecurityPolicy/ContentSecurityPolicy.js', () => {
+  return {
+    set: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
   return {
     invokeAndTransfer: jest.fn(),
@@ -24,6 +30,7 @@ jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
   }
 })
 
+const ContentSecurityPolicy = await import('../src/parts/ContentSecurityPolicy/ContentSecurityPolicy.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const LaunchIsolatedExtensionHostWorker = await import('../src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js')
 
@@ -74,4 +81,27 @@ test('launchIsolatedExtensionHostWorker - uses custom worker name', async () => 
       url: '/test/trello/packages/extension/dist/trelloMain.js',
     }),
   )
+})
+
+test('launchIsolatedExtensionHostWorker - applies the extension content security policy before launch', async () => {
+  const port = {}
+  // @ts-ignore
+  ContentSecurityPolicy.set.mockResolvedValue(undefined)
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockResolvedValue(undefined)
+
+  await LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker(
+    port,
+    'builtin.language-features-nvmrc',
+    'http://localhost:3000/remote/extensions/builtin.language-features-nvmrc/dist/languageFeaturesNvmrcMain.js',
+    '',
+    `default-src 'none'; connect-src https://nodejs.org; script-src 'self';`,
+  )
+
+  expect(ContentSecurityPolicy.set).toHaveBeenCalledWith(
+    '/remote/extensions/builtin.language-features-nvmrc/dist/languageFeaturesNvmrcMain.js',
+    `default-src 'none'; connect-src https://nodejs.org; script-src 'self';`,
+  )
+  // @ts-ignore
+  expect(ContentSecurityPolicy.set.mock.invocationCallOrder[0]).toBeLessThan(RendererProcess.invokeAndTransfer.mock.invocationCallOrder[0])
 })


### PR DESCRIPTION
Registers a declared isolated extension CSP before worker startup so Electron and remote server responses enforce it.