### PR TITLE
feature: align builtin extension label with VS Code

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -104,6 +104,27 @@ test('bundleCss preserves readable table links and invalid cell squiggles', asyn
   }
 }, 30_000)
 
+test('bundleCss preserves the builtin extension label style', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletExtensionDetailHeader.css'), 'utf8')
+
+    expect(css).toContain(`.ExtensionDetailNameBadge {
+  font-size: 10px;
+  font-style: italic;
+  margin-left: 10px;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss preserves the running extensions hover styles', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletExtensionDetailHeader.css
+++ b/static/css/parts/ViewletExtensionDetailHeader.css
@@ -27,21 +27,12 @@
   white-space: nowrap;
   overflow: hidden;
   margin: 0;
-  gap: 10px;
 }
 
 .ExtensionDetailNameBadge {
-  background: var(--BadgeBackground, color-mix(in srgb, var(--WorkbenchForeground) 14%, transparent));
-  border-radius: 2px;
-  color: var(--BadgeForeground, var(--WorkbenchForeground));
-  display: inline-flex;
   font-size: 10px;
   font-style: italic;
-  font-weight: 600;
-  line-height: 1.4;
-  padding: 1px 6px;
-  contain: content;
-  vertical-align: middle;
+  margin-left: 10px;
 }
 
 .ExtensionDetailDescription {


### PR DESCRIPTION
Summary:
- match the extension detail builtin label styling used by VS Code
- add 10px of left spacing between the extension name and label
- cover the bundled CSS output with a regression test