### PR TITLE
feature: expose application name to extension detail view

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js
@@ -2,9 +2,7 @@ import * as ExtensionDetailViewWorkerUrl from '../ExtensionDetailViewWorkerUrl/E
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
-import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
-import * as PlatformPaths from '../PlatformPaths/PlatformPaths.js'
 
 export const launchExtensionDetailViewWorker = async () => {
   const name = 'Extension Detail View Worker'
@@ -17,7 +15,5 @@ export const launchExtensionDetailViewWorker = async () => {
     ),
   })
   HandleIpc.handleIpc(ipc)
-  const applicationName = await PlatformPaths.getApplicationName()
-  await JsonRpc.invoke(ipc, 'ExtensionDetail.initialize', applicationName)
   return ipc
 }

--- a/packages/renderer-worker/src/parts/Layout/Layout.ipc.js
+++ b/packages/renderer-worker/src/parts/Layout/Layout.ipc.js
@@ -3,6 +3,7 @@ import * as Layout from './Layout.js'
 export const name = 'Layout'
 
 export const Commands = {
+  getApplicationName: Layout.getApplicationName,
   getAssetDir: Layout.getAssetDir,
   getPlatform: Layout.getPlatform,
 }

--- a/packages/renderer-worker/src/parts/Layout/Layout.js
+++ b/packages/renderer-worker/src/parts/Layout/Layout.js
@@ -1,5 +1,10 @@
 import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as Platform from '../Platform/Platform.js'
+import * as PlatformPaths from '../PlatformPaths/PlatformPaths.js'
+
+export const getApplicationName = () => {
+  return PlatformPaths.getApplicationName()
+}
 
 export const getAssetDir = () => {
   return AssetDir.assetDir

--- a/packages/renderer-worker/test/LaunchExtensionDetailViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchExtensionDetailViewWorker.test.ts
@@ -24,32 +24,16 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
   }
 })
 
-jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => {
-  return {
-    invoke: jest.fn(),
-  }
-})
-
-jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => {
-  return {
-    getApplicationName: jest.fn(() => {
-      throw new Error('not implemented')
-    }),
-  }
-})
-
 const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
 const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
-const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchExtensionDetailViewWorker = await import('../src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js')
-const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
 })
 
-test('passes the application name to the extension detail view worker', async () => {
+test('launches the extension detail view worker', async () => {
   const ipc = {
     send(): void {},
   }
@@ -57,9 +41,6 @@ test('passes the application name to the extension detail view worker', async ()
   GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///extension-detail-view-worker.js')
   // @ts-ignore
   IpcParent.create.mockResolvedValue(ipc)
-  // @ts-ignore
-  PlatformPaths.getApplicationName.mockResolvedValue('test-app')
-
   const result = await LaunchExtensionDetailViewWorker.launchExtensionDetailViewWorker()
 
   expect(IpcParent.create).toHaveBeenCalledWith({
@@ -68,7 +49,5 @@ test('passes the application name to the extension detail view worker', async ()
     url: 'file:///extension-detail-view-worker.js',
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
-  expect(PlatformPaths.getApplicationName).toHaveBeenCalledTimes(1)
-  expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'ExtensionDetail.initialize', 'test-app')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/Layout.test.ts
+++ b/packages/renderer-worker/test/Layout.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => {
+  return {
+    getApplicationName: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
+const Layout = await import('../src/parts/Layout/Layout.js')
+const LayoutIpc = await import('../src/parts/Layout/Layout.ipc.js')
+const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('gets the application name from platform paths', async () => {
+  // @ts-ignore
+  PlatformPaths.getApplicationName.mockResolvedValue('test-app')
+
+  await expect(Layout.getApplicationName()).resolves.toBe('test-app')
+  expect(PlatformPaths.getApplicationName).toHaveBeenCalledTimes(1)
+  expect(LayoutIpc.Commands.getApplicationName).toBe(Layout.getApplicationName)
+})


### PR DESCRIPTION
Remove eager extension-detail worker initialization introduced by #12975. Expose the application name through renderer layout so extension detail content can load its own cache configuration.