### PR TITLE
fix: open folders in new electron windows

### DIFF
--- a/packages/build/src/parts/Rpm/Rpm.ts
+++ b/packages/build/src/parts/Rpm/Rpm.ts
@@ -26,7 +26,7 @@ const copyMetaFiles = async ({ arch, product }) => {
       '@@NAME_LONG@@': product.nameLong,
       '@@NAME_SHORT@@': product.nameShort,
       '@@NAME@@': product.applicationName,
-      '@@EXEC@@': product.applicationName,
+      '@@EXEC@@': `${product.applicationName} %U`,
       '@@ICON@@': product.applicationName,
       '@@URLPROTOCOL@@': product.applicationName,
       '@@SUMMARY@@': product.linuxSummary,

--- a/packages/build/src/parts/Template/template_electron_builder_app_image.txt
+++ b/packages/build/src/parts/Template/template_electron_builder_app_image.txt
@@ -16,6 +16,7 @@
     "linux": {
       "executableName": "@@NAME@@",
       "category": "Utility;TextEditor;Development;IDE;",
+      "mimeTypes": ["inode/directory"],
       "synopsis": "A very short description, like a slogan",
       "description": "A description of the application on what it does.",
       "target": [

--- a/packages/build/src/parts/Template/template_electron_builder_arch_linux.txt
+++ b/packages/build/src/parts/Template/template_electron_builder_arch_linux.txt
@@ -17,6 +17,7 @@
     "linux": {
       "executableName": "@@NAME@@",
       "category": "Utility;TextEditor;Development;IDE;",
+      "mimeTypes": ["inode/directory"],
       "target": [
         {
           "target": "pacman"

--- a/packages/build/src/parts/Template/template_electron_builder_deb.txt
+++ b/packages/build/src/parts/Template/template_electron_builder_deb.txt
@@ -16,6 +16,7 @@
     "linux": {
       "executableName": "@@NAME@@",
       "category": "Utility;TextEditor;Development;IDE;",
+      "mimeTypes": ["inode/directory"],
       "synopsis": "A very short description, like a slogan",
       "description": "A description of the application on what it does.",
       "target": [

--- a/packages/build/src/parts/Template/template_electron_builder_snap.txt
+++ b/packages/build/src/parts/Template/template_electron_builder_snap.txt
@@ -16,6 +16,7 @@
     "linux": {
       "executableName": "@@NAME@@",
       "category": "Utility;TextEditor;Development;IDE;",
+      "mimeTypes": ["inode/directory"],
       "target": [
         {
           "target": "snap"

--- a/packages/build/src/parts/Template/template_linux_desktop.txt
+++ b/packages/build/src/parts/Template/template_linux_desktop.txt
@@ -10,6 +10,7 @@ StartupNotify=false
 StartupWMClass=@@APPLICATION_NAME@@
 X-GNOME-WMClass=@@APPLICATION_NAME@@
 Categories=Utility;TextEditor;Development;IDE;
+MimeType=inode/directory;
 Actions=new-empty-window;
 Keywords=@@KEYWORDS@@
 

--- a/packages/build/test/LinuxDesktopTemplate.test.ts
+++ b/packages/build/test/LinuxDesktopTemplate.test.ts
@@ -35,4 +35,10 @@ describe('linux desktop template', () => {
 
     expect(desktopFile).toContain('Exec=/usr/lib/lvce/lvce %U')
   })
+
+  test('registers as a folder handler', async () => {
+    const desktopFile = await renderTemplate('linux_desktop')
+
+    expect(desktopFile).toContain('MimeType=inode/directory;')
+  })
 })

--- a/packages/build/test/LinuxElectronBuilderMetadata.test.ts
+++ b/packages/build/test/LinuxElectronBuilderMetadata.test.ts
@@ -53,6 +53,7 @@ describe('linux electron-builder metadata', () => {
       expect(json.desktopName).toBe('lvce-editor.desktop')
       expect(json.build.icon).toBe('./build/icons/')
       expect(json.build.linux.executableName).toBe('lvce-editor')
+      expect(json.build.linux.mimeTypes).toEqual(['inode/directory'])
       expect(json.build.linux).not.toHaveProperty('desktop')
     },
   )

--- a/packages/renderer-worker/src/parts/GetResolvedRoot/GetResolvedRoot.js
+++ b/packages/renderer-worker/src/parts/GetResolvedRoot/GetResolvedRoot.js
@@ -9,8 +9,8 @@ import { state } from '../IsTest/IsTest.js'
 
 const SharedProcessCliArgSource = 'shared-process-cli-arg'
 
-const getResolvedRootFromSharedProcess = async () => {
-  const resolvedRoot = await SharedProcess.invoke(/* Workspace.resolveRoot */ SharedProcessCommandType.WorkspaceResolveRoot)
+const getResolvedRootFromSharedProcess = async (href) => {
+  const resolvedRoot = await SharedProcess.invoke(/* Workspace.resolveRoot */ SharedProcessCommandType.WorkspaceResolveRoot, href)
   return resolvedRoot
 }
 
@@ -72,7 +72,7 @@ const getResolvedRootFromRendererProcess = async (href) => {
 }
 
 const getResolvedRootRemote = async (href) => {
-  const resolvedRootFromSharedProcess = await getResolvedRootFromSharedProcess()
+  const resolvedRootFromSharedProcess = await getResolvedRootFromSharedProcess(href)
   if (resolvedRootFromSharedProcess?.source === SharedProcessCliArgSource) {
     return resolvedRootFromSharedProcess
   }

--- a/packages/renderer-worker/test/GetResolvedRoot.test.ts
+++ b/packages/renderer-worker/test/GetResolvedRoot.test.ts
@@ -62,6 +62,7 @@ test('getResolvedRoot - prefers explicit cli workspace over session storage', as
   })
   const resolvedRoot = await GetResolvedRoot.getResolvedRoot('http://localhost:3000')
   expect(resolvedRoot).toEqual(cliWorkspace)
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot', 'http://localhost:3000')
 })
 
 test('getResolvedRoot - keeps session workspace when no cli workspace was provided', async () => {
@@ -89,4 +90,5 @@ test('getResolvedRoot - keeps session workspace when no cli workspace was provid
   })
   const resolvedRoot = await GetResolvedRoot.getResolvedRoot('http://localhost:3000')
   expect(resolvedRoot).toEqual(sessionWorkspace)
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot', 'http://localhost:3000')
 })

--- a/packages/renderer-worker/test/Workspace.test.ts
+++ b/packages/renderer-worker/test/Workspace.test.ts
@@ -62,7 +62,7 @@ test('hydrate', async () => {
   RendererProcess.invoke.mockImplementation(() => {})
   await Workspace.hydrate({ href: 'http://localhost:3000' })
   expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
-  expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot', 'http://localhost:3000')
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
   expect(RendererProcess.invoke).toHaveBeenNthCalledWith(2, 'WindowTitle.set', '/tmp/some-folder')
 })
@@ -97,7 +97,7 @@ test.skip('hydrate - path changed in the meantime', async () => {
   await promise1
   expect(Workspace.state.workspacePath).toBe('/test')
   expect(SharedProcess.invoke).toHaveBeenCalledTimes(2)
-  expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot', 'http://localhost:3000')
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
 })
 

--- a/packages/shared-process/src/parts/AppWindow/AppWindow.ts
+++ b/packages/shared-process/src/parts/AppWindow/AppWindow.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as DefaultUrl from '../DefaultUrl/DefaultUrl.ts'
 import * as GetAppWindowOptions from '../GetAppWindowOptions/GetAppWindowOptions.ts'
 import * as GetTitleBarItems from '../GetTitleBarItems/GetTitleBarItems.ts'
@@ -23,8 +25,29 @@ const getValidatedAppUrl = (url: unknown): string => {
   return parsedUrl.toString()
 }
 
+const getWorkspaceUri = (parsedArgs: any, workingDirectory: any): string => {
+  const path = parsedArgs?._?.at(-1)
+  if (!path || typeof path !== 'string') {
+    return ''
+  }
+  if (path.startsWith('file://')) {
+    return pathToFileURL(fileURLToPath(path)).toString()
+  }
+  const absolutePath = isAbsolute(path) ? path : resolve(workingDirectory, path)
+  return pathToFileURL(absolutePath).toString()
+}
+
+const getAppWindowUrl = (url: unknown, parsedArgs: any, workingDirectory: any): string => {
+  const parsedUrl = new URL(getValidatedAppUrl(url))
+  const workspaceUri = getWorkspaceUri(parsedArgs, workingDirectory)
+  if (workspaceUri) {
+    parsedUrl.searchParams.set('workspace', workspaceUri)
+  }
+  return parsedUrl.toString()
+}
+
 export const createAppWindow = async ({ parsedArgs, preferences, preloadUrl, url = DefaultUrl.defaultUrl, workingDirectory }: any): Promise<any> => {
-  const validatedUrl = getValidatedAppUrl(url)
+  const validatedUrl = getAppWindowUrl(url, parsedArgs, workingDirectory)
   const { height, width } = await Screen.getBounds()
   const windowOptions = await GetAppWindowOptions.getAppWindowOptions({
     preferences,

--- a/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
+++ b/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as Env from '../Env/Env.ts'
 import * as GetWorkspaceId from '../GetWorkspaceId/GetWorkspaceId.ts'
 import * as IsAbsolutePath from '../IsAbsolutePath/IsAbsolutePath.ts'
@@ -30,8 +30,31 @@ const toUri = (path: any): any => {
   return pathToFileURL(path).toString()
 }
 
-export const resolveRoot = async (): Promise<any> => {
+const getWindowWorkspacePath = (href: string): string => {
+  if (!href) {
+    return ''
+  }
+  const workspaceUri = new URL(href).searchParams.get('workspace')
+  if (!workspaceUri) {
+    return ''
+  }
+  return fileURLToPath(workspaceUri)
+}
+
+export const resolveRoot = async (href = ''): Promise<any> => {
   if (IsElectron.isElectron) {
+    const windowWorkspacePath = getWindowWorkspacePath(href)
+    if (windowWorkspacePath) {
+      return {
+        homeDir: PlatformPaths.getHomeDir(),
+        homeDirUri: toUri(PlatformPaths.getHomeDir()),
+        path: windowWorkspacePath,
+        pathSeparator: Platform.getPathSeparator(),
+        source: WorkspaceSource.SharedProcessCliArg,
+        uri: toUri(windowWorkspacePath),
+        workspaceId: GetWorkspaceId.getWorkspaceId(windowWorkspacePath),
+      }
+    }
     const argv = await ParentIpc.invoke('Process.getArgv')
     const relevantArgv = argv.slice(1)
     const last = relevantArgv.at(-1)

--- a/packages/shared-process/test/AppWindow.test.ts
+++ b/packages/shared-process/test/AppWindow.test.ts
@@ -64,3 +64,24 @@ test('openNewWithUri', async () => {
   expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
   expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, [], '', [], 'lvce-oss://-/?openUri=%2Fworkspace%2Ffile.txt')
 })
+
+test.each([
+  ['dot path', '.', '/test/workspace', 'file:///test/workspace'],
+  ['relative path', 'folder', '/test/workspace', 'file:///test/workspace/folder'],
+  ['absolute path', '/test/workspace', '/other', 'file:///test/workspace'],
+  ['file url', 'file:///test/workspace', '/other', 'file:///test/workspace'],
+])('createAppWindow adds workspace from %s', async (_name, argument, workingDirectory, workspaceUri) => {
+  const url = new URL('lvce-oss://-/')
+  url.searchParams.set('workspace', workspaceUri)
+  const parsedArgs = { _: [argument] }
+
+  await AppWindow.createAppWindow({
+    parsedArgs,
+    preferences: {},
+    preloadUrl: 'file:///preload.js',
+    workingDirectory,
+  })
+
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, parsedArgs, workingDirectory, [], url.toString())
+})

--- a/packages/shared-process/test/AppWindow.test.ts
+++ b/packages/shared-process/test/AppWindow.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 jest.unstable_mockModule('../src/parts/GetAppWindowOptions/GetAppWindowOptions.js', () => ({
   getAppWindowOptions: jest.fn(() => ({})),
@@ -26,6 +28,10 @@ jest.unstable_mockModule('../src/parts/Screen/Screen.js', () => ({
 
 const AppWindow = await import('../src/parts/AppWindow/AppWindow.js')
 const ParentIpc = await import('../src/parts/MainProcess/MainProcess.js')
+
+const otherPath = resolve('test', 'other')
+const workspacePath = resolve('test', 'workspace')
+const workspaceUri = pathToFileURL(workspacePath).toString()
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -66,13 +72,13 @@ test('openNewWithUri', async () => {
 })
 
 test.each([
-  ['dot path', '.', '/test/workspace', 'file:///test/workspace'],
-  ['relative path', 'folder', '/test/workspace', 'file:///test/workspace/folder'],
-  ['absolute path', '/test/workspace', '/other', 'file:///test/workspace'],
-  ['file url', 'file:///test/workspace', '/other', 'file:///test/workspace'],
-])('createAppWindow adds workspace from %s', async (_name, argument, workingDirectory, workspaceUri) => {
+  ['dot path', '.', workspacePath, workspaceUri],
+  ['relative path', 'folder', workspacePath, pathToFileURL(resolve(workspacePath, 'folder')).toString()],
+  ['absolute path', workspacePath, otherPath, workspaceUri],
+  ['file url', workspaceUri, otherPath, workspaceUri],
+])('createAppWindow adds workspace from %s', async (_name, argument, workingDirectory, expectedWorkspaceUri) => {
   const url = new URL('lvce-oss://-/')
-  url.searchParams.set('workspace', workspaceUri)
+  url.searchParams.set('workspace', expectedWorkspaceUri)
   const parsedArgs = { _: [argument] }
 
   await AppWindow.createAppWindow({

--- a/packages/shared-process/test/ResolveRoot.test.ts
+++ b/packages/shared-process/test/ResolveRoot.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 jest.unstable_mockModule('../src/parts/IsElectron/IsElectron.js', () => ({
@@ -47,15 +48,17 @@ test('resolveRoot - resolves dot from development electron arguments', async () 
 })
 
 test('resolveRoot - resolves the workspace for a second window', async () => {
+  const workspacePath = resolve('test', 'second-workspace')
+  const workspaceUri = pathToFileURL(workspacePath).toString()
   const url = new URL('lvce-oss://-/')
-  url.searchParams.set('workspace', 'file:///test/second-workspace')
+  url.searchParams.set('workspace', workspaceUri)
 
   const resolvedRoot = await ResolveRoot.resolveRoot(url.toString())
 
   expect(resolvedRoot).toMatchObject({
-    path: '/test/second-workspace',
+    path: workspacePath,
     source: 'shared-process-cli-arg',
-    uri: 'file:///test/second-workspace',
+    uri: workspaceUri,
   })
   expect(MainProcess.invoke).not.toHaveBeenCalled()
 })

--- a/packages/shared-process/test/ResolveRoot.test.ts
+++ b/packages/shared-process/test/ResolveRoot.test.ts
@@ -46,6 +46,20 @@ test('resolveRoot - resolves dot from development electron arguments', async () 
   })
 })
 
+test('resolveRoot - resolves the workspace for a second window', async () => {
+  const url = new URL('lvce-oss://-/')
+  url.searchParams.set('workspace', 'file:///test/second-workspace')
+
+  const resolvedRoot = await ResolveRoot.resolveRoot(url.toString())
+
+  expect(resolvedRoot).toMatchObject({
+    path: '/test/second-workspace',
+    source: 'shared-process-cli-arg',
+    uri: 'file:///test/second-workspace',
+  })
+  expect(MainProcess.invoke).not.toHaveBeenCalled()
+})
+
 test('resolveRoot - uses cwd in prompt mode', async () => {
   // @ts-ignore
   MainProcess.invoke.mockResolvedValue(['/usr/lib/lvce-oss/lvce-oss', '--prompt', 'Fix the tests'])


### PR DESCRIPTION
Fix second-instance Electron windows so each window resolves the folder passed by the CLI or Linux file explorer, including relative paths and file URLs. Register LVCE as an inode/directory handler in Linux package metadata and ensure launchers forward selected folder URLs.