### PR TITLE
feature: render dynamic extension view css

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -9,6 +9,7 @@ import { getPlatform } from '../Platform/Platform.js'
 import type { ViewletExtensionViewState } from './ViewletExtensionViewState.ts'
 
 interface ViewRenderResult {
+  readonly css?: string
   readonly dom?: readonly unknown[]
   readonly focusSelector?: string
   readonly patches?: readonly unknown[]
@@ -72,6 +73,13 @@ const getScrollPositionCommands = (state: ViewletExtensionViewState, result: Vie
   return [['Viewlet.setProperty', state.uid, selector, 'scrollTop', scrollTop]]
 }
 
+const getCssCommands = (state: ViewletExtensionViewState, result: ViewRenderResult): readonly (readonly unknown[])[] => {
+  if (typeof result.css !== 'string') {
+    return []
+  }
+  return [['Viewlet.setCss', state.uid, result.css]]
+}
+
 const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRenderResult | undefined): ViewletExtensionViewState => {
   if (!result) {
     return {
@@ -83,7 +91,7 @@ const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRe
   }
   return {
     ...state,
-    commands: getScrollPositionCommands(state, result),
+    commands: [...getScrollPositionCommands(state, result), ...getCssCommands(state, result)],
     dom: result.type === 'setDom' ? result.dom || [] : state.dom,
     error: undefined,
     focusSelector: typeof result.focusSelector === 'string' ? result.focusSelector : '',

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
@@ -189,6 +189,39 @@ test('handleClick forwards rendered scroll position as a renderer process comman
   expect(newState.commands).toEqual([['Viewlet.setProperty', 1, '.Messages', 'scrollTop', 9_999_999]])
 })
 
+test('loadContent forwards dynamic css without replacing contributed css', async () => {
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    css: '.Testing { --DetailWidth: 360px; }',
+    dom: [],
+    type: 'setDom',
+  })
+  const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
+
+  const newState = await ViewletExtensionView.loadContent(state, undefined)
+
+  expect(newState.css).toBe('.Testing { color: red; }')
+  expect(newState.cssId).toBe('ExtensionView:sample.views.testing')
+  expect(newState.commands).toEqual([['Viewlet.setCss', 1, '.Testing { --DetailWidth: 360px; }']])
+})
+
+test('handleClick forwards updated dynamic css', async () => {
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    css: '.Testing { --DetailWidth: 400px; }',
+    patches: [],
+    type: 'setPatches',
+  })
+  const state = {
+    ...ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100),
+    kind: 'virtualDom',
+  }
+
+  const newState = await ViewletExtensionView.handleClick(state, 'resize')
+
+  expect(newState.commands).toEqual([['Viewlet.setCss', 1, '.Testing { --DetailWidth: 400px; }']])
+})
+
 test('loadContent stores rendered sidebar actions', async () => {
   // @ts-ignore
   ExtensionManagementWorker.invoke.mockImplementation(async (method) => {


### PR DESCRIPTION
Forwards dynamic CSS returned by extension views to a separate per-instance stylesheet while preserving contributed static CSS.