### PR TITLE
test: cover source control activity bar clicks

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-nested-icon.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-nested-icon.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.activity-bar-source-control-nested-icon'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ expect, Locator, SideBar }) => {
+  const sourceControlItem = Locator('.ActivityBarItem[title="Source Control"]')
+  await SideBar.open('Explorer')
+
+  await sourceControlItem.click()
+  await waitFor(() => expect(sourceControlItem).toHaveAttribute('aria-selected', 'true'))
+
+  const sourceControlIcon = sourceControlItem.locator('.MaskIconSourceControl')
+  await waitFor(() => expect(sourceControlIcon).toBeVisible())
+  await sourceControlIcon.click()
+  await waitFor(() => expect(sourceControlItem).toHaveAttribute('aria-selected', 'false'))
+}

--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-repeated.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-repeated.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.activity-bar-source-control-repeated'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ expect, Locator, SideBar }) => {
+  const sourceControlItem = Locator('.ActivityBarItem[title="Source Control"]')
+  const sourceControlView = Locator('.Viewlet.SourceControl')
+
+  await SideBar.open('Explorer')
+  await sourceControlItem.click()
+  await waitFor(() => expect(sourceControlItem).toHaveAttribute('aria-selected', 'true'))
+  await waitFor(() => expect(sourceControlView).toBeVisible())
+
+  await SideBar.open('Explorer')
+  await waitFor(() => expect(sourceControlItem).toHaveAttribute('aria-selected', 'false'))
+  await sourceControlItem.click()
+  await waitFor(() => expect(sourceControlItem).toHaveAttribute('aria-selected', 'true'))
+  await waitFor(() => expect(sourceControlView).toBeVisible())
+}


### PR DESCRIPTION
## Summary
- exercise repeated Source Control activity bar switching
- click the selected Source Control nested icon and verify the sidebar hides
- guard both direct and nested click routing regressions

## Tests
- targeted browser E2E: 2 passed
- focused eslint and prettier checks
- extension-host-worker-tests TypeScript check