### PR TITLE
fix: scope native title bar menu regions

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-app-regions.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-app-regions.ts
@@ -1,0 +1,15 @@
+export const name = 'viewlet.title-bar-app-regions'
+
+export const test = async ({ Locator, expect }) => {
+  const titleBar = Locator('.TitleBar')
+  await expect(titleBar).toHaveCSS('app-region', 'no-drag')
+
+  const titleBarIcon = Locator('.TitleBarIcon')
+  await expect(titleBarIcon).toHaveCSS('app-region', 'drag')
+
+  const titleBarMenuEntry = Locator('.TitleBarTopLevelEntry').first()
+  await expect(titleBarMenuEntry).toHaveCSS('app-region', 'no-drag')
+
+  const titleBarButtons = Locator('.TitleBarButtons')
+  await expect(titleBarButtons).toHaveCSS('app-region', 'drag')
+}

--- a/static/css/parts/ViewletTitleBar.css
+++ b/static/css/parts/ViewletTitleBar.css
@@ -1,8 +1,8 @@
 .TitleBar {
   display: flex;
   color: var(--TitleBarForeground, rgba(204, 204, 204, 0.6));
-  -webkit-app-region: drag;
-  app-region: drag;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
   contain: strict;
 }
 

--- a/static/css/parts/ViewletTitleBarButtons.css
+++ b/static/css/parts/ViewletTitleBarButtons.css
@@ -1,5 +1,6 @@
 .TitleBarButtons {
   margin-left: auto;
+  -webkit-app-region: drag;
   app-region: drag;
   contain: strict;
   flex-grow: 2;
@@ -14,6 +15,7 @@
   background: transparent;
   border: none;
   color: currentColor;
+  -webkit-app-region: no-drag;
   app-region: no-drag;
 }
 

--- a/static/css/parts/ViewletTitleBarIcon.css
+++ b/static/css/parts/ViewletTitleBarIcon.css
@@ -1,4 +1,6 @@
 .TitleBarIcon {
+  -webkit-app-region: drag;
+  app-region: drag;
   contain: strict;
   flex-basis: 30px !important;
   flex-grow: 0 !important;


### PR DESCRIPTION
Summary:
- keep the title bar center available for the editor context menu
- limit draggable/native window-menu regions to the app icon and window controls area
- cover the expected app-region CSS values with an e2e test