### PR TITLE
fix: prevent problem labels from wrapping

### DIFF
--- a/static/css/parts/ViewletProblems.css
+++ b/static/css/parts/ViewletProblems.css
@@ -39,6 +39,10 @@
   opacity: 0.7;
 }
 
+.ProblemLabel {
+  white-space: nowrap;
+}
+
 .ProblemsLabel {
   flex: initial;
   display: flex;


### PR DESCRIPTION
Keep problem-message labels on one line so long diagnostics show their start and crop at the end.