### PR TITLE
feature: pass editor syntax highlighting metadata

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -133,7 +133,8 @@ export const loadContent = async (state, savedState, context) => {
   const columnToReveal = context?.columnIndex || 0
 
   if (useFunctionalRendering) {
-    await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir)
+    const tokenizePath = GetTokenizePath.getTokenizePath(languageId)
+    await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath)
     await EditorWorker.invoke('Editor.loadContent', id)
     const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const editorWorkerInvoke = jest.fn()
+const getTokenizePath = jest.fn<(languageId: string) => string>()
 const rendererProcessInvoke = jest.fn()
 const tokenizerRemoveConnectedEditor = jest.fn()
 
 beforeEach(() => {
   jest.resetAllMocks()
+  getTokenizePath.mockImplementation((languageId: string): string => `/tokenize-${languageId}.js`)
 })
 
 jest.unstable_mockModule('../src/parts/MeasureTextWidth/MeasureTextWidth.js', () => {
@@ -24,6 +26,10 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => {
 
 jest.unstable_mockModule('../src/parts/GetTextEditorContent/GetTextEditorContent.js', () => ({
   getTextEditorContent: jest.fn(() => 'first line\nsecond line'),
+}))
+
+jest.unstable_mockModule('../src/parts/GetTokenizePath/GetTokenizePath.js', () => ({
+  getTokenizePath,
 }))
 
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
@@ -54,8 +60,21 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   const state = ViewletEditorText.create(1, '/test/file.txt', 0, 0, 800, 600)
   const selections = new Uint32Array([1, 2, 1, 8])
 
-  const newState = await ViewletEditorText.loadContent(state, { selections: [0, 0, 0, 0] }, { selections })
+  const newState = await ViewletEditorText.loadContent(state, { selections: [0, 0, 0, 0] }, { languageId: 'typescript', selections })
 
+  expect(editorWorkerInvoke).toHaveBeenCalledWith(
+    'Editor.create2',
+    1,
+    '/test/file.txt',
+    0,
+    0,
+    800,
+    600,
+    expect.any(Number),
+    expect.any(String),
+    'typescript',
+    '/tokenize-typescript.js',
+  )
   expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, selections)
   const editorMethods = editorWorkerInvoke.mock.calls
     .map(([method]) => method)


### PR DESCRIPTION
Passes the resolved language ID and tokenizer path to the functional editor worker so it can request syntax-highlighted lines.