### PR TITLE
fix: synchronize split editors for the same file

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.main-open-side-by-side.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-open-side-by-side.ts
@@ -1,5 +1,3 @@
-export const skip = true
-
 export const name = 'viewlet.main-open-side-by-side'
 
 export const test = async ({ FileSystem, Workspace, Main, Locator, expect, SideBar }) => {

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-delete.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-delete.ts
@@ -1,0 +1,18 @@
+export const name = 'viewlet.main-same-file-delete'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+
+  await Editor.setCursor(0, 3)
+  await Editor.deleteCharacterLeft()
+
+  await expect(editors.nth(0)).toHaveText('ab')
+  await expect(editors.nth(1)).toHaveText('ab')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-edit-bidirectional.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-edit-bidirectional.ts
@@ -1,0 +1,22 @@
+export const name = 'viewlet.main-same-file-edit-bidirectional'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+
+  await editors.nth(0).click()
+  await Editor.setCursor(0, 0)
+  await Editor.type('left-')
+  await editors.nth(1).click()
+  await Editor.setCursor(0, 8)
+  await Editor.type('-right')
+
+  await expect(editors.nth(0)).toHaveText('left-abc-right')
+  await expect(editors.nth(1)).toHaveText('left-abc-right')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-edit-left.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-edit-left.ts
@@ -1,0 +1,19 @@
+export const name = 'viewlet.main-same-file-edit-left'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+
+  await editors.nth(0).click()
+  await Editor.setCursor(0, 3)
+  await Editor.type('x')
+
+  await expect(editors.nth(0)).toHaveText('abcx')
+  await expect(editors.nth(1)).toHaveText('abcx')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-edit-right.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-edit-right.ts
@@ -1,0 +1,18 @@
+export const name = 'viewlet.main-same-file-edit-right'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+
+  await Editor.setCursor(0, 3)
+  await Editor.type('x')
+
+  await expect(editors.nth(0)).toHaveText('abcx')
+  await expect(editors.nth(1)).toHaveText('abcx')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-multiline-edit.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-multiline-edit.ts
@@ -1,0 +1,21 @@
+export const name = 'viewlet.main-same-file-multiline-edit'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+
+  await Editor.setCursor(0, 3)
+  await Editor.insertLineBreak()
+  await Editor.type('def')
+
+  await expect(editors.nth(0).locator('.EditorRow')).toHaveCount(2)
+  await expect(editors.nth(1).locator('.EditorRow')).toHaveCount(2)
+  await expect(editors.nth(0)).toHaveText('abcdef')
+  await expect(editors.nth(1)).toHaveText('abcdef')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-open-after-unsaved-edit.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-open-after-unsaved-edit.ts
@@ -1,0 +1,19 @@
+export const name = 'viewlet.main-same-file-open-after-unsaved-edit'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Editor.setCursor(0, 3)
+  await Editor.type('x')
+
+  await Main.splitRight()
+  await Main.openUri(uri)
+
+  const editors = Locator('.Editor')
+  await expect(editors).toHaveCount(2)
+  await expect(editors.nth(0)).toHaveText('abcx')
+  await expect(editors.nth(1)).toHaveText('abcx')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-save-from-other-group.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-save-from-other-group.ts
@@ -1,0 +1,22 @@
+export const name = 'viewlet.main-same-file-save-from-other-group'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+  await editors.nth(0).click()
+  await Editor.setCursor(0, 3)
+  await Editor.type('x')
+
+  await editors.nth(1).click()
+  await Main.save()
+
+  await FileSystem.shouldHaveFile(uri, 'abcx')
+  await expect(editors.nth(0)).toHaveText('abcx')
+  await expect(editors.nth(1)).toHaveText('abcx')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-two-groups.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-two-groups.ts
@@ -1,0 +1,18 @@
+export const name = 'viewlet.main-same-file-two-groups'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+
+  const editors = Locator('.Editor')
+  await expect(editors).toHaveCount(2)
+  await expect(editors.nth(0)).toHaveText('abc')
+  await expect(editors.nth(1)).toHaveText('abc')
+  await Editor.shouldHaveText('abc')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.main-same-file-undo-redo.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-same-file-undo-redo.ts
@@ -1,0 +1,23 @@
+export const name = 'viewlet.main-same-file-undo-redo'
+
+export const test = async ({ Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(uri, 'abc')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Main.splitRight()
+  await Main.openUri(uri)
+  const editors = Locator('.Editor')
+
+  await Editor.setCursor(0, 3)
+  await Editor.type('x')
+  await editors.nth(0).click()
+  await Editor.undo()
+  await expect(editors.nth(0)).toHaveText('abc')
+  await expect(editors.nth(1)).toHaveText('abc')
+  await Editor.redo()
+
+  await expect(editors.nth(0)).toHaveText('abcx')
+  await expect(editors.nth(1)).toHaveText('abcx')
+}

--- a/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
+++ b/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
@@ -1,11 +1,40 @@
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 const queues = new Map()
 
+const getEditorUids = (editor) => {
+  const uids = new Set([editor.uid])
+  for (const instance of Object.values(ViewletStates.getAllInstances())) {
+    const state = instance?.state
+    if (instance?.moduleId === 'EditorText' && state?.uri === editor.uri && typeof state.uid === 'number') {
+      uids.add(state.uid)
+    }
+  }
+  return uids
+}
+
+const adjustCommands = (commands, uid) => {
+  return commands.map((command) => {
+    if (typeof command[0] === 'string' && command[0].startsWith('Viewlet.')) {
+      return command
+    }
+    return ['Viewlet.send', uid, ...command]
+  })
+}
+
 const runEditorCommand = async (editor, fullId, restArgs) => {
   await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
-  const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
-  const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
+  const commands = []
+  for (const uid of getEditorUids(editor)) {
+    const diffResult = await EditorWorker.invoke('Editor.diff2', uid)
+    const editorCommands = await EditorWorker.invoke('Editor.render2', uid, diffResult)
+    if (uid === editor.uid) {
+      commands.push(...editorCommands)
+    } else {
+      commands.push(...adjustCommands(editorCommands, uid))
+    }
+  }
   return {
     ...editor,
     commands,
@@ -23,9 +52,10 @@ export const wrapEditorCommand = (id) => {
     if (fullId === 'Editor.openFind' || fullId === 'Editor.openFind2' || fullId === 'Editor.closeFind') {
       return runEditorCommand(editor, fullId, restArgs)
     }
-    const previous = queues.get(editor.uid)
+    const queueKey = editor.uri || editor.uid
+    const previous = queues.get(queueKey)
     const { promise: next, resolve } = Promise.withResolvers()
-    queues.set(editor.uid, next)
+    queues.set(queueKey, next)
 
     if (previous) {
       await previous
@@ -34,8 +64,8 @@ export const wrapEditorCommand = (id) => {
       return await runEditorCommand(editor, fullId, restArgs)
     } finally {
       resolve(undefined)
-      if (queues.get(editor.uid) === next) {
-        queues.delete(editor.uid)
+      if (queues.get(queueKey) === next) {
+        queues.delete(queueKey)
       }
     }
   }

--- a/packages/renderer-worker/test/WrapEditorCommands.test.ts
+++ b/packages/renderer-worker/test/WrapEditorCommands.test.ts
@@ -7,9 +7,11 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
 
 const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
 const WrapEditorCommands = await import('../src/parts/WrapEditorCommands/WrapEditorCommands.js')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 beforeEach(() => {
   jest.clearAllMocks()
+  ViewletStates.reset()
 })
 
 test('does not serialize find widget intents', async () => {
@@ -40,4 +42,84 @@ test('does not serialize find widget intents', async () => {
   expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.closeFind', 1)
   resolveOpen!()
   await Promise.all([opening, closing])
+})
+
+test('renders every text editor showing the same uri', async () => {
+  ViewletStates.set(2, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: { uid: 2 },
+    state: {
+      uid: 2,
+      uri: 'file:///same.txt',
+    },
+  })
+  EditorWorker.invoke.mockImplementation((method: string, uid: number) => {
+    if (method === 'Editor.diff2') {
+      return Promise.resolve([uid])
+    }
+    if (method === 'Editor.render2') {
+      return Promise.resolve(uid === 1 ? [['setText', 'left']] : [['setText', 'right']])
+    }
+    return Promise.resolve(undefined)
+  })
+  const type = WrapEditorCommands.wrapEditorCommand('type')
+
+  const result = await type({ uid: 1, uri: 'file:///same.txt' }, 'x')
+
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.diff2', 1)
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.diff2', 2)
+  expect(result.commands).toEqual([
+    ['setText', 'left'],
+    ['Viewlet.send', 2, 'setText', 'right'],
+  ])
+})
+
+test('does not render a text editor showing another uri', async () => {
+  ViewletStates.set(2, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: { uid: 2 },
+    state: {
+      uid: 2,
+      uri: 'file:///other.txt',
+    },
+  })
+  EditorWorker.invoke.mockImplementation((method: string) => {
+    if (method === 'Editor.diff2' || method === 'Editor.render2') {
+      return Promise.resolve([])
+    }
+    return Promise.resolve(undefined)
+  })
+  const type = WrapEditorCommands.wrapEditorCommand('type')
+
+  await type({ uid: 1, uri: 'file:///same.txt' }, 'x')
+
+  expect(EditorWorker.invoke).not.toHaveBeenCalledWith('Editor.diff2', 2)
+})
+
+test('preserves global sibling render commands', async () => {
+  ViewletStates.set(2, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: { uid: 2 },
+    state: {
+      uid: 2,
+      uri: 'file:///same.txt',
+    },
+  })
+  EditorWorker.invoke.mockImplementation((method: string, uid: number) => {
+    if (method === 'Editor.diff2') {
+      return Promise.resolve([uid])
+    }
+    if (method === 'Editor.render2') {
+      return Promise.resolve(uid === 1 ? [] : [['Viewlet.setFocusContext', 2, 1]])
+    }
+    return Promise.resolve(undefined)
+  })
+  const focus = WrapEditorCommands.wrapEditorCommand('handleFocus')
+
+  const result = await focus({ uid: 1, uri: 'file:///same.txt' })
+
+  expect(result.commands).toEqual([['Viewlet.setFocusContext', 2, 1]])
 })


### PR DESCRIPTION
## Summary

- render every editor group showing the same file after an edit
- preserve unsaved content when the same file is opened in another group
- add broad end-to-end coverage for bidirectional edits, multiline changes, deletion, undo/redo, save, and isolation

## Validation

- focused renderer-worker tests
- renderer-worker type-check
- extension-host-worker-tests type-check
- formatting check
- static build