### PR TITLE
fix: retry websocket startup

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -34,7 +34,7 @@
         "@lvce-editor/extension-detail-view": "^7.23.2",
         "@lvce-editor/extension-host-sub-worker": "^3.14.0",
         "@lvce-editor/extension-host-worker": "^8.66.0",
-        "@lvce-editor/extension-management-worker": "^4.41.2",
+        "@lvce-editor/extension-management-worker": "^4.42.0",
         "@lvce-editor/extension-search-view": "^7.11.0",
         "@lvce-editor/file-search-worker": "^8.7.0",
         "@lvce-editor/file-system-worker": "^5.11.0",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-management-worker": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-management-worker/-/extension-management-worker-4.41.2.tgz",
-      "integrity": "sha512-mBPaM2sUVgHRUZqqn3zlqXxiuNF0zJ7FuWZzmGtE7Dgq/lypMHYSnxBG+ME6PTVsrWyFa34UYiA9i5sOGjv9tA==",
+      "version": "4.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-management-worker/-/extension-management-worker-4.42.0.tgz",
+      "integrity": "sha512-/lbig2q/KgJNWpPubfmJkjV1jFyR0um7C/cLDJaH8h1lUKo+1fpcJZq19ZGylZJwiWaXKIPfRDKNRp/NOxiTmQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-search-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -66,7 +66,7 @@
     "@lvce-editor/extension-detail-view": "^7.23.2",
     "@lvce-editor/extension-host-sub-worker": "^3.14.0",
     "@lvce-editor/extension-host-worker": "^8.66.0",
-    "@lvce-editor/extension-management-worker": "^4.41.2",
+    "@lvce-editor/extension-management-worker": "^4.42.0",
     "@lvce-editor/extension-search-view": "^7.11.0",
     "@lvce-editor/file-search-worker": "^8.7.0",
     "@lvce-editor/file-system-worker": "^5.11.0",

--- a/packages/renderer-worker/src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.js
+++ b/packages/renderer-worker/src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.js
@@ -12,7 +12,10 @@ export const create = async ({ type }) => {
   const host = Location.getHost()
   const wsUrl = GetWebSocketUrl.getWebSocketUrl(type, host)
   const webSocket = ReconnectingWebSocket.create(wsUrl)
-  const firstWebSocketEvent = await WaitForWebSocketToBeOpen.waitForWebSocketToBeOpen(webSocket)
+  let firstWebSocketEvent = await WaitForWebSocketToBeOpen.waitForWebSocketToBeOpen(webSocket)
+  if (firstWebSocketEvent.type === FirstWebSocketEventType.Close) {
+    firstWebSocketEvent = await WaitForWebSocketToBeOpen.waitForWebSocketToBeOpen(webSocket)
+  }
   if (firstWebSocketEvent.type === FirstWebSocketEventType.Close) {
     throw new IpcError('Websocket connection was immediately closed')
   }

--- a/packages/renderer-worker/src/parts/ReconnectingWebSocket/ReconnectingWebSocket.js
+++ b/packages/renderer-worker/src/parts/ReconnectingWebSocket/ReconnectingWebSocket.js
@@ -1,14 +1,20 @@
 export const create = (url, args) => {
   const webSocket = new WebSocket(url, args)
+  const listeners = new Map()
 
   const reconnect = () => {
     const originalOnMessage = context.webSocket.onmessage
     context.webSocket = new WebSocket(url, args)
     context.webSocket.onmessage = originalOnMessage
     context.webSocket.onclose = handleClose
+    for (const [type, typeListeners] of listeners) {
+      for (const listener of typeListeners) {
+        context.webSocket.addEventListener(type, listener)
+      }
+    }
   }
 
-  const handleClose = (event) => {
+  const handleClose = () => {
     setTimeout(reconnect, 2000)
   }
 
@@ -24,9 +30,20 @@ export const create = (url, args) => {
       this.webSocket.send(message)
     },
     addEventListener(type, listener) {
+      let typeListeners = listeners.get(type)
+      if (!typeListeners) {
+        typeListeners = new Set()
+        listeners.set(type, typeListeners)
+      }
+      typeListeners.add(listener)
       this.webSocket.addEventListener(type, listener)
     },
     removeEventListener(type, listener) {
+      const typeListeners = listeners.get(type)
+      typeListeners?.delete(listener)
+      if (typeListeners?.size === 0) {
+        listeners.delete(type)
+      }
       this.webSocket.removeEventListener(type, listener)
     },
   }

--- a/packages/renderer-worker/test/ReconnectingWebSocket.test.ts
+++ b/packages/renderer-worker/test/ReconnectingWebSocket.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import * as IpcParentWithWebSocket from '../src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.js'
+import * as ReconnectingWebSocket from '../src/parts/ReconnectingWebSocket/ReconnectingWebSocket.js'
+
+const originalLocation = globalThis.location
+const originalWebSocket = globalThis.WebSocket
+
+class MockWebSocket extends EventTarget {
+  static instances: MockWebSocket[] = []
+
+  onclose: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+
+  constructor() {
+    super()
+    MockWebSocket.instances.push(this)
+  }
+
+  emitClose(): void {
+    const event = new Event('close')
+    this.onclose?.(event)
+    this.dispatchEvent(event)
+  }
+
+  emitOpen(): void {
+    this.dispatchEvent(new Event('open'))
+  }
+
+  send(): void {}
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  MockWebSocket.instances = []
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: {
+      host: 'localhost:3000',
+      protocol: 'http:',
+    },
+  })
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: MockWebSocket,
+  })
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: originalLocation,
+  })
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: originalWebSocket,
+  })
+})
+
+test('preserves event listeners when reconnecting', async () => {
+  const webSocket = ReconnectingWebSocket.create('ws://localhost:3000')
+  const listener = jest.fn()
+  webSocket.addEventListener('open', listener)
+
+  MockWebSocket.instances[0].emitClose()
+  await jest.advanceTimersByTimeAsync(2000)
+  MockWebSocket.instances[1].emitOpen()
+
+  expect(MockWebSocket.instances).toHaveLength(2)
+  expect(listener).toHaveBeenCalledTimes(1)
+})
+
+test('removes event listeners before reconnecting', async () => {
+  const webSocket = ReconnectingWebSocket.create('ws://localhost:3000')
+  const listener = jest.fn()
+  webSocket.addEventListener('open', listener)
+  webSocket.removeEventListener('open', listener)
+
+  MockWebSocket.instances[0].emitClose()
+  await jest.advanceTimersByTimeAsync(2000)
+  MockWebSocket.instances[1].emitOpen()
+
+  expect(listener).not.toHaveBeenCalled()
+})
+
+test('waits for the existing websocket to reconnect during startup', async () => {
+  const ipcPromise = IpcParentWithWebSocket.create({
+    type: 'shared-process',
+  })
+
+  MockWebSocket.instances[0].emitClose()
+  await jest.advanceTimersByTimeAsync(2000)
+  MockWebSocket.instances[1].emitOpen()
+
+  const webSocket = await ipcPromise
+  expect(MockWebSocket.instances).toHaveLength(2)
+  expect(webSocket.webSocket).toBe(MockWebSocket.instances[1])
+})


### PR DESCRIPTION
## Summary

- preserve registered WebSocket event listeners when the renderer reconnects
- wait for one existing reconnect during renderer shared-process startup instead of failing on the first transient close
- include the released file-system-worker 5.11.0 and extension-management-worker 4.42.0 startup fixes
- cover listener persistence, listener removal, and startup reconnection with focused unit tests

## Root-cause evidence

The chat-view Windows E2E investigation showed intermittent browser-side WebSocket establishment failures before an HTTP upgrade reached the server. The renderer already reconnected successfully two seconds later, but startup treated the first close as terminal and its event listeners remained attached to the replaced socket. The same bounded retry in the RPC-owned worker paths plus this listener-preserving renderer reconnect passed 20/20 isolated full Windows E2E runs.

## Validation

- `npm test --prefix packages/renderer-worker -- --runInBand test/ReconnectingWebSocket.test.ts`
- `npm test --prefix packages/renderer-worker -- --runInBand` (285 suites, 1,106 passed; 26 suites intentionally skipped)
- `npm run type-check --prefix packages/renderer-worker`
- Prettier check for all changed renderer files
- 20/20 full chat-view Windows E2E diagnostic runs