### PR TITLE
fix: clear activity bar focus on blur

### DIFF
--- a/packages/renderer-worker/src/parts/Focus/Focus.js
+++ b/packages/renderer-worker/src/parts/Focus/Focus.js
@@ -32,6 +32,19 @@ export const setFocus = (focusKey, additionalFocusKey, uid, viewletModuleId) => 
 }
 
 /**
+ * @param {number} focusKey
+ */
+export const clearFocus = (focusKey) => {
+  Assert.number(focusKey)
+  if (FocusState.get() !== focusKey) {
+    return
+  }
+  Context.remove(focusKey)
+  FocusState.set(WhenExpression.Empty)
+  KeyBindingsState.update()
+}
+
+/**
  * @param {number} key
  * @param {number=} uid - Optional: UID of the viewlet instance
  * @param {string=} viewletModuleId - Optional: Module ID of the viewlet instance

--- a/packages/renderer-worker/src/parts/FocusState/FocusState.js
+++ b/packages/renderer-worker/src/parts/FocusState/FocusState.js
@@ -1,6 +1,5 @@
 export const state = {
-  // TODO use numeric focus key
-  currentFocus: '',
+  currentFocus: 0,
 }
 
 export const get = () => {

--- a/packages/renderer-worker/src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts
@@ -6,6 +6,8 @@ export const wrapActivityBarCommand = (key: string) => {
   const fn = async (state, ...args) => {
     if (key === 'handleFocus') {
       Focus.setFocus(FocusKey.ActivityBar)
+    } else if (key === 'handleBlur') {
+      Focus.clearFocus(FocusKey.ActivityBar)
     }
     await ActivityBarWorker.invoke(`ActivityBar.${key}`, state.uid, ...args)
     const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', state.uid)

--- a/packages/renderer-worker/test/Focus.test.ts
+++ b/packages/renderer-worker/test/Focus.test.ts
@@ -9,6 +9,7 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
 const Context = await import('../src/parts/Context/Context.js')
 const ExtensionViewContext = await import('../src/parts/ExtensionViewContext/ExtensionViewContext.js')
 const Focus = await import('../src/parts/Focus/Focus.js')
+const FocusState = await import('../src/parts/FocusState/FocusState.js')
 const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
@@ -37,4 +38,31 @@ test('setFocus preserves extension view context keybindings', () => {
 
   expect(Context.get('chat2.composerFocus')).toBeUndefined()
   expect(RendererProcess.invoke).toHaveBeenLastCalledWith('KeyBindings.setIdentifiers', new Uint32Array())
+})
+
+test('clearFocus removes the current focus keyboard context', () => {
+  KeyBindingsState.setKeyBindings('activity-bar-test', [
+    {
+      command: 'ActivityBar.selectCurrent',
+      key: 9,
+      when: WhenExpression.FocusActivityBar,
+    },
+  ])
+  Focus.setFocus(WhenExpression.FocusActivityBar)
+
+  Focus.clearFocus(WhenExpression.FocusActivityBar)
+
+  expect(FocusState.get()).toBe(WhenExpression.Empty)
+  expect(Context.get(WhenExpression.FocusActivityBar)).toBeUndefined()
+  expect(RendererProcess.invoke).toHaveBeenLastCalledWith('KeyBindings.setIdentifiers', new Uint32Array())
+})
+
+test('clearFocus preserves a newer focus keyboard context', () => {
+  Focus.setFocus(WhenExpression.FocusActivityBar)
+  Focus.setFocus(WhenExpression.FocusExplorer)
+
+  Focus.clearFocus(WhenExpression.FocusActivityBar)
+
+  expect(FocusState.get()).toBe(WhenExpression.FocusExplorer)
+  expect(Context.get(WhenExpression.FocusExplorer)).toBe(true)
 })

--- a/packages/renderer-worker/test/WrapActivityBarCommand.test.ts
+++ b/packages/renderer-worker/test/WrapActivityBarCommand.test.ts
@@ -10,6 +10,7 @@ jest.unstable_mockModule('../src/parts/ActivityBarWorker/ActivityBarWorker.js', 
 }))
 
 jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => ({
+  clearFocus: jest.fn(),
   setFocus: jest.fn(),
 }))
 
@@ -28,7 +29,18 @@ test('handleFocus sets the activity bar keyboard context', async () => {
   await wrapActivityBarCommand('handleFocus')(state)
 
   expect(Focus.setFocus).toHaveBeenCalledWith(FocusKey.ActivityBar)
+  expect(Focus.clearFocus).not.toHaveBeenCalled()
   expect(ActivityBarWorker.invoke).toHaveBeenNthCalledWith(1, 'ActivityBar.handleFocus', 7)
+})
+
+test('handleBlur clears the activity bar keyboard context', async () => {
+  const state = { uid: 7 }
+
+  await wrapActivityBarCommand('handleBlur')(state)
+
+  expect(Focus.clearFocus).toHaveBeenCalledWith(FocusKey.ActivityBar)
+  expect(Focus.setFocus).not.toHaveBeenCalled()
+  expect(ActivityBarWorker.invoke).toHaveBeenNthCalledWith(1, 'ActivityBar.handleBlur', 7)
 })
 
 test('other activity bar commands do not change the keyboard context', async () => {
@@ -36,5 +48,6 @@ test('other activity bar commands do not change the keyboard context', async () 
 
   await wrapActivityBarCommand('focusNext')(state)
 
+  expect(Focus.clearFocus).not.toHaveBeenCalled()
   expect(Focus.setFocus).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Summary:
- clear the activity bar keyboard context when its DOM focus leaves
- preserve any newer focus when a delayed blur arrives
- prevent Space in extension inputs from selecting another activity bar item