### PR TITLE
feature: persist encrypted extension secrets

### DIFF
--- a/packages/shared-process/src/parts/Module/Module.ts
+++ b/packages/shared-process/src/parts/Module/Module.ts
@@ -140,6 +140,8 @@ export const load = (moduleId: any): any => {
       return import('../RecentlyOpened/RecentlyOpened.ipc.ts')
     case ModuleId.Screen:
       return import('../Screen/Screen.ipc.ts')
+    case ModuleId.SecretStorage:
+      return import('../SecretStorage/SecretStorage.ipc.ts')
     case ModuleId.SendMessagePortToMainProcess:
       return import('../SendMessagePortToMainProcess/SendMessagePortToMainProcess.ipc.ts')
     case ModuleId.TemporaryMessagePort:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.ts
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.ts
@@ -80,3 +80,4 @@ export const PlatformPaths = 84
 export const HandleMessagePortForAuthProcess = 86
 export const LanguageServer = 87
 export const SendMessagePortToMainProcess = 88
+export const SecretStorage = 89

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -320,6 +320,10 @@ export const getModuleId = (commandId: any): any => {
     case 'Screen.getHeight':
     case 'Screen.getWidth':
       return ModuleId.Screen
+    case 'SecretStorage.delete':
+    case 'SecretStorage.get':
+    case 'SecretStorage.store':
+      return ModuleId.SecretStorage
     case 'SendMessagePortToMainProcess.sendMessagePortToMainProcess':
       return ModuleId.SendMessagePortToMainProcess
     case 'TemporaryMessagePort.getPortTuple2':

--- a/packages/shared-process/src/parts/SecretStorage/SecretStorage.ipc.ts
+++ b/packages/shared-process/src/parts/SecretStorage/SecretStorage.ipc.ts
@@ -1,0 +1,9 @@
+import * as SecretStorage from './SecretStorage.ts'
+
+export const name = 'SecretStorage'
+
+export const Commands = {
+  delete: SecretStorage.deleteSecret,
+  get: SecretStorage.get,
+  store: SecretStorage.store,
+}

--- a/packages/shared-process/src/parts/SecretStorage/SecretStorage.ts
+++ b/packages/shared-process/src/parts/SecretStorage/SecretStorage.ts
@@ -1,0 +1,71 @@
+import * as ElectronSafeStorage from '../ElectronSafeStorage/ElectronSafeStorage.ts'
+import { FileNotFoundError } from '../FileNotFoundError/FileNotFoundError.ts'
+import * as JsonFile from '../JsonFile/JsonFile.ts'
+import * as Path from '../Path/Path.ts'
+import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
+import * as Queue from '../Queue/Queue.ts'
+
+type StoredSecrets = Readonly<Record<string, Readonly<Record<string, string>>>>
+
+const queueKey = 'secret-storage'
+
+const getStoragePath = (): string => {
+  return Path.join(PlatformPaths.getConfigDir(), 'secrets.json')
+}
+
+const readStoredSecrets = async (): Promise<StoredSecrets> => {
+  try {
+    const stored = await JsonFile.readJson(getStoragePath())
+    if (!stored || typeof stored !== 'object' || Array.isArray(stored)) {
+      return {}
+    }
+    return stored
+  } catch (error) {
+    if (error instanceof FileNotFoundError) {
+      return {}
+    }
+    throw error
+  }
+}
+
+export const get = async (extensionId: string, key: string): Promise<string | undefined> => {
+  const stored = await readStoredSecrets()
+  const encrypted = stored[extensionId]?.[key]
+  if (typeof encrypted !== 'string') {
+    return undefined
+  }
+  return ElectronSafeStorage.decryptString(encrypted)
+}
+
+export const store = async (extensionId: string, key: string, value: string): Promise<void> => {
+  await Queue.add(queueKey, async () => {
+    const encrypted = await ElectronSafeStorage.encryptString(value)
+    const stored = await readStoredSecrets()
+    await JsonFile.writeJson(getStoragePath(), {
+      ...stored,
+      [extensionId]: {
+        ...stored[extensionId],
+        [key]: encrypted,
+      },
+    })
+  })
+}
+
+export const deleteSecret = async (extensionId: string, key: string): Promise<void> => {
+  await Queue.add(queueKey, async () => {
+    const stored = await readStoredSecrets()
+    const extensionSecrets = stored[extensionId]
+    if (!extensionSecrets || typeof extensionSecrets[key] !== 'string') {
+      return
+    }
+    const nextExtensionSecrets = { ...extensionSecrets }
+    delete nextExtensionSecrets[key]
+    const nextStored = { ...stored }
+    if (Object.keys(nextExtensionSecrets).length === 0) {
+      delete nextStored[extensionId]
+    } else {
+      nextStored[extensionId] = nextExtensionSecrets
+    }
+    await JsonFile.writeJson(getStoragePath(), nextStored)
+  })
+}

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -9,3 +9,7 @@ test('getModuleId - Platform.getConfigJsonPath', () => {
 test('getModuleId - SendMessagePortToMainProcess.sendMessagePortToMainProcess', () => {
   expect(ModuleMap.getModuleId('SendMessagePortToMainProcess.sendMessagePortToMainProcess')).toBe(ModuleId.SendMessagePortToMainProcess)
 })
+
+test('getModuleId - SecretStorage.get', () => {
+  expect(ModuleMap.getModuleId('SecretStorage.get')).toBe(ModuleId.SecretStorage)
+})

--- a/packages/shared-process/test/SecretStorage.test.ts
+++ b/packages/shared-process/test/SecretStorage.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { FileNotFoundError } from '../src/parts/FileNotFoundError/FileNotFoundError.js'
+
+jest.unstable_mockModule('../src/parts/ElectronSafeStorage/ElectronSafeStorage.js', () => ({
+  decryptString: jest.fn(),
+  encryptString: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/JsonFile/JsonFile.js', () => ({
+  readJson: jest.fn(),
+  writeJson: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
+  getConfigDir: jest.fn(() => '/test/config'),
+}))
+
+const ElectronSafeStorage = await import('../src/parts/ElectronSafeStorage/ElectronSafeStorage.js')
+const JsonFile = await import('../src/parts/JsonFile/JsonFile.js')
+const SecretStorage = await import('../src/parts/SecretStorage/SecretStorage.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('get returns undefined when the secret file does not exist', async () => {
+  jest.mocked(JsonFile.readJson).mockRejectedValue(new FileNotFoundError('/test/config/secrets.json'))
+
+  await expect(SecretStorage.get('sample.extension', 'token')).resolves.toBeUndefined()
+  expect(ElectronSafeStorage.decryptString).not.toHaveBeenCalled()
+})
+
+test('get decrypts the extension-scoped value', async () => {
+  jest.mocked(JsonFile.readJson).mockResolvedValue({
+    'other.extension': {
+      token: 'other-encrypted',
+    },
+    'sample.extension': {
+      token: 'encrypted',
+    },
+  })
+  jest.mocked(ElectronSafeStorage.decryptString).mockResolvedValue('plain-text')
+
+  await expect(SecretStorage.get('sample.extension', 'token')).resolves.toBe('plain-text')
+  expect(ElectronSafeStorage.decryptString).toHaveBeenCalledWith('encrypted')
+})
+
+test('store encrypts values before persisting them outside the browser cache', async () => {
+  jest.mocked(JsonFile.readJson).mockResolvedValue({
+    'sample.extension': {
+      existing: 'existing-encrypted',
+    },
+  })
+  jest.mocked(ElectronSafeStorage.encryptString).mockResolvedValue('new-encrypted')
+
+  await SecretStorage.store('sample.extension', 'token', 'plain-text')
+
+  expect(ElectronSafeStorage.encryptString).toHaveBeenCalledWith('plain-text')
+  expect(JsonFile.writeJson).toHaveBeenCalledWith('/test/config/secrets.json', {
+    'sample.extension': {
+      existing: 'existing-encrypted',
+      token: 'new-encrypted',
+    },
+  })
+})
+
+test('delete removes only the selected extension secret', async () => {
+  jest.mocked(JsonFile.readJson).mockResolvedValue({
+    'other.extension': {
+      token: 'other-encrypted',
+    },
+    'sample.extension': {
+      token: 'encrypted',
+    },
+  })
+
+  await SecretStorage.deleteSecret('sample.extension', 'token')
+
+  expect(JsonFile.writeJson).toHaveBeenCalledWith('/test/config/secrets.json', {
+    'other.extension': {
+      token: 'other-encrypted',
+    },
+  })
+})

--- a/packages/shared-process/test/SecretStorage.test.ts
+++ b/packages/shared-process/test/SecretStorage.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { join } from 'node:path'
 import { FileNotFoundError } from '../src/parts/FileNotFoundError/FileNotFoundError.js'
 
 jest.unstable_mockModule('../src/parts/ElectronSafeStorage/ElectronSafeStorage.js', () => ({
@@ -18,13 +19,14 @@ jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
 const ElectronSafeStorage = await import('../src/parts/ElectronSafeStorage/ElectronSafeStorage.js')
 const JsonFile = await import('../src/parts/JsonFile/JsonFile.js')
 const SecretStorage = await import('../src/parts/SecretStorage/SecretStorage.js')
+const storagePath = join('/test/config', 'secrets.json')
 
 beforeEach(() => {
   jest.clearAllMocks()
 })
 
 test('get returns undefined when the secret file does not exist', async () => {
-  jest.mocked(JsonFile.readJson).mockRejectedValue(new FileNotFoundError('/test/config/secrets.json'))
+  jest.mocked(JsonFile.readJson).mockRejectedValue(new FileNotFoundError(storagePath))
 
   await expect(SecretStorage.get('sample.extension', 'token')).resolves.toBeUndefined()
   expect(ElectronSafeStorage.decryptString).not.toHaveBeenCalled()
@@ -56,7 +58,7 @@ test('store encrypts values before persisting them outside the browser cache', a
   await SecretStorage.store('sample.extension', 'token', 'plain-text')
 
   expect(ElectronSafeStorage.encryptString).toHaveBeenCalledWith('plain-text')
-  expect(JsonFile.writeJson).toHaveBeenCalledWith('/test/config/secrets.json', {
+  expect(JsonFile.writeJson).toHaveBeenCalledWith(storagePath, {
     'sample.extension': {
       existing: 'existing-encrypted',
       token: 'new-encrypted',
@@ -76,7 +78,7 @@ test('delete removes only the selected extension secret', async () => {
 
   await SecretStorage.deleteSecret('sample.extension', 'token')
 
-  expect(JsonFile.writeJson).toHaveBeenCalledWith('/test/config/secrets.json', {
+  expect(JsonFile.writeJson).toHaveBeenCalledWith(storagePath, {
     'other.extension': {
       token: 'other-encrypted',
     },


### PR DESCRIPTION
Adds a desktop secret-storage backend that encrypts values with Electron safeStorage and persists ciphertext outside the browser cache.