### PR TITLE
feature: import Chrome cookies in simple browser

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -450,6 +450,10 @@ export const getQuickPickMenuEntries = () => {
       label: 'Simple Browser: Open Dev Devtools',
     },
     {
+      id: 'SimpleBrowser.importChromeCookies',
+      label: 'Simple Browser: Import Cookies from Chrome',
+    },
+    {
       id: 'Workspace.close',
       label: 'Workspace: Close',
     },

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -27,6 +27,7 @@ export const LazyCommands = {
   copyImage: () => import('./ViewletSimpleBrowserCopyImage.js'),
   backward: () => import('./ViewletSimpleBrowserBackward.js'),
   forward: () => import('./ViewletSimpleBrowserForward.js'),
+  importChromeCookies: () => import('./ViewletSimpleBrowserImportChromeCookies.js'),
   openDevtools: () => import('./ViewletSimpleBrowserOpenDevtools.js'),
   reload: () => import('./ViewletSimpleBrowserReload.js'),
   cancelNavigation: () => import('./ViewletSimpleBrowserCancelNavigation.js'),

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserImportChromeCookies.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserImportChromeCookies.js
@@ -1,0 +1,41 @@
+import * as ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt.js'
+import * as ElectronBrowserViewFunctions from '../ElectronBrowserViewFunctions/ElectronBrowserViewFunctions.js'
+import * as Notification from '../Notification/Notification.js'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+const getConfirmationMessage = ({ cookieCount, profileDirectory, profileName }) => {
+  const cookieLabel = cookieCount === 1 ? 'cookie' : 'cookies'
+  return `Import ${cookieCount} ${cookieLabel} from Chrome profile "${profileName}" (${profileDirectory})? This gives Simple Browser the same website access as Chrome.`
+}
+
+const getResultMessage = ({ failed, imported, skipped }) => {
+  return `Imported ${imported} Chrome cookies (${skipped} skipped, ${failed} failed).`
+}
+
+const getErrorMessage = (error) => {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export const importChromeCookies = async (state) => {
+  try {
+    const info = await SharedProcess.invoke('ChromeCookieImport.getInfo')
+    const confirmed = await ConfirmPrompt.prompt(getConfirmationMessage(info), {
+      confirmMessage: 'Import',
+      title: 'Import Chrome Cookies',
+    })
+    if (!confirmed) {
+      return state
+    }
+    const result = await SharedProcess.invoke('ChromeCookieImport.importCookies')
+    await ElectronBrowserViewFunctions.reload(state.browserViewId)
+    const notificationType = result.failed > 0 ? 'warning' : 'info'
+    await Notification.create(notificationType, getResultMessage(result))
+    return {
+      ...state,
+      isLoading: true,
+    }
+  } catch (error) {
+    await Notification.create('error', `Failed to import Chrome cookies: ${getErrorMessage(error)}`)
+    return state
+  }
+}

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -78,6 +78,15 @@ test('getQuickPickMenuEntries includes simple browser preview command', () => {
   })
 })
 
+test('getQuickPickMenuEntries includes Chrome cookie import command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'SimpleBrowser.importChromeCookies',
+    label: 'Simple Browser: Import Cookies from Chrome',
+  })
+})
+
 test('getQuickPickMenuEntries includes close all editors command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowserImportChromeCookies.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserImportChromeCookies.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ConfirmPrompt/ConfirmPrompt.js', () => ({
+  prompt: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/ElectronBrowserViewFunctions/ElectronBrowserViewFunctions.js', () => ({
+  reload: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Notification/Notification.js', () => ({
+  create: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const ConfirmPrompt = await import('../src/parts/ConfirmPrompt/ConfirmPrompt.js')
+const ElectronBrowserViewFunctions = await import('../src/parts/ElectronBrowserViewFunctions/ElectronBrowserViewFunctions.js')
+const Notification = await import('../src/parts/Notification/Notification.js')
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const ViewletSimpleBrowserImportChromeCookies = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserImportChromeCookies.js')
+
+const state = {
+  browserViewId: 12,
+  isLoading: false,
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('asks for confirmation and imports Chrome cookies', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValueOnce({
+    cookieCount: 12,
+    profileDirectory: 'Default',
+    profileName: 'Personal',
+  })
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValueOnce({
+    failed: 0,
+    imported: 10,
+    skipped: 2,
+  })
+  // @ts-ignore
+  ConfirmPrompt.prompt.mockResolvedValue(true)
+
+  await expect(ViewletSimpleBrowserImportChromeCookies.importChromeCookies(state)).resolves.toEqual({
+    ...state,
+    isLoading: true,
+  })
+  expect(ConfirmPrompt.prompt).toHaveBeenCalledWith(
+    'Import 12 cookies from Chrome profile "Personal" (Default)? This gives Simple Browser the same website access as Chrome.',
+    {
+      confirmMessage: 'Import',
+      title: 'Import Chrome Cookies',
+    },
+  )
+  expect(SharedProcess.invoke).toHaveBeenNthCalledWith(1, 'ChromeCookieImport.getInfo')
+  expect(SharedProcess.invoke).toHaveBeenNthCalledWith(2, 'ChromeCookieImport.importCookies')
+  expect(ElectronBrowserViewFunctions.reload).toHaveBeenCalledWith(12)
+  expect(Notification.create).toHaveBeenCalledWith('info', 'Imported 10 Chrome cookies (2 skipped, 0 failed).')
+})
+
+test('does not import when confirmation is canceled', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue({
+    cookieCount: 1,
+    profileDirectory: 'Default',
+    profileName: 'Personal',
+  })
+  // @ts-ignore
+  ConfirmPrompt.prompt.mockResolvedValue(false)
+
+  await expect(ViewletSimpleBrowserImportChromeCookies.importChromeCookies(state)).resolves.toBe(state)
+  expect(ConfirmPrompt.prompt).toHaveBeenCalledWith(
+    'Import 1 cookie from Chrome profile "Personal" (Default)? This gives Simple Browser the same website access as Chrome.',
+    {
+      confirmMessage: 'Import',
+      title: 'Import Chrome Cookies',
+    },
+  )
+  expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(ElectronBrowserViewFunctions.reload).not.toHaveBeenCalled()
+  expect(Notification.create).not.toHaveBeenCalled()
+})
+
+test('shows an actionable import error', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockRejectedValue(new Error('Chrome cookie database is busy. Close Chrome and try again.'))
+
+  await expect(ViewletSimpleBrowserImportChromeCookies.importChromeCookies(state)).resolves.toBe(state)
+  expect(Notification.create).toHaveBeenCalledWith(
+    'error',
+    'Failed to import Chrome cookies: Chrome cookie database is busy. Close Chrome and try again.',
+  )
+  expect(ElectronBrowserViewFunctions.reload).not.toHaveBeenCalled()
+})

--- a/packages/shared-process/src/parts/ChromeCookieImport/ChromeCookieImport.ipc.ts
+++ b/packages/shared-process/src/parts/ChromeCookieImport/ChromeCookieImport.ipc.ts
@@ -1,0 +1,8 @@
+import * as ChromeCookieImport from './ChromeCookieImport.ts'
+
+export const name = 'ChromeCookieImport'
+
+export const Commands = {
+  getInfo: ChromeCookieImport.getInfo,
+  importCookies: ChromeCookieImport.importCookies,
+}

--- a/packages/shared-process/src/parts/ChromeCookieImport/ChromeCookieImport.ts
+++ b/packages/shared-process/src/parts/ChromeCookieImport/ChromeCookieImport.ts
@@ -1,0 +1,9 @@
+import * as MainProcess from '../MainProcess/MainProcess.ts'
+
+export const getInfo = (): any => {
+  return MainProcess.invoke('ChromeCookieImport.getInfo')
+}
+
+export const importCookies = (): any => {
+  return MainProcess.invoke('ChromeCookieImport.importCookies')
+}

--- a/packages/shared-process/src/parts/Module/Module.ts
+++ b/packages/shared-process/src/parts/Module/Module.ts
@@ -12,6 +12,8 @@ export const load = (moduleId: any): any => {
       return import('../AutoUpdaterWindowsNsis/AutoUpdaterWindowsNsis.ipc.ts')
     case ModuleId.BulkReplacement:
       return import('../BulkReplacement/BulkReplacement.ipc.ts')
+    case ModuleId.ChromeCookieImport:
+      return import('../ChromeCookieImport/ChromeCookieImport.ipc.ts')
     case ModuleId.ClipBoard:
       return import('../ClipBoard/ClipBoard.ipc.ts')
     case ModuleId.ContentSecurityPolicy:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.ts
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.ts
@@ -81,3 +81,4 @@ export const HandleMessagePortForAuthProcess = 86
 export const LanguageServer = 87
 export const SendMessagePortToMainProcess = 88
 export const SecretStorage = 89
+export const ChromeCookieImport = 90

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -18,6 +18,9 @@ export const getModuleId = (commandId: any): any => {
       return ModuleId.AutoUpdaterWindowsNsis
     case 'BulkReplacement.applyBulkReplacement':
       return ModuleId.BulkReplacement
+    case 'ChromeCookieImport.getInfo':
+    case 'ChromeCookieImport.importCookies':
+      return ModuleId.ChromeCookieImport
     case 'ChromeExtension.install':
     case 'ChromeExtension.uninstall':
       return ModuleId.ChromeExtension

--- a/packages/shared-process/test/ChromeCookieImport.test.ts
+++ b/packages/shared-process/test/ChromeCookieImport.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+const ChromeCookieImport = await import('../src/parts/ChromeCookieImport/ChromeCookieImport.ts')
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('getInfo', async () => {
+  const info = {
+    cookieCount: 12,
+    profileDirectory: 'Default',
+    profileName: 'Personal',
+  }
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(info)
+
+  await expect(ChromeCookieImport.getInfo()).resolves.toEqual(info)
+  expect(MainProcess.invoke).toHaveBeenCalledWith('ChromeCookieImport.getInfo')
+})
+
+test('importCookies', async () => {
+  const result = {
+    failed: 0,
+    imported: 10,
+    skipped: 2,
+  }
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(result)
+
+  await expect(ChromeCookieImport.importCookies()).resolves.toEqual(result)
+  expect(MainProcess.invoke).toHaveBeenCalledWith('ChromeCookieImport.importCookies')
+})

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -13,3 +13,7 @@ test('getModuleId - SendMessagePortToMainProcess.sendMessagePortToMainProcess', 
 test('getModuleId - SecretStorage.get', () => {
   expect(ModuleMap.getModuleId('SecretStorage.get')).toBe(ModuleId.SecretStorage)
 })
+
+test('getModuleId - ChromeCookieImport.importCookies', () => {
+  expect(ModuleMap.getModuleId('ChromeCookieImport.importCookies')).toBe(ModuleId.ChromeCookieImport)
+})


### PR DESCRIPTION
## Summary

- forward Chrome cookie import RPCs through the shared process
- add `Simple Browser: Import Cookies from Chrome` with profile/count confirmation
- reload the active Simple Browser and report imported/skipped/failed totals
- surface actionable import errors without exposing cookie metadata or values

## Testing

- shared-process type-check and full test suite (323 passed)
- renderer-worker type-check and full test suite (1,116 passed)
- repository shared-process lint
- Prettier check