### PR TITLE
fix: show editor load errors

### DIFF
--- a/packages/renderer-worker/src/parts/GetEditorErrorinfo/GetEditorErrorInfo.ts
+++ b/packages/renderer-worker/src/parts/GetEditorErrorinfo/GetEditorErrorInfo.ts
@@ -6,7 +6,7 @@ const isFileNotFoundError = (error: any) => {
   return error && error.code === ErrorCodes.ENOENT
 }
 
-export const getEditorErrorInfo = (error: any): EditorErrorInfo => {
+export const getEditorErrorInfo = (error: any, preparedMessage = ''): EditorErrorInfo => {
   if (isFileNotFoundError(error)) {
     return {
       type: EditorErrorType.Error,
@@ -20,7 +20,7 @@ export const getEditorErrorInfo = (error: any): EditorErrorInfo => {
   }
   return {
     type: EditorErrorType.Error,
-    message: `${error}`,
+    message: preparedMessage || `${error}`,
     actions: [],
   }
 }

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -788,17 +788,19 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       if (viewlet.setBounds !== false) {
         commands.push([kSetBounds, viewletUid, viewlet.x, viewlet.y, viewlet.width, viewlet.height])
       }
+      const message = GetViewletErrorMessage.getViewletErrorMessage(prettyError)
       if (module && module.customErrorRenderer) {
         const errorModule = await loadModule(viewlet.getModule, module.customErrorRenderer)
-        const dom = await errorModule.render(error)
+        const dom = await errorModule.render(error, message)
         await RendererProcess.invoke(kLoadModule, module.customErrorRenderer)
         commands.push([kCreate, module.customErrorRenderer, viewletUid])
         commands.push(['Viewlet.setDom2', viewletUid, dom])
-        commands.push([kAppend, parentUid, viewletUid])
+        if (viewlet.append) {
+          commands.push([kAppend, parentUid, viewletUid])
+        }
         // TODO
         // const errorCommands=
       } else {
-        const message = GetViewletErrorMessage.getViewletErrorMessage(prettyError)
         commands.push(['Viewlet.send', /* id */ viewletUid, 'setMessage', message])
         // @ts-ignore
         if (viewlet.append) {

--- a/packages/renderer-worker/src/parts/ViewletTextEditorError/ViewletTextEditorError.js
+++ b/packages/renderer-worker/src/parts/ViewletTextEditorError/ViewletTextEditorError.js
@@ -15,8 +15,8 @@ export const loadContent = (state) => {
   return state
 }
 
-export const render = (error) => {
-  const info = GetEditorErrorinfo.getEditorErrorInfo(error)
+export const render = (error, message) => {
+  const info = GetEditorErrorinfo.getEditorErrorInfo(error, message)
   return RenderTextEditorError.renderTextEditorError(info)
 }
 

--- a/packages/renderer-worker/test/GetEditorErrorInfo.test.ts
+++ b/packages/renderer-worker/test/GetEditorErrorInfo.test.ts
@@ -28,3 +28,19 @@ test('error - other', () => {
     actions: [],
   })
 })
+
+test('error - prepared message', () => {
+  const error = new RangeError('Maximum call stack size exceeded')
+  const preparedMessage = `RangeError: Maximum call stack size exceeded
+
+  10 | result.push(...treeToArray(child))
+     |        ^
+
+    at treeToArray (editorWorkerMain.js:10:8)`
+  const info = GetEditorErrorInfo.getEditorErrorInfo(error, preparedMessage)
+  expect(info).toEqual({
+    type: EditorErrorType.Error,
+    message: preparedMessage,
+    actions: [],
+  })
+})

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -29,6 +29,19 @@ jest.unstable_mockModule('../src/parts/ErrorHandling/ErrorHandling.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/PrettyError/PrettyError.js', () => {
+  return {
+    prepare: async (error: any) => ({
+      codeFrame: error.codeFrame || '',
+      message: error.message,
+      stack: '    at treeToArray (editorWorkerMain.js:10:8)',
+      type: error.name,
+    }),
+    getMessage: (error: any) => `${error.type}: ${error.message}`,
+    print: async () => {},
+  }
+})
+
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 
 const Command = await import('../src/parts/Command/Command.js')
@@ -561,6 +574,64 @@ test('load should mark the loaded instance as focused for its module type', asyn
   await ViewletManager.load(state)
 
   expect(ViewletStates.getFocusedInstanceByType('ChatDebug')).toBe(1)
+})
+
+test('load - custom error renderer preserves the original error and does not append a detached viewlet', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const error = new RangeError('Maximum call stack size exceeded')
+  // @ts-ignore
+  error.codeFrame = `  10 | result.push(...treeToArray(child))
+     |        ^`
+  const errorDom = [{ childCount: 0, type: 1 }]
+  const renderError = jest.fn((_error: unknown, _message: string) => errorDom)
+  const getModule = async (id?: string) => {
+    if (id === 'EditorTextError') {
+      return {
+        render: renderError,
+      }
+    }
+    return {
+      create() {
+        return {
+          uid: 42,
+        }
+      },
+      customErrorRenderer: 'EditorTextError',
+      loadContent() {
+        throw error
+      },
+    }
+  }
+  const viewlet = {
+    append: false,
+    disposed: false,
+    getModule,
+    id: 'EditorText',
+    parentUid: -1,
+    setBounds: false,
+    show: false,
+    type: 0,
+    uid: 42,
+    uri: '/tmp/large.heapsnapshot',
+  }
+
+  const commands = await ViewletManager.load(viewlet)
+
+  expect(renderError).toHaveBeenCalledWith(
+    error,
+    `RangeError: Maximum call stack size exceeded
+
+  10 | result.push(...treeToArray(child))
+     |        ^
+
+    at treeToArray (editorWorkerMain.js:10:8)`,
+  )
+  expect(commands).toEqual([
+    ['Viewlet.create', 'Error', 42],
+    ['Viewlet.create', 'EditorTextError', 42],
+    ['Viewlet.setDom2', 42, errorDom],
+  ])
 })
 
 test.skip('load - error - no create method', async () => {

--- a/static/css/parts/ViewletEditorError.css
+++ b/static/css/parts/ViewletEditorError.css
@@ -20,6 +20,10 @@
   user-select: text;
 }
 
+.TextEditorErrorMessage {
+  white-space: pre-wrap;
+}
+
 .EditorTextIcon {
   width: 48px;
   height: 48px;


### PR DESCRIPTION
Preserve the prepared editor load error, codeframe, and stack in the visible error view.

Avoid appending detached custom error viewlets to sentinel parent -1, and preserve codeframe whitespace.