### PR TITLE
fix: show extension detail feature sash

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -78,6 +78,26 @@ test('bundleCss preserves the locations flex growth', async () => {
   }
 }, 30_000)
 
+test('bundleCss preserves the extension detail sash divider', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletExtensionDetail.css'), 'utf8')
+
+    expect(css).toContain(`.ExtensionDetail .Sash {
+  border-left: 1px solid var(--SashBorder, gray);
+  position: relative;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss preserves readable table links and invalid cell squiggles', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletExtensionDetail.css
+++ b/static/css/parts/ViewletExtensionDetail.css
@@ -123,5 +123,6 @@
 
 /* TODO change this maybe */
 .ExtensionDetail .Sash {
+  border-left: 1px solid var(--SashBorder, gray);
   position: relative;
 }


### PR DESCRIPTION
## Summary

- show a theme-aware divider for the extension detail Features sash
- preserve the existing resize hit area and add CSS bundle regression coverage