### PR TITLE
fix: serialize activity bar clicks

### DIFF
--- a/packages/renderer-worker/src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts
@@ -2,26 +2,51 @@ import * as ActivityBarWorker from '../ActivityBarWorker/ActivityBarWorker.js'
 import * as Focus from '../Focus/Focus.js'
 import * as FocusKey from '../FocusKey/FocusKey.js'
 
+const clickQueues = new Map<number, Promise<void>>()
+
+const isClickCommand = (key: string): boolean => {
+  return key === 'handleClick' || key === 'handleClickIndex'
+}
+
+const runActivityBarCommand = async (key: string, state, args) => {
+  if (key === 'handleFocus') {
+    Focus.setFocus(FocusKey.ActivityBar)
+  } else if (key === 'handleBlur') {
+    Focus.clearFocus(FocusKey.ActivityBar)
+  }
+  await ActivityBarWorker.invoke(`ActivityBar.${key}`, state.uid, ...args)
+  const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', state.uid)
+  if (diffResult.length === 0) {
+    return state
+  }
+  const commands = await ActivityBarWorker.invoke('ActivityBar.render2', state.uid, diffResult)
+  if (commands.length === 0) {
+    return state
+  }
+  return {
+    ...state,
+    commands,
+  }
+}
+
 export const wrapActivityBarCommand = (key: string) => {
-  const fn = async (state, ...args) => {
-    if (key === 'handleFocus') {
-      Focus.setFocus(FocusKey.ActivityBar)
-    } else if (key === 'handleBlur') {
-      Focus.clearFocus(FocusKey.ActivityBar)
+  return async (state, ...args) => {
+    if (!isClickCommand(key)) {
+      return runActivityBarCommand(key, state, args)
     }
-    await ActivityBarWorker.invoke(`ActivityBar.${key}`, state.uid, ...args)
-    const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', state.uid)
-    if (diffResult.length === 0) {
-      return state
+    const previous = clickQueues.get(state.uid)
+    const { promise: next, resolve } = Promise.withResolvers<void>()
+    clickQueues.set(state.uid, next)
+    if (previous) {
+      await previous
     }
-    const commands = await ActivityBarWorker.invoke('ActivityBar.render2', state.uid, diffResult)
-    if (commands.length === 0) {
-      return state
-    }
-    return {
-      ...state,
-      commands,
+    try {
+      return await runActivityBarCommand(key, state, args)
+    } finally {
+      resolve()
+      if (clickQueues.get(state.uid) === next) {
+        clickQueues.delete(state.uid)
+      }
     }
   }
-  return fn
 }

--- a/packages/renderer-worker/test/WrapActivityBarCommand.test.ts
+++ b/packages/renderer-worker/test/WrapActivityBarCommand.test.ts
@@ -18,6 +18,7 @@ const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityB
 const Focus = await import('../src/parts/Focus/Focus.js')
 const FocusKey = await import('../src/parts/FocusKey/FocusKey.js')
 const { wrapActivityBarCommand } = await import('../src/parts/WrapActivityBarCommand/WrapActivityBarCommand.ts')
+const invoke = jest.mocked(ActivityBarWorker.invoke)
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -50,4 +51,36 @@ test('other activity bar commands do not change the keyboard context', async () 
 
   expect(Focus.clearFocus).not.toHaveBeenCalled()
   expect(Focus.setFocus).not.toHaveBeenCalled()
+})
+
+test('serializes activity bar click intents', async () => {
+  const firstClick = Promise.withResolvers<void>()
+  let clickCount = 0
+  invoke.mockImplementation(async (command: string) => {
+    if (command === 'ActivityBar.handleClick') {
+      clickCount++
+      if (clickCount === 1) {
+        await firstClick.promise
+      }
+      return undefined
+    }
+    if (command === 'ActivityBar.diff2' || command === 'ActivityBar.render2') {
+      return []
+    }
+    return undefined
+  })
+  const state = { uid: 7 }
+  const handleClick = wrapActivityBarCommand('handleClick')
+
+  const first = handleClick(state)
+  await Promise.resolve()
+  const second = handleClick(state)
+  await Promise.resolve()
+
+  expect(invoke.mock.calls.filter((call) => call[0] === 'ActivityBar.handleClick')).toHaveLength(1)
+
+  firstClick.resolve()
+  await Promise.all([first, second])
+
+  expect(invoke.mock.calls.filter((call) => call[0] === 'ActivityBar.handleClick')).toHaveLength(2)
 })


### PR DESCRIPTION
## Summary
- serialize Activity Bar click commands per viewlet so sidebar switches cannot overlap
- keep worker state and rendered sidebar updates in user-intent order
- add a regression test that holds the first click open and verifies the next click waits

## Verification
- renderer-worker type-check
- renderer-worker focused regression tests (4 passed)
- renderer-worker full test suite (1,135 passed; 238 skipped)
- browser stress test: 10 rapid Source Control → Explorer switches, Explorer retained both rows every time

## Note
- the repository-wide renderer lint command currently reports existing baseline style/configuration errors across untouched files; `git diff --check` passes.