### PR TITLE
Fix completion-only language server diagnostics

### DIFF
--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -104,6 +104,8 @@ const wait = (duration: number): Promise<void> => {
   })
 }
 
+const PublishDiagnosticsTimeout = 1_000
+
 export class LanguageServerConnection {
   private readonly child: ChildProcessWithoutNullStreams
   private readonly configurationHandled = createDeferred()
@@ -514,7 +516,25 @@ export class LanguageServerConnection {
   private waitForPublishedDiagnostics(uri: string): Promise<readonly unknown[]> {
     return new Promise<readonly unknown[]>((resolve, reject) => {
       const waiters = this.diagnosticWaiters.get(uri) || new Set()
-      waiters.add({ reject, resolve })
+      let timeout: ReturnType<typeof setTimeout>
+      const waiter = {
+        reject(error: Error): void {
+          clearTimeout(timeout)
+          reject(error)
+        },
+        resolve(value: readonly unknown[]): void {
+          clearTimeout(timeout)
+          resolve(value)
+        },
+      }
+      timeout = setTimeout(() => {
+        waiters.delete(waiter)
+        if (waiters.size === 0) {
+          this.diagnosticWaiters.delete(uri)
+        }
+        resolve(this.publishedDiagnostics.get(uri) || [])
+      }, PublishDiagnosticsTimeout)
+      waiters.add(waiter)
       this.diagnosticWaiters.set(uri, waiters)
     })
   }

--- a/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
+++ b/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
@@ -2,9 +2,22 @@ import { pathToFileURL } from 'node:url'
 
 const windowsFileUriRegex = /^file:\/\/\/([a-z])(?::|%3a)(?=\/|$)/i
 
+const normalizeRemoteFileUrl = (uri: string): string | undefined => {
+  try {
+    const url = new URL(uri)
+    if ((url.protocol === 'http:' || url.protocol === 'https:') && url.pathname.startsWith('/remote/')) {
+      return pathToFileURL(decodeURIComponent(url.pathname.slice('/remote'.length))).href
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
+}
+
 export const normalizeLanguageServerDocumentUri = (uri: string): string => {
   if (uri.startsWith('/')) {
     return pathToFileURL(uri).href
   }
-  return uri.replace(windowsFileUriRegex, (_, driveLetter: string) => `file:///${driveLetter.toLowerCase()}%3A`)
+  const normalizedUri = normalizeRemoteFileUrl(uri) || uri
+  return normalizedUri.replace(windowsFileUriRegex, (_, driveLetter: string) => `file:///${driveLetter.toLowerCase()}%3A`)
 }

--- a/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
+++ b/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
@@ -6,7 +6,7 @@ const normalizeRemoteFileUrl = (uri: string): string | undefined => {
   try {
     const url = new URL(uri)
     if ((url.protocol === 'http:' || url.protocol === 'https:') && url.pathname.startsWith('/remote/')) {
-      return pathToFileURL(decodeURIComponent(url.pathname.slice('/remote'.length))).href
+      return `file://${url.pathname.slice('/remote'.length)}`
     }
   } catch {
     return undefined

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { complete, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
+const completionOnlyServerScript = fileURLToPath(new URL('./fixtures/languageServerCompletionOnly.js', import.meta.url))
 const pushDiagnosticsServerScript = fileURLToPath(new URL('./fixtures/languageServerPushDiagnostics.js', import.meta.url))
 
 afterEach(() => {
@@ -108,3 +109,22 @@ test('diagnostic supports published diagnostics and uses the provided workspace 
     }),
   ).resolves.toEqual([])
 })
+
+test(
+  'diagnostic resolves when a completion-only server does not publish diagnostics',
+  async () => {
+    const options = {
+      argv: [completionOnlyServerScript],
+      id: 'sample.completion-only-fixture',
+      textDocument: {
+        languageId: 'typescript',
+        text: 'const value = 1',
+        uri: '/tmp/sample.ts',
+      },
+      uri: pathToFileURL(process.execPath).href,
+    }
+
+    await expect(diagnostic(options)).resolves.toEqual([])
+  },
+  2000,
+)

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -18,6 +18,12 @@ test('preserves a normalized file URI', () => {
   expect(normalizeLanguageServerDocumentUri('file:///tmp/README.md')).toBe('file:///tmp/README.md')
 })
 
+test('normalizes a remote file URL', () => {
+  expect(normalizeLanguageServerDocumentUri('http://localhost:41283/remote/tmp/My%20Project/src/Main.elm')).toBe(
+    'file:///tmp/My%20Project/src/Main.elm',
+  )
+})
+
 test('preserves a non-file URI', () => {
   expect(normalizeLanguageServerDocumentUri('memfs:///workspace/README.md')).toBe('memfs:///workspace/README.md')
 })

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -20,7 +20,7 @@ test('preserves a normalized file URI', () => {
 
 test('normalizes a remote file URL', () => {
   expect(normalizeLanguageServerDocumentUri('http://localhost:41283/remote/tmp/My%20Project/src/Main.elm')).toBe(
-    'file:///tmp/My%20Project/src/Main.elm',
+    pathToFileURL('/tmp/My Project/src/Main.elm').href,
   )
 })
 

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -19,8 +19,8 @@ test('preserves a normalized file URI', () => {
 })
 
 test('normalizes a remote file URL', () => {
-  expect(normalizeLanguageServerDocumentUri('http://localhost:41283/remote/tmp/My%20Project/src/Main.elm')).toBe(
-    pathToFileURL('/tmp/My Project/src/Main.elm').href,
+  expect(normalizeLanguageServerDocumentUri('http://localhost:41283/remote/C:/My%20Project/src/Main.elm')).toBe(
+    'file:///c%3A/My%20Project/src/Main.elm',
   )
 })
 

--- a/packages/shared-process/test/fixtures/languageServerCompletionOnly.js
+++ b/packages/shared-process/test/fixtures/languageServerCompletionOnly.js
@@ -1,0 +1,50 @@
+const headerSeparator = Buffer.from('\r\n\r\n')
+let buffer = Buffer.alloc(0)
+
+/** @param {any} message */
+const send = (message) => {
+  const content = JSON.stringify(message)
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`)
+}
+
+/** @param {any} message */
+const handleMessage = (message) => {
+  if (message.method !== 'initialize') {
+    return
+  }
+  send({
+    id: message.id,
+    jsonrpc: '2.0',
+    result: {
+      capabilities: {
+        completionProvider: {},
+        textDocumentSync: 1,
+      },
+    },
+  })
+}
+
+process.stdin.on('data', (chunk) => {
+  const data = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
+  buffer = Buffer.concat([buffer, data])
+  while (true) {
+    const headerEnd = buffer.indexOf(headerSeparator)
+    if (headerEnd === -1) {
+      return
+    }
+    const header = buffer.subarray(0, headerEnd).toString('ascii')
+    const match = /Content-Length:\s*(\d+)/i.exec(header)
+    if (!match) {
+      throw new Error('Missing Content-Length')
+    }
+    const contentLength = Number(match[1])
+    const contentStart = headerEnd + headerSeparator.length
+    const contentEnd = contentStart + contentLength
+    if (buffer.length < contentEnd) {
+      return
+    }
+    const message = JSON.parse(buffer.subarray(contentStart, contentEnd).toString('utf8'))
+    buffer = buffer.subarray(contentEnd)
+    handleMessage(message)
+  }
+})


### PR DESCRIPTION
## Summary
- bound push-diagnostic waits so completion-only language servers cannot block editor requests indefinitely
- normalize editor remote-file URLs to file URIs for native language server processes
- cover completion-only diagnostics and remote workspace URI normalization

## Validation
- shared-process tests: 326 passed, 35 skipped
- shared-process type check
- shared-process lint
- focused extension-management E2E: synthetic server crash recovery, Elm completion, and Elm diagnostics