### PR TITLE
fix: use registered rename widget commands

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -12,12 +12,12 @@ export const getKeyBindings = () => {
     },
     {
       key: KeyCode.Enter,
-      command: 'EditorRename.finish',
+      command: 'EditorRename.accept',
       when: WhenExpression.FocusEditorRename,
     },
     {
       key: KeyCode.Escape,
-      command: 'EditorRename.abort',
+      command: 'EditorRename.close',
       when: WhenExpression.FocusEditorRename,
     },
     {

--- a/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@jest/globals'
+import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
+import * as ViewletLayoutKeyBindings from '../src/parts/ViewletLayout/ViewletLayoutKeyBindings.js'
+import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.js'
+
+test('getKeyBindings - rename widget', () => {
+  const keyBindings = ViewletLayoutKeyBindings.getKeyBindings()
+
+  expect(keyBindings).toEqual(
+    expect.arrayContaining([
+      {
+        command: 'EditorRename.accept',
+        key: KeyCode.Enter,
+        when: WhenExpression.FocusEditorRename,
+      },
+      {
+        command: 'EditorRename.close',
+        key: KeyCode.Escape,
+        when: WhenExpression.FocusEditorRename,
+      },
+    ]),
+  )
+})


### PR DESCRIPTION
## Summary
- bind Enter in the focused rename widget to EditorRename.accept
- bind Escape to EditorRename.close
- add regression coverage for both keybindings

The previous bindings referenced commands that do not exist, so Enter fell through and inserted a newline into the editor instead of accepting the rename.

## Testing
- npm test -- --runInBand test/ViewletLayoutKeyBindings.test.ts (packages/renderer-worker)
- npm run type-check (packages/renderer-worker)

The package-local XO script reports the existing repository-wide legacy-style baseline; LVCE's root lint remains the authoritative CI check.