### PR TITLE
fix: open go to line quick pick

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -306,6 +306,7 @@ export const commandMap = {
   'Process.getV8Version': lazy('Process.getV8Version'),
   'Prompt.prompt': lazy('Prompt.prompt'),
   'QuickPick.executeCallback': lazy('QuickPick.executeCallback'),
+  'QuickPick.openGoToLine': lazy('QuickPick.openGoToLine'),
   'QuickPick.show': lazy('QuickPick.show'),
   'QuickPick.showColorTheme': lazy('QuickPick.showColorTheme'),
   'QuickPick.showCommands': lazy('QuickPick.showCommands'),

--- a/packages/renderer-worker/src/parts/QuickPick/QuickPick.ipc.js
+++ b/packages/renderer-worker/src/parts/QuickPick/QuickPick.ipc.js
@@ -3,6 +3,7 @@ import * as QuickPick from './QuickPick.js'
 export const name = 'QuickPick'
 
 export const Commands = {
+  openGoToLine: QuickPick.openGoToLine,
   show: QuickPick.show,
   showColorTheme: QuickPick.showColorTheme,
   showCommands: QuickPick.showCommands,

--- a/packages/renderer-worker/src/parts/QuickPick/QuickPick.js
+++ b/packages/renderer-worker/src/parts/QuickPick/QuickPick.js
@@ -16,6 +16,10 @@ export const showRecent = () => {
   return show('recent')
 }
 
+export const openGoToLine = () => {
+  return show('go-to-line')
+}
+
 export const showEveryThing = () => {
   return show('everything')
 }

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@jest/globals'
+import { commandMap } from '../src/parts/CommandMap/CommandMap.js'
+
+test('registers the go-to-line quick pick command', () => {
+  expect(commandMap['QuickPick.openGoToLine']).toBeDefined()
+})

--- a/packages/renderer-worker/test/QuickPick.test.ts
+++ b/packages/renderer-worker/test/QuickPick.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const execute = jest.fn()
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute,
+}))
+
+const QuickPick = await import('../src/parts/QuickPick/QuickPick.js')
+const QuickPickIpc = await import('../src/parts/QuickPick/QuickPick.ipc.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('openGoToLine opens the go-to-line quick pick', async () => {
+  await QuickPick.openGoToLine()
+
+  expect(execute).toHaveBeenCalledWith('Viewlet.openWidget', 'QuickPick', 'go-to-line')
+})
+
+test('openGoToLine is registered as an IPC command', () => {
+  expect(QuickPickIpc.Commands.openGoToLine).toBe(QuickPick.openGoToLine)
+})


### PR DESCRIPTION
## Summary

- add the missing renderer command for the Ctrl+G go-to-line keybinding
- register the command through quick-pick IPC and the lazy command map
- cover command behavior and registration with renderer-worker regressions

The go-to-line provider initialization fix is available in `@lvce-editor/quick-pick-worker@4.5.3`, already merged into `main` by #13175.

## Tests

- `npm test -- QuickPick.test.ts CommandMap.test.ts --runInBand` in `packages/renderer-worker`
- full renderer-worker suite: 1,152 passed, 238 skipped
- `npm run type-check` in `packages/renderer-worker`

`npm run lint` in `packages/renderer-worker` is baseline-broken on current main with 98,776 whole-tree legacy violations; no lint-only changes are included.