### PR TITLE
fix: handle dialog worker like other workers

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -59,7 +59,6 @@
         "@lvce-editor/references-view": "^2.9.0",
         "@lvce-editor/rename-worker": "^1.33.0",
         "@lvce-editor/renderer-process": "^30.12.3",
-        "@lvce-editor/rpc-registry": "^9.40.0",
         "@lvce-editor/running-extensions-view": "^1.12.0",
         "@lvce-editor/settings-view": "^2.14.0",
         "@lvce-editor/settings-worker": "^1.6.0",
@@ -93,12 +92,6 @@
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/@lvce-editor/activity-bar-worker/-/activity-bar-worker-7.14.1.tgz",
       "integrity": "sha512-G+KKqAFFXdj4tykkQEKxsuQnwH2xTGydr8yWGuvFYSrpVDoL85E/W3r6Cr/foJ8iyFHeSkqHRJ4UrEOyzzNLjw==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/assert": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
-      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/auth-worker": {
@@ -179,12 +172,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/color-picker-worker/-/color-picker-worker-3.7.0.tgz",
       "integrity": "sha512-8wE0cNwCz1uPRxDLI7Tqh9Kw1ixqmgDl4PGeP6Zb7q2tWWLX6RAofVOZgsrS//EYqUqnx3j9LbQrc/QNtOAXrg==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-2.0.0.tgz",
-      "integrity": "sha512-NZokXOACzuRoIpsHVHx+VhNQwM/QcQ4bl3wc8DgDM/+AxAVT2EU8S9cVQQedtJj94N35zmAB2To6Egm8aifOlw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/completion-worker": {
@@ -325,26 +312,6 @@
       "integrity": "sha512-dxBiM8qGgpobj5jnEmLn/uq5NRIX8NIVW11fEavd3gZtXmAmWXgBdy6jdGSJ5W5PTWXwGN5/E2XOxb3U8nXwGw==",
       "license": "MIT"
     },
-    "node_modules/@lvce-editor/ipc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.5.0.tgz",
-      "integrity": "sha512-SgCmkVlkleWGwKgesKMNI3zlcjS9Hg7sHQ7HsayngbODhtLSUpLb/ZXpw0ziCCZHp377YCw/jwiT4MlzLRRTxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.4.0.tgz",
-      "integrity": "sha512-P88S6+tTtDTk7esMVwdVxhNeVE0SszWOS6HFflVmza/T/MvKQ88KjYJqTACd+6MWQmw+ZHV8hLwdL+9YXLfIoQ==",
-      "license": "MIT"
-    },
     "node_modules/@lvce-editor/keybindings-view": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/keybindings-view/-/keybindings-view-8.7.0.tgz",
@@ -440,30 +407,6 @@
       "resolved": "https://registry.npmjs.org/@lvce-editor/renderer-process/-/renderer-process-30.12.4.tgz",
       "integrity": "sha512-c1X091BWkgFzuGEx9x5ths2twGWDd6kISYRj3fzOiFguu9UPxxcBZ2+a/9oyvpjr5G3QqQLmowS33oCFAau2sQ==",
       "license": "MIT"
-    },
-    "node_modules/@lvce-editor/rpc": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.10.0.tgz",
-      "integrity": "sha512-yOvmhLpnRIbfa0/PmlIUOnP9hWscuYomztFNzj9Rkv/R2QpptmqC/xZKYNONIkT6yg+SWmWnhbl/6q98zxFIZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.4.0",
-        "@lvce-editor/json-rpc": "^8.4.0",
-        "@lvce-editor/verror": "^1.7.0"
-      }
-    },
-    "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.41.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.41.0.tgz",
-      "integrity": "sha512-wV6rAUnpqd1MhiNqeNrzvC9jGN6et/G3Gzbk0xG52CbSs9wsyKr4jgksc6j4GyOphFN4JL0vxPC9Rts83Fk8+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.22.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
     },
     "node_modules/@lvce-editor/running-extensions-view": {
       "version": "1.13.0",
@@ -564,12 +507,6 @@
       "integrity": "sha512-5AWCNw1xMDMKc75G2tXF29YyROqjZ36wLW7IB0MaYBrHsn6bTsfKx4jZEfvTyt/c0F0lsLY3LWTQx015cuG1LA==",
       "license": "MIT"
     },
-    "node_modules/@lvce-editor/verror": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/verror/-/verror-1.7.0.tgz",
-      "integrity": "sha512-+LGuAEIC2L7pbvkyAQVWM2Go0dAy+UWEui28g07zNtZsCBhm+gusBK8PNwLJLV5Jay+TyUYuwLIbJdjLLzqEBg==",
-      "license": "MIT"
-    },
     "node_modules/@lvce-editor/virtual-dom-worker": {
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.9.0.tgz",
@@ -577,18 +514,6 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/constants": "^5.20.0"
-      }
-    },
-    "node_modules/@lvce-editor/web-socket-server": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/web-socket-server/-/web-socket-server-2.1.0.tgz",
-      "integrity": "sha512-Yldf6nJ4seaFaysYTkkLkOhuJQxkdyX/u01vk1X0dXi21882wMtQbDmYZoAg9rVGWbdBFDIdAJ99pFCAM8eUQA==",
-      "license": "MIT",
-      "dependencies": {
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@types/node": {
@@ -614,27 +539,6 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -91,7 +91,6 @@
     "@lvce-editor/references-view": "^2.9.0",
     "@lvce-editor/rename-worker": "^1.33.0",
     "@lvce-editor/renderer-process": "^30.12.3",
-    "@lvce-editor/rpc-registry": "^9.40.0",
     "@lvce-editor/running-extensions-view": "^1.12.0",
     "@lvce-editor/settings-view": "^2.14.0",
     "@lvce-editor/settings-worker": "^1.6.0",

--- a/packages/renderer-worker/src/parts/DialogWorker/DialogWorker.js
+++ b/packages/renderer-worker/src/parts/DialogWorker/DialogWorker.js
@@ -1,8 +1,6 @@
-import { createLazyRpc, RpcId } from '@lvce-editor/rpc-registry'
+import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import { launchDialogWorker } from '../LaunchDialogWorker/LaunchDialogWorker.js'
 
-const rpc = createLazyRpc(RpcId.DialogWorker)
+const { invoke, invokeAndTransfer } = GetOrCreateWorker.getOrCreateWorker(launchDialogWorker)
 
-rpc.setFactory(launchDialogWorker)
-
-export const { invoke, invokeAndTransfer } = rpc
+export { invoke, invokeAndTransfer }

--- a/packages/renderer-worker/test/DialogWorker.test.ts
+++ b/packages/renderer-worker/test/DialogWorker.test.ts
@@ -1,30 +1,25 @@
-/* eslint-disable jest/no-restricted-jest-methods -- Dialog worker tests use ESM module mocks for RPC dependencies. */
+/* eslint-disable jest/no-restricted-jest-methods -- Dialog worker tests use ESM module mocks for worker dependencies. */
 import { expect, jest, test } from '@jest/globals'
 
-const lazyRpc = {
+const worker = {
   invoke: jest.fn(),
   invokeAndTransfer: jest.fn(),
-  setFactory: jest.fn(),
 }
 
-jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
-  createLazyRpc: jest.fn(() => lazyRpc),
-  RpcId: {
-    DialogWorker: 7014,
-  },
+jest.unstable_mockModule('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js', () => ({
+  getOrCreateWorker: jest.fn(() => worker),
 }))
 
 jest.unstable_mockModule('../src/parts/LaunchDialogWorker/LaunchDialogWorker.js', () => ({
   launchDialogWorker: jest.fn(),
 }))
 
-const RpcRegistry = await import('@lvce-editor/rpc-registry')
 const DialogWorker = await import('../src/parts/DialogWorker/DialogWorker.js')
+const GetOrCreateWorker = await import('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js')
 const LaunchDialogWorker = await import('../src/parts/LaunchDialogWorker/LaunchDialogWorker.js')
 
-test('configures a lazy dialog worker rpc', () => {
-  expect(RpcRegistry.createLazyRpc).toHaveBeenCalledWith(RpcRegistry.RpcId.DialogWorker)
-  expect(lazyRpc.setFactory).toHaveBeenCalledWith(LaunchDialogWorker.launchDialogWorker)
-  expect(DialogWorker.invoke).toBe(lazyRpc.invoke)
-  expect(DialogWorker.invokeAndTransfer).toBe(lazyRpc.invokeAndTransfer)
+test('configures a dialog worker', () => {
+  expect(GetOrCreateWorker.getOrCreateWorker).toHaveBeenCalledWith(LaunchDialogWorker.launchDialogWorker)
+  expect(DialogWorker.invoke).toBe(worker.invoke)
+  expect(DialogWorker.invokeAndTransfer).toBe(worker.invokeAndTransfer)
 })


### PR DESCRIPTION
- Use the renderer worker’s existing lazy worker helper for dialog-worker RPC calls.
- Remove the renderer-worker rpc-registry dependency so it cannot remain as an external bundle import.