### PR TITLE
fix: style extension size link via css

### DIFF
--- a/static/css/parts/AdditionalDetails.css
+++ b/static/css/parts/AdditionalDetails.css
@@ -81,3 +81,9 @@
   contain: content;
   margin: 0;
 }
+
+.MoreInfoEntryValue.Link {
+  color: var(--vscode-textLink-foreground, #3794ff);
+  cursor: pointer;
+  text-decoration: none;
+}


### PR DESCRIPTION
Styles extension detail size links through the existing MoreInfoEntryValue and Link classes, preserving the link color, pointer cursor, and no-underline appearance without inline CSS.