### PR TITLE
feature: open preferred views in preview

### DIFF
--- a/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
+++ b/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
@@ -29,6 +29,7 @@ export interface ExtensionView {
   readonly iframe?: ExtensionViewIframe
   readonly kind?: string
   readonly name?: string
+  readonly preferredLocation?: 'preview' | 'sideBar'
   readonly selector?: readonly string[]
   readonly showSideBarHeader?: boolean
   readonly title: string

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -8,6 +8,7 @@ import * as Command from '../Command/Command.js'
 import * as Commit from '../Commit/Commit.js'
 import * as GetAutoUpdateType from '../GetAutoUpdateType/GetAutoUpdateType.js'
 import * as GetDefaultTitleBarHeight from '../GetDefaultTitleBarHeight/GetDefaultTitleBarHeight.js'
+import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
 import * as Id from '../Id/Id.js'
 import * as LayoutKeys from '../LayoutKeys/LayoutKeys.js'
 import * as LayoutModules from '../LayoutModules/LayoutModules.ts'
@@ -633,14 +634,33 @@ export const toggleSideBar = (state: LayoutState) => {
 
 export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<LayoutStateResult> => {
   const sideBarView = moduleId || state.sideBarView || ViewletModuleId.Explorer
-  if (state.sideBarVisible && state.sideBarView === sideBarView) {
-    return hideSideBar(state)
+  const preferredLocation = await getPreferredViewLocation(sideBarView)
+  if (preferredLocation === 'preview') {
+    if (state.previewVisible && state.previewUri === sideBarView) {
+      return hidePreview(state)
+    }
+    const sideBarResult = state.sideBarVisible ? await hideSideBar(state) : { newState: state, commands: [] }
+    const previewResult = await showPreview(sideBarResult.newState, sideBarView, ViewletModuleId.ExtensionView)
+    const focusCommands = await Viewlet.getFocusCommands(sideBarView)
+    return {
+      newState: previewResult.newState,
+      commands: [...sideBarResult.commands, ...previewResult.commands, ...focusCommands],
+    }
   }
-  const result = await showSideBar(state, sideBarView)
+  const previewResult = await hidePreferredLocationPreview(state)
+  const activeState = previewResult.newState
+  if (activeState.sideBarVisible && activeState.sideBarView === sideBarView) {
+    const result = await hideSideBar(activeState)
+    return {
+      newState: result.newState,
+      commands: [...previewResult.commands, ...result.commands],
+    }
+  }
+  const result = await showSideBar(activeState, sideBarView)
   const focusCommands = await Viewlet.getFocusCommands(sideBarView)
   return {
     newState: result.newState,
-    commands: [...result.commands, ...focusCommands],
+    commands: [...previewResult.commands, ...result.commands, ...focusCommands],
   }
 }
 
@@ -795,6 +815,31 @@ export const toggleActivityBar = (state: LayoutState) => {
   return toggle(state, LayoutModules.ActivityBar)
 }
 
+const getPreferredViewLocation = async (viewId: string): Promise<'preview' | 'sideBar'> => {
+  if (!viewId.includes('.')) {
+    return 'sideBar'
+  }
+  const view = await GetExtensionViews.getExtensionView(viewId)
+  return view?.preferredLocation === 'preview' ? 'preview' : 'sideBar'
+}
+
+const hidePreferredLocationPreview = async (state: LayoutState): Promise<LayoutStateResult> => {
+  if (!state.previewVisible || state.previewViewletId !== ViewletModuleId.ExtensionView) {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
+  const preferredLocation = await getPreferredViewLocation(state.previewUri)
+  if (preferredLocation !== 'preview') {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
+  return hidePreview(state)
+}
+
 export const showStatusBar = (state: LayoutState) => {
   // @ts-ignore
   return show(state, LayoutModules.StatusBar)
@@ -851,12 +896,11 @@ const replacePreview = async (state: LayoutState, uri: string, previewViewletId:
   }
 }
 
-export const showPreview = async (state: LayoutState, uri: string = state.previewUri) => {
+export const showPreview = async (state: LayoutState, uri: string = state.previewUri, previewViewletId: string = getPreviewViewletId(uri)) => {
   const { previewVisible, previewId, uid } = state
-  const previewViewletId = getPreviewViewletId(uri)
 
   if (previewVisible && previewId !== -1) {
-    if (state.previewViewletId !== previewViewletId) {
+    if (state.previewViewletId !== previewViewletId || (previewViewletId === ViewletModuleId.ExtensionView && state.previewUri !== uri)) {
       return replacePreview(state, uri, previewViewletId)
     }
     if (previewViewletId === ViewletModuleId.Preview) {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -8,6 +8,12 @@ jest.unstable_mockModule('../src/parts/ActivityBarWorker/ActivityBarWorker.js', 
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => {
+  return {
+    getExtensionView: jest.fn(() => undefined),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => {
   return {
     load: jest.fn(() => {
@@ -19,6 +25,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
 jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
   return {
     saveViewletState: jest.fn(() => undefined),
+    saveViewletStateWithStorageId: jest.fn(() => undefined),
   }
 })
 
@@ -35,10 +42,12 @@ jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => {
     getAllInstances: jest.fn(() => ({})),
     getInstance: jest.fn(() => undefined),
     getState: jest.fn(() => ({ uid: 12 })),
+    setState: jest.fn(() => undefined),
   }
 })
 
 const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityBarWorker.js')
+const GetExtensionViews = await import('../src/parts/GetExtensionViews/GetExtensionViews.ts')
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
@@ -53,6 +62,10 @@ beforeEach(() => {
   jest.resetAllMocks()
   // @ts-ignore
   SaveState.saveViewletState.mockResolvedValue(undefined)
+  // @ts-ignore
+  SaveState.saveViewletStateWithStorageId.mockResolvedValue(undefined)
+  // @ts-ignore
+  GetExtensionViews.getExtensionView.mockResolvedValue(undefined)
   // @ts-ignore
   Viewlet.disposeFunctional.mockReturnValue([])
   // @ts-ignore
@@ -444,6 +457,120 @@ test('toggleSideBarView appends focus commands after showing the requested view'
 
   expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Search')
   expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusElementByName', 12, 'SearchValue']])
+})
+
+test('toggleSideBarView opens a preview-preferred extension view in the preview area', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  GetExtensionViews.getExtensionView.mockResolvedValue({
+    id: 'sample.views.preview',
+    preferredLocation: 'preview',
+  })
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'ExtensionView', 1, true]])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    sideBarId: 12,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+    statusBarHeight: 20,
+    titleBarHeight: 0,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const result = await ViewletLayout.toggleSideBarView(state, 'sample.views.preview')
+
+  expect(result.newState).toMatchObject({
+    previewUri: 'sample.views.preview',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+    sideBarVisible: false,
+  })
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'ExtensionView',
+      uri: 'sample.views.preview',
+    }),
+    false,
+    true,
+    undefined,
+  )
+})
+
+test('toggleSideBarView hides the preview when its selected activity item is clicked again', async () => {
+  // @ts-ignore
+  GetExtensionViews.getExtensionView.mockResolvedValue({
+    id: 'sample.views.preview',
+    preferredLocation: 'preview',
+  })
+  const state = {
+    ...ViewletLayout.create(1),
+    previewId: 11,
+    previewUri: 'sample.views.preview',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+  }
+
+  const result = await ViewletLayout.toggleSideBarView(state, 'sample.views.preview')
+
+  expect(result.newState).toMatchObject({
+    previewId: -1,
+    previewVisible: false,
+  })
+  expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(11, 'ExtensionView')
+  expect(Viewlet.disposeFunctional).toHaveBeenCalledWith(11)
+})
+
+test('toggleSideBarView closes a preview-preferred extension view before opening a sidebar view', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  GetExtensionViews.getExtensionView.mockImplementation(async (id) => {
+    return id === 'sample.views.preview'
+      ? {
+          id,
+          preferredLocation: 'preview',
+        }
+      : undefined
+  })
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'SideBar', 1, true]])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    previewId: 11,
+    previewUri: 'sample.views.preview',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+    sideBarView: 'Explorer',
+    sideBarVisible: false,
+    statusBarHeight: 20,
+    titleBarHeight: 0,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const result = await ViewletLayout.toggleSideBarView(state, 'Explorer')
+
+  expect(result.newState).toMatchObject({
+    previewVisible: false,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  })
+  expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(11, 'ExtensionView')
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'SideBar',
+    }),
+    false,
+    true,
+    undefined,
+  )
 })
 
 test('layout allows the side bar to grow when the preview uses half the window', () => {


### PR DESCRIPTION
Routes preview-preferred activity bar views into the preview area and restores the sidebar when switching back to ordinary views.