### PR TITLE
fix: enable web diagnostics by default

### DIFF
--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -16,6 +16,7 @@
   "editor.autoClosingBrackets": true,
   "editor.autoClosingQuotes": true,
   "editor.cache": true,
+  "editor.diagnostics": true,
   "editor.quickSuggestions": false,
 
   "extensions.autoUpdate": true,


### PR DESCRIPTION
Summary:
- enable editor diagnostics in the default web settings
- surface TypeScript and JavaScript errors as editor squiggles and Problems entries