### PR TITLE
fix: deduplicate electron app icons

### DIFF
--- a/packages/build/src/parts/BundleCss/BundleCss.ts
+++ b/packages/build/src/parts/BundleCss/BundleCss.ts
@@ -4,8 +4,8 @@ import * as Copy from '../Copy/Copy.ts'
 import * as EagerLoadedCss from '../EagerLoadedCss/EagerLoadedCss.ts'
 import * as EncodingType from '../EncodingType/EncodingType.ts'
 import * as Path from '../Path/Path.ts'
-import * as Replace from '../Replace/Replace.ts'
 import * as Root from '../Root/Root.ts'
+import * as RewriteCssAssetUrls from '../RewriteCssAssetUrls/RewriteCssAssetUrls.ts'
 import * as SplitLines from '../SplitLines/SplitLines.ts'
 import * as WriteFile from '../WriteFile/WriteFile.ts'
 
@@ -67,6 +67,7 @@ export const bundleCss = async ({ outDir, additionalCss = '', assetDir = '', pat
         if (shouldPrependFileNameComment(dirent)) {
           await prependFileNameComment(outPath, dirent)
         }
+        await RewriteCssAssetUrls.rewriteCssAssetUrlsInFile(outPath, assetDir)
       }
     }
 
@@ -77,14 +78,6 @@ export const bundleCss = async ({ outDir, additionalCss = '', assetDir = '', pat
       css += `/* ${part} */\n`
       css += `/*************/\n`
       css += content
-    }
-
-    for (const file of ['MaskIcon', 'Symbol', 'ProblemsIcon']) {
-      await Replace.replace({
-        path: Path.join(outDir, 'parts', `${file}.css`),
-        occurrence: `url(/icons/`,
-        replacement: `url(${assetDir}/icons/`,
-      })
     }
 
     for (const part of EagerLoadedCss.eagerLoadedCss) {
@@ -102,19 +95,7 @@ export const bundleCss = async ({ outDir, additionalCss = '', assetDir = '', pat
 
     await WriteFile.writeFile({
       to: appCssPath,
-      content: css,
-    })
-
-    await Replace.replace({
-      path: appCssPath,
-      occurrence: `url(/icons/`,
-      replacement: `url(${assetDir}/icons/`,
-    })
-
-    await Replace.replace({
-      path: appCssPath,
-      occurrence: `url(/fonts/`,
-      replacement: `url(${assetDir}/fonts/`,
+      content: RewriteCssAssetUrls.rewriteCssAssetUrls(css, assetDir),
     })
   } catch (error) {
     throw new VError(error, `Failed to bundle css`)

--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs'
-import { readdir } from 'node:fs/promises'
 import * as AddRootPackageJson from '../AddRootPackageJson/AddRootPackageJson.ts'
 import * as Assert from '../Assert/Assert.ts'
 import * as BundleCss from '../BundleCss/BundleCss.ts'
@@ -8,9 +7,9 @@ import * as BundleOptions from '../BundleOptions/BundleOptions.ts'
 import * as BundleSharedProcessCached from '../BundleSharedProcessCached/BundleSharedProcessCached.ts'
 import * as BundleWorkers from '../BundleWorkers/BundleWorkers.ts'
 import * as CommitHash from '../CommitHash/CommitHash.ts'
-import * as CodiconsPath from '../CodiconsPath/CodiconsPath.ts'
 import * as Copy from '../Copy/Copy.ts'
 import * as CopyElectron from '../CopyElectron/CopyElectron.ts'
+import * as CopyElectronIcons from '../CopyElectronIcons/CopyElectronIcons.ts'
 import * as CopyElectronLicense from '../CopyElectronLicense/CopyElectronLicense.ts'
 import * as GetCommitDate from '../GetCommitDate/GetCommitDate.ts'
 import * as GetElectronVersion from '../GetElectronVersion/GetElectronVersion.ts'
@@ -19,6 +18,7 @@ import * as Rename from '../Rename/Rename.ts'
 import * as Logger from '../Logger/Logger.ts'
 import * as Path from '../Path/Path.ts'
 import * as Platform from '../Platform/Platform.ts'
+import * as PrepareElectronCss from '../PrepareElectronCss/PrepareElectronCss.ts'
 import * as ReadFile from '../ReadFile/ReadFile.ts'
 import * as Remove from '../Remove/Remove.ts'
 import * as RemoveUnusedLocales from '../RemoveUnusedLocales/RemoveUnusedLocales.ts'
@@ -136,29 +136,13 @@ const copyExtensions = async ({ resourcesPath, commitHash }) => {
   // })
 }
 
-const copyIcons = async ({ resourcesPath, commitHash }) => {
-  const codiconNames = await readdir(CodiconsPath.codiconsIconsPath)
-  for (const iconPath of [`${resourcesPath}/app/static/${commitHash}/icons`, `${resourcesPath}/app/static/icons`]) {
-    await Copy.copy({
-      from: CodiconsPath.codiconsIconsPath,
-      to: iconPath,
-    })
-    await Copy.copy({
-      from: 'static/icons',
-      to: iconPath,
-      ignore: codiconNames,
-    })
-  }
-}
-
 const copyStaticFiles = async ({ resourcesPath, commitHash }) => {
   await Copy.copy({
     from: 'static',
     to: `${resourcesPath}/app/static/${commitHash}`,
     ignore: ['css'],
   })
-  await copyIcons({ resourcesPath, commitHash })
-  await Remove.remove(`${resourcesPath}/app/static/icons/pwa-icon-512.png`)
+  await CopyElectronIcons.copyElectronIcons({ resourcesPath, commitHash })
   await Rename.rename({
     from: `${resourcesPath}/app/static/${commitHash}/index.html`,
     to: `${resourcesPath}/app/static/index.html`,
@@ -348,6 +332,10 @@ export const build = async ({
   console.time('copyExtensions')
   await copyExtensions({ resourcesPath, commitHash })
   console.timeEnd('copyExtensions')
+
+  console.time('prepareElectronCss')
+  await PrepareElectronCss.prepareElectronCss({ resourcesPath, commitHash })
+  console.timeEnd('prepareElectronCss')
 
   console.time('copyStaticFiles')
   await copyStaticFiles({ resourcesPath, commitHash })

--- a/packages/build/src/parts/CopyElectronIcons/CopyElectronIcons.ts
+++ b/packages/build/src/parts/CopyElectronIcons/CopyElectronIcons.ts
@@ -1,0 +1,17 @@
+import { readdir } from 'node:fs/promises'
+import * as CodiconsPath from '../CodiconsPath/CodiconsPath.ts'
+import * as Copy from '../Copy/Copy.ts'
+
+export const copyElectronIcons = async ({ resourcesPath, commitHash }) => {
+  const iconPath = `${resourcesPath}/app/static/${commitHash}/icons`
+  await Copy.copy({
+    from: CodiconsPath.codiconsIconsPath,
+    to: iconPath,
+  })
+  const codiconNames = await readdir(CodiconsPath.codiconsIconsPath)
+  await Copy.copy({
+    from: 'static/icons',
+    to: iconPath,
+    ignore: codiconNames,
+  })
+}

--- a/packages/build/src/parts/PrepareElectronCss/PrepareElectronCss.ts
+++ b/packages/build/src/parts/PrepareElectronCss/PrepareElectronCss.ts
@@ -1,0 +1,18 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import * as Path from '../Path/Path.ts'
+import * as RewriteCssAssetUrls from '../RewriteCssAssetUrls/RewriteCssAssetUrls.ts'
+
+const rewriteProcessExplorerCss = async ({ resourcesPath, commitHash }): Promise<void> => {
+  const path = Path.join(resourcesPath, 'app', 'packages', 'main-process', 'pages', 'process-explorer', 'process-explorer.css')
+  const content = await readFile(path, 'utf8')
+  const newContent = content.replaceAll('../../../../static/icons/', `../../../../static/${commitHash}/icons/`)
+  if (newContent !== content) {
+    await writeFile(path, newContent)
+  }
+}
+
+export const prepareElectronCss = async ({ resourcesPath, commitHash }): Promise<void> => {
+  const extensionsPath = Path.join(resourcesPath, 'app', 'static', commitHash, 'extensions')
+  await RewriteCssAssetUrls.rewriteCssAssetUrlsInDirectory(extensionsPath, `/${commitHash}`)
+  await rewriteProcessExplorerCss({ resourcesPath, commitHash })
+}

--- a/packages/build/src/parts/RewriteCssAssetUrls/RewriteCssAssetUrls.ts
+++ b/packages/build/src/parts/RewriteCssAssetUrls/RewriteCssAssetUrls.ts
@@ -1,0 +1,26 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import * as Path from '../Path/Path.ts'
+
+export const rewriteCssAssetUrls = (content: string, assetDir: string): string => {
+  return content.replaceAll(/url\((['"]?)\/icons\//g, `url($1${assetDir}/icons/`).replaceAll(/url\((['"]?)\/fonts\//g, `url($1${assetDir}/fonts/`)
+}
+
+export const rewriteCssAssetUrlsInFile = async (path: string, assetDir: string): Promise<void> => {
+  const content = await readFile(path, 'utf8')
+  const newContent = rewriteCssAssetUrls(content, assetDir)
+  if (newContent !== content) {
+    await writeFile(path, newContent)
+  }
+}
+
+export const rewriteCssAssetUrlsInDirectory = async (path: string, assetDir: string): Promise<void> => {
+  const dirents = await readdir(path, { withFileTypes: true })
+  for (const dirent of dirents) {
+    const childPath = Path.join(path, dirent.name)
+    if (dirent.isDirectory()) {
+      await rewriteCssAssetUrlsInDirectory(childPath, assetDir)
+    } else if (dirent.name.endsWith('.css')) {
+      await rewriteCssAssetUrlsInFile(childPath, assetDir)
+    }
+  }
+}

--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -230,3 +230,21 @@ test('bundleCss preserves the running extensions empty state artwork', async () 
     await rm(dir, { recursive: true, force: true })
   }
 }, 30_000)
+
+test('bundleCss rewrites icon urls in lazy-loaded css', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '/abc1234',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletMainWaterMark.css'), 'utf8')
+
+    expect(css).toContain(`mask-image: url(/abc1234/icons/icon.svg);`)
+    expect(css).not.toContain(`url(/icons/`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/packages/build/test/CopyElectronIcons.test.ts
+++ b/packages/build/test/CopyElectronIcons.test.ts
@@ -1,0 +1,34 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('node:fs/promises', () => ({
+  readdir: jest.fn(async () => ['add.svg', 'close.svg']),
+}))
+
+jest.unstable_mockModule('../src/parts/CodiconsPath/CodiconsPath.ts', () => ({
+  codiconsIconsPath: '/test/codicons/icons',
+}))
+
+jest.unstable_mockModule('../src/parts/Copy/Copy.ts', () => ({
+  copy: jest.fn(),
+}))
+
+const CopyElectronIcons = await import('../src/parts/CopyElectronIcons/CopyElectronIcons.ts')
+const Copy = await import('../src/parts/Copy/Copy.ts')
+
+test('copies Electron icons only to the commit-scoped directory', async () => {
+  await CopyElectronIcons.copyElectronIcons({
+    resourcesPath: '/test/resources',
+    commitHash: 'abc1234',
+  })
+
+  expect(Copy.copy).toHaveBeenCalledTimes(2)
+  expect(Copy.copy).toHaveBeenNthCalledWith(1, {
+    from: '/test/codicons/icons',
+    to: '/test/resources/app/static/abc1234/icons',
+  })
+  expect(Copy.copy).toHaveBeenNthCalledWith(2, {
+    from: 'static/icons',
+    to: '/test/resources/app/static/abc1234/icons',
+    ignore: ['add.svg', 'close.svg'],
+  })
+})

--- a/packages/build/test/PrepareElectronCss.test.ts
+++ b/packages/build/test/PrepareElectronCss.test.ts
@@ -1,0 +1,28 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { prepareElectronCss } from '../src/parts/PrepareElectronCss/PrepareElectronCss.ts'
+
+test('rewrites Electron CSS to use commit-scoped icons', async () => {
+  const resourcesPath = await mkdtemp(join(tmpdir(), 'lvce-electron-css-'))
+  const extensionCssPath = join(resourcesPath, 'app', 'static', 'abc1234', 'extensions', 'builtin.test', 'view.css')
+  const processExplorerCssPath = join(resourcesPath, 'app', 'packages', 'main-process', 'pages', 'process-explorer', 'process-explorer.css')
+
+  try {
+    await mkdir(join(extensionCssPath, '..'), { recursive: true })
+    await mkdir(join(processExplorerCssPath, '..'), { recursive: true })
+    await writeFile(extensionCssPath, `mask-image: url('/icons/archive.svg');`)
+    await writeFile(processExplorerCssPath, `mask-image: url(../../../../static/icons/chevron-down.svg);`)
+
+    await prepareElectronCss({
+      resourcesPath,
+      commitHash: 'abc1234',
+    })
+
+    expect(await readFile(extensionCssPath, 'utf8')).toBe(`mask-image: url('/abc1234/icons/archive.svg');`)
+    expect(await readFile(processExplorerCssPath, 'utf8')).toBe(`mask-image: url(../../../../static/abc1234/icons/chevron-down.svg);`)
+  } finally {
+    await rm(resourcesPath, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Removes the duplicate unversioned Electron icon directory and keeps icons only under the commit-scoped static path. Rewrites production application, extension, and Process Explorer CSS so all icon references resolve to that hashed directory.