### PR TITLE
fix: use absolute web asset urls

### DIFF
--- a/packages/renderer-worker/src/parts/GetLicenseUri/GetLicenseUri.js
+++ b/packages/renderer-worker/src/parts/GetLicenseUri/GetLicenseUri.js
@@ -1,11 +1,12 @@
 import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as GetWebAssetUrl from '../GetWebAssetUrl/GetWebAssetUrl.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 
 export const getLicenseUri = async (platform = Platform.getPlatform(), assetDir = AssetDir.assetDir) => {
   if (platform === PlatformType.Web) {
-    return `${assetDir}/LICENSE`
+    return GetWebAssetUrl.getWebAssetUrl(assetDir, 'LICENSE')
   }
   const rootUri = await SharedProcess.invoke('Platform.getRootUri')
   return `${rootUri.replace(/\/$/, '')}/LICENSE`

--- a/packages/renderer-worker/src/parts/GetWebAssetUrl/GetWebAssetUrl.js
+++ b/packages/renderer-worker/src/parts/GetWebAssetUrl/GetWebAssetUrl.js
@@ -1,0 +1,7 @@
+import * as Origin from '../Origin/Origin.js'
+
+export const getWebAssetUrl = (assetDir, fileName, origin = Origin.origin) => {
+  const normalizedAssetDir = assetDir.endsWith('/') ? assetDir.slice(0, -1) : assetDir
+  const assetPath = `${normalizedAssetDir}/${fileName}`
+  return new URL(assetPath, `${origin}/`).toString()
+}

--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
@@ -1,4 +1,5 @@
 import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as GetWebAssetUrl from '../GetWebAssetUrl/GetWebAssetUrl.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
@@ -26,7 +27,7 @@ export const getDisabledExtensionsJsonPath = () => {
 
 export const getConfigJsonPath = (platform = Platform.getPlatform(), assetDir = AssetDir.assetDir) => {
   if (platform === PlatformType.Web) {
-    return `${assetDir}/config.json`
+    return GetWebAssetUrl.getWebAssetUrl(assetDir, 'config.json')
   }
   return SharedProcess.invoke(/* Platform.getConfigJsonPath */ 'Platform.getConfigJsonPath')
 }

--- a/packages/renderer-worker/test/GetLicenseUri.test.ts
+++ b/packages/renderer-worker/test/GetLicenseUri.test.ts
@@ -7,6 +7,13 @@ jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
   }),
 }))
 
+Object.defineProperty(globalThis, 'location', {
+  configurable: true,
+  value: {
+    origin: 'https://lvce-editor.github.io',
+  },
+})
+
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const GetLicenseUri = await import('../src/parts/GetLicenseUri/GetLicenseUri.js')
 
@@ -15,8 +22,8 @@ beforeEach(() => {
 })
 
 test('web', async () => {
-  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Web, '/abc123')
-  expect(uri).toBe('/abc123/LICENSE')
+  const uri = await GetLicenseUri.getLicenseUri(PlatformType.Web, '/lvce-editor/abc123')
+  expect(uri).toBe('https://lvce-editor.github.io/lvce-editor/abc123/LICENSE')
   expect(SharedProcess.invoke).not.toHaveBeenCalled()
 })
 

--- a/packages/renderer-worker/test/GetWebAssetUrl.test.ts
+++ b/packages/renderer-worker/test/GetWebAssetUrl.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import * as GetWebAssetUrl from '../src/parts/GetWebAssetUrl/GetWebAssetUrl.js'
+
+test('returns an absolute url for a root-relative asset directory', () => {
+  expect(GetWebAssetUrl.getWebAssetUrl('/lvce-editor/abc123', 'config.json', 'https://lvce-editor.github.io')).toBe(
+    'https://lvce-editor.github.io/lvce-editor/abc123/config.json',
+  )
+})
+
+test('preserves an absolute asset directory', () => {
+  expect(GetWebAssetUrl.getWebAssetUrl('https://example.com/static/abc123/', 'LICENSE', 'https://unused.example.com')).toBe(
+    'https://example.com/static/abc123/LICENSE',
+  )
+})

--- a/packages/renderer-worker/test/PlatformPaths.test.ts
+++ b/packages/renderer-worker/test/PlatformPaths.test.ts
@@ -13,6 +13,13 @@ jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
   }
 })
 
+Object.defineProperty(globalThis, 'location', {
+  configurable: true,
+  value: {
+    origin: 'https://lvce-editor.github.io',
+  },
+})
+
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
@@ -74,7 +81,9 @@ test('getUserSettingsPath', async () => {
 })
 
 test('getConfigJsonPath - web', async () => {
-  expect(await PlatformPaths.getConfigJsonPath(PlatformType.Web, '/test/commit-hash')).toBe('/test/commit-hash/config.json')
+  expect(await PlatformPaths.getConfigJsonPath(PlatformType.Web, '/lvce-editor/commit-hash')).toBe(
+    'https://lvce-editor.github.io/lvce-editor/commit-hash/config.json',
+  )
   expect(SharedProcess.invoke).not.toHaveBeenCalled()
 })
 


### PR DESCRIPTION
Resolve web config and license assets against the current origin so About and View License use the HTTPS filesystem provider.