### PR TITLE
feature: clean up static workers after load

### DIFF
--- a/packages/renderer-worker/src/parts/ActivityBarWorker/ActivityBarWorker.js
+++ b/packages/renderer-worker/src/parts/ActivityBarWorker/ActivityBarWorker.js
@@ -1,6 +1,10 @@
-import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
+import * as GetOrCreateWorkerWithSleep from '../GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js'
 import * as LaunchActivityBarWorker from '../LaunchActivityBarWorker/LaunchActivityBarWorker.ts'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchActivityBarWorker.launchActivityBarWorker)
+const { invoke, restart, sleep } = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(
+  LaunchActivityBarWorker.launchActivityBarWorker,
+  'ActivityBar.sleep',
+  'ActivityBar.wakeUp',
+)
 
-export { invoke, restart }
+export { invoke, restart, sleep }

--- a/packages/renderer-worker/src/parts/CleanUpWorkersAfterLoad/CleanUpWorkersAfterLoad.js
+++ b/packages/renderer-worker/src/parts/CleanUpWorkersAfterLoad/CleanUpWorkersAfterLoad.js
@@ -1,0 +1,26 @@
+import * as ActivityBarWorker from '../ActivityBarWorker/ActivityBarWorker.js'
+import * as Preferences from '../Preferences/Preferences.js'
+import * as TitleBarWorker from '../TitleBarWorker/TitleBarWorker.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+
+const getUid = (moduleId) => {
+  const instance = ViewletStates.getInstance(moduleId)
+  return instance?.state.uid
+}
+
+export const cleanUpWorkersAfterLoad = async () => {
+  if (!Preferences.get('Workers.cleanUpAfterLoad')) {
+    return
+  }
+  const activityBarUid = getUid(ViewletModuleId.ActivityBar)
+  const titleBarUid = getUid(ViewletModuleId.TitleBar)
+  const promises = []
+  if (typeof activityBarUid === 'number') {
+    promises.push(ActivityBarWorker.sleep(activityBarUid))
+  }
+  if (typeof titleBarUid === 'number') {
+    promises.push(TitleBarWorker.sleep(titleBarUid))
+  }
+  await Promise.all(promises)
+}

--- a/packages/renderer-worker/src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js
+++ b/packages/renderer-worker/src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js
@@ -1,0 +1,75 @@
+import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
+
+export const getOrCreateWorkerWithSleep = (launchWorker, sleepCommand, wakeUpCommand) => {
+  const worker = GetOrCreateWorker.getOrCreateWorker(launchWorker)
+  const activeInvocations = new Set()
+  let hasSleepState = false
+  let sleepState
+  let sleepPromise
+  let wakeUpPromise
+
+  const wakeUp = () => {
+    if (!hasSleepState) {
+      return undefined
+    }
+    if (!wakeUpPromise) {
+      const state = sleepState
+      wakeUpPromise = worker
+        .invoke(wakeUpCommand, state)
+        .then(() => {
+          hasSleepState = false
+          sleepState = undefined
+        })
+        .finally(() => {
+          wakeUpPromise = undefined
+        })
+    }
+    return wakeUpPromise
+  }
+
+  const run = (fn) => {
+    const invocation = (async () => {
+      if (sleepPromise) {
+        await sleepPromise
+      }
+      await wakeUp()
+      return fn()
+    })()
+    activeInvocations.add(invocation)
+    invocation.then(
+      () => activeInvocations.delete(invocation),
+      () => activeInvocations.delete(invocation),
+    )
+    return invocation
+  }
+
+  const invoke = (method, ...params) => {
+    return run(() => worker.invoke(method, ...params))
+  }
+
+  const restart = (terminateCommand) => {
+    return run(() => worker.restart(terminateCommand))
+  }
+
+  const sleep = (...params) => {
+    if (!sleepPromise) {
+      const currentInvocations = [...activeInvocations]
+      sleepPromise = (async () => {
+        await Promise.all(currentInvocations)
+        await wakeUp()
+        sleepState = await worker.invoke(sleepCommand, ...params)
+        hasSleepState = true
+        await worker.dispose()
+      })().finally(() => {
+        sleepPromise = undefined
+      })
+    }
+    return sleepPromise
+  }
+
+  return {
+    invoke,
+    restart,
+    sleep,
+  }
+}

--- a/packages/renderer-worker/src/parts/TitleBarWorker/TitleBarWorker.js
+++ b/packages/renderer-worker/src/parts/TitleBarWorker/TitleBarWorker.js
@@ -1,6 +1,10 @@
-import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
+import * as GetOrCreateWorkerWithSleep from '../GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js'
 import * as LaunchTitleBarWorker from '../LaunchTitleBarWorker/LaunchTitleBarWorker.js'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchTitleBarWorker.launchTitleBarWorker)
+const { invoke, restart, sleep } = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(
+  LaunchTitleBarWorker.launchTitleBarWorker,
+  'TitleBar.sleep',
+  'TitleBar.wakeUp',
+)
 
-export { invoke, restart }
+export { invoke, restart, sleep }

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -2,6 +2,7 @@ import * as Bounds from '../Bounds/Bounds.js'
 import * as ColorTheme from '../ColorTheme/ColorTheme.js'
 import * as Command from '../Command/Command.js'
 import * as CleanAuthCallbackUrl from '../CleanAuthCallbackUrl/CleanAuthCallbackUrl.js'
+import * as CleanUpWorkersAfterLoad from '../CleanUpWorkersAfterLoad/CleanUpWorkersAfterLoad.js'
 import * as DevelopFileWatcher from '../DevelopFileWatcher/DevelopFileWatcher.js'
 import * as ExecuteCurrentTest from '../ExecuteCurrentTest/ExecuteCurrentTest.js'
 import * as FileSystemMap from '../FileSystemMap/FileSystemMap.js'
@@ -234,6 +235,7 @@ export const startup = async (platform, assetDir) => {
   LifeCycle.mark(LifeCyclePhase.Five)
 
   await Promise.all(actions.map((action) => action(platform, assetDir)))
+  await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
 
   LifeCycle.mark(LifeCyclePhase.Fifteen)
 

--- a/packages/renderer-worker/test/CleanUpWorkersAfterLoad.test.ts
+++ b/packages/renderer-worker/test/CleanUpWorkersAfterLoad.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Startup cleanup tests use ESM module mocks for worker dependencies. */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const activityBarSleep = jest.fn()
+const getPreference = jest.fn()
+const getInstance = jest.fn()
+const titleBarSleep = jest.fn()
+
+jest.unstable_mockModule('../src/parts/ActivityBarWorker/ActivityBarWorker.js', () => ({
+  sleep: activityBarSleep,
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  get: getPreference,
+}))
+
+jest.unstable_mockModule('../src/parts/TitleBarWorker/TitleBarWorker.js', () => ({
+  sleep: titleBarSleep,
+}))
+
+jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({
+  getInstance,
+}))
+
+const CleanUpWorkersAfterLoad = await import('../src/parts/CleanUpWorkersAfterLoad/CleanUpWorkersAfterLoad.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('does not clean up workers by default', async () => {
+  getPreference.mockReturnValue(false)
+
+  await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
+
+  expect(getPreference).toHaveBeenCalledTimes(1)
+  expect(getPreference).toHaveBeenCalledWith('Workers.cleanUpAfterLoad')
+  expect(activityBarSleep).not.toHaveBeenCalled()
+  expect(titleBarSleep).not.toHaveBeenCalled()
+})
+
+test('sleeps loaded activity bar and title bar workers when enabled', async () => {
+  getPreference.mockReturnValue(true)
+  getInstance.mockImplementation((moduleId) => {
+    if (moduleId === 'ActivityBar') {
+      return { state: { uid: 1 } }
+    }
+    return { state: { uid: 2 } }
+  })
+
+  await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
+
+  expect(activityBarSleep).toHaveBeenCalledTimes(1)
+  expect(activityBarSleep).toHaveBeenCalledWith(1)
+  expect(titleBarSleep).toHaveBeenCalledTimes(1)
+  expect(titleBarSleep).toHaveBeenCalledWith(2)
+})
+
+test('skips component workers that were not loaded', async () => {
+  getPreference.mockReturnValue(true)
+  getInstance.mockImplementation((moduleId) => {
+    if (moduleId === 'ActivityBar') {
+      return { state: { uid: 1 } }
+    }
+    return undefined
+  })
+
+  await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
+
+  expect(activityBarSleep).toHaveBeenCalledTimes(1)
+  expect(activityBarSleep).toHaveBeenCalledWith(1)
+  expect(titleBarSleep).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/GetOrCreateWorkerWithSleep.test.ts
+++ b/packages/renderer-worker/test/GetOrCreateWorkerWithSleep.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Worker lifecycle tests use an ESM module mock for the worker dependency. */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const worker = {
+  dispose: jest.fn<() => Promise<void>>(),
+  invoke: jest.fn<(method: string, ...params: readonly unknown[]) => Promise<unknown>>(),
+  restart: jest.fn<(terminateCommand: string) => Promise<void>>(),
+}
+
+jest.unstable_mockModule('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js', () => ({
+  getOrCreateWorker: jest.fn(() => worker),
+}))
+
+const GetOrCreateWorkerWithSleep = await import('../src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('invokes an awake worker without a wake-up command', async () => {
+  worker.invoke.mockResolvedValue('result')
+  const wrappedWorker = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(jest.fn(), 'Worker.sleep', 'Worker.wakeUp')
+
+  await expect(wrappedWorker.invoke('Worker.doSomething', 1)).resolves.toBe('result')
+
+  expect(worker.invoke).toHaveBeenCalledTimes(1)
+  expect(worker.invoke).toHaveBeenCalledWith('Worker.doSomething', 1)
+})
+
+test('sleeps and restores a worker before its next invocations', async () => {
+  const sleepState = { uid: 1, content: ['Item 1'] }
+  worker.invoke.mockImplementation(async (method) => {
+    if (method === 'Worker.sleep') {
+      return sleepState
+    }
+    return undefined
+  })
+  const wrappedWorker = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(jest.fn(), 'Worker.sleep', 'Worker.wakeUp')
+
+  await wrappedWorker.sleep(1)
+  await Promise.all([wrappedWorker.invoke('Worker.firstEvent', 1), wrappedWorker.invoke('Worker.secondEvent', 1)])
+
+  expect(worker.dispose).toHaveBeenCalledTimes(1)
+  expect(worker.invoke).toHaveBeenNthCalledWith(1, 'Worker.sleep', 1)
+  expect(worker.invoke).toHaveBeenNthCalledWith(2, 'Worker.wakeUp', sleepState)
+  expect(worker.invoke).toHaveBeenNthCalledWith(3, 'Worker.firstEvent', 1)
+  expect(worker.invoke).toHaveBeenNthCalledWith(4, 'Worker.secondEvent', 1)
+})
+
+test('waits for active invocations before sleeping', async () => {
+  let resolveInvocation
+  let markInvocationStarted
+  const invocationStarted = new Promise<void>((resolve) => {
+    markInvocationStarted = resolve
+  })
+  const invocation = new Promise<void>((resolve) => {
+    resolveInvocation = resolve
+  })
+  worker.invoke.mockImplementation(async (method) => {
+    if (method === 'Worker.activeEvent') {
+      markInvocationStarted()
+      return invocation
+    }
+    return {}
+  })
+  const wrappedWorker = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(jest.fn(), 'Worker.sleep', 'Worker.wakeUp')
+
+  const activeInvocation = wrappedWorker.invoke('Worker.activeEvent')
+  await invocationStarted
+  const sleep = wrappedWorker.sleep(1)
+
+  expect(worker.invoke).not.toHaveBeenCalledWith('Worker.sleep', 1)
+  resolveInvocation()
+  await activeInvocation
+  await sleep
+
+  expect(worker.invoke).toHaveBeenNthCalledWith(1, 'Worker.activeEvent')
+  expect(worker.invoke).toHaveBeenNthCalledWith(2, 'Worker.sleep', 1)
+})
+
+test('waits for cleanup before handling a new event', async () => {
+  const sleepState = { uid: 1 }
+  let resolveSleep
+  let markSleepStarted
+  const sleepStarted = new Promise<void>((resolve) => {
+    markSleepStarted = resolve
+  })
+  const sleepResult = new Promise((resolve) => {
+    resolveSleep = resolve
+  })
+  worker.invoke.mockImplementation(async (method) => {
+    if (method === 'Worker.sleep') {
+      markSleepStarted()
+      return sleepResult
+    }
+    return undefined
+  })
+  const wrappedWorker = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(jest.fn(), 'Worker.sleep', 'Worker.wakeUp')
+
+  const sleep = wrappedWorker.sleep(1)
+  await sleepStarted
+  const invocation = wrappedWorker.invoke('Worker.eventDuringCleanup', 1)
+
+  expect(worker.invoke).not.toHaveBeenCalledWith('Worker.eventDuringCleanup', 1)
+  resolveSleep(sleepState)
+  await sleep
+  await invocation
+
+  expect(worker.invoke).toHaveBeenNthCalledWith(1, 'Worker.sleep', 1)
+  expect(worker.invoke).toHaveBeenNthCalledWith(2, 'Worker.wakeUp', sleepState)
+  expect(worker.invoke).toHaveBeenNthCalledWith(3, 'Worker.eventDuringCleanup', 1)
+})

--- a/packages/renderer-worker/test/SleepingWorkerConfigurations.test.ts
+++ b/packages/renderer-worker/test/SleepingWorkerConfigurations.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Worker configuration tests use ESM module mocks for worker dependencies. */
+import { expect, jest, test } from '@jest/globals'
+
+const activityBarWorker = {
+  invoke: jest.fn(),
+  restart: jest.fn(),
+  sleep: jest.fn(),
+}
+const titleBarWorker = {
+  invoke: jest.fn(),
+  restart: jest.fn(),
+  sleep: jest.fn(),
+}
+
+jest.unstable_mockModule('../src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js', () => ({
+  getOrCreateWorkerWithSleep: jest.fn().mockReturnValueOnce(activityBarWorker).mockReturnValueOnce(titleBarWorker),
+}))
+
+jest.unstable_mockModule('../src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts', () => ({
+  launchActivityBarWorker: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js', () => ({
+  launchTitleBarWorker: jest.fn(),
+}))
+
+const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityBarWorker.js')
+const GetOrCreateWorkerWithSleep = await import('../src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js')
+const LaunchActivityBarWorker = await import('../src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts')
+const LaunchTitleBarWorker = await import('../src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js')
+const TitleBarWorker = await import('../src/parts/TitleBarWorker/TitleBarWorker.js')
+
+test('configures the activity bar worker sleep lifecycle', () => {
+  expect(GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep).toHaveBeenNthCalledWith(
+    1,
+    LaunchActivityBarWorker.launchActivityBarWorker,
+    'ActivityBar.sleep',
+    'ActivityBar.wakeUp',
+  )
+  expect(ActivityBarWorker.invoke).toBe(activityBarWorker.invoke)
+  expect(ActivityBarWorker.restart).toBe(activityBarWorker.restart)
+  expect(ActivityBarWorker.sleep).toBe(activityBarWorker.sleep)
+})
+
+test('configures the title bar worker sleep lifecycle', () => {
+  expect(GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep).toHaveBeenNthCalledWith(
+    2,
+    LaunchTitleBarWorker.launchTitleBarWorker,
+    'TitleBar.sleep',
+    'TitleBar.wakeUp',
+  )
+  expect(TitleBarWorker.invoke).toBe(titleBarWorker.invoke)
+  expect(TitleBarWorker.restart).toBe(titleBarWorker.restart)
+  expect(TitleBarWorker.sleep).toBe(titleBarWorker.sleep)
+})

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -45,6 +45,8 @@
   "window.zoomLevel": 0,
   "window.controlsOverlay.enabled": true,
 
+  "Workers.cleanUpAfterLoad": false,
+
   "workbench.colorTheme": "slime",
   "workbench.iconTheme": "vscode-icons",
   "workbench.activityBar.visible": true,


### PR DESCRIPTION
## Summary

- add the opt-in `Workers.cleanUpAfterLoad` setting
- sleep activity bar and title bar workers after startup, preserving their full state
- transparently recreate and wake workers before later events
- serialize cleanup with in-flight and newly arriving worker calls