### PR TITLE
fix: await keybinding widget disposal

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js
+++ b/packages/renderer-worker/src/parts/ViewletDefineKeyBinding/ViewletDefineKeyBinding.js
@@ -22,17 +22,17 @@ export const loadContent = (state) => {
   }
 }
 
-const dispose = (state, value) => {
+const dispose = async (state, value) => {
   const { uid } = state
-  Viewlet.disposeWidgetWithValue(uid, value)
+  await Viewlet.disposeWidgetWithValue(uid, value)
   return state
 }
 
-export const handleBlur = (state) => {
+export const handleBlur = async (state) => {
   return dispose(state, '')
 }
 
-export const handleKeyDown = (state, key, altKey, ctrlKey, shiftKey, metaKey) => {
+export const handleKeyDown = async (state, key, altKey, ctrlKey, shiftKey, metaKey) => {
   // TODO handle with keybindings?
   if (key === BrowserKey.Control || key === BrowserKey.Shift || key === BrowserKey.Alt) {
     return state

--- a/packages/renderer-worker/test/ViewletDefineKeyBinding.test.ts
+++ b/packages/renderer-worker/test/ViewletDefineKeyBinding.test.ts
@@ -16,13 +16,28 @@ test('create - stores the parent keybindings view uid', () => {
   })
 })
 
-test('handleKeyDown - Enter submits the recorded keybinding', () => {
+test('handleKeyDown - Enter waits for the recorded keybinding to be submitted', async () => {
   const state = {
     uid: 42,
     value: 'Ctrl+Alt+9',
   }
+  let resolveDispose = () => {}
+  const disposePromise = new Promise<undefined>((resolve) => {
+    resolveDispose = () => resolve(undefined)
+  })
+  jest.mocked(Viewlet.disposeWidgetWithValue).mockReturnValue(disposePromise)
 
-  ViewletDefineKeyBinding.handleKeyDown(state, 'Enter', false, false, false, false)
+  let completed = false
+  const resultPromise = ViewletDefineKeyBinding.handleKeyDown(state, 'Enter', false, false, false, false).then((result) => {
+    completed = true
+    return result
+  })
 
   expect(Viewlet.disposeWidgetWithValue).toHaveBeenCalledWith(42, 'Ctrl+Alt+9')
+  expect(completed).toBe(false)
+
+  resolveDispose()
+
+  await expect(resultPromise).resolves.toBe(state)
+  expect(completed).toBe(true)
 })


### PR DESCRIPTION
## Description

Await `disposeWidgetWithValue` from the define-keybinding dialog before its Enter/Escape/blur command completes. This sequences dialog disposal, parent mutation, and rendering in one observed promise instead of leaving the parent handoff fire-and-forget.

## Testing

- `npm test -- Viewlet.test.ts ViewletDefineKeyBinding.test.ts ViewletStates.test.ts` in `packages/renderer-worker`
- `npm run type-check` in `packages/renderer-worker`
- Unit coverage verifies Enter remains pending until disposal resolves