### PR TITLE
test: cover running extensions live updates

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/main.js
@@ -1,6 +1,6 @@
 const currentUrl = new URL(import.meta.url)
 const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
-const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+const { WebWorkerRpcClient } = await import(`${assetDir}/static/js/lvce-editor-rpc.js`)
 
 const commandMap = {
   'ExtensionApi.getStatusBarItems'() {

--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/test.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/test.js
@@ -4,15 +4,12 @@ export const activityBarItemSelector = '.ActivityBarItem[title="Extension Lifecy
 
 export const statusBarItemSelector = '.StatusBarItem[name="extension-lifecycle"]'
 
-export const runningExtensionSelector = `.RunningExtension:has-text("${extensionId}")`
+export const runningExtensionSelector = '.RunningExtensionId'
 
-export const addLifecycleExtension = async ({ ActivityBar, Extension, Settings, StatusBar }) => {
-  await Settings.update({
-    'statusBar.itemsVisible': true,
-  })
-  await Extension.addWebExtension(import.meta.resolve('.'))
-  await StatusBar.update()
+export const addLifecycleExtension = async ({ ActivityBar, Extension }) => {
+  await Extension.addWebExtension(new URL('.', import.meta.url).toString())
   await ActivityBar.handleExtensionsChanged()
+  await Extension.activateByEvent('onStatusBarItem', '', 0)
 }
 
 export const disableLifecycleExtension = async ({ ExtensionDetail }) => {

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/extension.json
@@ -1,0 +1,17 @@
+{
+  "id": "sample.running-extensions-live-view",
+  "name": "Running Extensions Live View",
+  "description": "Activates while the Running Extensions view is open",
+  "version": "1.2.3",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onView:sample.running-extensions-live-view"],
+  "views": [
+    {
+      "id": "sample.running-extensions-live-view",
+      "title": "Running Extensions Live View",
+      "icon": "symbol-play",
+      "kind": "virtualDom"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/main.js
@@ -1,0 +1,43 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/static/js/lvce-editor-rpc.js`)
+
+const view = {
+  icon: 'symbol-play',
+  id: 'sample.running-extensions-live-view',
+  kind: 'virtualDom',
+  title: 'Running Extensions Live View',
+}
+
+const commandMap = {
+  'ExtensionApi.createViewInstance'() {
+    return {
+      dom: [],
+      type: 'setDom',
+    }
+  },
+  'ExtensionApi.disposeViewInstance'() {},
+  'ExtensionApi.getViewActions'() {
+    return []
+  },
+  'ExtensionApi.getViewMenuEntries'() {
+    return []
+  },
+  'ExtensionApi.getStatusBarItems'() {
+    return []
+  },
+  'ExtensionApi.getViewRegistrySnapshot'() {
+    return {
+      views: [view],
+    }
+  },
+  'ExtensionApi.renderViewInstance'() {
+    return {
+      patches: [],
+      type: 'setPatches',
+    }
+  },
+  'ExtensionApi.saveViewInstanceState'() {},
+}
+
+await WebWorkerRpcClient.create({ commandMap })

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/test.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/test.js
@@ -1,0 +1,18 @@
+export const extensionId = 'sample.running-extensions-live-view'
+
+export const activityBarItemSelector = '.ActivityBarItem[title="Running Extensions Live View"]'
+
+export const runningExtensionSelector = '.RunningExtensionId'
+
+export const addLiveViewExtension = async ({ ActivityBar, Extension }) => {
+  await Extension.addWebExtension(new URL('.', import.meta.url).toString())
+  await ActivityBar.handleExtensionsChanged()
+}
+
+export const activateLiveViewExtension = async ({ expect, Locator }) => {
+  const activityBarItem = Locator(activityBarItemSelector)
+  await expect(activityBarItem).toBeVisible()
+  // eslint-disable-next-line e2e/no-direct-click
+  await activityBarItem.click()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+}

--- a/packages/extension-host-worker-tests/src/_all.js
+++ b/packages/extension-host-worker-tests/src/_all.js
@@ -28,7 +28,11 @@ const getRelativePath = (testFile) => {
 const getPaths = async () => {
   const testsPath = join(root, 'packages', 'extension-host-worker-tests', 'src')
   const dirents = await readdir(testsPath)
-  const testFiles = dirents.filter(isTestFile)
+  const testNamePrefixArgument = process.argv.find((argument) => argument.startsWith('--test-name-prefix='))
+  const testNamePrefix = testNamePrefixArgument ? testNamePrefixArgument.slice('--test-name-prefix='.length) : ''
+  const testFiles = dirents.filter((dirent) => {
+    return isTestFile(dirent) && dirent.startsWith(testNamePrefix)
+  })
   return testFiles
 }
 

--- a/packages/extension-host-worker-tests/src/extension.disable-removes-running-extension.ts
+++ b/packages/extension-host-worker-tests/src/extension.disable-removes-running-extension.ts
@@ -11,9 +11,9 @@ export const name = 'extension.disable-removes-running-extension'
 export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
   await addLifecycleExtension(api)
   await RunningExtensions.show()
-  const runningExtension = Locator(runningExtensionSelector)
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
   await expect(runningExtension).toBeVisible()
-  await expect(runningExtension.locator('.RunningExtensionId')).toHaveText(extensionId)
+  await expect(runningExtension).toHaveText(extensionId)
 
   await disableLifecycleExtension(api)
   await RunningExtensions.show()

--- a/packages/extension-host-worker-tests/src/extension.enable-restores-running-extension.ts
+++ b/packages/extension-host-worker-tests/src/extension.enable-restores-running-extension.ts
@@ -12,8 +12,8 @@ export const name = 'extension.enable-restores-running-extension'
 export const test: Test = async ({ expect, ExtensionDetail, Locator, RunningExtensions, ...api }) => {
   await addLifecycleExtension(api)
   await RunningExtensions.show()
-  const runningExtension = Locator(runningExtensionSelector)
-  await expect(runningExtension.locator('.RunningExtensionId')).toHaveText(extensionId)
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+  await expect(runningExtension).toHaveText(extensionId)
   await disableLifecycleExtension({ ExtensionDetail })
   await RunningExtensions.show()
   await expect(runningExtension).toBeHidden()
@@ -23,5 +23,5 @@ export const test: Test = async ({ expect, ExtensionDetail, Locator, RunningExte
   await RunningExtensions.show()
 
   await expect(runningExtension).toBeVisible()
-  await expect(runningExtension.locator('.RunningExtensionId')).toHaveText(extensionId)
+  await expect(runningExtension).toHaveText(extensionId)
 }

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-activation.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-activation.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  activateLiveViewExtension,
+  addLiveViewExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-activation'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+  await expect(runningExtension).toBeHidden()
+
+  await activateLiveViewExtension({ expect, Locator, ...api })
+
+  await expect(runningExtension).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-metadata.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-metadata.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  activateLiveViewExtension,
+  addLiveViewExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-metadata'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+
+  await activateLiveViewExtension({ expect, Locator, ...api })
+
+  await expect(runningExtension).toHaveText(extensionId)
+  await expect(Locator('.RunningExtensionName', { hasText: 'Running Extensions Live View' })).toHaveText('Running Extensions Live View')
+  await expect(Locator('.RunningExtensionVersion', { hasText: '1.2.3' })).toHaveText('1.2.3')
+  const activationReason = 'Activation reason: onView:sample.running-extensions-live-view'
+  await expect(Locator('.RunningExtensionActivationReason', { hasText: activationReason })).toHaveText(activationReason)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-no-duplicate.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-no-duplicate.ts
@@ -1,0 +1,26 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  activateLiveViewExtension,
+  activityBarItemSelector,
+  addLiveViewExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-no-duplicate'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+  await activateLiveViewExtension({ expect, Locator, ...api })
+  await expect(runningExtension).toHaveCount(1)
+  const activityBarItem = Locator(activityBarItemSelector)
+
+  // eslint-disable-next-line e2e/no-direct-click
+  await activityBarItem.click()
+  // eslint-disable-next-line e2e/no-direct-click
+  await activityBarItem.click()
+
+  await expect(runningExtension).toHaveCount(1)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-preserves-existing-row.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-preserves-existing-row.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  addLifecycleExtension,
+  extensionId as lifecycleExtensionId,
+  runningExtensionSelector as lifecycleExtensionSelector,
+} from '../fixtures/sample.extension-disable-lifecycle/test.js'
+import {
+  activateLiveViewExtension,
+  addLiveViewExtension,
+  extensionId as liveViewExtensionId,
+  runningExtensionSelector as liveViewExtensionSelector,
+} from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-preserves-existing-row'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLifecycleExtension(api)
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const lifecycleExtension = Locator(lifecycleExtensionSelector, { hasText: lifecycleExtensionId })
+  const liveViewExtension = Locator(liveViewExtensionSelector, { hasText: liveViewExtensionId })
+  await expect(lifecycleExtension).toBeVisible()
+  await expect(liveViewExtension).toBeHidden()
+
+  await activateLiveViewExtension({ expect, Locator, ...api })
+
+  await expect(lifecycleExtension).toBeVisible()
+  await expect(liveViewExtension).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-row-count.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-row-count.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateLiveViewExtension, addLiveViewExtension } from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-row-count'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const rows = Locator('.RunningExtension')
+  await expect(rows).toHaveCount(1)
+
+  await activateLiveViewExtension({ expect, Locator, ...api })
+
+  await expect(rows).toHaveCount(2)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-stays-open.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-stays-open.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  activateLiveViewExtension,
+  addLiveViewExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-stays-open'
+
+export const test: Test = async ({ expect, Locator, RunningExtensions, ...api }) => {
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const runningExtensionsView = Locator('.RunningExtensions')
+
+  await activateLiveViewExtension({ expect, Locator, ...api })
+
+  await expect(runningExtensionsView).toBeVisible()
+  await expect(Locator(runningExtensionSelector, { hasText: extensionId })).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/tsconfig.json
+++ b/packages/extension-host-worker-tests/tsconfig.json
@@ -16,5 +16,11 @@
     "noImplicitAny": false,
     "composite": true
   },
-  "include": ["src", "test", "typings", "fixtures/sample.extension-disable-lifecycle/test.js"]
+  "include": [
+    "src",
+    "test",
+    "typings",
+    "fixtures/sample.extension-disable-lifecycle/test.js",
+    "fixtures/sample.running-extensions-live-view/test.js"
+  ]
 }


### PR DESCRIPTION
Adds browser-level regression coverage for extensions that start while the Running Extensions editor is already open.

Covers immediate appearance without reopening, metadata, row counts, duplicate prevention, preserving existing rows, and editor visibility. Also makes the existing extension lifecycle fixture browser-compatible.

The producer fix is included through @lvce-editor/extension-management-worker 4.41.1.