### PR TITLE
Add running extensions lifecycle e2e coverage

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -245,6 +245,15 @@ test('bundleCss preserves the running extensions row layout', async () => {
   margin-left: auto;
   text-align: right;
 }`)
+    expect(css).toContain(`.RunningExtensionStatus {
+  flex: none;
+  font-weight: 600;`)
+    expect(css).toContain(`.RunningExtensionStatusError {
+  color: var(--InputValidationErrorForeground, #f48771);
+}`)
+    expect(css).toContain(`.RunningExtensionStatusTerminated {
+  color: var(--EditorWarningForeground, #cca700);
+}`)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/extension-host-worker-tests/fixtures/running-extensions-test-helpers.js
+++ b/packages/extension-host-worker-tests/fixtures/running-extensions-test-helpers.js
@@ -1,0 +1,22 @@
+export const activateFixture = async ({ Command, Extension }, fixtureName, activationEvent) => {
+  const uri = new URL(`./${fixtureName}`, import.meta.url).toString()
+  await Extension.addWebExtension(uri)
+  try {
+    await Command.execute('ExtensionHostManagement.activateByEvent', activationEvent, '', 1)
+  } catch {
+    // Activation failures are the state under test.
+  }
+}
+
+export const getRunningExtension = async ({ Command, expect, Locator, RunningExtensions }, extensionId) => {
+  const runningExtensions = await Command.execute('ExtensionManagement.getRunningExtensions')
+  await RunningExtensions.show()
+  await RunningExtensions.setExtensions(runningExtensions)
+  const id = Locator('.RunningExtensionId', { hasText: extensionId })
+  await expect(id).toBeVisible()
+  return Locator('.RunningExtension').first()
+}
+
+export const wait = async (milliseconds) => {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.error-activate-dynamic-import-not-found/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-activate-dynamic-import-not-found/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-activate-dynamic-import-not-found",
+  "name": "Dynamic Import Activation Error",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-cannot-read-properties-of-null-reading-value/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-cannot-read-properties-of-null-reading-value/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-cannot-read-properties-of-null-reading-value",
+  "name": "Runtime Type Error",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-clone/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-clone/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-clone",
+  "name": "Data Clone Error",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-dependency-module-not-found-complex/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-dependency-module-not-found-complex/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-dependency-module-not-found-complex",
+  "name": "Missing Nested Dependency",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-dependency-module-not-found/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-dependency-module-not-found/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-dependency-module-not-found",
+  "name": "Missing Dependency",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-dynamic-import-not-found/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-dynamic-import-not-found/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-dynamic-import-not-found",
+  "name": "Missing Dynamic Import",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-export-not-found/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-export-not-found/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-export-not-found",
+  "name": "Missing Export",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-identifier-has-already-been-declared-other-file/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-identifier-has-already-been-declared-other-file/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-identifier-has-already-been-declared-other-file",
+  "name": "Duplicate Dependency Identifier",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-identifier-has-already-been-declared/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-identifier-has-already-been-declared/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-identifier-has-already-been-declared",
+  "name": "Duplicate Identifier",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-unexpected-token/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-unexpected-token/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-unexpected-token",
+  "name": "Syntax Error",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.error-uri/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.error-uri/extension.json
@@ -1,4 +1,7 @@
 {
+  "id": "sample.error-uri",
+  "name": "URI Error",
+  "version": "1.0.0",
   "browser": "main.js",
   "activation": "onCommand:xyz.sampleCommand",
   "commands": [

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-100ms/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-100ms/extension.json
@@ -1,0 +1,8 @@
+{
+  "id": "sample.running-extensions-close-100ms",
+  "name": "Short Lived Extension",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onCommand:runningExtensions.close100ms"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-100ms/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-100ms/main.js
@@ -1,0 +1,13 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+await WebWorkerRpcClient.create({
+  commandMap: {
+    'ExtensionApi.ping'() {
+      return true
+    },
+  },
+})
+
+setTimeout(() => close(), 100)

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-1s/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-1s/extension.json
@@ -1,0 +1,8 @@
+{
+  "id": "sample.running-extensions-close-1s",
+  "name": "One Second Extension",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onCommand:runningExtensions.close1s"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-1s/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-1s/main.js
@@ -1,0 +1,13 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+await WebWorkerRpcClient.create({
+  commandMap: {
+    'ExtensionApi.ping'() {
+      return true
+    },
+  },
+})
+
+setTimeout(() => close(), 1000)

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-immediately/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-immediately/extension.json
@@ -1,0 +1,8 @@
+{
+  "id": "sample.running-extensions-close-immediately",
+  "name": "Immediate Termination",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onCommand:runningExtensions.closeImmediately"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-immediately/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-close-immediately/main.js
@@ -1,0 +1,13 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+await WebWorkerRpcClient.create({
+  commandMap: {
+    'ExtensionApi.ping'() {
+      return true
+    },
+  },
+})
+
+setTimeout(() => close(), 0)

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-delayed/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-delayed/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-delayed",
+  "name": "Delayed Activation",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.delayed"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-delayed/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-delayed/main.js
@@ -1,0 +1,3 @@
+export const activate = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 250))
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-empty-name/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-empty-name/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-empty-name",
+  "name": "",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.emptyName"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-empty-name/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-empty-name/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-icon/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-icon/extension.json
@@ -1,0 +1,8 @@
+{
+  "id": "sample.running-extensions-invalid-icon",
+  "name": "Invalid Icon",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "icon": "missing.svg",
+  "activation": ["onCommand:runningExtensions.invalidIcon"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-icon/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-icon/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-name/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-name/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-invalid-name",
+  "name": 42,
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.invalidName"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-name/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-invalid-name/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-isolated-healthy/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-isolated-healthy/extension.json
@@ -1,0 +1,8 @@
+{
+  "id": "sample.running-extensions-isolated-healthy",
+  "name": "Healthy Isolated Extension",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onCommand:runningExtensions.isolatedHealthy"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-isolated-healthy/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-isolated-healthy/main.js
@@ -1,0 +1,11 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+await WebWorkerRpcClient.create({
+  commandMap: {
+    'ExtensionApi.ping'() {
+      return true
+    },
+  },
+})

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-long-name/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-long-name/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-long-name",
+  "name": "A deliberately very long extension display name that verifies the running extensions view remains stable when metadata is much wider than the available editor area",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.longName"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-long-name/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-long-name/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-activate/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-activate/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-missing-activate",
+  "name": "Missing Activate Export",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.missingActivate"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-activate/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-activate/main.js
@@ -1,0 +1,1 @@
+export const notActivate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-icon/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-icon/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-missing-icon",
+  "name": "Missing Icon",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.missingIcon"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-icon/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-icon/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-main/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-main/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-missing-main",
+  "name": "Missing Main Entry",
+  "version": "1.0.0",
+  "browser": "not-found.js",
+  "activation": ["onCommand:runningExtensions.missingMain"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-name/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-name/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "sample.running-extensions-missing-name",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.missingName"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-name/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-name/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-version/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-version/extension.json
@@ -1,0 +1,6 @@
+{
+  "id": "sample.running-extensions-missing-version",
+  "name": "Missing Version",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.missingVersion"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-version/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-missing-version/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-reject-string/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-reject-string/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-reject-string",
+  "name": "String Rejection",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.rejectString"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-reject-string/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-reject-string/main.js
@@ -1,0 +1,3 @@
+export const activate = async () => {
+  throw 'Activation rejected with a string'
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-rich/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-rich/extension.json
@@ -1,0 +1,10 @@
+{
+  "id": "sample.running-extensions-rich",
+  "name": "扩展 Runtime 🚀",
+  "description": "A metadata-rich running extension fixture",
+  "version": "2.3.4-beta.5",
+  "browser": "main.js",
+  "icon": "icon.svg",
+  "repository": "https://github.com/lvce-editor/lvce-editor",
+  "activation": ["onCommand:runningExtensions.rich"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-rich/icon.svg
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-rich/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="#7c3aed"/>
+  <path d="M7 12h10M12 7v10" stroke="#fff" stroke-width="2"/>
+</svg>

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-rich/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-rich/main.js
@@ -1,0 +1,1 @@
+export const activate = () => {}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-throw/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-throw/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-throw",
+  "name": "Throwing Activation",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.throw"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-throw/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-throw/main.js
@@ -1,0 +1,3 @@
+export const activate = () => {
+  throw new Error('Activation exploded')
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-timeout/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-timeout/extension.json
@@ -1,0 +1,7 @@
+{
+  "id": "sample.running-extensions-timeout",
+  "name": "Activation Timeout",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "activation": ["onCommand:runningExtensions.timeout"]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-timeout/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-timeout/main.js
@@ -1,0 +1,3 @@
+export const activate = async () => {
+  await new Promise(() => {})
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.activation-dynamic-import-not-found.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.activation-dynamic-import-not-found.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.activation-dynamic-import-not-found'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-activate-dynamic-import-not-found'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('add.js')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.activation-reason.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.activation-reason.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.activation-reason'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-rich'
+  const event = 'onCommand:runningExtensions.rich'
+  await activateFixture(api, id, event)
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionActivationReason')).toHaveText(`Activation reason: ${event}`)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.activation-rejects-string.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.activation-rejects-string.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.activation-rejects-string'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-reject-string'
+  await activateFixture(api, id, 'onCommand:runningExtensions.rejectString')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('JsonRpc Error')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.activation-throws.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.activation-throws.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.activation-throws'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-throw'
+  await activateFixture(api, id, 'onCommand:runningExtensions.throw')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toHaveText('Error: Activation exploded')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.activation-time.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.activation-time.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.activation-time'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-rich'
+  await activateFixture(api, id, 'onCommand:runningExtensions.rich')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionActivationTime')).toContainText('Activation:')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.activation-timeout.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.activation-timeout.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.activation-timeout'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-timeout'
+  await activateFixture(api, id, 'onCommand:runningExtensions.timeout')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('Activation timeout of 10000ms exceeded')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.data-clone-error.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.data-clone-error.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.data-clone-error'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-clone'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('could not be cloned')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.delayed-activation-time.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.delayed-activation-time.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.delayed-activation-time'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-delayed'
+  await activateFixture(api, id, 'onCommand:runningExtensions.delayed')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionActivationTime')).toContainText('Activation: 25')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.delayed-activation.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.delayed-activation.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.delayed-activation'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-delayed'
+  await activateFixture(api, id, 'onCommand:runningExtensions.delayed')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionName')).toHaveText('Delayed Activation')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.dependency-duplicate-identifier.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.dependency-duplicate-identifier.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.dependency-duplicate-identifier'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-identifier-has-already-been-declared-other-file'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText("Identifier 'x' has already been declared")
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.dependency-not-found.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.dependency-not-found.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.dependency-not-found'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-dependency-module-not-found'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('not-found.js')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.duplicate-identifier.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.duplicate-identifier.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.duplicate-identifier'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-identifier-has-already-been-declared'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText("Identifier 'x' has already been declared")
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.dynamic-import-not-found.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.dynamic-import-not-found.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.dynamic-import-not-found'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-dynamic-import-not-found'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('add.js')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.empty-name.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.empty-name.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.empty-name'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-empty-name'
+  await activateFixture(api, id, 'onCommand:runningExtensions.emptyName')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionName')).toHaveText(id)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.error-activation-reason.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.error-activation-reason.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.error-activation-reason'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-throw'
+  const event = 'onCommand:runningExtensions.throw'
+  await activateFixture(api, id, event)
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionActivationReason')).toHaveText(`Activation reason: ${event}`)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.error-default-icon.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.error-default-icon.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.error-default-icon'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-throw'
+  await activateFixture(api, id, 'onCommand:runningExtensions.throw')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toBeVisible()
+  await api.expect(row.locator('.RunningExtensionDefaultIcon')).toHaveCount(1)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.export-not-found.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.export-not-found.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.export-not-found'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-export-not-found'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('add.js')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.invalid-icon.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.invalid-icon.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.invalid-icon'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-invalid-icon'
+  await activateFixture(api, id, 'onCommand:runningExtensions.invalidIcon')
+  const row = await getRunningExtension(api, id)
+  const icon = row.locator('img.RunningExtensionIcon')
+  const iconUrl = new URL(`../fixtures/${id}/missing.svg`, import.meta.url).href
+
+  await api.expect(icon).toHaveAttribute('src', iconUrl)
+  await api.expect(icon).toHaveJSProperty('naturalWidth', 0)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.invalid-name.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.invalid-name.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.invalid-name'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-invalid-name'
+  await activateFixture(api, id, 'onCommand:runningExtensions.invalidName')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionName')).toHaveText(id)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.isolated-healthy.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.isolated-healthy.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.isolated-healthy'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-isolated-healthy'
+  await activateFixture(api, id, 'onCommand:runningExtensions.isolatedHealthy')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionActivationTime')).toBeVisible()
+  await api.expect(row.locator('.RunningExtensionStatus')).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.long-name.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.long-name.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.long-name'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-long-name'
+  await activateFixture(api, id, 'onCommand:runningExtensions.longName')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionName')).toContainText('deliberately very long extension display name')
+  await api.expect(row).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.missing-activate-export.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.missing-activate-export.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.missing-activate-export'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-missing-activate'
+  await activateFixture(api, id, 'onCommand:runningExtensions.missingActivate')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('Error:')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.missing-icon.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.missing-icon.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.missing-icon'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-missing-icon'
+  await activateFixture(api, id, 'onCommand:runningExtensions.missingIcon')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionDefaultIcon')).toHaveCount(1)
+  await api.expect(row.locator('img.RunningExtensionIcon')).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.missing-main-entry.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.missing-main-entry.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.missing-main-entry'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-missing-main'
+  await activateFixture(api, id, 'onCommand:runningExtensions.missingMain')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('not-found.js')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.missing-name.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.missing-name.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.missing-name'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-missing-name'
+  await activateFixture(api, id, 'onCommand:runningExtensions.missingName')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionName')).toHaveText(id)
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.missing-version.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.missing-version.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.missing-version'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-missing-version'
+  await activateFixture(api, id, 'onCommand:runningExtensions.missingVersion')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionVersion')).toHaveText('')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.mixed-all-statuses.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.mixed-all-statuses.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension, wait } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.mixed-all-statuses'
+
+export const test: Test = async (api) => {
+  const runningId = 'sample.running-extensions-rich'
+  const errorId = 'sample.running-extensions-throw'
+  const terminatedId = 'sample.running-extensions-close-immediately'
+  await activateFixture(api, runningId, 'onCommand:runningExtensions.rich')
+  await activateFixture(api, errorId, 'onCommand:runningExtensions.throw')
+  await activateFixture(api, terminatedId, 'onCommand:runningExtensions.closeImmediately')
+  await wait(400)
+  await getRunningExtension(api, runningId)
+
+  await api.expect(api.Locator('.RunningExtension')).toHaveCount(3)
+  await api.expect(api.Locator('.RunningExtensionId', { hasText: errorId })).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionId', { hasText: terminatedId })).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionStatusError')).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionStatusTerminated')).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.mixed-running-and-error.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.mixed-running-and-error.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.mixed-running-and-error'
+
+export const test: Test = async (api) => {
+  const runningId = 'sample.running-extensions-rich'
+  const errorId = 'sample.running-extensions-throw'
+  await activateFixture(api, runningId, 'onCommand:runningExtensions.rich')
+  await activateFixture(api, errorId, 'onCommand:runningExtensions.throw')
+  await getRunningExtension(api, runningId)
+
+  await api.expect(api.Locator('.RunningExtensionId', { hasText: errorId })).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionActivationTime')).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionStatusError')).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.mixed-running-and-terminated.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.mixed-running-and-terminated.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension, wait } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.mixed-running-and-terminated'
+
+export const test: Test = async (api) => {
+  const runningId = 'sample.running-extensions-rich'
+  const terminatedId = 'sample.running-extensions-close-100ms'
+  await activateFixture(api, runningId, 'onCommand:runningExtensions.rich')
+  await activateFixture(api, terminatedId, 'onCommand:runningExtensions.close100ms')
+  await wait(500)
+  await getRunningExtension(api, runningId)
+
+  await api.expect(api.Locator('.RunningExtensionId', { hasText: terminatedId })).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionActivationTime')).toBeVisible()
+  await api.expect(api.Locator('.RunningExtensionStatusTerminated')).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.nested-dependency-not-found.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.nested-dependency-not-found.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.nested-dependency-not-found'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-dependency-module-not-found-complex'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('parts/math.js')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.prerelease-version.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.prerelease-version.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.prerelease-version'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-rich'
+  await activateFixture(api, id, 'onCommand:runningExtensions.rich')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionVersion')).toHaveText('2.3.4-beta.5')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.repository-metadata.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.repository-metadata.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.repository-metadata'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-rich'
+  await activateFixture(api, id, 'onCommand:runningExtensions.rich')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionId')).toHaveText(id)
+  await api.expect(row).toHaveAttribute('role', 'listitem')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.syntax-error.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.syntax-error.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.syntax-error'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-unexpected-token'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('Missing semicolon')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.terminates-after-100ms.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.terminates-after-100ms.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension, wait } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.terminates-after-100ms'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-close-100ms'
+  await activateFixture(api, id, 'onCommand:runningExtensions.close100ms')
+  await wait(500)
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusTerminated')).toContainText('Extension worker stopped responding')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.terminates-after-one-second.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.terminates-after-one-second.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension, wait } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.terminates-after-one-second'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-close-1s'
+  await activateFixture(api, id, 'onCommand:runningExtensions.close1s')
+  await wait(1400)
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusTerminated')).toContainText('Terminated:')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.terminates-immediately.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.terminates-immediately.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension, wait } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.terminates-immediately'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-close-immediately'
+  await activateFixture(api, id, 'onCommand:runningExtensions.closeImmediately')
+  await wait(400)
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusTerminated')).toContainText('Terminated:')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.top-level-type-error.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.top-level-type-error.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.top-level-type-error'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-cannot-read-properties-of-null-reading-value'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('Cannot read properties of null')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.unicode-name.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.unicode-name.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.unicode-name'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-rich'
+  await activateFixture(api, id, 'onCommand:runningExtensions.rich')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionName')).toHaveText('扩展 Runtime 🚀')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.uri-error.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.uri-error.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.uri-error'
+
+export const test: Test = async (api) => {
+  const id = 'sample.error-uri'
+  await activateFixture(api, id, 'onCommand:xyz.sampleCommand')
+  const row = await getRunningExtension(api, id)
+
+  await api.expect(row.locator('.RunningExtensionStatusError')).toContainText('URI')
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.valid-icon.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.valid-icon.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { activateFixture, getRunningExtension } from '../fixtures/running-extensions-test-helpers.js'
+
+export const name = 'running-extensions.valid-icon'
+
+export const test: Test = async (api) => {
+  const id = 'sample.running-extensions-rich'
+  await activateFixture(api, id, 'onCommand:runningExtensions.rich')
+  const row = await getRunningExtension(api, id)
+  const iconUrl = new URL(`../fixtures/${id}/icon.svg`, import.meta.url).href
+
+  await api.expect(row.locator('img.RunningExtensionIcon')).toHaveAttribute('src', iconUrl)
+}

--- a/packages/extension-host-worker-tests/tsconfig.json
+++ b/packages/extension-host-worker-tests/tsconfig.json
@@ -20,6 +20,7 @@
     "src",
     "test",
     "typings",
+    "fixtures/running-extensions-test-helpers.js",
     "fixtures/sample.extension-disable-lifecycle/test.js",
     "fixtures/sample.running-extensions-live-view/test.js"
   ]

--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -80,6 +80,25 @@
   overflow: hidden;
 }
 
+.RunningExtensionStatus {
+  flex: none;
+  font-weight: 600;
+  margin-left: auto;
+  max-width: min(42%, 440px);
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.RunningExtensionStatusError {
+  color: var(--InputValidationErrorForeground, #f48771);
+}
+
+.RunningExtensionStatusTerminated {
+  color: var(--EditorWarningForeground, #cca700);
+}
+
 .RunningExtensionsEmpty {
   align-items: center;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary

- add exactly 40 running-extensions-view e2e scenarios
- cover missing and invalid metadata, icons, activation errors, import and syntax failures, mixed status lists, activation timing, and isolated extension termination
- assert running, error, and terminated presentation against the released extension-management-worker and running-extensions-view packages
- add focused mock extensions and CSS bundle assertions

## Validation

- all 40 new browser tests pass against extension-management-worker 4.41.2 and running-extensions-view 1.16.0
- extension-host-worker-tests type-check passes
- ESLint passes for all 40 new tests
- BundleCss: 28 tests pass
- static build, server build, and static export pass