### PR TITLE
fix: preserve initial editor render

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -135,7 +135,13 @@ export const loadContent = async (state, savedState, context) => {
   if (useFunctionalRendering) {
     await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir)
     await EditorWorker.invoke('Editor.loadContent', id)
+    const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)
+    const selectionRender = await rerender(newState2)
+    return {
+      ...selectionRender,
+      commands: [...initialRender.commands, ...selectionRender.commands],
+    }
   } else {
     await EditorWorker.invoke('Editor.create', {
       assetDir,

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -38,11 +38,15 @@ jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
 
 test('loadContent - restores the selection supplied by the opener', async () => {
+  const initialCommands = [['Viewlet.setDom2']]
+  const selectionCommands = [['Viewlet.setPatches']]
+  let renderCount = 0
   editorWorkerInvoke.mockImplementation((method) => {
     switch (method) {
       case 'Editor.diff2':
-      case 'Editor.render2':
         return []
+      case 'Editor.render2':
+        return renderCount++ === 0 ? initialCommands : selectionCommands
       default:
         return undefined
     }
@@ -50,9 +54,19 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   const state = ViewletEditorText.create(1, '/test/file.txt', 0, 0, 800, 600)
   const selections = new Uint32Array([1, 2, 1, 8])
 
-  await ViewletEditorText.loadContent(state, { selections: [0, 0, 0, 0] }, { selections })
+  const newState = await ViewletEditorText.loadContent(state, { selections: [0, 0, 0, 0] }, { selections })
 
   expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, selections)
+  expect(editorWorkerInvoke.mock.calls.map(([method]) => method).filter((method) => method.startsWith('Editor.'))).toEqual([
+    'Editor.create2',
+    'Editor.loadContent',
+    'Editor.diff2',
+    'Editor.render2',
+    'Editor.setSelections2',
+    'Editor.diff2',
+    'Editor.render2',
+  ])
+  expect(newState.commands).toEqual([...initialCommands, ...selectionCommands])
 })
 
 test('dispose', async () => {

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -57,7 +57,10 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   const newState = await ViewletEditorText.loadContent(state, { selections: [0, 0, 0, 0] }, { selections })
 
   expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, selections)
-  expect(editorWorkerInvoke.mock.calls.map(([method]) => method).filter((method) => method.startsWith('Editor.'))).toEqual([
+  const editorMethods = editorWorkerInvoke.mock.calls
+    .map(([method]) => method)
+    .filter((method): method is string => typeof method === 'string' && method.startsWith('Editor.'))
+  expect(editorMethods).toEqual([
     'Editor.create2',
     'Editor.loadContent',
     'Editor.diff2',


### PR DESCRIPTION
Opening an editor with restored selections replaced the pending initial editor state before it could render, leaving only a blank tab. Render and retain the initial editor commands before applying the restored selection, then append the selection render commands.