### PR TITLE
fix: detect languages from shebangs

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.editor-extensionless-shebang-syntax-highlighting.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-extensionless-shebang-syntax-highlighting.ts
@@ -1,0 +1,13 @@
+export const name = 'viewlet.editor-extensionless-shebang-syntax-highlighting'
+
+export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/acorn`
+  await FileSystem.writeFile(filePath, '#!/usr/bin/env node\nconst value = 1')
+  await Workspace.setPath(tmpDir)
+
+  await Main.openUri(filePath)
+
+  await expect(Locator('.Token.Keyword')).toHaveText('const')
+  await expect(Locator('.Token.Numeric')).toHaveText('1')
+}

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -80,15 +80,21 @@ const getSavedDeltaY = (savedState) => {
   return 0
 }
 
-const getLanguageId = (state) => {
+const getFirstLine = (content) => {
+  const lineFeedIndex = content.indexOf('\n')
+  const lineEndIndex = lineFeedIndex === -1 ? content.length : lineFeedIndex
+  const hasCarriageReturn = lineEndIndex > 0 && content.charCodeAt(lineEndIndex - 1) === 13
+  return content.slice(0, hasCarriageReturn ? lineEndIndex - 1 : lineEndIndex)
+}
+
+const getLanguageId = (state, content) => {
   const fileName = Workspace.pathBaseName(state.uri)
   const languageId = Languages.getLanguageId(fileName)
   if (languageId === 'unknown') {
-    if (state.languageId) {
+    if (state.languageId && state.languageId !== 'unknown') {
       return state.languageId
     }
-    console.log('try to get language from content', state)
-    const firstLine = state.lines[0] || ''
+    const firstLine = getFirstLine(content)
     const languageIdFromContent = Languages.getLanguageIdByFirstLine(firstLine)
     return languageIdFromContent
   }
@@ -113,7 +119,7 @@ export const loadContent = async (state, savedState, context) => {
   const completionTriggerCharacters = EditorPreferences.getCompletionTriggerCharacters()
   const diagnosticsEnabled = EditorPreferences.diagnosticsEnabled()
   const content = await GetTextEditorContent.getTextEditorContent(uri)
-  const languageId = context?.languageId || getLanguageId(state)
+  const languageId = context?.languageId || getLanguageId(state, content)
   const tokenizer = Tokenizer.getTokenizer(languageId)
   const tokenizerId = Id.create()
   TokenizerMap.set(tokenizerId, tokenizer)

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const editorWorkerInvoke = jest.fn()
+const getTextEditorContent = jest.fn<() => string>()
 const getTokenizePath = jest.fn<(languageId: string) => string>()
 const rendererProcessInvoke = jest.fn()
 const tokenizerRemoveConnectedEditor = jest.fn()
 
 beforeEach(() => {
   jest.resetAllMocks()
+  getTextEditorContent.mockReturnValue('first line\nsecond line')
   getTokenizePath.mockImplementation((languageId: string): string => `/tokenize-${languageId}.js`)
 })
 
@@ -25,7 +27,7 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => {
 })
 
 jest.unstable_mockModule('../src/parts/GetTextEditorContent/GetTextEditorContent.js', () => ({
-  getTextEditorContent: jest.fn(() => 'first line\nsecond line'),
+  getTextEditorContent,
 }))
 
 jest.unstable_mockModule('../src/parts/GetTokenizePath/GetTokenizePath.js', () => ({
@@ -42,6 +44,7 @@ jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
 }))
 
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+const Languages = await import('../src/parts/Languages/Languages.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
 beforeEach(() => {
@@ -116,6 +119,41 @@ test('loadContent - disables the editor file cache through preferences', async (
 
   const createCall = editorWorkerInvoke.mock.calls.find(([method]) => method === 'Editor.create2')
   expect(createCall?.at(-1)).toBe(false)
+})
+
+test('loadContent - detects the language from the first line for an extensionless file', async () => {
+  Languages.addLanguage({
+    id: 'javascript',
+    firstLine: '^#!.*\\bnode',
+  })
+  getTextEditorContent.mockReturnValue('#!/usr/bin/env node\n"use strict"')
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.diff2':
+      case 'Editor.render2':
+        return []
+      default:
+        return undefined
+    }
+  })
+  const state = ViewletEditorText.create(1, '/test/acorn', 0, 0, 800, 600)
+
+  await ViewletEditorText.loadContent(state, {}, {})
+
+  expect(editorWorkerInvoke).toHaveBeenCalledWith(
+    'Editor.create2',
+    1,
+    '/test/acorn',
+    0,
+    0,
+    800,
+    600,
+    expect.any(Number),
+    expect.any(String),
+    'javascript',
+    '/tokenize-javascript.js',
+    true,
+  )
 })
 
 test('dispose', async () => {


### PR DESCRIPTION
Extensionless files now use registered first-line language patterns after their content is read.

This enables JavaScript syntax highlighting for Node shebang scripts and adds unit and end-to-end regression coverage.