### PR TITLE
fix: refresh explorer actions on workspace change

### DIFF
--- a/packages/renderer-worker/src/parts/WrapExplorerCommand/WrapExplorerCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapExplorerCommand/WrapExplorerCommand.ts
@@ -1,35 +1,61 @@
 import * as ExplorerViewWorker from '../ExplorerViewWorker/ExplorerViewWorker.js'
 import * as ViewletExplorer from '../ViewletExplorer/ViewletExplorer.js'
 
-export const wrapExplorerCommand = (key: string) => {
-  const fn = async (state, ...args) => {
-    await ExplorerViewWorker.invoke(`Explorer.${key}`, state.uid, ...args)
-    const diffResult = await ExplorerViewWorker.invoke('Explorer.diff2', state.uid)
-    const title = await ViewletExplorer.getTitle(state.uid)
+interface ExplorerCommandDependencies {
+  readonly getTitle: (uid: number) => Promise<string>
+  readonly invoke: (command: string, ...args: readonly unknown[]) => Promise<unknown>
+}
+
+interface ExplorerViewState {
+  readonly actionsDom: readonly unknown[]
+  readonly [key: string]: unknown
+  readonly title: string
+  readonly uid: number
+}
+
+type ExplorerCommand = (state: ExplorerViewState, ...args: readonly unknown[]) => Promise<ExplorerViewState>
+
+const defaultDependencies: ExplorerCommandDependencies = {
+  getTitle: ViewletExplorer.getTitle,
+  invoke: ExplorerViewWorker.invoke,
+}
+
+const updateActionsAndTitle = (state: ExplorerViewState, actionsDom: readonly unknown[], title: string): ExplorerViewState => {
+  const { actionsDom: oldActionsDom, title: oldTitle } = state
+  if (oldTitle === title && JSON.stringify(oldActionsDom) === JSON.stringify(actionsDom)) {
+    return state
+  }
+  return {
+    ...state,
+    actionsDom,
+    title,
+  }
+}
+
+export const wrapExplorerCommandWithDependencies = (key: string, dependencies: ExplorerCommandDependencies): ExplorerCommand => {
+  const { getTitle, invoke } = dependencies
+  const fn: ExplorerCommand = async (state, ...args) => {
+    const { uid } = state
+    await invoke(`Explorer.${key}`, uid, ...args)
+    const diffResult = (await invoke('Explorer.diff2', uid)) as readonly unknown[]
+    const title = await getTitle(uid)
+    const actionsDom = (await invoke('Explorer.renderActions2', uid)) as readonly unknown[]
+    const updatedState = updateActionsAndTitle(state, actionsDom, title)
     if (diffResult.length === 0) {
-      if (state.title === title) {
-        return state
-      }
-      return {
-        ...state,
-        title,
-      }
+      return updatedState
     }
-    const commands = await ExplorerViewWorker.invoke('Explorer.render2', state.uid, diffResult)
+    const commands = (await invoke('Explorer.render2', uid, diffResult)) as readonly unknown[]
     if (commands.length === 0) {
-      if (state.title === title) {
-        return state
-      }
-      return {
-        ...state,
-        title,
-      }
+      return updatedState
     }
     return {
-      ...state,
+      ...updatedState,
       commands,
-      title,
     }
   }
   return fn
+}
+
+export const wrapExplorerCommand = (key: string): ExplorerCommand => {
+  return wrapExplorerCommandWithDependencies(key, defaultDependencies)
 }

--- a/packages/renderer-worker/test/WrapExplorerCommand.test.ts
+++ b/packages/renderer-worker/test/WrapExplorerCommand.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const { wrapExplorerCommandWithDependencies } = await import('../src/parts/WrapExplorerCommand/WrapExplorerCommand.ts')
+
+const getTitle = jest.fn<(uid: number) => Promise<string>>()
+const invoke = jest.fn<(command: string, ...args: readonly unknown[]) => Promise<unknown>>()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('updates explorer actions when the workspace changes without a content diff', async () => {
+  const actionsDom = [['newFile'], ['newFolder'], ['refresh'], ['collapseAll']]
+  invoke.mockImplementation(async (command: string) => {
+    if (command === 'Explorer.diff2') {
+      return []
+    }
+    if (command === 'Explorer.renderActions2') {
+      return actionsDom
+    }
+    return undefined
+  })
+  getTitle.mockResolvedValue('workspace')
+  const state = {
+    actionsDom: [['refresh'], ['collapseAll']],
+    commands: [],
+    title: 'workspace',
+    uid: 7,
+  }
+
+  const result = await wrapExplorerCommandWithDependencies('handleWorkspaceChange', { getTitle, invoke })(state, '/workspace')
+
+  expect(result).toEqual({
+    ...state,
+    actionsDom,
+  })
+  expect(invoke).toHaveBeenNthCalledWith(1, 'Explorer.handleWorkspaceChange', 7, '/workspace')
+  expect(invoke).toHaveBeenNthCalledWith(2, 'Explorer.diff2', 7)
+  expect(getTitle).toHaveBeenCalledWith(7)
+  expect(invoke).toHaveBeenNthCalledWith(3, 'Explorer.renderActions2', 7)
+})
+
+test('returns the existing state when explorer actions, title, and content are unchanged', async () => {
+  const actionsDom = [['refresh'], ['collapseAll']]
+  invoke.mockImplementation(async (command: string) => {
+    if (command === 'Explorer.diff2') {
+      return []
+    }
+    if (command === 'Explorer.renderActions2') {
+      return actionsDom
+    }
+    return undefined
+  })
+  getTitle.mockResolvedValue('workspace')
+  const state = {
+    actionsDom,
+    commands: [],
+    title: 'workspace',
+    uid: 7,
+  }
+
+  const result = await wrapExplorerCommandWithDependencies('refresh', { getTitle, invoke })(state)
+
+  expect(result).toBe(state)
+})


### PR DESCRIPTION
Refresh the explorer action DOM after explorer commands so switching from a readonly folder to an editable workspace restores the New File and New Folder actions. Includes regression coverage for workspace changes with no explorer content diff.