### PR TITLE
feature: render dynamic extension view actions

### DIFF
--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -164,6 +164,13 @@ const getPreviewDom = (previewId: number) => {
   }
 }
 
+const getPreviewActionsDom = (previewActionsUid: number) => {
+  return {
+    type: VirtualDomElements.Reference,
+    uid: previewActionsUid,
+  }
+}
+
 const getPreviewCloseButtonDom = () => {
   return [
     {
@@ -193,6 +200,7 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
     mainId,
     secondarySideBarVisible,
     secondarySideBarId,
+    previewActionsUid,
     previewSashVisible,
     previewVisible,
     previewId,
@@ -230,6 +238,9 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
 
   if (previewVisible) {
     children.push(getPreviewDom(previewId))
+    if (typeof previewActionsUid === 'number' && previewActionsUid !== -1) {
+      children.push(getPreviewActionsDom(previewActionsUid))
+    }
     children.push(...getPreviewCloseButtonDom())
     delta--
   }
@@ -255,6 +266,7 @@ const getContentAreaVirtualDomRight = (state: LayoutState) => {
     sideBarId,
     activityBarVisible,
     activityBarId,
+    previewActionsUid,
     previewSashVisible,
     previewVisible,
     previewId,
@@ -284,6 +296,9 @@ const getContentAreaVirtualDomRight = (state: LayoutState) => {
   }
   if (previewVisible) {
     children.push(getPreviewDom(previewId))
+    if (typeof previewActionsUid === 'number' && previewActionsUid !== -1) {
+      children.push(getPreviewActionsDom(previewActionsUid))
+    }
     children.push(...getPreviewCloseButtonDom())
     delta--
   }

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -53,6 +53,8 @@ export interface LayoutState {
   readonly panelVisible: boolean
   readonly panelWidth: number
   readonly platform: number
+  readonly previewActionsEventListeners: readonly unknown[]
+  readonly previewActionsUid: number
   readonly previewHeight: number
   readonly previewId: number
   readonly previewLeft: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -116,6 +116,8 @@ export const create = (id: number): LayoutState => {
     statusBarId: -1,
     titleBarId: -1,
     workbenchId: -1,
+    previewActionsEventListeners: [],
+    previewActionsUid: -1,
     previewId: -1,
     previewSashId: -1,
     activityBarVisible: false,
@@ -395,6 +397,14 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
   const height = intermediateState[kHeight]
   const uid = state.uid
   const childUid = Id.create()
+  if (module === LayoutModules.Preview) {
+    ViewletStates.setState(uid, {
+      ...intermediateState,
+      previewActionsEventListeners: [],
+      previewActionsUid: -1,
+      previewId: childUid,
+    })
+  }
   const viewletModuleId = module === LayoutModules.Preview ? state.previewViewletId : moduleId
   let uri = ''
   if (module === LayoutModules.Preview && state.previewUri) {
@@ -426,9 +436,11 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
   // TODO component might already be hidden again at this point
   const resizeCommands = await getResizeCommands(state, intermediateState)
   commands.push(...resizeCommands)
+  const latestState = module === LayoutModules.Preview ? ViewletStates.getState(uid) : intermediateState
   return {
     newState: {
       ...intermediateState,
+      ...latestState,
       [kId]: childUid,
     },
     commands,
@@ -587,7 +599,14 @@ const hide = async (state: LayoutState, module): Promise<{ newState: LayoutState
   const newState = getPoints({
     ...state,
     [kVisible]: false,
-    ...(isPreview ? { previewId: -1, previewSashVisible: false } : {}),
+    ...(isPreview
+      ? {
+          previewActionsEventListeners: [],
+          previewActionsUid: -1,
+          previewId: -1,
+          previewSashVisible: false,
+        }
+      : {}),
   })
   // TODO save state to local storage after rending (in background)
   if (isPreview) {
@@ -597,6 +616,9 @@ const hide = async (state: LayoutState, module): Promise<{ newState: LayoutState
   }
   // TODO also resize other viewlets if necessary
   const commands = Viewlet.disposeFunctional(instanceId)
+  if (isPreview && state.previewActionsUid !== -1) {
+    commands.push(...Viewlet.disposeFunctional(state.previewActionsUid))
+  }
   const resizeCommands = await getResizeCommands(state, newState)
   commands.push(...resizeCommands)
 
@@ -864,9 +886,14 @@ const getPreviewViewletId = (uri: string) => {
 const replacePreview = async (state: LayoutState, uri: string, previewViewletId: string): Promise<LayoutStateResult> => {
   await SaveState.saveViewletStateWithStorageId(state.previewId, state.previewViewletId)
   const commands = Viewlet.disposeFunctional(state.previewId)
+  if (state.previewActionsUid !== -1) {
+    commands.push(...Viewlet.disposeFunctional(state.previewActionsUid))
+  }
   const childUid = Id.create()
   const newState = {
     ...state,
+    previewActionsEventListeners: [],
+    previewActionsUid: -1,
     previewId: childUid,
     previewUri: uri,
     previewViewletId,
@@ -890,8 +917,12 @@ const replacePreview = async (state: LayoutState, uri: string, previewViewletId:
   }
   const loadCommands = await ViewletManager.load(viewlet, false, true, undefined)
   commands.push(...loadCommands)
+  const latestState = ViewletStates.getState(state.uid)
   return {
-    newState,
+    newState: {
+      ...newState,
+      ...latestState,
+    },
     commands,
   }
 }
@@ -953,6 +984,57 @@ export const hideTitleBar = (state: LayoutState) => {
 export const toggleTitleBar = (state: LayoutState) => {
   // @ts-ignore
   return toggle(state, LayoutModules.TitleBar)
+}
+
+export const setActionsDom = (
+  state: LayoutState,
+  actionsDom: readonly unknown[],
+  childUid: number,
+  eventListeners: readonly unknown[] = state.previewActionsEventListeners,
+) => {
+  if (state.previewId !== childUid) {
+    return {
+      commands: [],
+      handled: false,
+      renderParent: false,
+      statePatch: {},
+    }
+  }
+  if (state.previewActionsUid !== -1) {
+    return {
+      commands: [['Viewlet.setDom2', state.previewActionsUid, actionsDom]],
+      handled: true,
+      renderParent: false,
+      statePatch: {
+        previewActionsEventListeners: eventListeners,
+      },
+    }
+  }
+  if (actionsDom.length === 0) {
+    return {
+      commands: [],
+      handled: true,
+      renderParent: false,
+      statePatch: {
+        previewActionsEventListeners: eventListeners,
+      },
+    }
+  }
+  const previewActionsUid = Id.create()
+  const commands: any[] = [['Viewlet.createFunctionalRoot', state.previewViewletId, previewActionsUid, true]]
+  if (eventListeners.length > 0) {
+    commands.push(['Viewlet.registerEventListeners', previewActionsUid, eventListeners])
+  }
+  commands.push(['Viewlet.setDom2', previewActionsUid, actionsDom], ['Viewlet.setUid', previewActionsUid, childUid])
+  return {
+    commands,
+    handled: true,
+    renderParent: true,
+    statePatch: {
+      previewActionsEventListeners: eventListeners,
+      previewActionsUid,
+    },
+  }
 }
 
 export const createViewlet = async (state: LayoutState, viewletModuleId: string, editorUid: number, tabId: number, bounds: any, uri: string) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
@@ -112,6 +112,7 @@ const renderDom = {
       oldState.previewVisible === newState.previewVisible &&
       oldState.previewSashVisible === newState.previewSashVisible &&
       oldState.previewId === newState.previewId &&
+      oldState.previewActionsUid === newState.previewActionsUid &&
       oldState.secondarySideBarVisible === newState.secondarySideBarVisible
     )
   },

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -261,12 +261,36 @@ export const create = (getModule, id, parentUid, uri, x, y, width, height) => {
   }
 }
 
-const getRenderCommands = (module, oldState, newState, uid = newState.uid || module.name, parentId) => {
+const getRenderCommands = (module, oldState, newState, uid = newState.uid || module.name, parentId, eventListeners) => {
   const commands = []
   if (module.renderActions && !module.renderActions.isEqual(oldState, newState)) {
     const actionsCommands = module.renderActions.apply(oldState, newState)
     if (parentId) {
-      commands.push(['Viewlet.send', parentId, 'setActionsDom', actionsCommands, uid])
+      const parentInstance = ViewletStates.getInstance(parentId)
+      if (parentInstance?.factory?.setActionsDom) {
+        const result = parentInstance.factory.setActionsDom(parentInstance.state, actionsCommands, uid, eventListeners)
+        if (result.handled) {
+          const oldParentRenderedState = parentInstance.renderedState
+          const newParentState = {
+            ...parentInstance.state,
+            ...result.statePatch,
+          }
+          const newParentRenderedState = {
+            ...oldParentRenderedState,
+            ...result.statePatch,
+          }
+          parentInstance.state = newParentState
+          parentInstance.renderedState = newParentRenderedState
+          commands.push(...result.commands)
+          if (result.renderParent) {
+            commands.push(...getRenderCommands(parentInstance.factory, oldParentRenderedState, newParentRenderedState, parentId))
+          }
+        } else {
+          commands.push(['Viewlet.send', parentId, 'setActionsDom', actionsCommands, uid])
+        }
+      } else {
+        commands.push(['Viewlet.send', parentId, 'setActionsDom', actionsCommands, uid])
+      }
     } else {
       // TODO
       // console.warn('parent id not found')
@@ -584,9 +608,10 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
 
     const commands = []
 
+    let eventListeners = []
     if (module.renderEventListeners) {
       // TODO reuse event listeners between components
-      const eventListeners = await module.renderEventListeners(newState)
+      eventListeners = await module.renderEventListeners(newState)
       if (eventListeners.length > 0) {
         if (shouldRenderEvents === false) {
           commands.push(['Viewlet.registerEventListeners', viewletUid, eventListeners])
@@ -701,7 +726,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     const instanceNow = ViewletStates.getInstance(viewletUid)
     viewletState = instanceNow.renderedState
     if (module.hasFunctionalRender && shouldRender) {
-      const renderCommands = getRenderCommands(module, viewletState, newState, viewletUid, parentUid)
+      const renderCommands = getRenderCommands(module, viewletState, newState, viewletUid, parentUid, eventListeners)
       ViewletStates.setRenderedState(viewletUid, newState)
       commands.push(...renderCommands)
       if (viewlet.show === false) {

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -25,8 +25,10 @@ export const create = (id, uri, x, y, width, height) => {
     height,
     titleAreaHeight: defaultTitleAreaHeight,
     actions: [],
+    actionsEventListeners: [],
     title: Character.EmptyString,
     childUid: -1,
+    actionsUid: -1,
   }
 }
 
@@ -182,6 +184,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     return state
   }
   let actionsDom = []
+  let actionsEventListeners = []
   let actionsUid = -1
   let title = Character.EmptyString
   if (commands) {
@@ -201,12 +204,12 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
       title = childInstance?.state?.title || Character.EmptyString
     }
     const eventsIndex = commands.findIndex((command) => command[0] === 'Viewlet.registerEventListeners')
+    actionsEventListeners = eventsIndex >= 0 ? commands[eventsIndex][2] : []
     if (titleAreaHeight > 0 && actionsDom.length > 0) {
-      const events = eventsIndex >= 0 ? commands[eventsIndex][2] : []
       actionsUid = Id.create()
       commands.push(['Viewlet.createFunctionalRoot', moduleId, actionsUid, true])
-      if (events.length > 0) {
-        commands.push(['Viewlet.registerEventListeners', actionsUid, events])
+      if (actionsEventListeners.length > 0) {
+        commands.push(['Viewlet.registerEventListeners', actionsUid, actionsEventListeners])
       }
       commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid])
     }
@@ -228,9 +231,56 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     currentViewletRequestId: requestId,
     currentViewletId: moduleId,
     childUid,
+    actionsEventListeners,
     actionsUid,
     titleAreaHeight,
     title,
+  }
+}
+
+export const setActionsDom = (state, actionsDom, childUid, eventListeners = state.actionsEventListeners) => {
+  if (state.childUid !== childUid || state.titleAreaHeight === 0) {
+    return {
+      commands: [],
+      handled: false,
+      renderParent: false,
+      statePatch: {},
+    }
+  }
+  if (state.actionsUid !== -1) {
+    return {
+      commands: [['Viewlet.setDom2', state.actionsUid, actionsDom]],
+      handled: true,
+      renderParent: false,
+      statePatch: {
+        actionsEventListeners: eventListeners,
+      },
+    }
+  }
+  if (actionsDom.length === 0) {
+    return {
+      commands: [],
+      handled: true,
+      renderParent: false,
+      statePatch: {
+        actionsEventListeners: eventListeners,
+      },
+    }
+  }
+  const actionsUid = Id.create()
+  const commands = [['Viewlet.createFunctionalRoot', state.currentViewletId, actionsUid, true]]
+  if (state.actionsEventListeners.length > 0) {
+    commands.push(['Viewlet.registerEventListeners', actionsUid, state.actionsEventListeners])
+  }
+  commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid])
+  return {
+    commands,
+    handled: true,
+    renderParent: false,
+    statePatch: {
+      actionsEventListeners: eventListeners,
+      actionsUid,
+    },
   }
 }
 

--- a/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
@@ -12,6 +12,7 @@ test('getLayoutVirtualDom renders sashes with tabIndex -1', () => {
     panelVisible: true,
     panelId: 2,
     previewSashVisible: true,
+    previewActionsUid: 6,
     previewVisible: true,
     previewId: 3,
     secondarySideBarVisible: true,
@@ -30,6 +31,7 @@ test('getLayoutVirtualDom renders sashes with tabIndex -1', () => {
   const dom = getLayoutVirtualDom(state)
   const sashes = dom.filter((node) => node.className?.includes('Sash'))
   const previewCloseButton = dom.find((node) => node.className?.includes('PreviewCloseButton'))
+  const previewActions = dom.find((node) => node.uid === 6)
 
   expect(sashes).toHaveLength(4)
   expect(sashes).toEqual(
@@ -63,6 +65,10 @@ test('getLayoutVirtualDom renders sashes with tabIndex -1', () => {
       title: 'Close Preview',
     }),
   )
+  expect(previewActions).toEqual({
+    type: 100,
+    uid: 6,
+  })
 })
 
 test('getLayoutVirtualDom does not render the preview close button when preview is hidden', () => {

--- a/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
@@ -135,3 +135,14 @@ test('renderEventListeners registers preview close handler', () => {
     params: ['hidePreview'],
   })
 })
+
+test('renderDom detects changed preview actions', () => {
+  const oldState = {
+    previewActionsUid: -1,
+  } as any
+  const newState = {
+    previewActionsUid: 8,
+  } as any
+
+  expect(ViewletLayoutRender2.render[0].isEqual(oldState, newState)).toBe(false)
+})

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -80,6 +80,45 @@ beforeEach(() => {
   ViewletStates.getState.mockReturnValue({ uid: 12 })
 })
 
+test('setActionsDom creates preview actions with the child event listeners', () => {
+  const state = {
+    ...ViewletLayout.create(12),
+    previewId: 7,
+    previewViewletId: 'ExtensionView',
+  }
+
+  const result = ViewletLayout.setActionsDom(state, ['preview-actions'], 7, ['click'])
+
+  expect(result.handled).toBe(true)
+  expect(result.renderParent).toBe(true)
+  expect(result.statePatch.previewActionsUid).not.toBe(-1)
+  expect(result.commands).toEqual([
+    ['Viewlet.createFunctionalRoot', 'ExtensionView', result.statePatch.previewActionsUid, true],
+    ['Viewlet.registerEventListeners', result.statePatch.previewActionsUid, ['click']],
+    ['Viewlet.setDom2', result.statePatch.previewActionsUid, ['preview-actions']],
+    ['Viewlet.setUid', result.statePatch.previewActionsUid, 7],
+  ])
+})
+
+test('setActionsDom updates existing preview actions', () => {
+  const state = {
+    ...ViewletLayout.create(12),
+    previewActionsUid: 8,
+    previewId: 7,
+  }
+
+  const result = ViewletLayout.setActionsDom(state, ['updated-actions'], 7)
+
+  expect(result).toEqual({
+    commands: [['Viewlet.setDom2', 8, ['updated-actions']]],
+    handled: true,
+    renderParent: false,
+    statePatch: {
+      previewActionsEventListeners: [],
+    },
+  })
+})
+
 const mockActivityBarRender = () => {
   // @ts-ignore
   ActivityBarWorker.invoke.mockImplementation(async (method, ...args) => {

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -47,6 +47,7 @@ const RendererProcess = await import('../src/parts/RendererProcess/RendererProce
 const Command = await import('../src/parts/Command/Command.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const ViewletExtensionViewRender = await import('../src/parts/ViewletExtensionView/ViewletExtensionViewRender.ts')
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ipc.js')
 
 test('runLoadContentLater starts deferred loading once', async () => {
   const loadContentLater = jest.fn(async (_state: unknown) => {})
@@ -375,6 +376,92 @@ test('extension view render sends a dynamic title to its parent', () => {
   const commands = ViewletManager.render(ViewletExtensionViewRender, oldState, newState, 1, 2)
 
   expect(commands).toEqual([['Viewlet.send', 2, 'setTitle', 'Testing: Updated']])
+})
+
+test('extension view render keeps the parent actions state in sync', () => {
+  const parentState = {
+    actionsUid: 3,
+    childUid: 1,
+    pending: true,
+    uid: 2,
+  }
+  const parentRenderedState = {
+    ...parentState,
+    pending: false,
+  }
+  ViewletStates.set(2, {
+    factory: {
+      setActionsDom(state, actionsDom) {
+        return {
+          commands: [['Viewlet.setDom2', state.actionsUid, actionsDom]],
+          handled: true,
+          renderParent: false,
+          statePatch: {},
+        }
+      },
+    },
+    renderedState: parentRenderedState,
+    state: parentState,
+  })
+  const dom = []
+  const oldState = {
+    actionsDom: ['old-actions'],
+    commands: [],
+    dom,
+    kind: 'virtualDom',
+    patches: [],
+    title: 'Testing',
+  }
+  const newState = {
+    ...oldState,
+    actionsDom: ['new-actions'],
+  }
+
+  const commands = ViewletManager.render(ViewletExtensionViewRender, oldState, newState, 1, 2)
+
+  expect(commands).toEqual([['Viewlet.setDom2', 3, ['new-actions']]])
+  expect(ViewletStates.getState(2)).toEqual(parentState)
+  expect(ViewletStates.getInstance(2).renderedState).toEqual(parentRenderedState)
+})
+
+test('extension view render creates preview actions and adds them to the layout', () => {
+  const parentState = {
+    ...ViewletLayout.create(2),
+    previewActionsEventListeners: ['click'],
+    previewId: 7,
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+  }
+  ViewletStates.set(2, {
+    factory: ViewletLayout,
+    renderedState: parentState,
+    state: parentState,
+  })
+  const dom = []
+  const oldState = {
+    actionsDom: [],
+    commands: [],
+    dom,
+    kind: 'virtualDom',
+    parentUid: 2,
+    patches: [],
+    title: 'Testing',
+  }
+  const newState = {
+    ...oldState,
+    actionsDom: ['new-actions'],
+  }
+
+  const commands = ViewletManager.render(ViewletExtensionViewRender, oldState, newState, 7, 2)
+
+  expect(commands.slice(0, 4)).toEqual([
+    ['Viewlet.createFunctionalRoot', 'ExtensionView', 1, true],
+    ['Viewlet.registerEventListeners', 1, ['click']],
+    ['Viewlet.setDom2', 1, ['new-actions']],
+    ['Viewlet.setUid', 1, 7],
+  ])
+  expect(commands[4][0]).toBe('Viewlet.setDom2')
+  expect(ViewletStates.getState(2).previewActionsUid).toBe(1)
 })
 
 test('extension view render keeps the parent title state in sync', () => {

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -230,3 +230,57 @@ test('setTitle', () => {
     title: 'workspace-name',
   })
 })
+
+test('setActionsDom updates an existing actions root', () => {
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    actionsUid: 3,
+    childUid: 2,
+  }
+
+  const result = ViewletSideBar.setActionsDom(state, ['updated-actions'], 2)
+
+  expect(result).toEqual({
+    commands: [['Viewlet.setDom2', 3, ['updated-actions']]],
+    handled: true,
+    renderParent: false,
+    statePatch: {
+      actionsEventListeners: [],
+    },
+  })
+})
+
+test('setActionsDom creates an actions root when actions become available', () => {
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    actionsEventListeners: ['click'],
+    childUid: 2,
+    currentViewletId: 'sample.views.main',
+  }
+
+  const result = ViewletSideBar.setActionsDom(state, ['new-actions'], 2)
+
+  expect(result.commands).toEqual([
+    ['Viewlet.createFunctionalRoot', 'sample.views.main', result.statePatch.actionsUid, true],
+    ['Viewlet.registerEventListeners', result.statePatch.actionsUid, ['click']],
+    ['Viewlet.setDom2', result.statePatch.actionsUid, ['new-actions']],
+    ['Viewlet.setUid', result.statePatch.actionsUid, 2],
+  ])
+  expect(result.statePatch.actionsUid).not.toBe(-1)
+})
+
+test('setActionsDom ignores updates from a stale child', () => {
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    childUid: 2,
+  }
+
+  const result = ViewletSideBar.setActionsDom(state, ['stale-actions'], 3)
+
+  expect(result).toEqual({
+    commands: [],
+    handled: false,
+    renderParent: false,
+    statePatch: {},
+  })
+})

--- a/packages/renderer-worker/test/ViewletSideBarRace.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBarRace.test.ts
@@ -84,6 +84,7 @@ test('handleSideBarViewletChange does not create title actions root without acti
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.registerEventListeners', 201, events]])
   expect(result).toEqual({
     ...state,
+    actionsEventListeners: events,
     actionsUid: -1,
     childUid: 201,
     currentViewletId: 'trello.views.boards',
@@ -140,6 +141,7 @@ test('handleSideBarViewletChange ignores stale loads', async () => {
   expect(Viewlet.disposeFunctional).toHaveBeenCalledWith(101)
   expect(sourceControlResult).toEqual({
     ...state,
+    actionsEventListeners: ['click'],
     actionsUid: 102,
     childUid: 201,
     currentViewletId: 'SourceControl',


### PR DESCRIPTION
## Summary
- route dynamic extension action DOM updates through the owning sidebar or preview layout
- create and retain action roots when actions become available after initial render
- render preview actions alongside the preview close action and dispose them with the view

## Testing
- renderer-worker focused tests: 59 passed, 12 skipped
- renderer-worker type-check
- Prettier check for changed files
- Trello filter e2e suite against a local server build: 10 passed