### PR TITLE
feature: start electron without default workspace

### DIFF
--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -82,28 +82,6 @@ const copyDependencies = async ({ cachePath, resourcesPath }) => {
   })
 }
 
-const copyPlaygroundFiles = async ({ arch, resourcesPath }) => {
-  await WriteFile.writeFile({
-    to: `${resourcesPath}/app/playground/index.html`,
-    content: `<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <link rel="stylesheet" href="index.css" />
-    <title>Document</title>
-  </head>
-  <body>
-    <h1>hello world</h1>
-  </body>
-</html>
-`,
-  })
-  await WriteFile.writeFile({
-    to: `${resourcesPath}/app/playground/index.css`,
-    content: `h1 { color: dodgerblue; }`,
-  })
-}
-
 const copyExtensionHostHelperProcessSources = async ({ resourcesPath }) => {
   await Copy.copy({
     from: 'packages/extension-host-helper-process/src',
@@ -369,10 +347,6 @@ export const build = async ({
     toRoot,
     product,
   })
-
-  console.time('copyPlaygroundFiles')
-  await copyPlaygroundFiles({ arch, resourcesPath })
-  console.timeEnd('copyPlaygroundFiles')
 
   const etag = `W/"${commitHash}"`
 

--- a/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
+++ b/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
@@ -5,6 +5,7 @@ import * as Env from '../Env/Env.ts'
 import * as GetWorkspaceId from '../GetWorkspaceId/GetWorkspaceId.ts'
 import * as IsAbsolutePath from '../IsAbsolutePath/IsAbsolutePath.ts'
 import * as IsElectron from '../IsElectron/IsElectron.ts'
+import * as IsProduction from '../IsProduction/IsProduction.ts'
 import * as IsPromptMode from '../IsPromptMode/IsPromptMode.ts'
 import * as ParentIpc from '../MainProcess/MainProcess.ts'
 import * as Platform from '../Platform/Platform.ts'
@@ -62,14 +63,14 @@ export const resolveRoot = async (): Promise<any> => {
   // TODO shared process should have no logic, this should probably be somewhere else
   const folder = Env.getFolder()
   if (!folder) {
-    const path = join(Root.root, 'playground')
+    const path = IsElectron.isElectron && IsProduction.isProduction ? '' : join(Root.root, 'playground')
     return {
       homeDir: PlatformPaths.getHomeDir(),
       homeDirUri: toUri(PlatformPaths.getHomeDir()),
       path,
       pathSeparator: Platform.getPathSeparator(),
       source: WorkspaceSource.SharedProcessEnv,
-      uri: toUri(path),
+      uri: path ? toUri(path) : '',
       workspaceId: GetWorkspaceId.getWorkspaceId(path),
     }
   }

--- a/packages/shared-process/test/ResolveRoot.test.ts
+++ b/packages/shared-process/test/ResolveRoot.test.ts
@@ -9,6 +9,10 @@ jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
   invoke: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/IsProduction/IsProduction.js', () => ({
+  isProduction: true,
+}))
+
 const MainProcess = await import('../src/parts/MainProcess/MainProcess.js')
 const ResolveRoot = await import('../src/parts/ResolveRoot/ResolveRoot.js')
 
@@ -52,5 +56,18 @@ test('resolveRoot - uses cwd in prompt mode', async () => {
     path: process.cwd(),
     source: 'shared-process-cli-arg',
     uri: pathToFileURL(process.cwd()).toString(),
+  })
+})
+
+test('resolveRoot - starts with an empty workspace in production electron', async () => {
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(['/usr/lib/lvce-oss/lvce-oss'])
+
+  const resolvedRoot = await ResolveRoot.resolveRoot()
+
+  expect(resolvedRoot).toMatchObject({
+    path: '',
+    source: 'shared-process-env',
+    uri: '',
   })
 })


### PR DESCRIPTION
Remove the bundled playground from production Electron builds.

Start packaged Electron with no workspace when no folder was explicitly provided, while preserving CLI and non-production behavior.