### PR TITLE
feature: open explorer item in integrated terminal

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -545,6 +545,7 @@ export const commandMap = {
   'Layout.moveSideBarRight': lazy('Layout.moveSideBarRight'),
   'Layout.openChat': lazy('Layout.openChat'),
   'Layout.openCommandPalette': lazy('Layout.openCommandPalette'),
+  'Layout.openIntegratedTerminal': lazy('Layout.openIntegratedTerminal'),
   'Layout.openSideBarViewlet': lazy('Layout.openSideBarViewlet'),
   'Layout.openSecondarySideBarViewlet': lazy('Layout.openSecondarySideBarViewlet'),
   'Layout.setBadgeCount': lazy('Layout.setBadgeCount'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -728,7 +728,7 @@ export const openCommandPalette = async (state: LayoutState): Promise<LayoutStat
   }
 }
 
-const getPanelViewChangeCommands = async (moduleId: string) => {
+const getPanelViewChangeCommands = async (moduleId: string, uri = '') => {
   if (!moduleId) {
     return []
   }
@@ -737,7 +737,7 @@ const getPanelViewChangeCommands = async (moduleId: string) => {
     return []
   }
   const panelUid = instance.state.uid
-  await PanelWorker.invoke('Panel.toggleView', panelUid, moduleId)
+  await PanelWorker.invoke('Panel.toggleView', panelUid, moduleId, uri)
   const diffResult = await PanelWorker.invoke('Panel.diff2', panelUid)
   if (diffResult.length === 0) {
     return []
@@ -745,9 +745,9 @@ const getPanelViewChangeCommands = async (moduleId: string) => {
   return PanelWorker.invoke('Panel.render2', panelUid, diffResult)
 }
 
-export const showPanel = async (state: LayoutState, moduleId = state.panelView) => {
+export const showPanel = async (state: LayoutState, moduleId = state.panelView, uri = '') => {
   if (state.panelVisible) {
-    const commands = await getPanelViewChangeCommands(moduleId)
+    const commands = await getPanelViewChangeCommands(moduleId, uri)
     return {
       newState: {
         ...state,
@@ -758,7 +758,7 @@ export const showPanel = async (state: LayoutState, moduleId = state.panelView) 
   }
   // @ts-ignore
   const { newState, commands } = await show(state, LayoutModules.Panel)
-  const panelViewCommands = await getPanelViewChangeCommands(moduleId)
+  const panelViewCommands = await getPanelViewChangeCommands(moduleId, uri)
   return {
     newState: {
       ...newState,
@@ -766,6 +766,15 @@ export const showPanel = async (state: LayoutState, moduleId = state.panelView) 
     },
     commands: [...commands, ...panelViewCommands],
   }
+}
+
+export const openIntegratedTerminal = async (state: LayoutState, cwd: string): Promise<LayoutStateResult> => {
+  const terminalsActive = state.panelView === ViewletModuleId.Terminals && Boolean(ViewletStates.getInstance(ViewletModuleId.Terminals))
+  const result = await showPanel(state, ViewletModuleId.Terminals, terminalsActive ? '' : cwd)
+  if (terminalsActive) {
+    await Command.execute('Terminals.addTerminal', cwd)
+  }
+  return result
 }
 
 export const hidePanel = (state: LayoutState) => {
@@ -1096,7 +1105,7 @@ export const createPanelViewlet = async (
       args: [],
       shouldRenderEvents: false,
     },
-    false,
+    focus,
     true,
   )
   const actionsDomIndex = commands.findIndex((command) => command[0] === 'Viewlet.send' && command[2] === 'setActionsDom')

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -69,6 +69,7 @@ export const CommandsWithSideEffects = {
   moveSideBarRight: ViewletLayout.moveSideBarRight,
   openChat: ViewletLayout.openChat,
   openCommandPalette: ViewletLayout.openCommandPalette,
+  openIntegratedTerminal: ViewletLayout.openIntegratedTerminal,
   openSideBarViewlet: ViewletLayout.openSideBarView,
   openSecondarySideBarViewlet: ViewletLayout.openSecondarySideBarView,
   openPanelViewlet: ViewletLayout.openPanelView,

--- a/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -13,7 +13,7 @@ const getBackend = () => {
   return Preferences.get('terminal.backend') || defaultBackend
 }
 
-export const create = (id) => {
+export const create = (id, cwd = '') => {
   Assert.number(id)
   return {
     disposed: false,
@@ -24,15 +24,16 @@ export const create = (id) => {
     args: [],
     setBounds: false,
     columns: 80,
+    cwd,
     rows: 24,
     xtermMounted: false,
   }
 }
 
 export const loadContent = async (state) => {
-  const { uid } = state
+  const { cwd, uid } = state
   const { command, args } = await GetTerminalSpawnOptions.getTerminalSpawnOptions()
-  await TerminalWorker.invoke('Terminal.create', uid, Workspace.state.workspacePath, command, args, {
+  await TerminalWorker.invoke('Terminal.create', uid, cwd || Workspace.state.workspacePath, command, args, {
     backend: getBackend(),
   })
   return {

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -18,6 +18,7 @@ export const create = (id, uri, x, y, width, height) => {
     width,
     height,
     childUid: -1,
+    cwd: uri,
     focusVersion: 0,
     selectedIndex: -1,
   }
@@ -45,9 +46,9 @@ const getChildBounds = (state) => {
   }
 }
 
-const createViewlet = async (state, childUid) => {
+const createViewlet = async (state, childUid, cwd = '') => {
   const bounds = getChildBounds(state)
-  await Command.execute('Layout.createViewlet', ViewletModuleId.Terminal2, childUid, 0, bounds, '')
+  await Command.execute('Layout.createViewlet', ViewletModuleId.Terminal2, childUid, 0, bounds, cwd)
 }
 
 export const loadContent = async (state) => {
@@ -59,6 +60,7 @@ export const loadContent = async (state) => {
       terminalTabsEnabled,
     },
     childUid,
+    state.cwd,
   )
 
   return {
@@ -76,7 +78,7 @@ export const loadContent = async (state) => {
   }
 }
 
-export const addTerminal = async (state) => {
+export const addTerminal = async (state, cwd = '') => {
   const { tabs, childUid: oldChildUid } = state
   const childUid = Id.create()
   const newTab = {
@@ -86,7 +88,7 @@ export const addTerminal = async (state) => {
   }
   const newTabs = [...tabs, newTab]
   const newSelectedIndex = newTabs.length - 1
-  await createViewlet(state, childUid)
+  await createViewlet(state, childUid, cwd)
   if (oldChildUid !== -1) {
     const disposeCommands = Viewlet.disposeFunctional(oldChildUid)
     await RendererProcess.invoke('Viewlet.sendMultiple', disposeCommands)
@@ -95,6 +97,7 @@ export const addTerminal = async (state) => {
     ...state,
     tabs: newTabs,
     childUid,
+    focusVersion: state.focusVersion + 1,
     selectedIndex: newSelectedIndex,
   }
 }

--- a/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const commandExecute = jest.fn()
+const panelWorkerInvocations: any[] = []
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: commandExecute,
+  }
+})
+
+jest.unstable_mockModule('../src/parts/PanelWorker/PanelWorker.js', () => {
+  return {
+    invoke: async (method, ...args) => {
+      panelWorkerInvocations.push([method, ...args])
+      switch (method) {
+        case 'Panel.toggleView':
+          return undefined
+        case 'Panel.diff2':
+        case 'Panel.render2':
+          return []
+        default:
+          throw new Error(`unexpected panel worker method ${method}`)
+      }
+    },
+    restart: async () => {},
+  }
+})
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
+
+beforeEach(() => {
+  commandExecute.mockClear()
+  panelWorkerInvocations.length = 0
+  ViewletStates.reset()
+  ViewletStates.set('Panel', {
+    factory: {},
+    moduleId: 'Panel',
+    renderedState: { uid: 77 },
+    state: { uid: 77 },
+  })
+})
+
+test('opens a new terminal panel view with the requested cwd', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    panelView: 'Problems',
+    panelVisible: true,
+  }
+
+  const result = await ViewletLayout.openIntegratedTerminal(state, 'file:///workspace/folder')
+
+  expect(result.newState.panelView).toBe('Terminals')
+  expect(panelWorkerInvocations).toEqual([
+    ['Panel.toggleView', 77, 'Terminals', 'file:///workspace/folder'],
+    ['Panel.diff2', 77],
+  ])
+  expect(commandExecute).not.toHaveBeenCalled()
+})
+
+test('adds a focused terminal when the terminal panel view is already active', async () => {
+  ViewletStates.set('Terminals', {
+    factory: {},
+    moduleId: 'Terminals',
+    renderedState: { uid: 88 },
+    state: { uid: 88 },
+  })
+  const state = {
+    ...ViewletLayout.create(1),
+    panelView: 'Terminals',
+    panelVisible: true,
+  }
+
+  await ViewletLayout.openIntegratedTerminal(state, 'file:///workspace/folder')
+
+  expect(panelWorkerInvocations).toEqual([
+    ['Panel.toggleView', 77, 'Terminals', ''],
+    ['Panel.diff2', 77],
+  ])
+  expect(commandExecute).toHaveBeenCalledWith('Terminals.addTerminal', 'file:///workspace/folder')
+})

--- a/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
@@ -167,12 +167,12 @@ test('showPanel selects requested panel view when panel is visible', async () =>
     panelView: 'Problems',
   }
 
-  const result = await ViewletLayout.showPanel(state, 'Terminals')
+  const result = await ViewletLayout.showPanel(state, 'Terminals', 'file:///workspace/folder')
 
   expect(result.newState.panelView).toBe('Terminals')
   expect(result.commands).toEqual([['Viewlet.setPatches', 77, []]])
   expect(panelWorkerInvocations).toEqual([
-    ['Panel.toggleView', 77, 'Terminals'],
+    ['Panel.toggleView', 77, 'Terminals', 'file:///workspace/folder'],
     ['Panel.diff2', 77],
     ['Panel.render2', 77, [11]],
   ])

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -470,7 +470,7 @@ test('createPanelViewlet forwards focus to the loaded panel view', async () => {
       id: 'Terminals',
       uid: 11,
     }),
-    false,
+    true,
     true,
   )
 })

--- a/packages/renderer-worker/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminal2.test.ts
@@ -84,6 +84,15 @@ test('loadContent starts the terminal transport', async () => {
   })
 })
 
+test('loadContent starts the terminal transport in the requested cwd', async () => {
+  const state = ViewletTerminal2.create(2, 'file:///workspace/folder')
+  await ViewletTerminal2.loadContent(state)
+
+  expect(terminalWorkerInvoke).toHaveBeenCalledWith('Terminal.create', 2, 'file:///workspace/folder', 'bash', ['-i'], {
+    backend: 'mock',
+  })
+})
+
 test('handleInput forwards xterm input to the terminal worker', async () => {
   const state = ViewletTerminal2.create(3)
   await expect(ViewletTerminal2.handleInput(state, 'echo hello\r')).resolves.toBe(state)

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -31,8 +31,8 @@ const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModule
 const ViewletTerminals = await import('../src/parts/ViewletTerminals/ViewletTerminals.js')
 const ViewletTerminalsRender = await import('../src/parts/ViewletTerminals/ViewletTerminalsRender.js')
 
-test('loadContent always creates the xterm terminal view', async () => {
-  const state = ViewletTerminals.create(1, '', 10, 20, 800, 400)
+test('loadContent creates the xterm terminal view with the requested cwd', async () => {
+  const state = ViewletTerminals.create(1, 'file:///workspace/folder', 10, 20, 800, 400)
   const newState = await ViewletTerminals.loadContent(state)
 
   expect(commandExecute).toHaveBeenCalledWith(
@@ -46,12 +46,42 @@ test('loadContent always creates the xterm terminal view', async () => {
       x: 10,
       y: 20,
     },
-    '',
+    'file:///workspace/folder',
   )
   expect(newState).toMatchObject({
     childUid: 42,
     selectedIndex: 0,
     terminalTabsEnabled: true,
+  })
+})
+
+test('addTerminal creates and focuses a terminal with the requested cwd', async () => {
+  const state = {
+    ...ViewletTerminals.create(1, '', 10, 20, 800, 400),
+    childUid: -1,
+    focusVersion: 2,
+    tabs: [{ icon: 'Terminal', label: 'tab 1', uid: 41 }],
+  }
+
+  const newState = await ViewletTerminals.addTerminal(state, 'file:///workspace/folder')
+
+  expect(commandExecute).toHaveBeenCalledWith(
+    'Layout.createViewlet',
+    ViewletModuleId.Terminal2,
+    42,
+    0,
+    {
+      height: 400,
+      width: 710,
+      x: 10,
+      y: 20,
+    },
+    'file:///workspace/folder',
+  )
+  expect(newState).toMatchObject({
+    childUid: 42,
+    focusVersion: 3,
+    selectedIndex: 1,
   })
 })
 


### PR DESCRIPTION
## Summary
- expose Layout.openIntegratedTerminal with cwd forwarding
- open and focus the terminals panel, creating a new terminal when needed
- preserve the requested cwd for initial and additional terminals
- fix panel view creation so its focus argument reaches the viewlet manager

## Dependencies
- lvce-editor/explorer-view#1791
- lvce-editor/panel-worker#113

## Validation
- 50 focused renderer tests passed
- renderer-worker type-check passed
- Prettier check passed
- git diff --check passed