### PR TITLE
feature: reset running extension list styles

### DIFF
--- a/static/css/parts/ViewletRunningExtensions.css
+++ b/static/css/parts/ViewletRunningExtensions.css
@@ -4,8 +4,10 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  list-style: none;
   margin: 0;
   overflow: auto;
+  padding: 0;
 }
 
 .RunningExtensions:has(> .RunningExtensionsEmpty) {


### PR DESCRIPTION
## Summary

Reset native list padding and markers so the semantic running extensions list keeps its existing layout.