### PR TITLE
fix: make preview sash transparent

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -57,6 +57,35 @@ test('bundleCss preserves the simple browser preview width', async () => {
   }
 }, 30_000)
 
+test('bundleCss keeps the preview sash transparent', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'App.css'), 'utf8')
+
+    expect(css).toContain(`.Sash {
+  position: absolute;
+  contain: strict;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  z-index: 1;
+  background: transparent;
+  display: flex;
+}`)
+    expect(css).toContain(`.SashPreview {
+  left: var(--SashPreviewLeft);
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss centers quick pick in the non-preview area', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletSash.css
+++ b/static/css/parts/ViewletSash.css
@@ -59,7 +59,6 @@
 
 .SashPreview {
   left: var(--SashPreviewLeft);
-  border-left: 1px solid var(--SashBorder, gray);
 }
 
 .SashSecondarySideBar {


### PR DESCRIPTION
Removes the persistent divider from the preview sash so Simple Browser content no longer shows a small highlighted line beside the activity bar. The sash position and resize behavior remain unchanged.