### PR TITLE
fix: use isolated view api event listeners

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -19,6 +19,7 @@ interface ViewRenderResult {
 }
 
 interface CreateViewInstanceSuccess {
+  readonly eventListeners?: readonly unknown[]
   readonly ok: true
   readonly result: ViewRenderResult
 }
@@ -189,7 +190,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
   const title = getViewTitle(view)
   const css = await loadCss(view)
   const cssId = css ? getCssId(view) : ''
-  const eventListeners = view.eventListeners || []
+  const contributedEventListeners = view.eventListeners || []
   const stateWithViewId = {
     ...state,
     viewId: view.id,
@@ -208,6 +209,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
       throw restoreError(createResult.error)
     }
     const renderResult = createResult.ok === true ? createResult.result : (result as ViewRenderResult)
+    const eventListeners = createResult.ok === true ? createResult.eventListeners || contributedEventListeners : contributedEventListeners
     const initialState = {
       ...stateWithViewId,
       title,
@@ -234,7 +236,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
     cssId,
     csp: view.iframe.csp,
     credentialless: view.iframe.credentialless,
-    eventListeners,
+    eventListeners: contributedEventListeners,
     iframeSandbox: view.iframe.sandbox,
     iframeSrc: view.iframe.src,
     kind: 'iframe',

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
@@ -127,6 +127,29 @@ test('loadContent stores virtual dom without duplicate commands', async () => {
   expect(newState.patches).toEqual([])
 })
 
+test('loadContent prefers event listeners registered through the isolated extension api', async () => {
+  const eventListeners = [
+    {
+      name: 'handleVideoError',
+      params: ['handleError', 'event.target.error.code', 'event.target.error.message'],
+    },
+  ]
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce({
+    eventListeners,
+    ok: true,
+    result: {
+      dom: [],
+      type: 'setDom',
+    },
+  })
+  const state = ViewletExtensionView.create(1, 'sample.views.testing', 0, 0, 100, 100)
+
+  const newState = await ViewletExtensionView.loadContent(state, undefined)
+
+  expect(newState.eventListeners).toBe(eventListeners)
+})
+
 test('loadContent rejects when virtual dom creation fails', async () => {
   const stack = `Error: create failed
     at Object.create (main.ts:5:13)`


### PR DESCRIPTION
## Details

Prefer event listeners returned by an activated isolated view over static manifest metadata. This allows virtual DOM views to define handlers through registerView without duplicating them in extension.json.

## Testing

- 1,059 renderer-worker tests passed
- renderer-worker type-check
- focused isolated-view tests: 35 passed