### PR TITLE
feature: send message port to main process

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -368,6 +368,7 @@ export const commandMap = {
   'SendMessagePortToExtensionHostWorker.sendMessagePortToTextSearchWorker': lazy(
     'SendMessagePortToExtensionHostWorker.sendMessagePortToTextSearchWorker',
   ),
+  'SendMessagePortToMainProcess.sendMessagePortToMainProcess': lazy('SendMessagePortToMainProcess.sendMessagePortToMainProcess'),
   'SendMessagePortToRendererProcess.sendMessagePortToRendererProcess': lazy('SendMessagePortToRendererProcess.sendMessagePortToRendererProcess'),
   'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker': lazy(
     'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker',

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -166,6 +166,8 @@ export const load = (moduleId) => {
       return import('../ExtensionHost/ExtensionHostWorkerContentSecurityPolicy.ipc.js')
     case ModuleId.SendMessagePortToElectron:
       return import('../SendMessagePortToElectron/SendMessagePortToElectron.ipc.js')
+    case ModuleId.SendMessagePortToMainProcess:
+      return import('../SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.js')
     case ModuleId.OffscreenCanvas:
       return import('../OffscreenCanvas/OffscreenCanvas.ipc.js')
     case ModuleId.Timeout:

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -113,3 +113,4 @@ export const OAuthServer = 147
 export const LaunchIsolatedExtensionHostWorker = 148
 export const ExtensionNodeRpc = 149
 export const License = 150
+export const SendMessagePortToMainProcess = 151

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -192,6 +192,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.ExtensionHostWorkerContentSecurityPolicy
     case 'SendMessagePortToElectron':
       return ModuleId.SendMessagePortToElectron
+    case 'SendMessagePortToMainProcess':
+      return ModuleId.SendMessagePortToMainProcess
     case 'ExtensionHostBraceCompletion':
       return ModuleId.ExtensionHostBraceCompletion
     case 'OffscreenCanvas':

--- a/packages/renderer-worker/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.js
@@ -1,0 +1,7 @@
+import * as SendMessagePortToMainProcess from './SendMessagePortToMainProcess.js'
+
+export const name = 'SendMessagePortToMainProcess'
+
+export const Commands = {
+  sendMessagePortToMainProcess: SendMessagePortToMainProcess.sendMessagePortToMainProcess,
+}

--- a/packages/renderer-worker/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.js
@@ -1,0 +1,9 @@
+import * as Assert from '../Assert/Assert.ts'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+export const sendMessagePortToMainProcess = async (port, initialCommand, ipcId) => {
+  Assert.object(port)
+  Assert.string(initialCommand)
+  Assert.number(ipcId)
+  await SharedProcess.invokeAndTransfer('SendMessagePortToMainProcess.sendMessagePortToMainProcess', port, initialCommand, ipcId)
+}

--- a/packages/renderer-worker/test/ModuleMap.test.ts
+++ b/packages/renderer-worker/test/ModuleMap.test.ts
@@ -11,6 +11,7 @@ test('getModule - not found', () => {
 test('getModule', () => {
   expect(ModuleMap.getModuleId('About.showAbout')).toBe(ModuleId.About)
   expect(ModuleMap.getModuleId('License.openLicense')).toBe(ModuleId.License)
+  expect(ModuleMap.getModuleId('SendMessagePortToMainProcess.sendMessagePortToMainProcess')).toBe(ModuleId.SendMessagePortToMainProcess)
 })
 
 test('getModule - layout runtime context', async () => {

--- a/packages/renderer-worker/test/SendMessagePortToMainProcess.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToMainProcess.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invokeAndTransfer: jest.fn(),
+}))
+
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const SendMessagePortToMainProcess = await import('../src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.js')
+
+test('sendMessagePortToMainProcess', async () => {
+  const port = {}
+
+  await SendMessagePortToMainProcess.sendMessagePortToMainProcess(port, 'HandleMessagePort.handleMessagePort', 42)
+
+  expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledWith(
+    'SendMessagePortToMainProcess.sendMessagePortToMainProcess',
+    port,
+    'HandleMessagePort.handleMessagePort',
+    42,
+  )
+})

--- a/packages/shared-process/src/parts/Module/Module.ts
+++ b/packages/shared-process/src/parts/Module/Module.ts
@@ -140,6 +140,8 @@ export const load = (moduleId: any): any => {
       return import('../RecentlyOpened/RecentlyOpened.ipc.ts')
     case ModuleId.Screen:
       return import('../Screen/Screen.ipc.ts')
+    case ModuleId.SendMessagePortToMainProcess:
+      return import('../SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.ts')
     case ModuleId.TemporaryMessagePort:
       return import('../TemporaryMessagePort/TemporaryMessagePort.ipc.ts')
     case ModuleId.Terminal:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.ts
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.ts
@@ -79,3 +79,4 @@ export const Exec = 83
 export const PlatformPaths = 84
 export const HandleMessagePortForAuthProcess = 86
 export const LanguageServer = 87
+export const SendMessagePortToMainProcess = 88

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -320,6 +320,8 @@ export const getModuleId = (commandId: any): any => {
     case 'Screen.getHeight':
     case 'Screen.getWidth':
       return ModuleId.Screen
+    case 'SendMessagePortToMainProcess.sendMessagePortToMainProcess':
+      return ModuleId.SendMessagePortToMainProcess
     case 'TemporaryMessagePort.getPortTuple2':
     case 'TemporaryMessagePort.getPortTuple3':
     case 'TemporaryMessagePort.handlePorts':

--- a/packages/shared-process/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.ts
+++ b/packages/shared-process/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.ts
@@ -1,0 +1,7 @@
+import * as SendMessagePortToMainProcess from './SendMessagePortToMainProcess.ts'
+
+export const name = 'SendMessagePortToMainProcess'
+
+export const Commands = {
+  sendMessagePortToMainProcess: SendMessagePortToMainProcess.sendMessagePortToMainProcess,
+}

--- a/packages/shared-process/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ts
+++ b/packages/shared-process/src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.ts
@@ -1,0 +1,9 @@
+import * as Assert from '../Assert/Assert.ts'
+import * as MainProcess from '../MainProcess/MainProcess.ts'
+
+export const sendMessagePortToMainProcess = async (port: any, initialCommand: string, ipcId: number): Promise<void> => {
+  Assert.object(port)
+  Assert.string(initialCommand)
+  Assert.number(ipcId)
+  await MainProcess.invokeAndTransfer(initialCommand, port, ipcId)
+}

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -5,3 +5,7 @@ import * as ModuleMap from '../src/parts/ModuleMap/ModuleMap.js'
 test('getModuleId - Platform.getConfigJsonPath', () => {
   expect(ModuleMap.getModuleId('Platform.getConfigJsonPath')).toBe(ModuleId.Platform)
 })
+
+test('getModuleId - SendMessagePortToMainProcess.sendMessagePortToMainProcess', () => {
+  expect(ModuleMap.getModuleId('SendMessagePortToMainProcess.sendMessagePortToMainProcess')).toBe(ModuleId.SendMessagePortToMainProcess)
+})

--- a/packages/shared-process/test/SendMessagePortToMainProcess.test.ts
+++ b/packages/shared-process/test/SendMessagePortToMainProcess.test.ts
@@ -1,0 +1,17 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
+  invokeAndTransfer: jest.fn(),
+}))
+
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.js')
+const SendMessagePortToMainProcess = await import('../src/parts/SendMessagePortToMainProcess/SendMessagePortToMainProcess.js')
+
+test('sendMessagePortToMainProcess', async () => {
+  const port = {}
+
+  await SendMessagePortToMainProcess.sendMessagePortToMainProcess(port, 'HandleMessagePort.handleMessagePort', 42)
+
+  expect(MainProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(MainProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', port, 42)
+})


### PR DESCRIPTION
Routes message ports from renderer-worker through shared-process to main-process with a generic command, enabling process-explorer to connect directly without its specialized shared-process RPC path.