### PR TITLE
fix: resolve external viewlets by runtime uid

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -487,7 +487,7 @@ export const executeViewletCommand = async (uid, fnName, ...args) => {
   if (oldState === actualNewState) {
     return
   }
-  if (!ViewletStates.hasInstance(uid)) {
+  if (!ViewletStates.getByUid(uid) && !ViewletStates.hasInstance(uid)) {
     return
   }
   const commands = ViewletManager.render(instance.factory, instance.renderedState, actualNewState)
@@ -541,7 +541,7 @@ export const disposeWidgetWithValue = async (id, value) => {
     ViewletStates.remove(uid)
     await RendererProcess.invoke('Viewlet.sendMultiple', commands)
     // return commands
-    const parentInstance = ViewletStates.getInstance(parentUid) || ViewletStates.getInstance(ViewletModuleId.KeyBindings)
+    const parentInstance = ViewletStates.getByUid(parentUid) || ViewletStates.getInstance(ViewletModuleId.KeyBindings)
     if (!parentInstance) {
       return
     }

--- a/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
+++ b/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
@@ -62,6 +62,12 @@ export const getInstance = (key) => {
   if (fast) {
     return fast
   }
+  if (typeof key === 'number') {
+    const byUid = getByUid(key)
+    if (byUid) {
+      return byUid
+    }
+  }
   const normalizedKey = normalizeModuleId(key)
   if (normalizedKey !== key) {
     const normalizedFast = state.instances[normalizedKey]

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -192,7 +192,7 @@ test('disposeWidgetWithValue - dispatches the captured value to the parent keybi
     moduleId: 'DefineKeyBinding',
     factory: {},
   })
-  ViewletStates.set(7, {
+  ViewletStates.set('external-keybindings-view', {
     state: keyBindingsState,
     renderedState: keyBindingsState,
     moduleId: 'KeyBindings',


### PR DESCRIPTION
## Description

Resolve numeric viewlet identifiers through their rendered runtime UID when the registry key differs. Use the UID-aware lookup for the define-keybinding parent handoff and keep command liveness checks UID-aware as well.

This completes mutation routing for externally loaded keybindings views.

## Testing

- `npm test -- Viewlet.test.ts ViewletDefineKeyBinding.test.ts ViewletStates.test.ts` in `packages/renderer-worker`
- `npm run type-check` in `packages/renderer-worker`
- Downstream `keybindings.add-and-remove-keybinding` e2e exposed the previous registry-key mismatch