### PR TITLE
fix: derive native app config directories

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemAppShared.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemAppShared.js
@@ -1,11 +1,11 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as Command from '../Command/Command.js'
 import * as ErrorCodes from '../ErrorCodes/ErrorCodes.js'
+import * as GetPathDirName from '../GetPathDirName/GetPathDirName.js'
 import * as LocalStorage from '../LocalStorage/LocalStorage.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import { VError } from '../VError/VError.js'
-import * as Workspace from '../Workspace/Workspace.js'
 import * as FileSystem from './FileSystem.js'
 
 const isEnoentError = (error) => {
@@ -44,7 +44,7 @@ const readFileNode = async (path, defaultContent) => {
   } catch (error) {
     if (isEnoentError(error)) {
       try {
-        const dirname = Workspace.pathDirName(path)
+        const dirname = GetPathDirName.getPathDirName(path)
         await FileSystem.mkdir(dirname)
         await FileSystem.writeFile(path, defaultContent)
         return defaultContent
@@ -64,7 +64,7 @@ const readJsonNode = async (path, defaultContent) => {
   } catch (error) {
     if (isEnoentError(error)) {
       try {
-        const dirname = Workspace.pathDirName(path)
+        const dirname = GetPathDirName.getPathDirName(path)
         await FileSystem.mkdir(dirname)
         await FileSystem.writeFile(path, defaultContent)
         return defaultContent
@@ -111,7 +111,7 @@ const writeFileNode = async (path, content) => {
 
     if (isEnoentError(error)) {
       try {
-        const dirname = Workspace.pathDirName(path)
+        const dirname = GetPathDirName.getPathDirName(path)
         await FileSystem.mkdir(dirname)
         await FileSystem.writeFile(path, content)
         return

--- a/packages/renderer-worker/src/parts/GetPathDirName/GetPathDirName.js
+++ b/packages/renderer-worker/src/parts/GetPathDirName/GetPathDirName.js
@@ -1,0 +1,9 @@
+export const getPathDirName = (path) => {
+  const slashIndex = path.lastIndexOf('/')
+  const backslashIndex = path.lastIndexOf('\\')
+  const index = Math.max(slashIndex, backslashIndex)
+  if (index === -1) {
+    return ''
+  }
+  return path.slice(0, index)
+}

--- a/packages/renderer-worker/test/FileSystemApp.test.ts
+++ b/packages/renderer-worker/test/FileSystemApp.test.ts
@@ -181,3 +181,25 @@ test('writeFile - settings - error parent folder does not exist', async () => {
   expect(FileSystem.mkdir).toHaveBeenCalledTimes(1)
   expect(FileSystem.mkdir).toHaveBeenCalledWith('~/.config/app')
 })
+
+test('writeFile - settings - creates windows parent folder', async () => {
+  const settingsPath = String.raw`C:\Users\test\.config\lvce-oss\settings.json`
+  // @ts-ignore
+  PlatformPaths.getUserSettingsPath.mockImplementation(() => {
+    return settingsPath
+  })
+  // @ts-ignore
+  FileSystem.mkdir.mockImplementation(() => {})
+  let attempt = 0
+  // @ts-ignore
+  FileSystem.writeFile.mockImplementation(() => {
+    if (attempt++ === 0) {
+      throw new NodeError(FileSytemErrorCodes.ENOENT)
+    }
+  })
+
+  await FileSystemApp.writeFile('settings.json', '{}')
+
+  expect(FileSystem.mkdir).toHaveBeenCalledWith(String.raw`C:\Users\test\.config\lvce-oss`)
+  expect(FileSystem.writeFile).toHaveBeenLastCalledWith(settingsPath, '{}')
+})

--- a/packages/renderer-worker/test/GetPathDirName.test.ts
+++ b/packages/renderer-worker/test/GetPathDirName.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import * as GetPathDirName from '../src/parts/GetPathDirName/GetPathDirName.js'
+
+test('getPathDirName - posix path', () => {
+  expect(GetPathDirName.getPathDirName('/home/test/.config/lvce-oss/keybindings.json')).toBe('/home/test/.config/lvce-oss')
+})
+
+test('getPathDirName - windows path', () => {
+  expect(GetPathDirName.getPathDirName(String.raw`C:\Users\test\.config\lvce-oss\keybindings.json`)).toBe(String.raw`C:\Users\test\.config\lvce-oss`)
+})
+
+test('getPathDirName - windows file uri', () => {
+  expect(GetPathDirName.getPathDirName(String.raw`file://C:\Users\test\.config\lvce-oss\keybindings.json`)).toBe(
+    String.raw`file://C:\Users\test\.config\lvce-oss`,
+  )
+})


### PR DESCRIPTION
## Summary

- derive app-config parent directories from both `/` and `\\` separators
- use that native-path helper when settings, recently-opened data, or keybindings need their parent directory created
- cover POSIX, Windows, and Windows file-URI-shaped paths
- add an integration regression for creating a Windows settings parent directory

## Context

Keybinding persistence exposed this on the keybindings-view Windows e2e job: the existing workspace dirname helper truncated `C:\\Users\\...\\keybindings.json` to `file://`, so dialog disposal failed while writing the mutation.

## Verification

- renderer-worker targeted tests — 12 passed
- renderer-worker type check
- focused source lint and formatting
