### PR TITLE
fix: highlight selected source control activity item

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-selected-with-badge.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-selected-with-badge.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.activity-bar-source-control-selected-with-badge'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ Command, expect, Locator, SideBar }) => {
+  const sourceControlItem = Locator('.ActivityBarItem[title="Source Control"]')
+  const badge = sourceControlItem.locator('.ActivityBarItemBadge')
+  await Command.execute('Layout.setBadgeCount', 'Source Control', 2)
+  await SideBar.open('Explorer')
+
+  await sourceControlItem.click()
+  await waitFor(() => expect(sourceControlItem).toHaveAttribute('aria-selected', 'true'))
+
+  await expect(badge).toHaveText('2')
+  await expect(sourceControlItem).toHaveCSS('background-color', 'rgb(31, 39, 39)')
+}

--- a/static/css/parts/ActivityBarItem.css
+++ b/static/css/parts/ActivityBarItem.css
@@ -22,12 +22,12 @@
   color: var(--ActivityBarActiveForeground);
 }
 
-.ActivityBarItemSelected {
-  background: var(--ActivityBarActiveBackground);
-}
-
 .ActivityBarItemNested {
   background: var(--ActivityBarBackground);
+}
+
+.ActivityBarItemSelected {
+  background: var(--ActivityBarActiveBackground);
 }
 
 .ActivityBarItem:focus-visible {


### PR DESCRIPTION
Fix the activity bar CSS cascade so a selected badge-bearing Source Control item keeps the active background. Add an end-to-end regression test covering the selected Source Control item with a change-count badge.