### PR TITLE
fix: retry cli prompt cleanup several times

### DIFF
--- a/packages/main-process/test/CliPrompt.test.js
+++ b/packages/main-process/test/CliPrompt.test.js
@@ -110,7 +110,7 @@ afterAll(async () => {
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve(undefined)))
   })
-  await rm(temporaryDirectory, { force: true, maxRetries: 1, recursive: true, retryDelay: 100 })
+  await rm(temporaryDirectory, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })
   if (dbusPid) {
     process.kill(dbusPid)
   }


### PR DESCRIPTION
Retry temporary-directory removal several times so transient Windows file locks do not fail an otherwise successful CLI prompt test.