### PR TITLE
fix: forward webview opener when resolving module

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2000,8 +2000,8 @@ export const getBadgeCounts = (state: LayoutState) => {
   return state.badgeCounts
 }
 
-export const getModuleId = (state: LayoutState, uri: string) => {
-  return ViewletMap.getModuleId(uri)
+export const getModuleId = (state: LayoutState, uri: string, opener?: string) => {
+  return ViewletMap.getModuleId(uri, opener)
 }
 
 export const getHref = (state: LayoutState) => {

--- a/packages/renderer-worker/test/ViewletLayoutModuleId.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutModuleId.test.ts
@@ -1,0 +1,16 @@
+import { expect, jest, test } from '@jest/globals'
+
+const getModuleId = jest.fn(async (_uri?: string, _opener?: string) => 'WebView')
+
+jest.unstable_mockModule('../src/parts/ViewletMap/ViewletMap.js', () => ({
+  getModuleId,
+}))
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+
+test('forwards explicit opener when resolving viewlet module id', async () => {
+  const state = ViewletLayout.create(1)
+
+  await expect(ViewletLayout.getModuleId(state, '/workspace/readme.md', 'builtin.markdown-preview')).resolves.toBe('WebView')
+  expect(getModuleId).toHaveBeenCalledWith('/workspace/readme.md', 'builtin.markdown-preview')
+})


### PR DESCRIPTION
## Summary
- forward the explicit WebView opener through `Layout.getModuleId`
- cover Markdown-style opt-in WebView resolution with a regression test

## Validation
- `npm run type-check` in `packages/renderer-worker`
- focused Jest test delegated to CI because the local machine cannot persist Jest's haste-map cache
