### PR TITLE
fix: improve view load errors

### DIFF
--- a/packages/renderer-worker/src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js
+++ b/packages/renderer-worker/src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js
@@ -1,0 +1,18 @@
+import * as PrettyError from '../PrettyError/PrettyError.js'
+
+const isNonEmptyString = (value) => {
+  return typeof value === 'string' && value.length > 0
+}
+
+const getMessage = (error) => {
+  if (error?.type && error?.message) {
+    const prefix = `${error.type}: `
+    return error.message.startsWith(prefix) ? error.message : `${prefix}${error.message}`
+  }
+  return PrettyError.getMessage(error)
+}
+
+export const getViewletErrorMessage = (error) => {
+  const message = getMessage(error)
+  return [message, error?.codeFrame, error?.stack].filter(isNonEmptyString).join('\n\n')
+}

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -24,7 +24,11 @@ interface CreateViewInstanceSuccess {
 }
 
 interface CreateViewInstanceError {
-  readonly error: unknown
+  readonly error: {
+    readonly message: string
+    readonly name: string
+    readonly stack?: string
+  }
   readonly ok: false
 }
 
@@ -34,6 +38,15 @@ interface ViewAction {
   readonly command: string
   readonly icon: string
   readonly title: string
+}
+
+const restoreError = (serializedError: CreateViewInstanceError['error']): Error => {
+  const error = new Error(serializedError.message)
+  error.name = serializedError.name
+  if (serializedError.stack) {
+    error.stack = serializedError.stack
+  }
+  return error
 }
 
 const getCssId = (view: ExtensionView): string => {
@@ -93,7 +106,6 @@ const renderVirtualDomResult = (state: ViewletExtensionViewState, result: ViewRe
     ...state,
     commands: [...getScrollPositionCommands(state, result), ...getCssCommands(state, result)],
     dom: result.type === 'setDom' ? result.dom || [] : state.dom,
-    error: undefined,
     focusSelector: typeof result.focusSelector === 'string' ? result.focusSelector : '',
     patches: result.type === 'setPatches' ? result.patches || [] : [],
     title: typeof result.title === 'string' ? result.title : state.title,
@@ -193,18 +205,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
     )
     const createResult = result as CreateViewInstanceResult
     if (createResult.ok === false) {
-      return {
-        ...stateWithViewId,
-        actionsDom: [],
-        commands: [],
-        css,
-        cssId,
-        error: createResult.error,
-        eventListeners,
-        kind: view.kind,
-        patches: [],
-        title,
-      }
+      throw restoreError(createResult.error)
     }
     const renderResult = createResult.ok === true ? createResult.result : (result as ViewRenderResult)
     const initialState = {

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -6,7 +6,6 @@ export interface ViewletExtensionViewState {
   readonly csp: string
   readonly credentialless: boolean
   readonly dom: readonly unknown[]
-  readonly error?: unknown
   readonly eventListeners: readonly unknown[]
   readonly focusSelector: string
   readonly height: number

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -4,6 +4,7 @@ import * as Command from '../Command/Command.js'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.js'
 import { CancelationError } from '../Errors/CancelationError.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
+import * as GetViewletErrorMessage from '../GetViewletErrorMessage/GetViewletErrorMessage.js'
 import * as Id from '../Id/Id.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 import * as MenuEntriesRegistryState from '../MenuEntriesRegistryState/MenuEntriesRegistryState.js'
@@ -780,7 +781,8 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
         // TODO
         // const errorCommands=
       } else {
-        commands.push(['Viewlet.send', /* id */ viewletUid, 'setMessage', /* message */ `${error}`])
+        const message = GetViewletErrorMessage.getViewletErrorMessage(prettyError)
+        commands.push(['Viewlet.send', /* id */ viewletUid, 'setMessage', message])
         // @ts-ignore
         if (viewlet.append) {
           commands.push([kAppend, parentUid, viewletUid])

--- a/packages/renderer-worker/test/GetViewletErrorMessage.test.ts
+++ b/packages/renderer-worker/test/GetViewletErrorMessage.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@jest/globals'
+import { getViewletErrorMessage } from '../src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js'
+
+test('formats the message, code frame, and stack in order', () => {
+  expect(
+    getViewletErrorMessage({
+      codeFrame: `  4 |     create() {
+> 5 |       throw new Error('create failed')
+    |             ^`,
+      message: 'create failed',
+      stack: '    at Object.create (main.ts:5:13)',
+      type: 'Error',
+    }),
+  ).toBe(`Error: create failed
+
+  4 |     create() {
+> 5 |       throw new Error('create failed')
+    |             ^
+
+    at Object.create (main.ts:5:13)`)
+})
+
+test('omits empty code frame and stack sections', () => {
+  expect(
+    getViewletErrorMessage({
+      codeFrame: '',
+      message: 'create failed',
+      stack: '',
+      type: 'Error',
+    }),
+  ).toBe('Error: create failed')
+})
+
+test('does not duplicate a type already included in the prepared message', () => {
+  expect(
+    getViewletErrorMessage({
+      codeFrame: '',
+      message: 'Error: create failed',
+      stack: '',
+      type: 'Error',
+    }),
+  ).toBe('Error: create failed')
+})

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
@@ -127,6 +127,27 @@ test('loadContent stores virtual dom without duplicate commands', async () => {
   expect(newState.patches).toEqual([])
 })
 
+test('loadContent rejects when virtual dom creation fails', async () => {
+  const stack = `Error: create failed
+    at Object.create (main.ts:5:13)`
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    error: {
+      message: 'create failed',
+      name: 'Error',
+      stack,
+    },
+    ok: false,
+  })
+  const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
+
+  await expect(ViewletExtensionView.loadContent(state, undefined)).rejects.toMatchObject({
+    message: 'create failed',
+    name: 'Error',
+    stack,
+  })
+})
+
 test('loadContent opens a document view with its contributed id and resource uri', async () => {
   const state = ViewletExtensionView.create(1, 'file:///workspace/image.png', 0, 0, 100, 100)
 

--- a/static/css/parts/Viewlet.css
+++ b/static/css/parts/Viewlet.css
@@ -3,13 +3,15 @@
   /* flex: 1; */
 }
 
-.ViewletError {
+.Viewlet.Error {
+  box-sizing: border-box;
   color: lightgray;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  font-family: monospace;
+  inset: 0;
+  overflow: auto;
   padding: 1rem;
-  width: 100%;
-  text-align: center;
+  position: absolute;
+  user-select: text;
+  white-space: pre-wrap;
+  word-break: break-word;
 }


### PR DESCRIPTION
Shows prepared view-load errors with the message first, followed by the code frame and cleaned stack. Also makes the fallback error view top-aligned, scrollable, selectable, and readable in narrow views.