### PR TITLE
fix: show cursor for opened search results

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-result-cursor-visible.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-result-cursor-visible.ts
@@ -1,0 +1,20 @@
+export const name = 'viewlet.search-result-cursor-visible'
+
+export const test = async ({ FileSystem, Locator, Search, SideBar, Workspace, expect }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'first line\na')
+  await Workspace.setPath(tmpDir)
+  await SideBar.open('Search')
+  await Search.setValue('a')
+  const results = Locator('.Search .TreeItem')
+  await expect(results).toHaveCount(2)
+
+  // act
+  await results.nth(1).click()
+
+  // assert
+  const cursor = Locator('.EditorCursor')
+  await expect(cursor).toBeVisible()
+  await expect(cursor).toHaveCSS('translate', /^(6|7|8|9|10).*?px 20px$/)
+}

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -63,7 +63,10 @@ export const create = (id, uri, x, y, width, height) => {
   }
 }
 
-const getSavedSelections = (savedState) => {
+const getSavedSelections = (savedState, context) => {
+  if (context?.selections) {
+    return new Uint32Array(context.selections)
+  }
   if (savedState && savedState.selections) {
     return new Uint32Array(savedState.selections)
   }
@@ -114,7 +117,7 @@ export const loadContent = async (state, savedState, context) => {
   const tokenizer = Tokenizer.getTokenizer(languageId)
   const tokenizerId = Id.create()
   TokenizerMap.set(tokenizerId, tokenizer)
-  let savedSelections = getSavedSelections(savedState)
+  const savedSelections = getSavedSelections(savedState, context)
   const savedDeltaY = getSavedDeltaY(savedState)
   state.languageId = languageId
   let newState2 = Editor.setDeltaYFixedValue(state, savedDeltaY)
@@ -132,6 +135,7 @@ export const loadContent = async (state, savedState, context) => {
   if (useFunctionalRendering) {
     await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir)
     await EditorWorker.invoke('Editor.loadContent', id)
+    await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)
   } else {
     await EditorWorker.invoke('Editor.create', {
       assetDir,

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -22,6 +22,10 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetTextEditorContent/GetTextEditorContent.js', () => ({
+  getTextEditorContent: jest.fn(() => 'first line\nsecond line'),
+}))
+
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
   invoke: rendererProcessInvoke,
 }))
@@ -32,6 +36,24 @@ jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
 }))
 
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+
+test('loadContent - restores the selection supplied by the opener', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.diff2':
+      case 'Editor.render2':
+        return []
+      default:
+        return undefined
+    }
+  })
+  const state = ViewletEditorText.create(1, '/test/file.txt', 0, 0, 800, 600)
+  const selections = new Uint32Array([1, 2, 1, 8])
+
+  await ViewletEditorText.loadContent(state, { selections: [0, 0, 0, 0] }, { selections })
+
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, selections)
+})
 
 test('dispose', async () => {
   const commands = [['Viewlet.dispose', 2]]


### PR DESCRIPTION
Restore opener-provided editor selections when loading functional text editors.

Add regression coverage that clicks a search match and verifies the cursor is visible at the selected location.