### PR TITLE
fix: exclude config from electron static assets

### DIFF
--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -110,7 +110,7 @@ const copyStaticFiles = async ({ resourcesPath, commitHash }) => {
   await Copy.copy({
     from: 'static',
     to: `${resourcesPath}/app/static/${commitHash}`,
-    ignore: ['css'],
+    ignore: ['config.json', 'css'],
   })
   await CopyElectronIcons.copyElectronIcons({ resourcesPath, commitHash })
   await Rename.rename({


### PR DESCRIPTION
Summary:
- stop copying the development static/config.json into Electron commit-scoped assets
- keep the generated app-root config.json used by Electron runtime