### PR TITLE
fix: prevent problem location from wrapping

### DIFF
--- a/static/css/parts/ViewletProblems.css
+++ b/static/css/parts/ViewletProblems.css
@@ -37,6 +37,7 @@
 .ProblemAt {
   contain: content;
   opacity: 0.7;
+  white-space: nowrap;
 }
 
 .ProblemsLabel {


### PR DESCRIPTION
Add nowrap styling to problem locations so file positions stay on one line in the Problems view.