### PR TITLE
fix: switch sidebar when extension is disabled

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/test.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/test.js
@@ -1,5 +1,7 @@
 export const extensionId = 'sample.extension-disable-lifecycle'
 
+export const viewId = 'sample.extension-disable-lifecycle-view'
+
 export const activityBarItemSelector = '.ActivityBarItem[title="Extension Lifecycle"]'
 
 export const statusBarItemSelector = '.StatusBarItem[name="extension-lifecycle"]'

--- a/packages/extension-host-worker-tests/src/extension.disable-switches-active-sidebar-to-explorer.ts
+++ b/packages/extension-host-worker-tests/src/extension.disable-switches-active-sidebar-to-explorer.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { addLifecycleExtension, disableLifecycleExtension, viewId } from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.disable-switches-active-sidebar-to-explorer'
+
+export const test: Test = async ({ expect, Locator, SideBar, ...api }) => {
+  await addLifecycleExtension(api)
+  await SideBar.open(viewId)
+  const sideBarTitle = Locator('.SideBarTitleAreaTitle')
+  await expect(sideBarTitle).toHaveText('Extension Lifecycle')
+
+  await disableLifecycleExtension(api)
+
+  await expect(sideBarTitle).toHaveText('Explorer')
+}

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -27,12 +27,17 @@ export const doInvalidateExtensionsCache = async () => {
 
 export const handleExtensionsCacheInvalidated = async (extensionId, disabled) => {
   try {
-    if (typeof extensionId === 'string' && typeof disabled === 'boolean') {
+    const hasExtensionState = typeof extensionId === 'string' && typeof disabled === 'boolean'
+    if (hasExtensionState) {
       ExtensionHostManagement.handleExtensionStateChanged(extensionId, disabled)
     }
     await Command.execute('KeyBindings.hydrate')
     await Command.execute('ColorTheme.reload')
-    await Command.execute('Layout.handleExtensionsChanged')
+    if (hasExtensionState) {
+      await Command.execute('Layout.handleExtensionsChanged', extensionId, disabled)
+    } else {
+      await Command.execute('Layout.handleExtensionsChanged')
+    }
   } catch {
     // ignore
   }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1986,8 +1986,24 @@ export const setBadgeCount = async (state: LayoutState, moduleId: string, badgeC
   }
 }
 
-export const handleExtensionsChanged = async (state: LayoutState) => {
-  return callGlobalEvent(state, 'handleExtensionsChanged')
+const getActiveSideBarExtensionId = (state: LayoutState): string => {
+  if (!state.sideBarVisible) {
+    return ''
+  }
+  const sideBarInstance = ViewletStates.getInstance(state.sideBarId)
+  return sideBarInstance?.state?.currentExtensionId || ''
+}
+
+export const handleExtensionsChanged = async (state: LayoutState, extensionId?: string, disabled?: boolean): Promise<LayoutStateResult> => {
+  const globalEventResult = await callGlobalEvent(state, 'handleExtensionsChanged')
+  if (!disabled || !extensionId || getActiveSideBarExtensionId(state) !== extensionId) {
+    return globalEventResult
+  }
+  const fallbackResult = await showSideBar(globalEventResult.newState, ViewletModuleId.Explorer, false)
+  return {
+    newState: fallbackResult.newState,
+    commands: [...globalEventResult.commands, ...fallbackResult.commands],
+  }
 }
 
 export const handleColorThemeChanged = async (state: LayoutState, colorThemeId: string) => {

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -16,6 +16,7 @@ const defaultTitleAreaHeight = 35
 export const create = (id, uri, x, y, width, height) => {
   return {
     uid: id,
+    currentExtensionId: '',
     currentViewletId: '',
     currentViewletRequestId: 0,
     x,
@@ -94,9 +95,12 @@ const getChildModuleId = (moduleId) => {
   return ViewletModuleId.ExtensionView
 }
 
-const getExtensionViewTitleAreaHeight = async (moduleId) => {
+const getExtensionViewMetadata = async (moduleId) => {
   const view = await GetExtensionViews.getExtensionView(moduleId)
-  return view?.showSideBarHeader === false ? 0 : defaultTitleAreaHeight
+  return {
+    extensionId: view?.extensionId || '',
+    titleAreaHeight: view?.showSideBarHeader === false ? 0 : defaultTitleAreaHeight,
+  }
 }
 
 // TODO
@@ -133,8 +137,14 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   const uid = state.uid
 
   const childModuleId = getChildModuleId(moduleId)
-  const titleAreaHeight =
-    childModuleId === ViewletModuleId.ExtensionView ? await getExtensionViewTitleAreaHeight(moduleId) : defaultTitleAreaHeight
+  const extensionViewMetadata =
+    childModuleId === ViewletModuleId.ExtensionView
+      ? await getExtensionViewMetadata(moduleId)
+      : {
+          extensionId: '',
+          titleAreaHeight: defaultTitleAreaHeight,
+        }
+  const { extensionId, titleAreaHeight } = extensionViewMetadata
   if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
     await savePromise
     return state
@@ -214,6 +224,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   await savePromise
   return {
     ...state,
+    currentExtensionId: extensionId,
     currentViewletRequestId: requestId,
     currentViewletId: moduleId,
     childUid,

--- a/packages/renderer-worker/test/ExtensionManagement.test.ts
+++ b/packages/renderer-worker/test/ExtensionManagement.test.ts
@@ -76,7 +76,7 @@ test('handleExtensionsCacheInvalidated applies the disabled extension state', as
   expect(ExtensionHostManagement.state.runningExtensions['sample.extension']).toBeUndefined()
   expect(Command.execute).toHaveBeenNthCalledWith(1, 'KeyBindings.hydrate')
   expect(Command.execute).toHaveBeenNthCalledWith(2, 'ColorTheme.reload')
-  expect(Command.execute).toHaveBeenNthCalledWith(3, 'Layout.handleExtensionsChanged')
+  expect(Command.execute).toHaveBeenNthCalledWith(3, 'Layout.handleExtensionsChanged', 'sample.extension', true)
 })
 
 test('cache invalidation commands handle notifications without invalidating again', () => {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -141,6 +141,59 @@ test('showSideBar shows hidden side bar with requested viewlet', async () => {
   })
 })
 
+test('handleExtensionsChanged switches away from a view contributed by the disabled extension', async () => {
+  mockActivityBarRender()
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    sideBarId: 12,
+    sideBarView: 'sample.views.testing',
+    sideBarVisible: true,
+  }
+  // @ts-ignore
+  ViewletStates.getInstance.mockReturnValue({
+    state: {
+      currentExtensionId: 'sample.extension',
+    },
+  })
+
+  const result = await ViewletLayout.handleExtensionsChanged(state, 'sample.extension', true)
+
+  expect(result).toEqual({
+    commands: [['activity-bar.render2']],
+    newState: expect.objectContaining({
+      sideBarView: 'Explorer',
+      sideBarVisible: true,
+    }),
+  })
+  expect(activityBarInvokeMock.mock.calls).toEqual([
+    ['ActivityBar.handleSideBarStateChange', 7, 'Explorer', true],
+    ['ActivityBar.diff2', 7],
+    ['ActivityBar.render2', 7, 'diff-1'],
+  ])
+})
+
+test('handleExtensionsChanged preserves the active sidebar view when another extension is disabled', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    sideBarId: 12,
+    sideBarView: 'sample.views.testing',
+    sideBarVisible: true,
+  }
+  // @ts-ignore
+  ViewletStates.getInstance.mockReturnValue({
+    state: {
+      currentExtensionId: 'sample.extension',
+    },
+  })
+
+  const result = await ViewletLayout.handleExtensionsChanged(state, 'sample.other-extension', true)
+
+  expect(result.newState.sideBarView).toBe('sample.views.testing')
+  expect(ActivityBarWorker.invoke).not.toHaveBeenCalled()
+})
+
 test('showSideBar disables restore when the layout disables restore', async () => {
   mockActivityBarRender()
   // @ts-ignore

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -162,6 +162,7 @@ test('handleSideBarViewletChange uses child title', async () => {
 test('handleSideBarViewletChange gives an opted-out extension view the full sidebar', async () => {
   const state = ViewletSideBar.create(1, '', 0, 0, 300, 500)
   GetExtensionViews.getExtensionView.mockResolvedValue({
+    extensionId: 'builtin.chat-view-2',
     id: 'chat2.views.chat',
     showSideBarHeader: false,
   })
@@ -186,8 +187,20 @@ test('handleSideBarViewletChange gives an opted-out extension view the full side
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.createFunctionalRoot', 'ExtensionView', 2, true]])
   expect(newState).toMatchObject({
     actionsUid: -1,
+    currentExtensionId: 'builtin.chat-view-2',
     titleAreaHeight: 0,
   })
+})
+
+test('handleSideBarViewletChange clears the extension id when opening a built-in view', async () => {
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    currentExtensionId: 'sample.extension',
+  }
+
+  const newState = await ViewletSideBar.handleSideBarViewletChange(state, 'Explorer')
+
+  expect(newState.currentExtensionId).toBe('')
 })
 
 test('handleSideBarViewletChange omits empty listener registration for its new actions root', async () => {


### PR DESCRIPTION
When a disabled extension owns the active contributed sidebar view, switch the sidebar to Explorer instead of leaving the unavailable view visible.

Includes focused renderer coverage and an extension lifecycle regression test.