### PR TITLE
feature: sequence widget renderer lifecycle

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -1,4 +1,5 @@
 import { execute, loadCommand } from '../Command/Command.js'
+import * as WidgetLifecycle from '../WidgetLifecycle/WidgetLifecycle.js'
 
 const lazy =
   (key) =>
@@ -567,4 +568,9 @@ export const commandMap = {
   'Layout.toggleSideBarPosition': lazy('Layout.toggleSideBarPosition'),
   'Layout.toggleStatusBar': lazy('Layout.toggleStatusBar'),
   'Layout.toggleTitleBar': lazy('Layout.toggleTitleBar'),
+  'WidgetLifecycle.allocateRendererId': WidgetLifecycle.allocateRendererId,
+  'WidgetLifecycle.attach': WidgetLifecycle.attach,
+  'WidgetLifecycle.remove': WidgetLifecycle.remove,
+  'WidgetLifecycle.removeMany': WidgetLifecycle.removeMany,
+  'WidgetLifecycle.update': WidgetLifecycle.update,
 }

--- a/packages/renderer-worker/src/parts/WidgetLifecycle/WidgetLifecycle.js
+++ b/packages/renderer-worker/src/parts/WidgetLifecycle/WidgetLifecycle.js
@@ -1,0 +1,98 @@
+import * as Id from '../Id/Id.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+
+const latestIntents = new Map()
+
+const getKey = (editorUid, kind) => `${editorUid}:${kind}`
+
+const isCurrent = (request) => {
+  const current = latestIntents.get(getKey(request.editorUid, request.kind))
+  return current?.intentSequence === request.intentSequence && current?.instanceId === request.instanceId
+}
+
+const recordIntent = (request) => {
+  const key = getKey(request.editorUid, request.kind)
+  const current = latestIntents.get(key)
+  if (current && current.intentSequence > request.intentSequence) {
+    return false
+  }
+  latestIntents.set(key, {
+    instanceId: request.instanceId,
+    intentSequence: request.intentSequence,
+  })
+  return true
+}
+
+const dispose = async (rendererUid) => {
+  await RendererProcess.invoke('Viewlet.sendMultiple', [['Viewlet.dispose', rendererUid]])
+}
+
+const orderCommands = (rendererUid, commands) => {
+  const focusCommands = []
+  const contentCommands = []
+  for (const command of commands) {
+    if (command[0] === 'Viewlet.focusSelector') {
+      focusCommands.push(command)
+    } else {
+      contentCommands.push(command)
+    }
+  }
+  return [
+    ['Viewlet.createFunctionalRoot', 'FindWidget', rendererUid, true],
+    ...contentCommands,
+    ['Viewlet.appendToBody', rendererUid],
+    ...focusCommands,
+  ]
+}
+
+export const allocateRendererId = () => {
+  return Id.create()
+}
+
+export const attach = async (request) => {
+  if (!recordIntent(request)) {
+    await dispose(request.rendererUid)
+    return false
+  }
+  if (!isCurrent(request)) {
+    await dispose(request.rendererUid)
+    return false
+  }
+  const commands = orderCommands(request.rendererUid, request.commands)
+  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+  if (!isCurrent(request)) {
+    await dispose(request.rendererUid)
+    return false
+  }
+  return true
+}
+
+export const remove = async (request) => {
+  recordIntent(request)
+  await dispose(request.rendererUid)
+}
+
+export const update = async (request) => {
+  if (!isCurrent(request)) {
+    return false
+  }
+  await RendererProcess.invoke('Viewlet.sendMultiple', request.commands)
+  return isCurrent(request)
+}
+
+export const removeMany = async (requests) => {
+  for (const request of requests) {
+    recordIntent(request)
+  }
+  if (requests.length === 0) {
+    return
+  }
+  await RendererProcess.invoke(
+    'Viewlet.sendMultiple',
+    requests.map((request) => ['Viewlet.dispose', request.rendererUid]),
+  )
+}
+
+export const reset = () => {
+  latestIntents.clear()
+}

--- a/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
+++ b/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
@@ -2,6 +2,16 @@ import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 
 const queues = new Map()
 
+const runEditorCommand = async (editor, fullId, restArgs) => {
+  await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
+  const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
+  const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
+  return {
+    ...editor,
+    commands,
+  }
+}
+
 export const wrapEditorCommand = (id) => {
   return async (...args) => {
     if (args.length === 0) {
@@ -10,6 +20,9 @@ export const wrapEditorCommand = (id) => {
     const editor = args[0]
     const restArgs = args.slice(1)
     const fullId = id.includes('.') ? id : `Editor.${id}`
+    if (fullId === 'Editor.openFind' || fullId === 'Editor.openFind2' || fullId === 'Editor.closeFind') {
+      return runEditorCommand(editor, fullId, restArgs)
+    }
     const previous = queues.get(editor.uid)
     const { promise: next, resolve } = Promise.withResolvers()
     queues.set(editor.uid, next)
@@ -18,13 +31,7 @@ export const wrapEditorCommand = (id) => {
       await previous
     }
     try {
-      await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
-      const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
-      const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
-      return {
-        ...editor,
-        commands,
-      }
+      return await runEditorCommand(editor, fullId, restArgs)
     } finally {
       resolve(undefined)
       if (queues.get(editor.uid) === next) {

--- a/packages/renderer-worker/test/WidgetLifecycle.test.ts
+++ b/packages/renderer-worker/test/WidgetLifecycle.test.ts
@@ -1,0 +1,124 @@
+// @ts-nocheck
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: jest.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const WidgetLifecycle = await import('../src/parts/WidgetLifecycle/WidgetLifecycle.js')
+
+const request = (overrides: Record<string, unknown> = {}) => ({
+  editorUid: 1,
+  kind: 'find',
+  instanceId: 'editor:1:find:1',
+  intentSequence: 1,
+  rendererUid: 41,
+  commands: [
+    ['Viewlet.setDom2', 41, ['div', {}, 'find']],
+    ['Viewlet.focusSelector', 41, 'input'],
+  ],
+  ...overrides,
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  WidgetLifecycle.reset()
+})
+
+test('attaches a widget as one ordered renderer batch', async () => {
+  await expect(WidgetLifecycle.attach(request())).resolves.toBe(true)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.createFunctionalRoot', 'FindWidget', 41, true],
+    ['Viewlet.setDom2', 41, ['div', {}, 'find']],
+    ['Viewlet.appendToBody', 41],
+    ['Viewlet.focusSelector', 41, 'input'],
+  ])
+})
+
+test('rejects an attach superseded by a newer remove', async () => {
+  let resolveAttach: (() => void) | undefined
+  RendererProcess.invoke.mockImplementationOnce(
+    () =>
+      new Promise<void>((resolve) => {
+        resolveAttach = resolve
+      }),
+  )
+
+  const attaching = WidgetLifecycle.attach(request())
+  await Promise.resolve()
+  const removing = WidgetLifecycle.remove(
+    request({
+      instanceId: 'editor:1:find:closed',
+      intentSequence: 2,
+      commands: [],
+    }),
+  )
+  resolveAttach!()
+
+  await expect(attaching).resolves.toBe(false)
+  await removing
+  expect(RendererProcess.invoke.mock.calls).toEqual([
+    [
+      'Viewlet.sendMultiple',
+      [
+        ['Viewlet.createFunctionalRoot', 'FindWidget', 41, true],
+        ['Viewlet.setDom2', 41, ['div', {}, 'find']],
+        ['Viewlet.appendToBody', 41],
+        ['Viewlet.focusSelector', 41, 'input'],
+      ],
+    ],
+    ['Viewlet.sendMultiple', [['Viewlet.dispose', 41]]],
+    ['Viewlet.sendMultiple', [['Viewlet.dispose', 41]]],
+  ])
+})
+
+test('rejects a stale attach before rendering it', async () => {
+  await WidgetLifecycle.remove(
+    request({
+      instanceId: 'editor:1:find:closed',
+      intentSequence: 2,
+      commands: [],
+    }),
+  )
+
+  await expect(WidgetLifecycle.attach(request())).resolves.toBe(false)
+
+  expect(RendererProcess.invoke).toHaveBeenLastCalledWith('Viewlet.sendMultiple', [['Viewlet.dispose', 41]])
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
+})
+
+test('removes multiple widgets in one batch', async () => {
+  await WidgetLifecycle.removeMany([request({ rendererUid: 41 }), request({ kind: 'hover', instanceId: 'editor:1:hover:1', rendererUid: 42 })])
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.dispose', 41],
+    ['Viewlet.dispose', 42],
+  ])
+})
+
+test('updates only the current widget instance', async () => {
+  await WidgetLifecycle.attach(request())
+  RendererProcess.invoke.mockClear()
+
+  await expect(
+    WidgetLifecycle.update(
+      request({
+        commands: [['Viewlet.setValueByName', 41, 'SearchValue', 'needle']],
+      }),
+    ),
+  ).resolves.toBe(true)
+  await expect(
+    WidgetLifecycle.update(
+      request({
+        instanceId: 'editor:1:find:stale',
+        commands: [['Viewlet.setValueByName', 41, 'SearchValue', 'stale']],
+      }),
+    ),
+  ).resolves.toBe(false)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.setValueByName', 41, 'SearchValue', 'needle']])
+})

--- a/packages/renderer-worker/test/WrapEditorCommands.test.ts
+++ b/packages/renderer-worker/test/WrapEditorCommands.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
+  invoke: jest.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
+const WrapEditorCommands = await import('../src/parts/WrapEditorCommands/WrapEditorCommands.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('does not serialize find widget intents', async () => {
+  let resolveOpen: (() => void) | undefined
+  EditorWorker.invoke.mockImplementation((method: string) => {
+    if (method === 'Editor.openFind') {
+      return new Promise<void>((resolve) => {
+        resolveOpen = resolve
+      })
+    }
+    if (method === 'Editor.diff2') {
+      return Promise.resolve([])
+    }
+    if (method === 'Editor.render2') {
+      return Promise.resolve([])
+    }
+    return Promise.resolve(undefined)
+  })
+  const editor = { uid: 1 }
+  const open = WrapEditorCommands.wrapEditorCommand('openFind')
+  const close = WrapEditorCommands.wrapEditorCommand('closeFind')
+
+  const opening = open(editor)
+  await Promise.resolve()
+  const closing = close(editor)
+  await Promise.resolve()
+
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.closeFind', 1)
+  resolveOpen!()
+  await Promise.all([opening, closing])
+})


### PR DESCRIPTION
Adds renderer-owned widget instance sequencing so stale find-widget attach, update, and removal work is rejected deterministically.