### PR TITLE
fix: convert open folder paths to file uris

### DIFF
--- a/packages/renderer-worker/src/parts/OpenFolderRemote/OpenFolderRemote.js
+++ b/packages/renderer-worker/src/parts/OpenFolderRemote/OpenFolderRemote.js
@@ -1,10 +1,17 @@
 import * as Command from '../Command/Command.js'
 import * as Prompt from '../Prompt/Prompt.js'
 
+const toFileUri = (path) => {
+  const url = new URL('file:///')
+  url.pathname = path.replaceAll('\\', '/')
+  return url.toString()
+}
+
 export const openFolder = async () => {
   const path = await Prompt.prompt('Choose Path:', '/home')
   if (!path) {
     return
   }
-  await Command.execute(/* Workspace.setPath */ 'Workspace.setPath', /* path */ path)
+  const uri = toFileUri(path)
+  await Command.execute(/* Workspace.setUri */ 'Workspace.setUri', /* uri */ uri)
 }

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -28,7 +28,7 @@ export const setPath = async (path) => {
 }
 
 export const setUri = async (uri) => {
-  const path = uri.slice('file://'.length)
+  const path = decodeURIComponent(uri.slice('file://'.length))
   if (path !== state.workspacePath) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }

--- a/packages/renderer-worker/test/OpenFolderRemote.test.ts
+++ b/packages/renderer-worker/test/OpenFolderRemote.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Prompt/Prompt.js', () => ({
+  prompt: jest.fn(),
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const OpenFolderRemote = await import('../src/parts/OpenFolderRemote/OpenFolderRemote.js')
+const Prompt = await import('../src/parts/Prompt/Prompt.js')
+const prompt = jest.mocked(Prompt.prompt)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('openFolder', async () => {
+  prompt.mockResolvedValue('/home/test/project')
+
+  await OpenFolderRemote.openFolder()
+
+  expect(Prompt.prompt).toHaveBeenCalledWith('Choose Path:', '/home')
+  expect(Command.execute).toHaveBeenCalledWith('Workspace.setUri', 'file:///home/test/project')
+})
+
+test('openFolder - encodes path as file uri', async () => {
+  prompt.mockResolvedValue('/home/test/my folder/#project?')
+
+  await OpenFolderRemote.openFolder()
+
+  expect(Command.execute).toHaveBeenCalledWith('Workspace.setUri', 'file:///home/test/my%20folder/%23project%3F')
+})
+
+test('openFolder - canceled', async () => {
+  prompt.mockResolvedValue('')
+
+  await OpenFolderRemote.openFolder()
+
+  expect(Command.execute).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
+  set: jest.fn(async () => {}),
+}))
+
+const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+const Workspace = await import('../src/parts/Workspace/Workspace.js')
+
+beforeEach(() => {
+  GlobalEventBus.state.listenerMap = Object.create(null)
+  Workspace.state.pathSeparator = '/'
+  Workspace.state.workspacePath = ''
+  Workspace.state.workspaceUri = ''
+})
+
+test('setUri preserves the uri and decodes the workspace path', async () => {
+  await Workspace.setUri('file:///home/test/my%20folder/%23project%3F')
+
+  expect(Workspace.getWorkspacePath()).toBe('/home/test/my folder/#project?')
+  expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/my%20folder/%23project%3F')
+})


### PR DESCRIPTION
Convert paths entered in the remote Open Folder prompt to encoded file URIs before updating the workspace. Keep the decoded filesystem path available to path-based workspace consumers.