### PR TITLE
feature: style title bar command center

### DIFF
--- a/packages/build/src/parts/EagerLoadedCss/EagerLoadedCss.ts
+++ b/packages/build/src/parts/EagerLoadedCss/EagerLoadedCss.ts
@@ -77,6 +77,7 @@ export const eagerLoadedCss = [
   'ViewletStatusBar.css',
   'ViewletTitleBar.css',
   'ViewletTitleBarButtons.css',
+  'ViewletTitleBarCommandCenter.css',
   'ViewletTitleBarIcon.css',
   'ViewletTitleBarMenuBar.css',
   'ViewletTitleBarTitle.css',

--- a/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBarCss.ts
+++ b/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBarCss.ts
@@ -2,6 +2,7 @@ export const Css = [
   '/css/parts/ViewletTitleBar.css',
   '/css/parts/ViewletTitleBarMenuBar.css',
   '/css/parts/TitleBarEntry.css',
+  '/css/parts/ViewletTitleBarCommandCenter.css',
   '/css/parts/ViewletTitleBarTitle.css',
   '/css/parts/ViewletTitleBarButtons.css',
   '/css/parts/MaskIcon.css',

--- a/static/css/parts/ViewletTitleBarCommandCenter.css
+++ b/static/css/parts/ViewletTitleBarCommandCenter.css
@@ -1,0 +1,31 @@
+.TitleBarCommandCenter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  flex: 0 1 600px;
+  height: 22px;
+  margin: 4px auto;
+  padding: 0 12px;
+  overflow: hidden;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  outline: none;
+  cursor: pointer;
+  contain: content;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.TitleBarCommandCenter:hover {
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.TitleBarCommandCenter:focus-visible {
+  outline: 1px solid var(--FocusBorder, #007fd4);
+  outline-offset: -1px;
+}


### PR DESCRIPTION
Adds the title bar command-center stylesheet and loads it with the title bar CSS so the control has the compact input-like appearance used by VS Code.