### PR TITLE
Fix asynchronous native language server support

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -13,6 +13,7 @@ export interface CompleteOptions {
   readonly argv: readonly string[]
   readonly id: string
   readonly offset: number
+  readonly rootUri?: string
   readonly textDocument: TextDocument
   readonly uri: string
 }
@@ -20,6 +21,7 @@ export interface CompleteOptions {
 export interface DiagnosticOptions {
   readonly argv: readonly string[]
   readonly id: string
+  readonly rootUri?: string
   readonly textDocument: TextDocument
   readonly uri: string
 }
@@ -61,23 +63,23 @@ const getConnection = (id: string, uri: string, argv: readonly string[], rootUri
   return connection
 }
 
-export const complete = async ({ argv, id, offset, textDocument, uri }: CompleteOptions): Promise<readonly unknown[]> => {
+export const complete = async ({ argv, id, offset, rootUri, textDocument, uri }: CompleteOptions): Promise<readonly unknown[]> => {
   const normalizedDocument = {
     ...textDocument,
     uri: normalizeLanguageServerDocumentUri(textDocument.uri),
   }
-  const rootUri = getRootUri(normalizedDocument.uri)
-  const connection = getConnection(`${id}:${rootUri}`, uri, argv, rootUri)
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, uri, argv, normalizedRootUri)
   return connection.complete(normalizedDocument, offset)
 }
 
-export const diagnostic = async ({ argv, id, textDocument, uri }: DiagnosticOptions): Promise<readonly unknown[]> => {
+export const diagnostic = async ({ argv, id, rootUri, textDocument, uri }: DiagnosticOptions): Promise<readonly unknown[]> => {
   const normalizedDocument = {
     ...textDocument,
     uri: normalizeLanguageServerDocumentUri(textDocument.uri),
   }
-  const rootUri = getRootUri(normalizedDocument.uri)
-  const connection = getConnection(`${id}:${rootUri}`, uri, argv, rootUri)
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, uri, argv, normalizedRootUri)
   return connection.diagnostic(normalizedDocument)
 }
 

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -23,6 +23,22 @@ interface PendingRequest {
   readonly resolve: (value: unknown) => void
 }
 
+interface PendingDiagnostics {
+  readonly reject: (error: Error) => void
+  readonly resolve: (value: readonly unknown[]) => void
+}
+
+interface InitializeResult {
+  readonly capabilities?: {
+    readonly diagnosticProvider?: unknown
+  }
+}
+
+interface Deferred {
+  readonly promise: Promise<void>
+  readonly resolve: () => void
+}
+
 interface TextDocument {
   readonly languageId: string
   readonly text: string
@@ -74,17 +90,38 @@ const getWorkspaceName = (rootUri: string): string => {
   }
 }
 
+const createDeferred = (): Deferred => {
+  let resolve = (): void => {}
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+const wait = (duration: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, duration)
+  })
+}
+
 export class LanguageServerConnection {
   private readonly child: ChildProcessWithoutNullStreams
+  private readonly configurationHandled = createDeferred()
+  private readonly diagnosticWaiters = new Map<string, Set<PendingDiagnostics>>()
   private readonly documents = new Map<string, DocumentState>()
+  private readonly initializationProgressEnded = createDeferred()
+  private readonly initializationProgressStarted = createDeferred()
   private readonly parser = new LanguageServerMessageParser()
   private readonly pendingRequests = new Map<number | string, PendingRequest>()
+  private readonly publishedDiagnostics = new Map<string, readonly unknown[]>()
   private readonly ready: Promise<void>
   private readonly rootUri: string
+  private initializationProgressWasStarted = false
   private markdownConfigured = false
   private nextRequestId = 1
   private running = true
   private stderr = ''
+  private supportsPullDiagnostics = false
 
   constructor({ argv, rootUri, uri }: LanguageServerConnectionOptions) {
     this.rootUri = rootUri
@@ -147,16 +184,29 @@ export class LanguageServerConnection {
   async diagnostic(textDocument: TextDocument): Promise<readonly unknown[]> {
     await this.ready
     this.configureMarkdown(textDocument.languageId)
-    this.syncDocument(textDocument)
-    const result = await this.sendRequest('textDocument/diagnostic', {
-      textDocument: {
-        uri: textDocument.uri,
-      },
-    })
-    if (result && typeof result === 'object' && Array.isArray((result as { readonly items?: unknown }).items)) {
-      return (result as { readonly items: readonly unknown[] }).items
+    if (this.supportsPullDiagnostics) {
+      this.syncDocument(textDocument)
+      const result = await this.sendRequest('textDocument/diagnostic', {
+        textDocument: {
+          uri: textDocument.uri,
+        },
+      })
+      if (result && typeof result === 'object' && Array.isArray((result as { readonly items?: unknown }).items)) {
+        return (result as { readonly items: readonly unknown[] }).items
+      }
+      return []
     }
-    return []
+    const previous = this.documents.get(textDocument.uri)
+    const documentChanged = !previous || previous.languageId !== textDocument.languageId || previous.text !== textDocument.text
+    const cached = this.publishedDiagnostics.get(textDocument.uri)
+    if (!documentChanged && cached) {
+      return cached
+    }
+    const diagnostics = this.waitForPublishedDiagnostics(textDocument.uri)
+    if (documentChanged) {
+      this.syncDocument(textDocument)
+    }
+    return diagnostics
   }
 
   private configureMarkdown(languageId: string): void {
@@ -206,7 +256,7 @@ export class LanguageServerConnection {
   }
 
   private async initialize(): Promise<void> {
-    await this.sendRequest('initialize', {
+    const result = (await this.sendRequest('initialize', {
       capabilities: {
         textDocument: {
           completion: {
@@ -218,10 +268,16 @@ export class LanguageServerConnection {
             dynamicRegistration: false,
             relatedDocumentSupport: false,
           },
+          publishDiagnostics: {
+            relatedInformation: true,
+          },
           synchronization: {
             didSave: true,
             dynamicRegistration: false,
           },
+        },
+        window: {
+          workDoneProgress: true,
         },
         workspace: {
           configuration: true,
@@ -239,8 +295,15 @@ export class LanguageServerConnection {
           uri: this.rootUri,
         },
       ],
-    })
+    })) as InitializeResult
+    this.supportsPullDiagnostics = Boolean(result?.capabilities?.diagnosticProvider)
     this.sendNotification('initialized', {})
+    await Promise.race([this.initializationProgressStarted.promise, wait(100)])
+    if (this.initializationProgressWasStarted) {
+      await Promise.race([this.initializationProgressEnded.promise, wait(30_000)])
+    }
+    await Promise.race([this.configurationHandled.promise, wait(100)])
+    await wait(0)
   }
 
   private syncDocument(textDocument: TextDocument): void {
@@ -303,6 +366,14 @@ export class LanguageServerConnection {
   }
 
   private handleMessage(message: JsonRpcMessage): void {
+    if (message.method === 'textDocument/publishDiagnostics') {
+      this.handlePublishedDiagnostics(message.params)
+      return
+    }
+    if (message.method === '$/progress') {
+      this.handleProgress(message.params)
+      return
+    }
     if (message.method && message.id !== undefined && message.id !== null) {
       void this.handleServerRequest(message)
       return
@@ -322,12 +393,45 @@ export class LanguageServerConnection {
     pending.resolve(message.result)
   }
 
+  private handlePublishedDiagnostics(params: unknown): void {
+    if (!params || typeof params !== 'object') {
+      return
+    }
+    const { diagnostics, uri } = params as { readonly diagnostics?: unknown; readonly uri?: unknown }
+    if (typeof uri !== 'string' || !Array.isArray(diagnostics)) {
+      return
+    }
+    this.publishedDiagnostics.set(uri, diagnostics)
+    const waiters = this.diagnosticWaiters.get(uri)
+    if (!waiters) {
+      return
+    }
+    this.diagnosticWaiters.delete(uri)
+    for (const waiter of waiters) {
+      waiter.resolve(diagnostics)
+    }
+  }
+
+  private handleProgress(params: unknown): void {
+    if (!params || typeof params !== 'object') {
+      return
+    }
+    const { value } = params as { readonly value?: unknown }
+    if (!value || typeof value !== 'object' || (value as { readonly kind?: unknown }).kind !== 'end') {
+      return
+    }
+    this.initializationProgressEnded.resolve()
+  }
+
   private async handleServerRequest(message: JsonRpcMessage): Promise<void> {
     try {
       let result: unknown = null
       if (message.method === 'workspace/configuration') {
         const itemCount = Array.isArray(message.params?.items) ? message.params.items.length : 0
         result = Array.from({ length: itemCount }).fill(null)
+      } else if (message.method === 'window/workDoneProgress/create') {
+        this.initializationProgressWasStarted = true
+        this.initializationProgressStarted.resolve()
       } else if (message.method === 'workspace/workspaceFolders') {
         result = [
           {
@@ -346,6 +450,9 @@ export class LanguageServerConnection {
         jsonrpc: '2.0',
         result,
       })
+      if (message.method === 'workspace/configuration') {
+        this.configurationHandled.resolve()
+      }
     } catch (error) {
       this.sendMessage({
         error: {
@@ -371,6 +478,12 @@ export class LanguageServerConnection {
       pending.reject(error)
     }
     this.pendingRequests.clear()
+    for (const waiters of this.diagnosticWaiters.values()) {
+      for (const waiter of waiters) {
+        waiter.reject(error)
+      }
+    }
+    this.diagnosticWaiters.clear()
   }
 
   private sendNotification(method: string, params: unknown): void {
@@ -396,6 +509,14 @@ export class LanguageServerConnection {
       params,
     })
     return promise
+  }
+
+  private waitForPublishedDiagnostics(uri: string): Promise<readonly unknown[]> {
+    return new Promise<readonly unknown[]>((resolve, reject) => {
+      const waiters = this.diagnosticWaiters.get(uri) || new Set()
+      waiters.add({ reject, resolve })
+      this.diagnosticWaiters.set(uri, waiters)
+    })
   }
 
   private sendMessage(message: unknown): void {

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { complete, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
+const pushDiagnosticsServerScript = fileURLToPath(new URL('./fixtures/languageServerPushDiagnostics.js', import.meta.url))
 
 afterEach(() => {
   disposeAll()
@@ -72,4 +73,38 @@ test('diagnostic starts a stdio language server and synchronizes documents', asy
       severity: 2,
     },
   ])
+})
+
+test('diagnostic supports published diagnostics and uses the provided workspace root', async () => {
+  const options = {
+    argv: [pushDiagnosticsServerScript],
+    id: 'sample.push-diagnostics-fixture',
+    rootUri: 'file:///tmp/sample-workspace',
+    textDocument: {
+      languageId: 'elm',
+      text: 'invalid',
+      uri: '/tmp/sample-workspace/src/Main.elm',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+
+  await expect(diagnostic(options)).resolves.toEqual([
+    {
+      message: 'fixtureDiagnostic:invalid:file:///tmp/sample-workspace',
+      range: {
+        end: { character: 3, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+      severity: 2,
+    },
+  ])
+  await expect(
+    diagnostic({
+      ...options,
+      textDocument: {
+        ...options.textDocument,
+        text: 'valid',
+      },
+    }),
+  ).resolves.toEqual([])
 })

--- a/packages/shared-process/test/fixtures/languageServerPushDiagnostics.js
+++ b/packages/shared-process/test/fixtures/languageServerPushDiagnostics.js
@@ -1,6 +1,6 @@
 const headerSeparator = Buffer.from('\r\n\r\n')
 let buffer = Buffer.alloc(0)
-const documents = new Map()
+let rootUri = ''
 
 /** @param {any} message */
 const send = (message) => {
@@ -8,63 +8,44 @@ const send = (message) => {
   process.stdout.write(`Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`)
 }
 
-/** @param {any} message */
-const handleMessage = (message) => {
-  if (message.method === 'initialize') {
-    send({
-      id: message.id,
-      jsonrpc: '2.0',
-      result: {
-        capabilities: {
-          completionProvider: {},
-          diagnosticProvider: {
-            interFileDependencies: false,
-            workspaceDiagnostics: false,
-          },
-          textDocumentSync: 1,
-        },
-      },
-    })
-    return
-  }
-  if (message.method === 'textDocument/didOpen') {
-    documents.set(message.params.textDocument.uri, message.params.textDocument.text)
-    return
-  }
-  if (message.method === 'textDocument/didChange') {
-    documents.set(message.params.textDocument.uri, message.params.contentChanges[0].text)
-    return
-  }
-  if (message.method === 'textDocument/completion') {
-    const text = documents.get(message.params.textDocument.uri)
-    send({
-      id: message.id,
-      jsonrpc: '2.0',
-      result: {
-        items: [{ insertText: 'fixtureCompletion', kind: 6, label: `fixtureCompletion:${text}` }],
-      },
-    })
-    return
-  }
-  if (message.method === 'textDocument/diagnostic') {
-    const text = documents.get(message.params.textDocument.uri)
-    send({
-      id: message.id,
-      jsonrpc: '2.0',
-      result: {
-        items: [
+/** @param {string} uri @param {string} text */
+const publishDiagnostics = (uri, text) => {
+  const diagnostics =
+    text === 'valid'
+      ? []
+      : [
           {
-            message: `fixtureDiagnostic:${text}`,
+            message: `fixtureDiagnostic:${text}:${rootUri}`,
             range: {
               end: { character: 3, line: 0 },
               start: { character: 0, line: 0 },
             },
             severity: 2,
           },
-        ],
-        kind: 'full',
-      },
-    })
+        ]
+  send({
+    jsonrpc: '2.0',
+    method: 'textDocument/publishDiagnostics',
+    params: {
+      diagnostics,
+      uri,
+    },
+  })
+}
+
+/** @param {any} message */
+const handleMessage = (message) => {
+  if (message.method === 'initialize') {
+    rootUri = message.params.rootUri
+    send({ id: message.id, jsonrpc: '2.0', result: { capabilities: { textDocumentSync: 1 } } })
+    return
+  }
+  if (message.method === 'textDocument/didOpen') {
+    publishDiagnostics(message.params.textDocument.uri, message.params.textDocument.text)
+    return
+  }
+  if (message.method === 'textDocument/didChange') {
+    publishDiagnostics(message.params.textDocument.uri, message.params.contentChanges[0].text)
   }
 }
 


### PR DESCRIPTION
Support workspace-rooted language servers that finish initialization asynchronously, and handle both pull and published diagnostics. This enables native servers such as elm-language-server while preserving existing pull-diagnostic behavior.