### PR TITLE
fix: keep panel beside preview

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -86,6 +86,27 @@ test('bundleCss keeps the preview sash transparent', async () => {
   }
 }, 30_000)
 
+test('bundleCss keeps the panel sash within the non-preview area', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'App.css'), 'utf8')
+
+    expect(css).toContain('contain: size layout style;')
+    expect(css).toContain(`.SashPanel {
+  top: var(--SashPanelTop);
+  width: var(--PanelWidth);
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss centers quick pick in the non-preview area', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -159,7 +159,8 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
     const destinationPreviewLeft = previewVisible ? availableWidth : 0
     const destinationPreviewTop = p2
     const destinationPreviewWidth = previewVisible ? windowWidth - availableWidth : 0
-    const destinationPreviewHeight = p3 - p2 + (previewVisible && statusBarVisible ? statusBarHeight : 0)
+    const destinationPreviewHeight =
+      p3 - p2 + (previewVisible && panelVisible ? destinationPanelHeight : 0) + (previewVisible && statusBarVisible ? statusBarHeight : 0)
     const destinationPreviewVisible = previewVisible
     return {
       ...source,
@@ -289,7 +290,8 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
     const destinationPreviewLeft = previewVisible ? availableWidth : 0
     const destinationPreviewTop = p2
     const destinationPreviewWidth = previewVisible ? windowWidth - availableWidth : 0
-    const destinationPreviewHeight = p3 - p2 + (previewVisible && statusBarVisible ? statusBarHeight : 0)
+    const destinationPreviewHeight =
+      p3 - p2 + (previewVisible && panelVisible ? destinationPanelHeight : 0) + (previewVisible && statusBarVisible ? statusBarHeight : 0)
     const destinationPreviewVisible = previewVisible
     return {
       ...source,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
@@ -138,6 +138,7 @@ const getCss = (newState: LayoutState) => {
   const sideBarWidth = newState.sideBarWidth
   const activityBarWidth = newState.activityBarWidth
   const panelHeight = newState.panelHeight
+  const panelWidth = newState.panelWidth
   const secondarySideBarWidth = newState.secondarySideBarWidth
   const titleBarHeight = newState.titleBarHeight
   const previewLeft = newState.previewLeft
@@ -147,6 +148,7 @@ const getCss = (newState: LayoutState) => {
   const sashPanelTop = newState.panelTop
   Assert.number(activityBarWidth)
   Assert.number(panelHeight)
+  Assert.number(panelWidth)
   Assert.number(sideBarWidth)
   Assert.number(secondarySideBarWidth)
   Assert.number(titleBarHeight)
@@ -168,6 +170,7 @@ const getCss = (newState: LayoutState) => {
   --AppHeight: ${appHeight};
   --ActivityBarWidth: ${getPixelValue(activityBarWidth)};
   --PanelHeight: ${getPixelValue(panelHeight)};
+  --PanelWidth: ${getPixelValue(panelWidth)};
   --SideBarWidth: ${getRoundedPixelValue(sideBarWidth)};
   --SecondarySideBarWidth: ${getRoundedPixelValue(secondarySideBarWidth)};
   --TitleBarHeight: ${getPixelValue(titleBarHeight)};

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -255,6 +255,42 @@ test.each([
   })
 })
 
+test.each([
+  ['left', SideBarLocationType.Left],
+  ['right', SideBarLocationType.Right],
+])('panel ends at the preview and preview uses the space beside it with the side bar on the %s', (_name, sideBarLocation) => {
+  const state = LayoutPoints.getPoints(
+    {
+      ...ViewletLayout.create(1),
+      panelHeight: 200,
+      panelMaxHeight: 600,
+      panelMinHeight: 150,
+      panelVisible: true,
+      previewMinWidth: 100,
+      previewVisible: true,
+      previewWidth: 400,
+      statusBarHeight: 20,
+      statusBarVisible: true,
+      titleBarHeight: 35,
+      titleBarVisible: true,
+      windowHeight: 800,
+      windowWidth: 1200,
+    },
+    sideBarLocation,
+  )
+
+  expect(state).toMatchObject({
+    panelHeight: 200,
+    panelLeft: 0,
+    panelTop: 580,
+    panelWidth: 800,
+    previewHeight: 765,
+    previewLeft: 800,
+    previewTop: 35,
+    previewWidth: 400,
+  })
+})
+
 test('showPreview replaces an open file preview with the simple browser', async () => {
   const state = {
     ...ViewletLayout.create(1),

--- a/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
@@ -8,6 +8,7 @@ test('renderCss throws for invalid layout bounds', () => {
     uid: 1,
     activityBarWidth: undefined,
     panelHeight: Number.NaN,
+    panelWidth: Number.NaN,
     sideBarWidth: undefined,
     secondarySideBarWidth: Number.NaN,
     titleBarHeight: undefined,
@@ -26,6 +27,7 @@ test('renderCss serializes valid layout bounds', () => {
     uid: 1,
     activityBarWidth: 48,
     panelHeight: 200,
+    panelWidth: 800,
     sideBarWidth: 240.2,
     secondarySideBarWidth: 299.6,
     titleBarHeight: 35,
@@ -47,6 +49,7 @@ test('renderCss serializes valid layout bounds', () => {
   --AppHeight: 100%;
   --ActivityBarWidth: 48px;
   --PanelHeight: 200px;
+  --PanelWidth: 800px;
   --SideBarWidth: 240px;
   --SecondarySideBarWidth: 300px;
   --TitleBarHeight: 35px;
@@ -69,6 +72,7 @@ test('renderCss serializes explicit application bounds', () => {
     windowHeight: 320,
     activityBarWidth: 48,
     panelHeight: 200,
+    panelWidth: 800,
     sideBarWidth: 240.2,
     secondarySideBarWidth: 299.6,
     titleBarHeight: 35,
@@ -90,6 +94,7 @@ test('renderCss serializes explicit application bounds', () => {
   --AppHeight: 320px;
   --ActivityBarWidth: 48px;
   --PanelHeight: 200px;
+  --PanelWidth: 800px;
   --SideBarWidth: 240px;
   --SecondarySideBarWidth: 300px;
   --TitleBarHeight: 35px;

--- a/static/css/parts/ViewletLayout.css
+++ b/static/css/parts/ViewletLayout.css
@@ -11,7 +11,7 @@
 .ContentArea {
   flex: 1;
   display: flex;
-  contain: strict;
+  contain: size layout style;
   position: relative;
   /* flex-direction: column; */
 }

--- a/static/css/parts/ViewletSash.css
+++ b/static/css/parts/ViewletSash.css
@@ -67,6 +67,7 @@
 
 .SashPanel {
   top: var(--SashPanelTop);
+  width: var(--PanelWidth);
 }
 
 .SashBorder {


### PR DESCRIPTION
Keep the panel and its resize sash within the non-preview area so the preview can use the full vertical space beside them.