### PR TITLE
fix: refresh disabled extension contributions

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/extension.json
@@ -1,0 +1,21 @@
+{
+  "id": "sample.extension-disable-lifecycle",
+  "name": "Extension Lifecycle",
+  "description": "Exercises extension disable and enable lifecycle updates",
+  "version": "0.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onStatusBarItem"],
+  "statusBarItems": [
+    {
+      "id": "extension-lifecycle"
+    }
+  ],
+  "views": [
+    {
+      "id": "sample.extension-disable-lifecycle-view",
+      "title": "Extension Lifecycle",
+      "icon": "symbol-beaker"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/main.js
@@ -1,0 +1,29 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+const commandMap = {
+  'ExtensionApi.getStatusBarItems'() {
+    return [
+      {
+        icon: '',
+        name: 'extension-lifecycle',
+        onClick: '',
+        text: 'Lifecycle Ready',
+      },
+    ]
+  },
+  'ExtensionApi.getViewRegistrySnapshot'() {
+    return {
+      views: [
+        {
+          icon: 'symbol-beaker',
+          id: 'sample.extension-disable-lifecycle-view',
+          title: 'Extension Lifecycle',
+        },
+      ],
+    }
+  },
+}
+
+await WebWorkerRpcClient.create({ commandMap })

--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/test.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/test.js
@@ -1,0 +1,25 @@
+export const extensionId = 'sample.extension-disable-lifecycle'
+
+export const activityBarItemSelector = '.ActivityBarItem[title="Extension Lifecycle"]'
+
+export const statusBarItemSelector = '.StatusBarItem[name="extension-lifecycle"]'
+
+export const runningExtensionSelector = `.RunningExtension:has-text("${extensionId}")`
+
+export const addLifecycleExtension = async ({ ActivityBar, Extension, Settings, StatusBar }) => {
+  await Settings.update({
+    'statusBar.itemsVisible': true,
+  })
+  await Extension.addWebExtension(import.meta.resolve('.'))
+  await StatusBar.update()
+  await ActivityBar.handleExtensionsChanged()
+}
+
+export const disableLifecycleExtension = async ({ ExtensionDetail }) => {
+  await ExtensionDetail.open(extensionId)
+  await ExtensionDetail.handleClickDisable()
+}
+
+export const enableLifecycleExtension = async ({ ExtensionDetail }) => {
+  await ExtensionDetail.handleClickEnable()
+}

--- a/packages/extension-host-worker-tests/src/extension.disable-hides-activity-bar-item.ts
+++ b/packages/extension-host-worker-tests/src/extension.disable-hides-activity-bar-item.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activityBarItemSelector, addLifecycleExtension, disableLifecycleExtension } from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.disable-hides-activity-bar-item'
+
+export const test: Test = async ({ expect, Locator, ...api }) => {
+  await addLifecycleExtension(api)
+  const activityBarItem = Locator(activityBarItemSelector)
+  await expect(activityBarItem).toBeVisible()
+
+  await disableLifecycleExtension(api)
+
+  await expect(activityBarItem).toBeHidden()
+}

--- a/packages/extension-host-worker-tests/src/extension.disable-hides-status-bar-item.ts
+++ b/packages/extension-host-worker-tests/src/extension.disable-hides-status-bar-item.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { addLifecycleExtension, disableLifecycleExtension, statusBarItemSelector } from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.disable-hides-status-bar-item'
+
+export const test: Test = async ({ expect, Locator, ...api }) => {
+  await addLifecycleExtension(api)
+  const statusBarItem = Locator(statusBarItemSelector)
+  await expect(statusBarItem).toBeVisible()
+
+  await disableLifecycleExtension(api)
+
+  await expect(statusBarItem).toBeHidden()
+}

--- a/packages/extension-host-worker-tests/src/extension.disable-removes-running-extension.ts
+++ b/packages/extension-host-worker-tests/src/extension.disable-removes-running-extension.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  addLifecycleExtension,
+  disableLifecycleExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.disable-removes-running-extension'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLifecycleExtension(api)
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector)
+  await expect(runningExtension).toBeVisible()
+  await expect(runningExtension.locator('.RunningExtensionId')).toHaveText(extensionId)
+
+  await disableLifecycleExtension(api)
+  await RunningExtensions.show()
+
+  await expect(runningExtension).toBeHidden()
+}

--- a/packages/extension-host-worker-tests/src/extension.enable-restores-running-extension.ts
+++ b/packages/extension-host-worker-tests/src/extension.enable-restores-running-extension.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  addLifecycleExtension,
+  disableLifecycleExtension,
+  enableLifecycleExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.enable-restores-running-extension'
+
+export const test: Test = async ({ expect, ExtensionDetail, Locator, RunningExtensions, ...api }) => {
+  await addLifecycleExtension(api)
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector)
+  await expect(runningExtension.locator('.RunningExtensionId')).toHaveText(extensionId)
+  await disableLifecycleExtension({ ExtensionDetail })
+  await RunningExtensions.show()
+  await expect(runningExtension).toBeHidden()
+
+  await ExtensionDetail.open(extensionId)
+  await enableLifecycleExtension({ ExtensionDetail })
+  await RunningExtensions.show()
+
+  await expect(runningExtension).toBeVisible()
+  await expect(runningExtension.locator('.RunningExtensionId')).toHaveText(extensionId)
+}

--- a/packages/extension-host-worker-tests/src/extension.enable-shows-activity-bar-item.ts
+++ b/packages/extension-host-worker-tests/src/extension.enable-shows-activity-bar-item.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  activityBarItemSelector,
+  addLifecycleExtension,
+  disableLifecycleExtension,
+  enableLifecycleExtension,
+} from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.enable-shows-activity-bar-item'
+
+export const test: Test = async ({ expect, Locator, ...api }) => {
+  await addLifecycleExtension(api)
+  const activityBarItem = Locator(activityBarItemSelector)
+  await disableLifecycleExtension(api)
+  await expect(activityBarItem).toBeHidden()
+
+  await enableLifecycleExtension(api)
+
+  await expect(activityBarItem).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/extension.enable-shows-status-bar-item.ts
+++ b/packages/extension-host-worker-tests/src/extension.enable-shows-status-bar-item.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  addLifecycleExtension,
+  disableLifecycleExtension,
+  enableLifecycleExtension,
+  statusBarItemSelector,
+} from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.enable-shows-status-bar-item'
+
+export const test: Test = async ({ expect, Locator, ...api }) => {
+  await addLifecycleExtension(api)
+  const statusBarItem = Locator(statusBarItemSelector)
+  await disableLifecycleExtension(api)
+  await expect(statusBarItem).toBeHidden()
+
+  await enableLifecycleExtension(api)
+
+  await expect(statusBarItem).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/tsconfig.json
+++ b/packages/extension-host-worker-tests/tsconfig.json
@@ -16,5 +16,5 @@
     "noImplicitAny": false,
     "composite": true
   },
-  "include": ["src", "test", "typings"]
+  "include": ["src", "test", "typings", "fixtures/sample.extension-disable-lifecycle/test.js"]
 }

--- a/packages/renderer-worker/src/parts/ExtensionHostManagement/ExtensionHostManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionHostManagement/ExtensionHostManagement.js
@@ -85,3 +85,19 @@ export const activateByEvent = async (event, assetDir, platform) => {
 export const getStatusBarItems = async () => {
   return ExtensionManagementWorker.invoke('Extensions.getStatusBarItems')
 }
+
+export const handleExtensionStateChanged = (extensionId, disabled) => {
+  if (disabled) {
+    delete state.activatingExtensions[extensionId]
+    delete state.runningExtensions[extensionId]
+  }
+  ExtensionMetaState.state.webExtensions = ExtensionMetaState.state.webExtensions.map((extension) => {
+    if (extension.id !== extensionId) {
+      return extension
+    }
+    return {
+      ...extension,
+      disabled,
+    }
+  })
+}

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -2,6 +2,7 @@ import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as Command from '../Command/Command.js'
 import * as ContextMenu from '../ContextMenu/ContextMenu.js'
 import * as ExtensionHostWorker from '../ExtensionHostWorker/ExtensionHostWorker.js'
+import * as ExtensionHostManagement from '../ExtensionHostManagement/ExtensionHostManagement.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as ExtensionManifestStatus from '../ExtensionManifestStatus/ExtensionManifestStatus.js'
 import * as ExtensionViewContext from '../ExtensionViewContext/ExtensionViewContext.js'
@@ -24,8 +25,11 @@ export const doInvalidateExtensionsCache = async () => {
   }
 }
 
-export const handleExtensionsCacheInvalidated = async () => {
+export const handleExtensionsCacheInvalidated = async (extensionId, disabled) => {
   try {
+    if (typeof extensionId === 'string' && typeof disabled === 'boolean') {
+      ExtensionHostManagement.handleExtensionStateChanged(extensionId, disabled)
+    }
     await Command.execute('KeyBindings.hydrate')
     await Command.execute('ColorTheme.reload')
     await Command.execute('Layout.handleExtensionsChanged')

--- a/packages/renderer-worker/src/parts/ExtensionMeta/ExtensionMeta.js
+++ b/packages/renderer-worker/src/parts/ExtensionMeta/ExtensionMeta.js
@@ -96,7 +96,7 @@ export const filterByMatchingEvent = (extensions, event) => {
       console.warn(warning)
     }
     // TODO handle error when extension.activation is not of type array (null or number or ...)
-    if (extension.activation && extension.activation.includes(event)) {
+    if (!extension.disabled && extension.activation && extension.activation.includes(event)) {
       extensionsToActivate.push(extension)
     }
   }

--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.ipc.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.ipc.js
@@ -3,5 +3,6 @@ import * as LaunchIsolatedExtensionHostWorker from './LaunchIsolatedExtensionHos
 export const name = 'LaunchIsolatedExtensionHostWorker'
 
 export const Commands = {
+  disposeIsolatedExtensionHostWorker: LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker,
   launchIsolatedExtensionHostWorker: LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker,
 }

--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
@@ -5,6 +5,8 @@ import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as RendererProcessIpcParentType from '../RendererProcessIpcParentType/RendererProcessIpcParentType.js'
 
+const workerIds = Object.create(null)
+
 export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, workerName = '', contentSecurityPolicy = '') => {
   const suffix = extensionId ? `: ${extensionId}` : ''
   const fallbackName = Platform.getPlatform() === PlatformType.Electron ? `Extension API (Electron)${suffix}` : `Extension API${suffix}`
@@ -22,4 +24,20 @@ export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, 
     url,
     id,
   })
+  workerIds[extensionId] = id
+}
+
+export const disposeIsolatedExtensionHostWorker = async (extensionId) => {
+  const id = workerIds[extensionId]
+  if (typeof id !== 'number') {
+    return
+  }
+  delete workerIds[extensionId]
+  await RendererProcess.invoke('IpcParent.dispose', id)
+}
+
+export const clear = () => {
+  for (const extensionId of Object.keys(workerIds)) {
+    delete workerIds[extensionId]
+  }
 }

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts
@@ -30,6 +30,16 @@ export const loadContent = async (state: RunningExtensionsState): Promise<Runnin
   }
 }
 
+export const handleExtensionsChanged = async (state: RunningExtensionsState): Promise<RunningExtensionsState> => {
+  await RunningExtensionsViewWorker.invoke('RunningExtensions.loadContent', state.uid)
+  const diffResult = await RunningExtensionsViewWorker.invoke('RunningExtensions.diff2', state.uid)
+  const commands = await RunningExtensionsViewWorker.invoke('RunningExtensions.render2', state.uid, diffResult)
+  return {
+    ...state,
+    commands,
+  }
+}
+
 export const getTitle = (): string => {
   return title
 }

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCommands.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCommands.ts
@@ -1,5 +1,6 @@
 import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
 import { wrapRunningExtensionsCommand } from '../WrapRunningExtensionsCommand/WrapRunningExtensionsCommand.ts'
+import * as ViewletRunningExtensions from './ViewletRunningExtensions.ts'
 
 export const Commands = {}
 
@@ -8,5 +9,6 @@ export const getCommands = async () => {
   for (const command of commands) {
     Commands[command] = wrapRunningExtensionsCommand(command)
   }
+  Commands['handleExtensionsChanged'] = ViewletRunningExtensions.handleExtensionsChanged
   return Commands
 }

--- a/packages/renderer-worker/test/ExtensionHostManagement.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostManagement.test.ts
@@ -133,3 +133,56 @@ test('activateByEvent none waits for inflight activations', async () => {
   await expect(waitForNone).resolves.toEqual([undefined])
   await pendingActivation
 })
+
+test('handleExtensionStateChanged disables a dynamic extension and forgets its activation state', () => {
+  ExtensionHostManagement.state.activatingExtensions['sample.extension'] = Promise.resolve()
+  ExtensionHostManagement.state.runningExtensions['sample.extension'] = true
+  ExtensionHostManagement.state.runningExtensions['sample.other'] = true
+  ExtensionMetaState.state.webExtensions = [{ id: 'sample.extension' }, { id: 'sample.other' }]
+
+  ExtensionHostManagement.handleExtensionStateChanged('sample.extension', true)
+
+  expect(ExtensionHostManagement.state.activatingExtensions['sample.extension']).toBeUndefined()
+  expect(ExtensionHostManagement.state.runningExtensions['sample.extension']).toBeUndefined()
+  expect(ExtensionHostManagement.state.runningExtensions['sample.other']).toBe(true)
+  expect(ExtensionMetaState.state.webExtensions).toEqual([{ disabled: true, id: 'sample.extension' }, { id: 'sample.other' }])
+})
+
+test('handleExtensionStateChanged re-enables a dynamic extension', () => {
+  ExtensionMetaState.state.webExtensions = [{ disabled: true, id: 'sample.extension' }]
+
+  ExtensionHostManagement.handleExtensionStateChanged('sample.extension', false)
+
+  expect(ExtensionMetaState.state.webExtensions).toEqual([{ disabled: false, id: 'sample.extension' }])
+})
+
+test('disabled dynamic extension can activate again after it is re-enabled', async () => {
+  const extension = {
+    activation: ['onStatusBarItem'],
+    browser: 'main.js',
+    builtin: false,
+    id: 'sample.extension',
+    isWeb: true,
+    path: '/dynamic/sample.extension',
+    status: 'resolved',
+  }
+  ExtensionMetaState.state.webExtensions = [extension]
+  // @ts-ignore
+  invokeMock.mockImplementation(async (method) => {
+    if (method === 'Extensions.getAllExtensions') {
+      return []
+    }
+    if (method === 'Extensions.activate3') {
+      return undefined
+    }
+    throw new Error(`unexpected method: ${method}`)
+  })
+
+  await ExtensionHostManagement.activateByEvent('onStatusBarItem', '/asset', 'test-platform')
+  ExtensionHostManagement.handleExtensionStateChanged('sample.extension', true)
+  await ExtensionHostManagement.activateByEvent('onStatusBarItem', '/asset', 'test-platform')
+  ExtensionHostManagement.handleExtensionStateChanged('sample.extension', false)
+  await ExtensionHostManagement.activateByEvent('onStatusBarItem', '/asset', 'test-platform')
+
+  expect(invokeMock.mock.calls.filter(([method]) => method === 'Extensions.activate3')).toHaveLength(2)
+})

--- a/packages/renderer-worker/test/ExtensionManagement.test.ts
+++ b/packages/renderer-worker/test/ExtensionManagement.test.ts
@@ -48,6 +48,7 @@ const ExtensionManagementIpc = await import('../src/parts/ExtensionManagement/Ex
 const Command = await import('../src/parts/Command/Command.js')
 const ContextMenu = await import('../src/parts/ContextMenu/ContextMenu.js')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const ExtensionHostManagement = await import('../src/parts/ExtensionHostManagement/ExtensionHostManagement.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 
 test('doInvalidateExtensionsCache asks the extension management worker to invalidate', async () => {
@@ -62,6 +63,17 @@ test('handleExtensionsCacheInvalidated refreshes renderer state without invalida
   await ExtensionManagement.handleExtensionsCacheInvalidated()
 
   expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'KeyBindings.hydrate')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'ColorTheme.reload')
+  expect(Command.execute).toHaveBeenNthCalledWith(3, 'Layout.handleExtensionsChanged')
+})
+
+test('handleExtensionsCacheInvalidated applies the disabled extension state', async () => {
+  ExtensionHostManagement.state.runningExtensions['sample.extension'] = true
+
+  await ExtensionManagement.handleExtensionsCacheInvalidated('sample.extension', true)
+
+  expect(ExtensionHostManagement.state.runningExtensions['sample.extension']).toBeUndefined()
   expect(Command.execute).toHaveBeenNthCalledWith(1, 'KeyBindings.hydrate')
   expect(Command.execute).toHaveBeenNthCalledWith(2, 'ColorTheme.reload')
   expect(Command.execute).toHaveBeenNthCalledWith(3, 'Layout.handleExtensionsChanged')

--- a/packages/renderer-worker/test/ExtensionMeta.test.ts
+++ b/packages/renderer-worker/test/ExtensionMeta.test.ts
@@ -235,3 +235,17 @@ test('filterByMatchingEvent', () => {
     },
   ])
 })
+
+test('filterByMatchingEvent ignores disabled extensions', () => {
+  expect(
+    ExtensionMeta.filterByMatchingEvent(
+      [
+        {
+          activation: ['onCommand:xyz'],
+          disabled: true,
+        },
+      ],
+      'onCommand:xyz',
+    ),
+  ).toEqual([])
+})

--- a/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
@@ -4,6 +4,9 @@ import * as RendererProcessIpcParentType from '../src/parts/RendererProcessIpcPa
 
 beforeEach(() => {
   jest.resetAllMocks()
+  // @ts-ignore
+  Id.create.mockReturnValue(42)
+  LaunchIsolatedExtensionHostWorker.clear()
 })
 
 jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
@@ -20,6 +23,7 @@ jest.unstable_mockModule('../src/parts/ContentSecurityPolicy/ContentSecurityPoli
 
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
   return {
+    invoke: jest.fn(),
     invokeAndTransfer: jest.fn(),
   }
 })
@@ -31,6 +35,7 @@ jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
 })
 
 const ContentSecurityPolicy = await import('../src/parts/ContentSecurityPolicy/ContentSecurityPolicy.js')
+const Id = await import('../src/parts/Id/Id.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const LaunchIsolatedExtensionHostWorker = await import('../src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js')
 
@@ -104,4 +109,39 @@ test('launchIsolatedExtensionHostWorker - applies the extension content security
   )
   // @ts-ignore
   expect(ContentSecurityPolicy.set.mock.invocationCallOrder[0]).toBeLessThan(RendererProcess.invokeAndTransfer.mock.invocationCallOrder[0])
+})
+
+test('disposeIsolatedExtensionHostWorker terminates the renderer process worker', async () => {
+  const port = {}
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockResolvedValue(undefined)
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  await LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker(
+    port,
+    'sample.extension',
+    '/test/extension-host-worker/packages/e2e/fixtures/sample/main.js',
+  )
+
+  await LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker('sample.extension')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('IpcParent.dispose', 42)
+})
+
+test('disposeIsolatedExtensionHostWorker only disposes a worker once', async () => {
+  const port = {}
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockResolvedValue(undefined)
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  await LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker(
+    port,
+    'sample.extension',
+    '/test/extension-host-worker/packages/e2e/fixtures/sample/main.js',
+  )
+
+  await LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker('sample.extension')
+  await LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker('sample.extension')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
 })

--- a/packages/renderer-worker/test/ViewletRunningExtensions.test.ts
+++ b/packages/renderer-worker/test/ViewletRunningExtensions.test.ts
@@ -16,6 +16,9 @@ jest.unstable_mockModule('../src/parts/RunningExtensionsViewWorker/RunningExtens
     if (command === 'RunningExtensions.getMenuEntries') {
       return [{ command: 'RunningExtensions.copyId', id: 'copy-id', label: 'Copy id (test.extension)' }]
     }
+    if (command === 'RunningExtensions.getCommandIds') {
+      return ['copyId']
+    }
     return undefined
   }),
 }))
@@ -30,6 +33,7 @@ jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
 
 const RunningExtensionsViewWorker = await import('../src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts')
 const ViewletRunningExtensions = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ts')
+const ViewletRunningExtensionsCommands = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensionsCommands.ts')
 const ViewletRunningExtensionsName = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensionsName.ts')
 const ViewletRunningExtensionsRenderTitle = await import('../src/parts/ViewletRunningExtensions/ViewletRunningExtensionsRenderTitle.ts')
 
@@ -63,6 +67,26 @@ test('loadContent passes the platform and asset directory to the view worker', a
     2,
     '/test-assets',
   )
+})
+
+test('handleExtensionsChanged reloads and renders running extensions', async () => {
+  const state = ViewletRunningExtensions.create(1, 'running-extensions://', 10, 20, 800, 600)
+
+  const result = await ViewletRunningExtensions.handleExtensionsChanged(state)
+
+  expect(RunningExtensionsViewWorker.invoke).toHaveBeenNthCalledWith(1, 'RunningExtensions.loadContent', 1)
+  expect(RunningExtensionsViewWorker.invoke).toHaveBeenNthCalledWith(2, 'RunningExtensions.diff2', 1)
+  expect(RunningExtensionsViewWorker.invoke).toHaveBeenNthCalledWith(3, 'RunningExtensions.render2', 1, [])
+  expect(result).toEqual({
+    ...state,
+    commands: [],
+  })
+})
+
+test('getCommands includes the extension change handler', async () => {
+  await ViewletRunningExtensionsCommands.getCommands()
+
+  expect(ViewletRunningExtensionsCommands.Commands['handleExtensionsChanged']).toBe(ViewletRunningExtensions.handleExtensionsChanged)
 })
 
 test('getMenus provides running extensions menu entries', async () => {


### PR DESCRIPTION
## Summary

- dispose isolated extension workers when their extension is disabled and forget renderer/runtime activation state
- refresh keybindings, themes, layout contributions, activity bar entries, status bar items, and Running Extensions after disable or enable
- prevent disabled dynamic extensions and disabled custom views from being activated or displayed

## Tests

- add six extension-host e2e tests covering status bar, activity bar, and Running Extensions for disable and re-enable
- add focused renderer unit coverage for state cleanup, activation blocking/restoration, worker disposal, and contribution refresh
- 29 focused renderer tests pass
- renderer-worker and extension-host-worker-tests type-check pass