### PR TITLE
feature: center quick pick in non-preview area

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -57,6 +57,23 @@ test('bundleCss preserves the simple browser preview width', async () => {
   }
 }, 30_000)
 
+test('bundleCss centers quick pick in the non-preview area', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'App.css'), 'utf8')
+
+    expect(css).toContain('left: calc((100% - var(--PreviewWidth, 0px)) / 2);')
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss preserves the locations flex growth', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletQuickPick.css
+++ b/static/css/parts/ViewletQuickPick.css
@@ -6,7 +6,7 @@
   position: absolute;
   width: 600px;
   top: 50px;
-  left: 50%;
+  left: calc((100% - var(--PreviewWidth, 0px)) / 2);
   margin-left: -300px; /* TODO maybe this should be 301px because of padding to be centered */
   padding: 0 1px 6px;
   background: var(--QuickPickBackground);


### PR DESCRIPTION
Center Quick Pick in the editor's non-preview area when a right-side preview such as Simple Browser is open. Preserve the existing full-window centering when no preview is visible.