### PR TITLE
fix: avoid :has selector for empty editor groups

### DIFF
--- a/static/css/parts/ViewletMainEditorGroup.css
+++ b/static/css/parts/ViewletMainEditorGroup.css
@@ -28,7 +28,7 @@
   outline: none;
 }
 
-.EditorGroup:has(.EmptyGroupCloseButton) {
+.EditorGroupEmpty {
   opacity: var(--EmptyGroupOpacity);
 }
 


### PR DESCRIPTION
Target the explicit EditorGroupEmpty state class when applying empty-group opacity, avoiding the relational CSS selector.