### PR TITLE
fix: focus terminal when selecting panel tab

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
@@ -16,14 +16,16 @@ export const test = async ({ Command, KeyBoard, Locator, Settings, expect }) => 
     'terminal.backend': 'mock',
   })
 
-  await Command.execute('Layout.showPanel', 'Terminals')
-  await Command.execute('Panel.selectIndex', 3)
+  await Command.execute('Layout.showPanel', 'Problems')
+  const terminalsTab = Locator('.PanelTab[name="Terminals"]')
+  await terminalsTab.click()
 
   const terminal = Locator('.XtermTerminal')
   await expect(terminal).toBeVisible()
   const terminalViewport = terminal.locator('.xterm-viewport')
   await expect(terminalViewport).toHaveCSS('scrollbar-color', 'rgba(57, 71, 71, 0.6) rgba(0, 0, 0, 0)')
-  await terminal.click()
+  const terminalInput = terminal.locator('.xterm-helper-textarea')
+  await expect(terminalInput).toBeFocused()
 
   await runCommand(KeyBoard, 'echo hello > file.txt')
   await runCommand(KeyBoard, 'cat file.txt')

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -948,6 +948,7 @@ export const createPanelViewlet = async (
   actionsUid: number,
   bounds: any,
   uri: string,
+  focus = false,
 ) => {
   const commands = await ViewletManager.load(
     {
@@ -958,7 +959,7 @@ export const createPanelViewlet = async (
       uri,
       uid: editorUid,
       show: false,
-      focus: false,
+      focus,
       setBounds: false,
       x: bounds.x,
       y: bounds.y,

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -18,6 +18,7 @@ export const create = (id, uri, x, y, width, height) => {
     width,
     height,
     childUid: -1,
+    focusVersion: 0,
     selectedIndex: -1,
   }
 }
@@ -121,6 +122,13 @@ export const focusIndex = async (state, index) => {
 
 export const handleClickTab = (state, index) => {
   return focusIndex(state, index)
+}
+
+export const focus = (state) => {
+  return {
+    ...state,
+    focusVersion: state.focusVersion + 1,
+  }
 }
 
 export const resize = async (state, dimensions) => {

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminalsRender.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminalsRender.js
@@ -14,4 +14,14 @@ const renderDom = {
   },
 }
 
-export const render = [renderDom]
+export const renderFocus = {
+  isEqual(oldState, newState) {
+    return oldState.focusVersion === newState.focusVersion
+  },
+  apply(oldState, newState) {
+    return [['Viewlet.focus', newState.childUid]]
+  },
+  multiple: true,
+}
+
+export const render = [renderDom, renderFocus]

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -338,6 +338,38 @@ test('createPanelViewlet omits empty event listener registration for its new act
   ])
 })
 
+test('createPanelViewlet forwards focus to the loaded panel view', async () => {
+  const state = ViewletLayout.create(1)
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([])
+
+  await ViewletLayout.createPanelViewlet(
+    state,
+    'Terminals',
+    11,
+    22,
+    33,
+    {
+      x: 0,
+      y: 35,
+      width: 400,
+      height: 200,
+    },
+    '',
+    true,
+  )
+
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      focus: true,
+      id: 'Terminals',
+      uid: 11,
+    }),
+    false,
+    true,
+  )
+})
+
 test('toggleSideBarView hides the current side bar view when the same item is clicked', async () => {
   mockActivityBarRender()
   const state = {

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -29,6 +29,7 @@ jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => {
 
 const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
 const ViewletTerminals = await import('../src/parts/ViewletTerminals/ViewletTerminals.js')
+const ViewletTerminalsRender = await import('../src/parts/ViewletTerminals/ViewletTerminalsRender.js')
 
 test('loadContent always creates the xterm terminal view', async () => {
   const state = ViewletTerminals.create(1, '', 10, 20, 800, 400)
@@ -52,4 +53,17 @@ test('loadContent always creates the xterm terminal view', async () => {
     selectedIndex: 0,
     terminalTabsEnabled: true,
   })
+})
+
+test('focus eventually focuses the mounted xterm child', () => {
+  const state = {
+    ...ViewletTerminals.create(1, '', 10, 20, 800, 400),
+    childUid: 42,
+  }
+
+  const newState = ViewletTerminals.focus(state)
+
+  expect(newState.focusVersion).toBe(1)
+  expect(ViewletTerminalsRender.renderFocus.isEqual(state, newState)).toBe(false)
+  expect(ViewletTerminalsRender.renderFocus.apply(state, newState)).toEqual([['Viewlet.focus', 42]])
 })


### PR DESCRIPTION
Focuses the mounted xterm terminal after the Terminals panel tab is selected, removing the need for a second click. Adds renderer unit coverage and updates the terminal e2e to verify focus after clicking the panel tab.