### PR TITLE
fix: reset disabled extension color theme

### DIFF
--- a/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
@@ -1,8 +1,10 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as Command from '../Command/Command.js'
 import * as Css from '../Css/Css.js'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.js'
 import * as GetColorThemeCss from '../GetColorThemeCss/GetColorThemeCss.js'
+import * as GetColorThemeNames from '../GetColorThemeNames/GetColorThemeNames.js'
 import * as GetMetaThemeColor from '../GetMetaThemeColor/GetMetaThemeColor.js'
 import * as Meta from '../Meta/Meta.js'
 import * as Platform from '../Platform/Platform.js'
@@ -84,6 +86,17 @@ const applyPreferredColorTheme = async () => {
 }
 
 export const reload = async () => {
+  const colorThemeId = getPreferredColorTheme()
+  if (colorThemeId !== FALLBACK_COLOR_THEME_ID) {
+    const colorThemeNames = await GetColorThemeNames.getColorThemeNames(AssetDir.assetDir, Platform.getPlatform())
+    if (!colorThemeNames.includes(colorThemeId)) {
+      const error = await setColorTheme(FALLBACK_COLOR_THEME_ID)
+      if (error) {
+        throw error
+      }
+      return
+    }
+  }
   await applyPreferredColorTheme()
 }
 

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -27,6 +27,7 @@ export const doInvalidateExtensionsCache = async () => {
 export const handleExtensionsCacheInvalidated = async () => {
   try {
     await Command.execute('KeyBindings.hydrate')
+    await Command.execute('ColorTheme.reload')
     await Command.execute('Layout.handleExtensionsChanged')
   } catch {
     // ignore

--- a/packages/renderer-worker/test/ColorTheme.test.ts
+++ b/packages/renderer-worker/test/ColorTheme.test.ts
@@ -30,19 +30,36 @@ jest.unstable_mockModule('../src/parts/GetColorThemeCss/GetColorThemeCss.js', ()
   }),
 }))
 
+jest.unstable_mockModule('../src/parts/GetColorThemeNames/GetColorThemeNames.js', () => ({
+  getColorThemeNames: jest.fn(async () => ['cobalt2', 'slime']),
+}))
+
 const ColorTheme = await import('../src/parts/ColorTheme/ColorTheme.js')
 const Command = await import('../src/parts/Command/Command.js')
 const Css = await import('../src/parts/Css/Css.js')
 const ErrorHandling = await import('../src/parts/ErrorHandling/ErrorHandling.js')
 const GetColorThemeCss = await import('../src/parts/GetColorThemeCss/GetColorThemeCss.js')
+const GetColorThemeNames = await import('../src/parts/GetColorThemeNames/GetColorThemeNames.js')
 const IsTest = await import('../src/parts/IsTest/IsTest.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
 test('reload applies slime when no color theme is selected', async () => {
   await ColorTheme.reload()
 
+  expect(GetColorThemeNames.getColorThemeNames).not.toHaveBeenCalled()
   expect(GetColorThemeCss.getColorThemeCss).toHaveBeenCalledWith('slime')
   expect(Css.addCssStyleSheet).toHaveBeenCalledWith('ContributedColorTheme', ':root { --theme-id: "slime"; }')
+})
+
+test('reload switches to slime when the selected color theme is no longer contributed', async () => {
+  Preferences.state['workbench.colorTheme'] = 'disabled-theme'
+
+  await ColorTheme.reload()
+
+  expect(GetColorThemeCss.getColorThemeCss).not.toHaveBeenCalledWith('disabled-theme')
+  expect(GetColorThemeCss.getColorThemeCss).toHaveBeenCalledWith('slime')
+  expect(Preferences.state['workbench.colorTheme']).toBe('slime')
+  expect(Command.execute).toHaveBeenCalledWith('Layout.handleColorThemeChanged', 'slime')
 })
 
 test('hydrate falls back to slime when the selected color theme cannot be loaded', async () => {

--- a/packages/renderer-worker/test/ExtensionManagement.test.ts
+++ b/packages/renderer-worker/test/ExtensionManagement.test.ts
@@ -63,7 +63,8 @@ test('handleExtensionsCacheInvalidated refreshes renderer state without invalida
 
   expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
   expect(Command.execute).toHaveBeenNthCalledWith(1, 'KeyBindings.hydrate')
-  expect(Command.execute).toHaveBeenNthCalledWith(2, 'Layout.handleExtensionsChanged')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'ColorTheme.reload')
+  expect(Command.execute).toHaveBeenNthCalledWith(3, 'Layout.handleExtensionsChanged')
 })
 
 test('cache invalidation commands handle notifications without invalidating again', () => {


### PR DESCRIPTION
When extension state changes, re-check whether the saved color theme is still contributed. If its provider was disabled, apply and persist the default slime theme and notify layout consumers.