### PR TITLE
fix: preserve extension search context menu provider

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.extension-search-context-menu-after-detail.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.extension-search-context-menu-after-detail.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.extension-search-context-menu-after-detail'
+
+export const test: Test = async ({ expect, ExtensionSearch, Locator }) => {
+  await ExtensionSearch.open()
+  await ExtensionSearch.handleInput('atom')
+  const firstExtension = Locator('.ExtensionListItem').first()
+  await expect(firstExtension).toBeVisible()
+  await ExtensionSearch.handleClick(0)
+  const extensionDetail = Locator('.ExtensionDetail')
+  await expect(extensionDetail).toBeVisible()
+
+  await ExtensionSearch.handleContextMenu(0, 100, 100)
+
+  const contextMenu = Locator('.Menu')
+  await expect(contextMenu).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/MenuEntries/MenuEntries.js
+++ b/packages/renderer-worker/src/parts/MenuEntries/MenuEntries.js
@@ -24,7 +24,11 @@ export const getMenuEntries = async (id, ...args) => {
 
 export const getMenuEntries2 = async (uid, menuId, ...args) => {
   try {
-    const module = await getModule(menuId)
+    const instance = ViewletStates.getByUid(uid)
+    const module = MenuEntriesRegistryState.getForModuleId(menuId, instance?.moduleId)
+    if (!module) {
+      throw new Error(`menu entries for ${menuId} not found`)
+    }
     // @ts-ignore
     return module.getMenuEntries(uid, ...args)
   } catch (error) {

--- a/packages/renderer-worker/src/parts/MenuEntriesRegistryState/MenuEntriesRegistryState.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesRegistryState/MenuEntriesRegistryState.js
@@ -1,11 +1,23 @@
 const state = {
   idMap: Object.create(null),
+  idMapByModuleId: Object.create(null),
 }
 
-export const register = (id, module) => {
-  state.idMap[id] = module
+export const register = (id, module, moduleId) => {
+  const { idMap, idMapByModuleId } = state
+  idMap[id] = module
+  if (moduleId) {
+    idMapByModuleId[id] ||= Object.create(null)
+    idMapByModuleId[id][moduleId] = module
+  }
 }
 
 export const get = (id) => {
-  return state.idMap[id]
+  const { idMap } = state
+  return idMap[id]
+}
+
+export const getForModuleId = (id, moduleId) => {
+  const { idMapByModuleId } = state
+  return idMapByModuleId[id]?.[moduleId] || get(id)
 }

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -486,13 +486,13 @@ const maybeRegisterEvents = (module) => {
   }
 }
 
-const maybeRegisterMenuEntries = async (module) => {
+const maybeRegisterMenuEntries = async (id, module) => {
   if (module.menus) {
     for (const menu of module.menus) {
       if (!menu.id) {
         throw new Error('missing menu id')
       }
-      MenuEntriesRegistryState.register(menu.id, menu)
+      MenuEntriesRegistryState.register(menu.id, menu, id)
     }
   }
   if (module.getMenus) {
@@ -501,7 +501,7 @@ const maybeRegisterMenuEntries = async (module) => {
       if (!menu.id) {
         throw new Error('missing menu id')
       }
-      MenuEntriesRegistryState.register(menu.id, menu)
+      MenuEntriesRegistryState.register(menu.id, menu, id)
     }
   }
 }
@@ -517,7 +517,7 @@ const actuallyLoadModule = async (getModule, id) => {
   await ViewletManagerVisitor.loadModule(id, module)
   await maybeRegisterWrappedCommands(id, module)
   maybeRegisterEvents(module)
-  await maybeRegisterMenuEntries(module)
+  await maybeRegisterMenuEntries(id, module)
   return module
 }
 

--- a/packages/renderer-worker/test/MenuEntries.test.ts
+++ b/packages/renderer-worker/test/MenuEntries.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, expect, test } from '@jest/globals'
+import * as MenuEntries from '../src/parts/MenuEntries/MenuEntries.js'
+import * as MenuEntriesRegistryState from '../src/parts/MenuEntriesRegistryState/MenuEntriesRegistryState.js'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+const menuId = 9999
+
+interface ViewletInstance {
+  readonly factory: Record<string, never>
+  readonly moduleId: string
+  readonly renderedState: {
+    readonly uid: number
+  }
+  readonly state: {
+    readonly uid: number
+  }
+}
+
+const createInstance = (uid: number, moduleId: string): ViewletInstance => {
+  return {
+    factory: {},
+    moduleId,
+    renderedState: {
+      uid,
+    },
+    state: {
+      uid,
+    },
+  }
+}
+
+beforeEach(() => {
+  ViewletStates.reset()
+})
+
+test('getMenuEntries2 resolves duplicate menu ids by originating viewlet uid', async () => {
+  MenuEntriesRegistryState.register(
+    menuId,
+    {
+      getMenuEntries() {
+        return ['search']
+      },
+    },
+    'Extensions',
+  )
+  MenuEntriesRegistryState.register(
+    menuId,
+    {
+      getMenuEntries() {
+        return ['detail']
+      },
+    },
+    'ExtensionDetail',
+  )
+  ViewletStates.set(1, createInstance(1, 'Extensions'))
+  ViewletStates.set(2, createInstance(2, 'ExtensionDetail'))
+
+  await expect(MenuEntries.getMenuEntries2(1, menuId)).resolves.toEqual(['search'])
+  await expect(MenuEntries.getMenuEntries2(2, menuId)).resolves.toEqual(['detail'])
+})


### PR DESCRIPTION
Fix extension search context menus after an extension detail view is opened by resolving shared menu IDs through the originating view instance. Adds renderer-level and full editor regression coverage.