### PR TITLE
feature: configure text document cache

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -134,7 +134,8 @@ export const loadContent = async (state, savedState, context) => {
 
   if (useFunctionalRendering) {
     const tokenizePath = GetTokenizePath.getTokenizePath(languageId)
-    await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath)
+    const useCache = Preferences.get('editor.cache') ?? true
+    await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath, useCache)
     await EditorWorker.invoke('Editor.loadContent', id)
     const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -42,6 +42,11 @@ jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
 }))
 
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+
+beforeEach(() => {
+  delete Preferences.state['editor.cache']
+})
 
 test('loadContent - restores the selection supplied by the opener', async () => {
   const initialCommands = [['Viewlet.setDom2']]
@@ -74,6 +79,7 @@ test('loadContent - restores the selection supplied by the opener', async () => 
     expect.any(String),
     'typescript',
     '/tokenize-typescript.js',
+    true,
   )
   expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, selections)
   const editorMethods = editorWorkerInvoke.mock.calls
@@ -88,7 +94,28 @@ test('loadContent - restores the selection supplied by the opener', async () => 
     'Editor.diff2',
     'Editor.render2',
   ])
+  const createCall = editorWorkerInvoke.mock.calls.find(([method]) => method === 'Editor.create2')
+  expect(createCall?.at(-1)).toBe(true)
   expect(newState.commands).toEqual([...initialCommands, ...selectionCommands])
+})
+
+test('loadContent - disables the editor file cache through preferences', async () => {
+  Preferences.state['editor.cache'] = false
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.diff2':
+      case 'Editor.render2':
+        return []
+      default:
+        return undefined
+    }
+  })
+  const state = ViewletEditorText.create(1, '/test/file.txt', 0, 0, 800, 600)
+
+  await ViewletEditorText.loadContent(state, {}, {})
+
+  const createCall = editorWorkerInvoke.mock.calls.find(([method]) => method === 'Editor.create2')
+  expect(createCall?.at(-1)).toBe(false)
 })
 
 test('dispose', async () => {

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -15,6 +15,7 @@
 
   "editor.autoClosingBrackets": true,
   "editor.autoClosingQuotes": true,
+  "editor.cache": true,
   "editor.quickSuggestions": false,
 
   "extensions.autoUpdate": true,


### PR DESCRIPTION
Pass the text-document cache setting to editor creation and enable it by default in the built-in configuration.