### PR TITLE
fix: apply captured keybinding changes

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -43,7 +43,7 @@
         "@lvce-editor/icon-theme-worker": "^2.15.0",
         "@lvce-editor/iframe-inspector": "^2.4.0",
         "@lvce-editor/iframe-worker": "^6.12.0",
-        "@lvce-editor/keybindings-view": "^8.8.1",
+        "@lvce-editor/keybindings-view": "^8.8.2",
         "@lvce-editor/language-models-view": "^1.17.0",
         "@lvce-editor/main-area-worker": "^9.32.4",
         "@lvce-editor/markdown-worker": "^4.6.0",
@@ -313,9 +313,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/keybindings-view": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/keybindings-view/-/keybindings-view-8.8.1.tgz",
-      "integrity": "sha512-Oe6fInG6AwWr8z6PhrTIUfcfo8Nz0ncOA5LGfVRiS2ijU8AKi7SdGlNqdjIRROcL9m/iikMuV0nxcFBwZvzlEA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/keybindings-view/-/keybindings-view-8.8.2.tgz",
+      "integrity": "sha512-1eoraZtvGY/4D4tz/xZCbtjdVR9DlyridtRm51y2Toj82k+zdLqRO6KZzfy4QDoGfdwAz5sY6pyXDEWY7Np2kQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/language-models-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -75,7 +75,7 @@
     "@lvce-editor/icon-theme-worker": "^2.15.0",
     "@lvce-editor/iframe-inspector": "^2.4.0",
     "@lvce-editor/iframe-worker": "^6.12.0",
-    "@lvce-editor/keybindings-view": "^8.8.1",
+    "@lvce-editor/keybindings-view": "^8.8.2",
     "@lvce-editor/language-models-view": "^1.17.0",
     "@lvce-editor/main-area-worker": "^9.32.4",
     "@lvce-editor/markdown-worker": "^4.6.0",

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -545,8 +545,10 @@ export const disposeWidgetWithValue = async (id, value) => {
     if (!parentInstance) {
       return
     }
-    // @ts-ignore
-    const newState = parentInstance.factory.handleDefineKeyBindingDisposed(parentInstance.state, value)
+    if (!hasFn(parentInstance.factory, 'handleDefineKeyBindingDisposed')) {
+      return
+    }
+    await executeViewletCommand(parentInstance.state.uid, 'handleDefineKeyBindingDisposed', value)
   } catch (error) {
     console.error(error)
     // TODO use Error.cause once proper stack traces are supported by chrome

--- a/packages/renderer-worker/src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js
+++ b/packages/renderer-worker/src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js
@@ -37,7 +37,7 @@ export const handleKeyDown = (state, key, altKey, ctrlKey, shiftKey, metaKey) =>
     return state
   }
   if (key === BrowserKey.Enter) {
-    return dispose(state, key)
+    return dispose(state, state.value)
   }
   if (key === BrowserKey.Escape) {
     return dispose(state, '')

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -176,6 +176,43 @@ test('dispose - disposes the rendered viewlet when the factory has no dispose fu
   expect(ViewletStates.getInstance(2)).toBeUndefined()
 })
 
+test('disposeWidgetWithValue - dispatches the captured value to the keybindings view', async () => {
+  const widgetState = { uid: 42 }
+  const keyBindingsState = { uid: 7, value: '' }
+  const updatedKeyBindingsState = { uid: 7, value: 'Ctrl+Alt+9' }
+  const handleDefineKeyBindingDisposed = jest.fn((_state: typeof keyBindingsState, _value: string) => updatedKeyBindingsState)
+  const keyBindingsFactory = {
+    Commands: {
+      handleDefineKeyBindingDisposed,
+    },
+  }
+  ViewletStates.set(42, {
+    state: widgetState,
+    renderedState: widgetState,
+    moduleId: 'DefineKeyBinding',
+    factory: {},
+  })
+  ViewletStates.set(7, {
+    state: keyBindingsState,
+    renderedState: keyBindingsState,
+    moduleId: 'KeyBindings',
+    factory: keyBindingsFactory,
+  })
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(async () => {})
+  // @ts-ignore
+  ViewletManager.render.mockReturnValue([['Viewlet.setValueByName', 7, 'KeyBindingsFilter', 'Ctrl+Alt+9']])
+
+  await Viewlet.disposeWidgetWithValue(42, 'Ctrl+Alt+9')
+
+  expect(handleDefineKeyBindingDisposed).toHaveBeenCalledWith(keyBindingsState, 'Ctrl+Alt+9')
+  expect(ViewletManager.render).toHaveBeenCalledWith(keyBindingsFactory, keyBindingsState, updatedKeyBindingsState)
+  expect(RendererProcess.invoke).toHaveBeenNthCalledWith(1, 'Viewlet.sendMultiple', [['Viewlet.dispose', 42]])
+  expect(RendererProcess.invoke).toHaveBeenNthCalledWith(2, 'Viewlet.sendMultiple', [
+    ['Viewlet.setValueByName', 7, 'KeyBindingsFilter', 'Ctrl+Alt+9'],
+  ])
+})
+
 test('openWidget - once', async () => {
   // @ts-ignore
   ViewletManager.load.mockImplementation(() => {

--- a/packages/renderer-worker/test/ViewletDefineKeyBinding.test.ts
+++ b/packages/renderer-worker/test/ViewletDefineKeyBinding.test.ts
@@ -1,0 +1,21 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
+  return {
+    disposeWidgetWithValue: jest.fn(),
+  }
+})
+
+const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+const ViewletDefineKeyBinding = await import('../src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js')
+
+test('handleKeyDown - Enter submits the recorded keybinding', () => {
+  const state = {
+    uid: 42,
+    value: 'Ctrl+Alt+9',
+  }
+
+  ViewletDefineKeyBinding.handleKeyDown(state, 'Enter', false, false, false, false)
+
+  expect(Viewlet.disposeWidgetWithValue).toHaveBeenCalledWith(42, 'Ctrl+Alt+9')
+})


### PR DESCRIPTION
## Summary

- submit the recorded shortcut value when the Define Keybinding widget accepts Enter
- dispatch the captured value through the parent keybindings view command/render pipeline
- update the renderer workspace to `@lvce-editor/keybindings-view@8.8.2`
- cover both dialog submission and parent-view handoff

## Testing

- `npm test -- --runInBand Viewlet.test.ts ViewletDefineKeyBinding.test.ts` (12 passed, 2 existing skips)
- `npm run type-check` in `packages/renderer-worker`
- `git diff --check`

## Dependency

- https://github.com/lvce-editor/keybindings-view/pull/679
- https://github.com/lvce-editor/keybindings-view/releases/tag/v8.8.2