### PR TITLE
fix: render asynchronous editor updates

### DIFF
--- a/packages/renderer-worker/src/parts/EditorPreferences/EditorPreferences.js
+++ b/packages/renderer-worker/src/parts/EditorPreferences/EditorPreferences.js
@@ -41,7 +41,7 @@ export const getFontSize = () => {
 }
 
 export const getHoverEnabled = () => {
-  return Preferences.get(kHover) ?? false
+  return Preferences.get(kHover) ?? true
 }
 
 export const getFontFamily = () => {

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -108,11 +108,21 @@ const loadContentLater = async (editor) => {
   await Command.execute('Viewlet.executeViewletCommand', editor.uid, 'updateDiagnostics')
 }
 
+const renderPending = async (editor) => {
+  const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
+  const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
+  return {
+    ...editor,
+    commands,
+  }
+}
+
 export const getCommands = async () => {
   const commandIds = await EditorWorker.invoke('Editor.getCommandIds')
   Object.assign(Commands, WrapEditorCommands.wrapEditorCommands(commandIds), WrapEditorCommands.wrapEditorCommands(subWidgetCommandIds), {
     handleUriChange,
     loadContentLater,
+    renderPending,
     showOverlayMessage,
     hotReload,
   })

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -49,6 +49,7 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
   expect(commands['ColorPicker.handleSliderPointerDown']).toBeDefined()
   expect(commands.handleUriChange).toBeDefined()
   expect(commands.loadContentLater).toBeDefined()
+  expect(commands.renderPending).toBeDefined()
   expect(commands.showOverlayMessage).toBeDefined()
   expect(commands.hotReload).toBeDefined()
 })
@@ -67,19 +68,48 @@ test('loadContentLater requests diagnostics after the initial render', async () 
   expect(commandExecute).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'updateDiagnostics')
 })
 
-test('worker command wrapper invokes editor command, diff, and render', async () => {
+test('renderPending renders editor-worker state changed by an asynchronous effect', async () => {
   const editor = {
-    uid: 42,
     commands: [],
+    uid: 42,
   }
   editorWorkerInvoke.mockImplementation((method) => {
     switch (method) {
+      case 'Editor.diff2':
+        return [1]
       case 'Editor.getCommandIds':
-        return ['cursorLeft']
+        return []
+      case 'Editor.render2':
+        return [['Viewlet.createFunctionalRoot', 'EditorCompletion', 99, true]]
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const commands = await ViewletEditorTextCommands.getCommands()
+  const result = await commands.renderPending(editor)
+
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.diff2', 42)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(3, 'Editor.render2', 42, [1])
+  expect(result).toEqual({
+    ...editor,
+    commands: [['Viewlet.createFunctionalRoot', 'EditorCompletion', 99, true]],
+  })
+})
+
+test('worker command wrapper invokes editor command, diff, and render', async () => {
+  const editor = {
+    commands: [],
+    uid: 42,
+  }
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
       case 'Editor.cursorLeft':
         return undefined
       case 'Editor.diff2':
         return [1]
+      case 'Editor.getCommandIds':
+        return ['cursorLeft']
       case 'Editor.render2':
         return [['Viewlet.send', 42, 'setDeltaY', 0]]
       default:

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -11,7 +11,7 @@
   "editor.fontLigatures": true,
   "editor.links": true,
   "editor.tabSize": 2,
-  "editor.hover": false,
+  "editor.hover": true,
 
   "editor.autoClosingBrackets": true,
   "editor.autoClosingQuotes": true,


### PR DESCRIPTION
## Summary

- enable editor hover by default in renderer preferences and static settings
- render editor-worker state produced by delayed asynchronous language-feature effects
- add regression coverage for the renderer diff/render bridge

This completes the integration for the released TypeScript navigation fixes in language-features-typescript v5.11.3 and editor-worker v19.27.3.

## Validation

- focused renderer-worker test: 6 passed
- npm run type-check
- targeted ESLint and Prettier checks
- npm run build:server
- real browser verification against kinsta/hello-world-react-vite:
  - hover reports the App alias signature
  - F12 opens App.tsx at function App
  - Shift+F12 reports three references in two files
- git diff --check