### PR TITLE
fix: register panel action event listeners

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -968,6 +968,7 @@ export const createPanelViewlet = async (
       parentUid: -1,
       append: false,
       args: [],
+      shouldRenderEvents: false,
     },
     false,
     true,

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -271,9 +271,9 @@ test('createPanelViewlet creates a linked actions root for child-contributed act
   const events = [{ name: 'handleClickAction', params: ['run'] }]
   const actionsDom = [{ type: 'Button', childCount: 0 }]
   // @ts-ignore
-  ViewletManager.load.mockResolvedValue([
+  ViewletManager.load.mockImplementation(async (viewlet) => [
     ['Viewlet.create', 'Output', 11],
-    ['Viewlet.registerEventListeners', 11, events],
+    ...(viewlet.shouldRenderEvents === false ? [['Viewlet.registerEventListeners', 11, events]] : []),
     ['Viewlet.send', -1, 'setActionsDom', actionsDom, 11],
   ])
 


### PR DESCRIPTION
Registers child panel event listeners through the returned render command so they can also be attached to the panel actions root. This makes Output channel controls functional and allows Window logs and warnings to load when selected.