### PR TITLE
fix: style xterm scrollbar

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
@@ -21,6 +21,8 @@ export const test = async ({ Command, KeyBoard, Locator, Settings, expect }) => 
 
   const terminal = Locator('.XtermTerminal')
   await expect(terminal).toBeVisible()
+  const terminalViewport = terminal.locator('.xterm-viewport')
+  await expect(terminalViewport).toHaveCSS('scrollbar-color', 'rgba(57, 71, 71, 0.6) rgba(0, 0, 0, 0)')
   await terminal.click()
 
   await runCommand(KeyBoard, 'echo hello > file.txt')

--- a/static/css/parts/ViewletTerminal.css
+++ b/static/css/parts/ViewletTerminal.css
@@ -24,3 +24,7 @@
   width: 100%;
   height: 100%;
 }
+
+.XtermTerminal .xterm-viewport {
+  scrollbar-color: var(--EditorScrollBarBackground, rgba(57, 71, 71, 0.6)) transparent;
+}


### PR DESCRIPTION
## Summary

- style xterm’s native viewport scrollbar with LVCE’s theme color
- keep the scrollbar track transparent instead of falling back to the light system style
- verify the computed scrollbar color in the terminal e2e test