### PR TITLE
fix: preserve editor group bounds on resize

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMainResize.js
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMainResize.js
@@ -51,6 +51,7 @@ export const resize = async (state, dimensions) => {
     newState: {
       ...state,
       ...dimensions,
+      groups: newGroups,
     },
     commands,
   }

--- a/packages/renderer-worker/test/ViewletMainResize.test.ts
+++ b/packages/renderer-worker/test/ViewletMainResize.test.ts
@@ -1,0 +1,65 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
+  resize: jest.fn(() => []),
+}))
+
+const ViewletMainResize = await import('../src/parts/ViewletMain/ViewletMainResize.js')
+
+test('resize stores the updated editor group bounds', async () => {
+  const state = {
+    x: 0,
+    y: 20,
+    width: 100,
+    height: 160,
+    tabHeight: 35,
+    groups: [
+      {
+        activeIndex: -1,
+        editors: [],
+        height: 160,
+        tabsUid: -1,
+        width: 50,
+        x: 0,
+        y: 20,
+      },
+      {
+        activeIndex: -1,
+        editors: [],
+        height: 160,
+        tabsUid: -1,
+        width: 50,
+        x: 50,
+        y: 20,
+      },
+    ],
+  }
+
+  const { newState } = await ViewletMainResize.resize(state, {
+    x: 10,
+    y: 5,
+    width: 240,
+    height: 160,
+  })
+
+  expect(newState.groups).toEqual([
+    {
+      activeIndex: -1,
+      editors: [],
+      height: 160,
+      tabsUid: -1,
+      width: 120,
+      x: 0,
+      y: 25,
+    },
+    {
+      activeIndex: -1,
+      editors: [],
+      height: 160,
+      tabsUid: -1,
+      width: 120,
+      x: 120,
+      y: 25,
+    },
+  ])
+})


### PR DESCRIPTION
Persist resized editor group geometry in the main view state. This keeps later editor and cursor layout calculations aligned with the bounds already sent to the renderer.

Adds a regression test covering resized multi-group bounds.