### PR TITLE
fix: update simple browser url after navigation

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -255,6 +255,7 @@ export const handleDidNavigate = (state, url) => {
   return {
     ...state,
     iframeSrc: url,
+    inputValue: url,
     isLoading: false,
   }
 }

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -141,8 +141,16 @@ test('handleWillNavigate', () => {
 test('handleDidNavigate', () => {
   const state = { ...ViewletSimpleBrowser.create(), isLoading: true }
   // @ts-ignore
-  expect(ViewletSimpleBrowser.handleDidNavigate(state, 'https://example.com', false, false)).toMatchObject({
+  const newState = ViewletSimpleBrowser.handleDidNavigate(state, 'https://example.com/one', false, false)
+  expect(newState).toMatchObject({
+    iframeSrc: 'https://example.com/one',
+    inputValue: 'https://example.com/one',
     isLoading: false,
+  })
+  // @ts-ignore
+  expect(ViewletSimpleBrowser.handleDidNavigate(newState, 'https://example.com/two', false, false)).toMatchObject({
+    iframeSrc: 'https://example.com/two',
+    inputValue: 'https://example.com/two',
   })
 })
 


### PR DESCRIPTION
Update the Simple Browser URL input whenever the active page navigates, including repeated in-page link navigations. Add focused state-transition coverage for successive URLs.