### PR TITLE
fix: load extension detail on web

### DIFF
--- a/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
+++ b/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
@@ -213,6 +213,11 @@ export const bundleRendererWorker = async ({ cachePath, platform, commitHash, as
     })
     await Replace.replace({
       path: `${cachePath}/src/parts/Product/Product.js`,
+      occurrence: `applicationName = 'lvce-oss'`,
+      replacement: `applicationName = '${product.applicationName}'`,
+    })
+    await Replace.replace({
+      path: `${cachePath}/src/parts/Product/Product.js`,
       occurrence: `productNameLong = 'Lvce Editor - OSS'`,
       replacement: `productNameLong = '${product.nameLong}'`,
     })

--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
@@ -2,6 +2,7 @@ import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as GetWebAssetUrl from '../GetWebAssetUrl/GetWebAssetUrl.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as Product from '../Product/Product.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 /* istanbul ignore file */
 
@@ -137,6 +138,9 @@ export const getRepository = () => {
   return SharedProcess.invoke('Platform.getRepository')
 }
 
-export const getApplicationName = () => {
+export const getApplicationName = (platform = Platform.getPlatform()) => {
+  if (platform === PlatformType.Web) {
+    return Product.getApplicationName()
+  }
   return SharedProcess.invoke('Platform.getApplicationName')
 }

--- a/packages/renderer-worker/src/parts/Product/Product.js
+++ b/packages/renderer-worker/src/parts/Product/Product.js
@@ -1,6 +1,12 @@
 import product from './Product.json' with { type: 'json' }
 
+export const applicationName = 'lvce-oss'
+
 export const productNameLong = 'Lvce Editor - OSS'
+
+export const getApplicationName = () => {
+  return applicationName
+}
 
 export const getProductNameLong = () => {
   return productNameLong

--- a/packages/renderer-worker/test/PlatformPaths.test.ts
+++ b/packages/renderer-worker/test/PlatformPaths.test.ts
@@ -101,6 +101,23 @@ test('getConfigJsonPath - electron', async () => {
   expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getConfigJsonPath')
 })
 
+test('getApplicationName - web', () => {
+  expect(PlatformPaths.getApplicationName(PlatformType.Web)).toBe('lvce-oss')
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('getApplicationName - electron', () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockImplementation((method) => {
+    if (method === 'Platform.getApplicationName') {
+      return 'test-app'
+    }
+    throw new Error('unexpected message')
+  })
+  expect(PlatformPaths.getApplicationName(PlatformType.Electron)).toBe('test-app')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getApplicationName')
+})
+
 test('getUserSettingsPath - error', async () => {
   // @ts-ignore
   SharedProcess.invoke.mockImplementation(async (method, ...params) => {


### PR DESCRIPTION
Fix web extension details by reading the application name from the renderer product metadata instead of the unavailable shared-process transport. Preserve product-specific application names in renderer bundles and cover web and Electron lookup paths.