### PR TITLE
fix: resize explorer when panel is hidden

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.explorer-panel-hide-resize.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-panel-hide-resize.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-panel-hide-resize'
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const files = Array.from({ length: 50 }, (_, index) => `file-${String(index).padStart(2, '0')}.txt`)
+  await Promise.all(files.map((file) => FileSystem.writeFile(`${tmpDir}/${file}`, file)))
+
+  await Command.execute('Layout.showPanel', 'Problems')
+  await Workspace.setPath(tmpDir)
+
+  const newlyVisibleItem = Locator('.Explorer .TreeItem[aria-label="file-24.txt"]')
+  await expect(newlyVisibleItem).toHaveCount(0)
+
+  await Command.execute('Layout.hidePanel')
+
+  await expect(newlyVisibleItem).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/ViewletExplorer/ViewletExplorer.js
+++ b/packages/renderer-worker/src/parts/ViewletExplorer/ViewletExplorer.js
@@ -65,14 +65,20 @@ export const dispose = (state) => {}
 
 export const hasFunctionalResize = true
 
-export const resize = (state, dimensions) => {
-  const { minLineY, itemHeight } = state
-  const maxLineY = minLineY + Math.round(dimensions.height / itemHeight)
+export const resizeWithDependencies = async (state, dimensions, invoke) => {
+  const { uid } = state
+  await invoke('Explorer.handleResize', uid, dimensions)
+  const diffResult = await invoke('Explorer.diff2', uid)
+  const commands = diffResult.length === 0 ? [] : await invoke('Explorer.render2', uid, diffResult)
   return {
     ...state,
     ...dimensions,
-    maxLineY,
+    commands,
   }
+}
+
+export const resize = (state, dimensions) => {
+  return resizeWithDependencies(state, dimensions, ExplorerViewWorker.invoke)
 }
 
 export const getMouseActions = async () => {

--- a/packages/renderer-worker/test/ViewletExplorer.test.ts
+++ b/packages/renderer-worker/test/ViewletExplorer.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const ViewletExplorer = await import('../src/parts/ViewletExplorer/ViewletExplorer.js')
+const invoke = jest.fn<(method: string, ...args: readonly unknown[]) => Promise<unknown>>()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('resize updates the explorer worker viewport and renders newly visible items', async () => {
+  const dimensions = {
+    height: 600,
+    width: 240,
+    x: 0,
+    y: 0,
+  }
+  const commands = [['Viewlet.setPatches', 7, [['add', 24]]]]
+  invoke.mockImplementation(async (method) => {
+    if (method === 'Explorer.diff2') {
+      return [1]
+    }
+    if (method === 'Explorer.render2') {
+      return commands
+    }
+    return undefined
+  })
+  const state = {
+    commands: [],
+    height: 400,
+    uid: 7,
+    width: 240,
+    x: 0,
+    y: 0,
+  }
+
+  const result = await ViewletExplorer.resizeWithDependencies(state, dimensions, invoke)
+
+  expect(invoke).toHaveBeenNthCalledWith(1, 'Explorer.handleResize', 7, dimensions)
+  expect(invoke).toHaveBeenNthCalledWith(2, 'Explorer.diff2', 7)
+  expect(invoke).toHaveBeenNthCalledWith(3, 'Explorer.render2', 7, [1])
+  expect(result).toEqual({
+    ...state,
+    ...dimensions,
+    commands,
+  })
+})
+
+test('resize skips rendering when the explorer viewport has no changes', async () => {
+  invoke.mockImplementation(async (method) => {
+    if (method === 'Explorer.diff2') {
+      return []
+    }
+    return undefined
+  })
+  const state = {
+    commands: [],
+    height: 400,
+    uid: 7,
+    width: 240,
+  }
+  const dimensions = {
+    height: 400,
+    width: 240,
+  }
+
+  const result = await ViewletExplorer.resizeWithDependencies(state, dimensions, invoke)
+
+  expect(invoke).toHaveBeenCalledTimes(2)
+  expect(result).toEqual(state)
+})


### PR DESCRIPTION
Fix Explorer viewport updates when panel visibility changes so newly available rows render after the panel is hidden.

Add focused renderer-worker coverage and an end-to-end regression for the panel-hide layout transition.