### PR TITLE
fix: prioritize running extension details at narrow widths

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -228,6 +228,17 @@ test('bundleCss preserves the running extensions row layout', async () => {
     expect(css).toContain(`.RunningExtension:nth-child(even) {
   background: color-mix(in srgb, var(--WorkbenchForeground) 4%, transparent);
 }`)
+    expect(css).toContain(`.RunningExtensionDetails {
+  contain: content;
+  flex: none;
+  min-width: 0;
+  overflow: hidden;
+}`)
+    expect(css).toContain(`.RunningExtensionActivationDetails {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}`)
     expect(css).toContain(`.RunningExtensionActivationTime {
   contain: content;
   flex: none;

--- a/packages/extension-host-worker-tests/src/viewlet.running-extensions-narrow-width.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.running-extensions-narrow-width.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.running-extensions-narrow-width'
+
+export const test: Test = async ({ Command, expect, Locator, RunningExtensions }) => {
+  await RunningExtensions.show()
+  await RunningExtensions.setExtensions([
+    {
+      activationEvent: 'onCommand:sample.run',
+      activationTime: 12,
+      icon: '',
+      id: 'sample.extension',
+      name: 'Sample Extension',
+      version: '1.0.0',
+    },
+  ])
+  await Command.execute('Layout.handleResize', 320, 720)
+
+  const activationDetails = Locator('.RunningExtensionActivationDetails')
+  const details = Locator('.RunningExtensionDetails')
+
+  await expect(RunningExtensions.icon(0)).toHaveCSS('flex-shrink', '0')
+  await expect(details).toHaveCSS('flex-shrink', '0')
+  await expect(activationDetails).toHaveCSS('flex-grow', '1')
+  await expect(activationDetails).toHaveCSS('flex-shrink', '1')
+  await expect(activationDetails).toHaveCSS('min-width', '0px')
+  await expect(activationDetails).toHaveCSS('overflow', 'hidden')
+
+  await Command.execute('Layout.handleResize', 1280, 720)
+}

--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -55,7 +55,7 @@
 
 .RunningExtensionDetails {
   contain: content;
-  flex: 1;
+  flex: none;
   min-width: 0;
   overflow: hidden;
 }
@@ -72,6 +72,12 @@
   flex: none;
   margin-left: auto;
   text-align: right;
+}
+
+.RunningExtensionActivationDetails {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .RunningExtensionsEmpty {


### PR DESCRIPTION
Keep the running extension icon, title, version, and id from shrinking in narrow editor layouts. Let activation metadata on the right consume the remaining flexible space and clip first, with a narrow-width e2e regression covering the computed CSS.