### PR TITLE
feature: add search editor context line controls

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-context-lines.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-context-lines.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-context-lines'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Locator('.ActivityBarItem[title="Search"]').click()
+
+  await expect(Locator('#SideBar input[name="ContextLines"]')).toHaveCount(0)
+  await expect(Locator('#SideBar button[name="ToggleContextLines"]')).toHaveCount(0)
+
+  await Locator('#SideBar button[title="Open New Search Editor"]').click()
+
+  const contextLinesInput = Locator('#Main input[name="ContextLines"]')
+  const toggleContextLines = Locator('#Main button[name="ToggleContextLines"]')
+  await expect(contextLinesInput).toBeVisible()
+  await expect(contextLinesInput).toHaveValue('1')
+  await expect(toggleContextLines).toBeVisible()
+  await expect(toggleContextLines).toHaveAttribute('aria-checked', 'false')
+
+  await toggleContextLines.click()
+  await expect(toggleContextLines).toHaveAttribute('aria-checked', 'true')
+}

--- a/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearch.ts
+++ b/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearch.ts
@@ -14,6 +14,7 @@ export const create = (id: any, uri: string, x: number, y: number, width: number
     commands: [],
     actionsDom: [],
     assetDir: AssetDir.assetDir,
+    isSearchEditor: uri.startsWith('search-editor://'),
     platform: Platform.getPlatform(),
   }
 }
@@ -35,6 +36,7 @@ const doCreate = async (state: any): Promise<void> => {
     value,
     replacement,
     state.platform,
+    state.isSearchEditor,
   )
 }
 

--- a/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearchTypes.ts
+++ b/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearchTypes.ts
@@ -7,5 +7,6 @@ export interface SearchState {
   readonly height: number
   readonly actionsDom: readonly any[]
   readonly assetDir: string
+  readonly isSearchEditor: boolean
   readonly platform: number
 }

--- a/packages/renderer-worker/test/ViewletSearch.test.ts
+++ b/packages/renderer-worker/test/ViewletSearch.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
+  assetDir: '/test-assets',
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 2),
+}))
+
+jest.unstable_mockModule('../src/parts/TextSearchViewWorker/TextSearchViewWorker.js', () => ({
+  invoke: jest.fn(async (command) => {
+    if (command === 'TextSearch.renderActions') {
+      return []
+    }
+    return []
+  }),
+  restart: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
+  state: {
+    workspacePath: '/test-workspace',
+  },
+}))
+
+const TextSearchViewWorker = await import('../src/parts/TextSearchViewWorker/TextSearchViewWorker.js')
+const ViewletSearch = await import('../src/parts/ViewletSearch/ViewletSearch.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('create identifies sidebar search', () => {
+  const state = ViewletSearch.create(1, 'Search', 10, 20, 800, 600)
+
+  expect(state.isSearchEditor).toBe(false)
+})
+
+test('create identifies search editors', () => {
+  const state = ViewletSearch.create(1, 'search-editor://1/Search', 10, 20, 800, 600)
+
+  expect(state.isSearchEditor).toBe(true)
+})
+
+test('loadContent passes search editor mode to the text search view', async () => {
+  const state = ViewletSearch.create(1, 'search-editor://1/Search', 10, 20, 800, 600)
+
+  await ViewletSearch.loadContent(state, {})
+
+  expect(TextSearchViewWorker.invoke).toHaveBeenNthCalledWith(
+    1,
+    'TextSearch.create',
+    1,
+    10,
+    20,
+    800,
+    600,
+    '/test-workspace',
+    '/test-assets',
+    22,
+    '',
+    '',
+    2,
+    true,
+  )
+})

--- a/static/css/parts/MaskIcon.css
+++ b/static/css/parts/MaskIcon.css
@@ -405,6 +405,10 @@
   mask-image: url(/icons/list-tree.svg);
 }
 
+.MaskIconListSelection {
+  mask-image: url(/icons/list-selection.svg);
+}
+
 .MaskIconProgress {
   mask-image: url(/icons/progress.svg);
 }

--- a/static/css/parts/SearchField.css
+++ b/static/css/parts/SearchField.css
@@ -11,6 +11,11 @@
   flex: 1;
 }
 
+.SearchEditorContextLinesInput {
+  flex: 0 0 50px;
+  width: 50px;
+}
+
 .SearchField {
   display: flex;
   border: 1px solid var(--InputBoxBorder, rgb(55, 65, 63));


### PR DESCRIPTION
Adds VS Code-style context line controls to Search Editor only.

- forwards Search Editor mode into text-search-view
- styles the context line input and list-selection toggle icon
- adds renderer unit coverage and Search Editor e2e coverage

The controls currently update only text-search-view state, as requested.