### PR TITLE
fix: notify extensions about file changes

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -51,7 +51,9 @@ export const writeFile = async (uri, content, encoding = EncodingType.Utf8) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.writeFile(uri, content, encoding)
-  await notifyWorkspaceChanged()
+  await notifyWorkspaceChanged({
+    changed: [uri],
+  })
 }
 
 export const writeBlob = async (uri, blob) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -6,6 +6,7 @@ import * as AutoUpdateType from '../AutoUpdateType/AutoUpdateType.js'
 import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import * as Command from '../Command/Command.js'
 import * as Commit from '../Commit/Commit.js'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as GetAutoUpdateType from '../GetAutoUpdateType/GetAutoUpdateType.js'
 import * as GetDefaultTitleBarHeight from '../GetDefaultTitleBarHeight/GetDefaultTitleBarHeight.js'
 import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
@@ -2025,8 +2026,17 @@ export const setUpdateState = async (state, updateState) => {
   return callGlobalEvent(state, 'handleUpdateStateChange', updateState)
 }
 
+const handleExtensionFileChanges = async (refresh: WorkspaceRefresh): Promise<void> => {
+  try {
+    await ExtensionManagementWorker.invoke('Extensions.handleFileChanges', refresh)
+  } catch {
+    // Older extension management workers do not support file change listeners.
+  }
+}
+
 export const handleWorkspaceRefresh = async (state: LayoutState, refresh: WorkspaceRefresh = {}) => {
-  return callGlobalEvent(state, 'handleWorkspaceRefresh', refresh)
+  const [result] = await Promise.all([callGlobalEvent(state, 'handleWorkspaceRefresh', refresh), handleExtensionFileChanges(refresh)])
+  return result
 }
 
 export const handleActiveEditorChange = async (state: LayoutState, activeUri: string) => {

--- a/packages/renderer-worker/src/parts/WorkspaceChanges/WorkspaceChanges.ts
+++ b/packages/renderer-worker/src/parts/WorkspaceChanges/WorkspaceChanges.ts
@@ -1,6 +1,7 @@
 type UriRename = readonly [oldUri: string, newUri: string]
 
 export interface WorkspaceChanges {
+  readonly changed?: readonly string[]
   readonly deleted?: readonly string[]
   readonly renamed?: readonly UriRename[]
 }

--- a/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
+++ b/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
@@ -7,6 +7,7 @@ const RefreshDelay = 100
 
 let watcher
 let refreshTimeout
+const changedUris = new Set()
 const deletedUris = new Set()
 
 const isDeleteEvent = (eventName) => {
@@ -15,19 +16,27 @@ const isDeleteEvent = (eventName) => {
 
 const refresh = async () => {
   refreshTimeout = undefined
+  const changed = [...changedUris]
   const deleted = [...deletedUris]
+  changedUris.clear()
   deletedUris.clear()
-  await Promise.allSettled([
-    Command.execute('Layout.handleWorkspaceRefresh', {
-      deleted,
-    }),
-    Command.execute('Layout.refreshSourceControlBadgeCount'),
-  ])
+  const changes = {}
+  if (changed.length > 0) {
+    changes.changed = changed
+  }
+  if (deleted.length > 0) {
+    changes.deleted = deleted
+  }
+  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', changes), Command.execute('Layout.refreshSourceControlBadgeCount')])
 }
 
 const scheduleRefresh = (event) => {
   if (isDeleteEvent(event.eventName)) {
     deletedUris.add(event.uri)
+    changedUris.delete(event.uri)
+  } else {
+    changedUris.add(event.uri)
+    deletedUris.delete(event.uri)
   }
   if (refreshTimeout !== undefined) {
     clearTimeout(refreshTimeout)
@@ -77,6 +86,7 @@ export const dispose = async () => {
     clearTimeout(refreshTimeout)
     refreshTimeout = undefined
   }
+  changedUris.clear()
   deletedUris.clear()
   await disposeWatcher()
 }

--- a/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
+++ b/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const execute = jest.fn()
 const remove = jest.fn()
+const rename = jest.fn()
+const writeFile = jest.fn()
 
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
   return {
@@ -16,6 +18,8 @@ FileSystemState.registerAll({
   test() {
     return {
       remove,
+      rename,
+      writeFile,
     }
   },
 })
@@ -35,20 +39,21 @@ test('remove notifies workspace views with the deleted uri', async () => {
 })
 
 test('rename notifies workspace views with the old and new uris', async () => {
-  const rename = jest.fn()
-  FileSystemState.registerAll({
-    test() {
-      return {
-        rename,
-      }
-    },
-  })
-
   await FileSystem.rename('test://old-folder', 'test://new-folder')
 
   expect(rename).toHaveBeenCalledWith('test://old-folder', 'test://new-folder')
   expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
     renamed: [['test://old-folder', 'test://new-folder']],
+  })
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
+})
+
+test('writeFile notifies workspace views with the changed uri', async () => {
+  await FileSystem.writeFile('test://some-file.txt', 'updated')
+
+  expect(writeFile).toHaveBeenCalledWith('test://some-file.txt', 'updated', 'utf8')
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    changed: ['test://some-file.txt'],
   })
   expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -1,12 +1,19 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const hydratePreferences = jest.fn()
+const extensionManagementInvoke = jest.fn<(method: string, ...params: readonly unknown[]) => Promise<unknown>>(async () => undefined)
 
 jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => {
   return {
     get: jest.fn(),
     hydrate: hydratePreferences,
     update: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => {
+  return {
+    invoke: extensionManagementInvoke,
   }
 })
 
@@ -102,6 +109,7 @@ test('handleWorkspaceRefresh runs global event handlers in parallel', async () =
   const result = await resultPromise
 
   expect(calls).toEqual(['first:start', 'second:start', 'second:end', 'first:end'])
+  expect(extensionManagementInvoke).toHaveBeenCalledWith('Extensions.handleFileChanges', workspaceChanges)
   expect(ViewletManager.render).toHaveBeenCalledTimes(2)
   expect(result).toEqual({
     commands: [['render.1'], ['render.2']],

--- a/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
+++ b/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
@@ -94,6 +94,7 @@ test('watcher events - debounce refresh and forward deleted uris', async () => {
 
   expect(Command.execute).toHaveBeenCalledTimes(2)
   expect(Command.execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    changed: ['file:///workspace/new.txt'],
     deleted: ['file:///workspace/deleted.txt'],
   })
   expect(Command.execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')


### PR DESCRIPTION
Workspace refreshes now notify extensions that registered a file-change handler. Saves include the changed URI, file watcher events debounce changed and deleted URIs, and layout forwards the structured event through the extension-management worker.

Focused renderer tests cover saves, watcher events, and the management-worker notification.