### PR TITLE
feature: add reset view locations command

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -521,6 +521,7 @@ export const commandMap = {
   'Layout.handleWorkspaceRefresh': lazy('Layout.handleWorkspaceRefresh'),
   'Layout.refreshSourceControlBadgeCount': lazy('Layout.refreshSourceControlBadgeCount'),
   'Layout.reset': lazy('Layout.reset'),
+  'Layout.resetViewLocations': lazy('Layout.resetViewLocations'),
   'Layout.closeChat': lazy('Layout.closeChat'),
   'Layout.enterSideBarFocusMode': lazy('Layout.enterSideBarFocusMode'),
   'Layout.hideActivityBar': lazy('Layout.hideActivityBar'),

--- a/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
+++ b/packages/renderer-worker/src/parts/ResetLayout/ResetLayout.ts
@@ -59,6 +59,39 @@ const resetActivityBar = async (): Promise<void> => {
   await Command.execute('ActivityBar.reset')
 }
 
+const resetVisibility = async (state: Readonly<LayoutState>): Promise<void> => {
+  if (state.secondarySideBarVisible) {
+    await Command.execute('Layout.hideSecondarySideBar')
+  }
+  if (state.previewVisible) {
+    await Command.execute('Layout.hidePreview')
+  }
+  if (!state.mainVisible) {
+    await Command.execute('Layout.showMain')
+  }
+  if (!state.activityBarVisible) {
+    await Command.execute('Layout.showActivityBar')
+  }
+  if (!state.statusBarVisible) {
+    await Command.execute('Layout.showStatusBar')
+  }
+  if (!state.titleBarVisible) {
+    await Command.execute('Layout.showTitleBar')
+  }
+}
+
+export const resetViewLocations = async (state: Readonly<LayoutState>): Promise<LayoutStateResult> => {
+  const { panelMaximized, panelView, panelVisible, sideBarFocusMode, sideBarLocation, sideBarView, sideBarVisible } = state
+  await resetSideBar(sideBarFocusMode, sideBarLocation, sideBarView, sideBarVisible)
+  await resetPanel(panelMaximized, panelView, panelVisible)
+  await resetVisibility(state)
+  await resetActivityBar()
+  return {
+    commands: [],
+    newState: state,
+  }
+}
+
 export const reset = async (state: Readonly<LayoutState>): Promise<LayoutStateResult> => {
   const { panelMaximized, panelView, panelVisible, sideBarFocusMode, sideBarLocation, sideBarView, sideBarVisible, titleBarWidth } = state
   await Promise.all([

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -45,6 +45,7 @@ export const CommandsWithSideEffects = {
   handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
   refreshSourceControlBadgeCount: ViewletLayout.refreshSourceControlBadgeCount,
   reset: ResetLayout.reset,
+  resetViewLocations: ResetLayout.resetViewLocations,
   closeChat: ViewletLayout.closeChat,
   enterSideBarFocusMode: ViewletLayout.enterSideBarFocusMode,
   hideActivityBar: ViewletLayout.hideActivityBar,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -24,6 +24,11 @@ export const getQuickPickMenuEntries = () => {
       label: 'Layout: Toggle Side Bar',
     },
     {
+      id: 'Layout.resetViewLocations',
+      label: 'Layout: Reset View Locations',
+      aliases: ['View: Reset View Locations'],
+    },
+    {
       id: 'Layout.openChat',
       label: 'Layout: Open Chat',
       aliases: ['Show Chat'],

--- a/packages/renderer-worker/test/ResetLayout.test.ts
+++ b/packages/renderer-worker/test/ResetLayout.test.ts
@@ -7,6 +7,7 @@ jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
 
 const Command = await import('../src/parts/Command/Command.js')
 const ResetLayout = await import('../src/parts/ResetLayout/ResetLayout.ts')
+const execute = jest.mocked(Command.execute)
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -122,4 +123,65 @@ test('resets independent components in parallel', async () => {
     resolve()
   }
   await resetPromise
+})
+
+test('resetViewLocations restores the initial view arrangement', async () => {
+  const state = {
+    activityBarVisible: false,
+    mainVisible: false,
+    panelMaximized: true,
+    panelView: 'Output',
+    panelVisible: true,
+    previewVisible: true,
+    secondarySideBarVisible: true,
+    sideBarFocusMode: true,
+    sideBarLocation: SideBarLocationType.Left,
+    sideBarView: 'Search',
+    sideBarVisible: false,
+    statusBarVisible: false,
+    titleBarVisible: false,
+  } as any
+
+  await expect(ResetLayout.resetViewLocations(state)).resolves.toEqual({
+    commands: [],
+    newState: state,
+  })
+
+  expect(execute.mock.calls).toEqual([
+    ['Layout.leaveSideBarFocusMode'],
+    ['Layout.moveSideBarRight'],
+    ['Layout.showSideBar', 'Explorer', false],
+    ['Layout.unmaximizePanel'],
+    ['Layout.showPanel', 'Problems'],
+    ['Layout.hidePanel'],
+    ['Layout.hideSecondarySideBar'],
+    ['Layout.hidePreview'],
+    ['Layout.showMain'],
+    ['Layout.showActivityBar'],
+    ['Layout.showStatusBar'],
+    ['Layout.showTitleBar'],
+    ['ActivityBar.reset'],
+  ])
+})
+
+test('resetViewLocations leaves the initial view arrangement in place', async () => {
+  const state = {
+    activityBarVisible: true,
+    mainVisible: true,
+    panelMaximized: false,
+    panelView: 'Problems',
+    panelVisible: false,
+    previewVisible: false,
+    secondarySideBarVisible: false,
+    sideBarFocusMode: false,
+    sideBarLocation: SideBarLocationType.Right,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+    statusBarVisible: true,
+    titleBarVisible: true,
+  } as any
+
+  await ResetLayout.resetViewLocations(state)
+
+  expect(execute.mock.calls).toEqual([['ActivityBar.reset']])
 })

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -30,6 +30,16 @@ test('getQuickPickMenuEntries includes chat commands', () => {
   )
 })
 
+test('getQuickPickMenuEntries includes reset view locations command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Layout.resetViewLocations',
+    label: 'Layout: Reset View Locations',
+    aliases: ['View: Reset View Locations'],
+  })
+})
+
 test('getQuickPickMenuEntries includes GPU info command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 


### PR DESCRIPTION
Adds a Layout: Reset View Locations command that restores the default workbench arrangement, including the right sidebar and visible activity, title, and status bars.