### PR TITLE
fix: remove existing service workers

### DIFF
--- a/packages/build/src/parts/BuildStatic/BuildStatic.ts
+++ b/packages/build/src/parts/BuildStatic/BuildStatic.ts
@@ -149,6 +149,11 @@ const copyStaticFiles = async ({ pathPrefix, ignoreIconTheme, commitHash }) => {
   })
   await Replace.replace({
     path: `packages/build/.tmp/dist/index.html`,
+    occurrence: '/js/unregister-service-workers.js',
+    replacement: `${pathPrefix}/${commitHash}/js/unregister-service-workers.js`,
+  })
+  await Replace.replace({
+    path: `packages/build/.tmp/dist/index.html`,
     occurrence: '/icons',
     replacement: `${pathPrefix}/${commitHash}/icons`,
   })

--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
@@ -67,6 +67,11 @@ const copyStaticFiles = async ({ commitHash }) => {
   })
   await Replace.replace({
     path: `packages/build/.tmp/server/static-server/static/index.html`,
+    occurrence: '/js/unregister-service-workers.js',
+    replacement: `/${commitHash}/js/unregister-service-workers.js`,
+  })
+  await Replace.replace({
+    path: `packages/build/.tmp/server/static-server/static/index.html`,
     occurrence: '/icons',
     replacement: `/${commitHash}/icons`,
   })

--- a/packages/build/test/UnregisterServiceWorkers.test.js
+++ b/packages/build/test/UnregisterServiceWorkers.test.js
@@ -1,0 +1,50 @@
+import { expect, jest, test } from '@jest/globals'
+import { unregisterAllServiceWorkers } from '../../../static/js/unregister-service-workers.js'
+
+test('unregisters every service worker registration', async () => {
+  const firstRegistration = {
+    unregister: jest.fn(async () => true),
+  }
+  const secondRegistration = {
+    unregister: jest.fn(async () => true),
+  }
+  const serviceWorkerContainer = {
+    controller: null,
+    getRegistrations: jest.fn(async () => [firstRegistration, secondRegistration]),
+  }
+  const reload = jest.fn()
+
+  await unregisterAllServiceWorkers({ serviceWorkerContainer, reload })
+
+  expect(firstRegistration.unregister).toHaveBeenCalledTimes(1)
+  expect(secondRegistration.unregister).toHaveBeenCalledTimes(1)
+  expect(reload).not.toHaveBeenCalled()
+})
+
+test('reloads after unregistering a service worker that controls the page', async () => {
+  const registration = {
+    unregister: jest.fn(async () => true),
+  }
+  const serviceWorkerContainer = {
+    controller: {},
+    getRegistrations: jest.fn(async () => [registration]),
+  }
+  const reload = jest.fn()
+
+  await unregisterAllServiceWorkers({ serviceWorkerContainer, reload })
+
+  expect(registration.unregister).toHaveBeenCalledTimes(1)
+  expect(reload).toHaveBeenCalledTimes(1)
+})
+
+test('does not reload a controlled page when no registrations remain', async () => {
+  const serviceWorkerContainer = {
+    controller: {},
+    getRegistrations: jest.fn(async () => []),
+  }
+  const reload = jest.fn()
+
+  await unregisterAllServiceWorkers({ serviceWorkerContainer, reload })
+
+  expect(reload).not.toHaveBeenCalled()
+})

--- a/static/index.html
+++ b/static/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/css/App.css" />
     <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <link rel="apple-touch-icon" href="/icons/pwa-icon-192.png" />
+    <script type="module" src="/js/unregister-service-workers.js"></script>
     <script type="module" src="/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js"></script>
   </head>
 </html>

--- a/static/js/unregister-service-workers.js
+++ b/static/js/unregister-service-workers.js
@@ -1,0 +1,23 @@
+export const unregisterAllServiceWorkers = async ({ serviceWorkerContainer, reload }) => {
+  const isControlled = Boolean(serviceWorkerContainer.controller)
+  const registrations = await serviceWorkerContainer.getRegistrations()
+  if (registrations.length === 0) {
+    return
+  }
+  await Promise.all(registrations.map((registration) => registration.unregister()))
+  if (isControlled) {
+    reload()
+  }
+}
+
+const serviceWorkerContainer = globalThis.navigator?.serviceWorker
+if (serviceWorkerContainer) {
+  try {
+    await unregisterAllServiceWorkers({
+      serviceWorkerContainer,
+      reload: () => globalThis.location.reload(),
+    })
+  } catch (error) {
+    console.warn('Failed to unregister service workers', error)
+  }
+}


### PR DESCRIPTION
Unregister every existing service worker registration during web startup. Reload once when a legacy worker controls the current page so Chrome fully detaches and terminates it.