### PR TITLE
fix: route defined keybindings to their parent view

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -522,7 +522,7 @@ export const disposeWidgetWithValue = async (id, value) => {
     if (instance.factory.dispose) {
       instance.factory.dispose(instance.state)
     }
-    const uid = instance.state.uid
+    const { parentUid, uid } = instance.state
     Assert.number(uid)
     const commands = [[/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid]]
     if (instance.factory.getKeyBindings) {
@@ -541,7 +541,7 @@ export const disposeWidgetWithValue = async (id, value) => {
     ViewletStates.remove(uid)
     await RendererProcess.invoke('Viewlet.sendMultiple', commands)
     // return commands
-    const parentInstance = ViewletStates.getInstance(ViewletModuleId.KeyBindings)
+    const parentInstance = ViewletStates.getInstance(parentUid) || ViewletStates.getInstance(ViewletModuleId.KeyBindings)
     if (!parentInstance) {
       return
     }

--- a/packages/renderer-worker/src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js
+++ b/packages/renderer-worker/src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js
@@ -3,10 +3,11 @@ import * as GetKeyBindingsString from '../GetKeyBindingsString/GetKeyBindingsStr
 import * as KeyBindingsStrings from '../KeyBindingStrings/KeyBindingStrings.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
 
-export const create = (id, uri, x, y, width, height) => {
+export const create = (id, uri, x, y, width, height, args = []) => {
   return {
     id,
     uri,
+    parentUid: args[0],
     value: '',
     focused: false,
     message: '',

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -176,8 +176,8 @@ test('dispose - disposes the rendered viewlet when the factory has no dispose fu
   expect(ViewletStates.getInstance(2)).toBeUndefined()
 })
 
-test('disposeWidgetWithValue - dispatches the captured value to the keybindings view', async () => {
-  const widgetState = { uid: 42 }
+test('disposeWidgetWithValue - dispatches the captured value to the parent keybindings view', async () => {
+  const widgetState = { parentUid: 7, uid: 42 }
   const keyBindingsState = { uid: 7, value: '' }
   const updatedKeyBindingsState = { uid: 7, value: 'Ctrl+Alt+9' }
   const handleDefineKeyBindingDisposed = jest.fn((_state: typeof keyBindingsState, _value: string) => updatedKeyBindingsState)

--- a/packages/renderer-worker/test/ViewletDefineKeyBinding.test.ts
+++ b/packages/renderer-worker/test/ViewletDefineKeyBinding.test.ts
@@ -9,6 +9,13 @@ jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletDefineKeyBinding = await import('../src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js')
 
+test('create - stores the parent keybindings view uid', () => {
+  expect(ViewletDefineKeyBinding.create(42, '', 0, 0, 100, 100, [7])).toMatchObject({
+    id: 42,
+    parentUid: 7,
+  })
+})
+
 test('handleKeyDown - Enter submits the recorded keybinding', () => {
   const state = {
     uid: 42,


### PR DESCRIPTION
## Description

Record the UID of the view that opened the define-keybinding dialog and route the captured value back to that exact parent. Keep the existing module-ID lookup as a compatibility fallback.

This fixes keybinding changes in externally loaded keybindings views, whose runtime UID differs from the built-in module ID.

## Testing

- `npm test --workspace=@lvce-editor/renderer-worker -- Viewlet.test.ts ViewletDefineKeyBinding.test.ts`
- `npm run type-check --workspace=@lvce-editor/renderer-worker`