### PR TITLE
feature: contain running extensions layout

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -217,6 +217,7 @@ test('bundleCss preserves the running extensions row layout', async () => {
 
     expect(css).toContain(`.RunningExtension {
   align-items: center;
+  contain: strict;
   cursor: pointer;
   display: flex;
   flex-shrink: 0;
@@ -228,10 +229,54 @@ test('bundleCss preserves the running extensions row layout', async () => {
   background: color-mix(in srgb, var(--WorkbenchForeground) 4%, transparent);
 }`)
     expect(css).toContain(`.RunningExtensionActivationTime {
+  contain: content;
   flex: none;
   margin-left: auto;
   text-align: right;
 }`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
+test('bundleCss preserves the running extensions containment', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletRunningExtensions.css'), 'utf8')
+
+    expect(css).toContain(`.RunningExtensions {
+  box-sizing: border-box;
+  contain: strict;`)
+    expect(css).toContain(`.RunningExtension {
+  align-items: center;
+  contain: strict;`)
+    expect(css).toContain(`.RunningExtensionIcon {
+  contain: strict;`)
+    expect(css).toContain(`.RunningExtensionsEmpty {
+  align-items: center;
+  box-sizing: border-box;
+  color: var(--WorkbenchForeground);
+  contain: content;`)
+    expect(css).toContain(`.RunningExtensionDetails {
+  contain: content;`)
+    expect(css).toContain(`.RunningExtensionTitle {
+  align-items: baseline;
+  contain: content;`)
+    expect(css).toContain(`.RunningExtensionName,
+.RunningExtensionVersion,
+.RunningExtensionId,
+.RunningExtensionActivationDetails,
+.RunningExtensionActivationReason {
+  contain: content;
+}`)
+    expect(css).toContain(`.RunningExtensionActivationTime {
+  contain: content;`)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -1,5 +1,6 @@
 .RunningExtensions {
   box-sizing: border-box;
+  contain: strict;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -22,6 +23,7 @@
 
 .RunningExtension {
   align-items: center;
+  contain: strict;
   cursor: pointer;
   display: flex;
   flex-shrink: 0;
@@ -45,12 +47,14 @@
 }
 
 .RunningExtensionIcon {
+  contain: strict;
   flex: none;
   height: 36px;
   width: 36px;
 }
 
 .RunningExtensionDetails {
+  contain: content;
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -58,11 +62,13 @@
 
 .RunningExtensionTitle {
   align-items: baseline;
+  contain: content;
   display: flex;
   gap: 8px;
 }
 
 .RunningExtensionActivationTime {
+  contain: content;
   flex: none;
   margin-left: auto;
   text-align: right;
@@ -72,6 +78,7 @@
   align-items: center;
   box-sizing: border-box;
   color: var(--WorkbenchForeground);
+  contain: content;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -113,6 +120,14 @@
 .RunningExtensionActivationReason,
 .RunningExtensionActivationTime {
   color: var(--DescriptionForeground, rgba(156, 162, 160, 0.7));
+}
+
+.RunningExtensionName,
+.RunningExtensionVersion,
+.RunningExtensionId,
+.RunningExtensionActivationDetails,
+.RunningExtensionActivationReason {
+  contain: content;
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
Add strict CSS containment to fixed-size running extensions boxes and content containment to dynamically sized text and metadata. Preserve the containment rules in the bundled CSS regression coverage.