### PR TITLE
Expand preview below the status bar

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -141,7 +141,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
 
     const destinationStatusBarLeft = p1
     const destinationStatusBarTop = p4
-    const destinationStatusBarWidth = windowWidth
+    const destinationStatusBarWidth = availableWidth
     const destinationStatusBarHeight = 20
     const destinationStatusBarVisible = statusBarVisible
 
@@ -159,7 +159,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
     const destinationPreviewLeft = previewVisible ? availableWidth : 0
     const destinationPreviewTop = p2
     const destinationPreviewWidth = previewVisible ? windowWidth - availableWidth : 0
-    const destinationPreviewHeight = p3 - p2
+    const destinationPreviewHeight = p3 - p2 + (previewVisible && statusBarVisible ? statusBarHeight : 0)
     const destinationPreviewVisible = previewVisible
     return {
       ...source,
@@ -276,7 +276,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
 
     const destinationStatusBarLeft = p1
     const destinationStatusBarTop = p4
-    const destinationStatusBarWidth = windowWidth
+    const destinationStatusBarWidth = availableWidth
     const destinationStatusBarHeight = 20
     const destinationStatusBarVisible = statusBarVisible
 
@@ -289,7 +289,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
     const destinationPreviewLeft = previewVisible ? availableWidth : 0
     const destinationPreviewTop = p2
     const destinationPreviewWidth = previewVisible ? windowWidth - availableWidth : 0
-    const destinationPreviewHeight = p3 - p2
+    const destinationPreviewHeight = p3 - p2 + (previewVisible && statusBarVisible ? statusBarHeight : 0)
     const destinationPreviewVisible = previewVisible
     return {
       ...source,

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -32,6 +32,8 @@ jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => {
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const SideBarLocationType = await import('../src/parts/SideBarLocationType/SideBarLocationType.js')
+const LayoutPoints = await import('../src/parts/ViewletLayout/LayoutPoints.ts')
 const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
@@ -181,6 +183,35 @@ test('showPreview opens the simple browser in the preview area', async () => {
     true,
     undefined,
   )
+})
+
+test.each([
+  ['left', SideBarLocationType.Left],
+  ['right', SideBarLocationType.Right],
+])('preview uses the space below the shortened status bar with the side bar on the %s', (_name, sideBarLocation) => {
+  const state = LayoutPoints.getPoints(
+    {
+      ...ViewletLayout.create(1),
+      previewMinWidth: 100,
+      previewVisible: true,
+      previewWidth: 400,
+      statusBarHeight: 20,
+      statusBarVisible: true,
+      titleBarHeight: 35,
+      titleBarVisible: true,
+      windowHeight: 800,
+      windowWidth: 1200,
+    },
+    sideBarLocation,
+  )
+
+  expect(state).toMatchObject({
+    previewHeight: 765,
+    previewLeft: 800,
+    previewTop: 35,
+    previewWidth: 400,
+    statusBarWidth: 800,
+  })
 })
 
 test('showPreview replaces an open file preview with the simple browser', async () => {


### PR DESCRIPTION
Shorten the status bar to the non-preview portion of the workbench when a preview is open. The preview now uses the reclaimed vertical space, with layout coverage for both sidebar positions.