### PR TITLE
fix: ignore null utility process messages

### DIFF
--- a/packages/shared-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
+++ b/packages/shared-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
@@ -26,6 +26,9 @@ export const signal = (port: any): any => {
 
 const getActualData = (event: any): any => {
   const { data, ports } = event
+  if (!data) {
+    return data
+  }
   if (ports.length > 0) {
     return {
       ...data,
@@ -62,8 +65,12 @@ export const wrap = (port: any): any => {
         case 'message':
           // @ts-ignore
           this.wrappedListener = (event: any): void => {
+            const data = getActualData(event)
+            if (!data) {
+              return
+            }
             const syntheticEvent = {
-              data: getActualData(event),
+              data,
               target: this,
             }
             listener(syntheticEvent)

--- a/packages/shared-process/test/IpcParentWithElectronUtilityProcess.test.ts
+++ b/packages/shared-process/test/IpcParentWithElectronUtilityProcess.test.ts
@@ -1,0 +1,23 @@
+import { expect, jest, test } from '@jest/globals'
+import * as IpcParentWithElectronUtilityProcess from '../src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.js'
+
+test('wrap - ignores a null message with transferred ports', () => {
+  let handleMessage: any
+  const port = {
+    on: jest.fn((event, listener) => {
+      handleMessage = listener
+    }),
+  }
+  const listener = jest.fn()
+  const ipc = IpcParentWithElectronUtilityProcess.wrap(port)
+  ipc.on('message', listener)
+
+  expect(() => {
+    handleMessage({
+      data: null,
+      ports: [{}],
+    })
+  }).not.toThrow()
+
+  expect(listener).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Ignore malformed null Electron utility-port messages before JSON-RPC dispatch. This prevents an invalid transferred-port payload from terminating the shared process.