### PR TITLE
fix: restore preview with current bounds

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1160,7 +1160,7 @@ const loadIfVisible = async (
     const y = state[kTop]
     const width = state[kWidth]
     const height = state[kHeight]
-    let commands = []
+    let commands: any[] = []
     let childUid = -1
     if (visible) {
       childUid = Id.create()
@@ -1187,8 +1187,17 @@ const loadIfVisible = async (
         restoreState,
       )
     }
-    const orderedCommands = reorderCommands(commands)
     const latestState = ViewletStates.getState(ViewletModuleId.Layout)
+    if (visible && !isEqual(state, latestState, kTop, kLeft, kWidth, kHeight)) {
+      const resizeCommands = await Viewlet.resize(childUid, {
+        x: latestState[kLeft],
+        y: latestState[kTop],
+        width: latestState[kWidth],
+        height: latestState[kHeight],
+      })
+      commands.push(...resizeCommands)
+    }
+    const orderedCommands = reorderCommands(commands)
     return {
       newState: {
         ...latestState,

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -105,6 +105,47 @@ test('loadPreviewIfVisible restores the simple browser preview', async () => {
     true,
     undefined,
   )
+  expect(Viewlet.resize).not.toHaveBeenCalled()
+})
+
+test('loadPreviewIfVisible uses the latest preview bounds when the window is resized during restore', async () => {
+  const state = ViewletLayout.loadContent(ViewletLayout.create(1), {
+    Layout: {
+      bounds: {
+        windowWidth: 1200,
+        windowHeight: 800,
+      },
+    },
+    previewUri: 'simple-browser://',
+    previewViewletId: 'SimpleBrowser',
+    previewVisible: true,
+    previewWidth: 400,
+  })
+  const latestState = LayoutPoints.getPoints({
+    ...state,
+    windowWidth: 1600,
+    windowHeight: 900,
+  })
+  // @ts-ignore
+  ViewletStates.getState.mockReturnValue(latestState)
+
+  const result = await ViewletLayout.loadPreviewIfVisible(state)
+  // @ts-ignore
+  const loadedViewlet = ViewletManager.load.mock.calls[0][0]
+  const latestBounds = {
+    x: latestState.previewLeft,
+    y: latestState.previewTop,
+    width: latestState.previewWidth,
+    height: latestState.previewHeight,
+  }
+
+  expect(Viewlet.resize).toHaveBeenCalledWith(loadedViewlet.uid, latestBounds)
+  expect(result.newState).toMatchObject({
+    previewHeight: latestBounds.height,
+    previewLeft: latestBounds.x,
+    previewTop: latestBounds.y,
+    previewWidth: latestBounds.width,
+  })
 })
 
 test('loadContent ignores saved layout when restore is disabled', () => {


### PR DESCRIPTION
Summary:
- reconcile restored preview bounds with the latest window layout after async loading
- cover window resizing during Simple Browser preview restoration