### PR TITLE
fix: preserve focused editor command routing

### DIFF
--- a/packages/renderer-worker/src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js
+++ b/packages/renderer-worker/src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js
@@ -1,4 +1,5 @@
 import * as Focus from '../Focus/Focus.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 const updateDynamic = (commands, key, fn) => {
   const matchingCommands = []
@@ -11,18 +12,30 @@ const updateDynamic = (commands, key, fn) => {
   }
   // TODO send focus changes to renderer process together with other message
   for (let i = matchingCommands.length - 1; i >= 0; i--) {
-    fn(...matchingCommands[i].slice(2))
+    fn(matchingCommands[i])
   }
 }
 
+const getModuleId = (uid) => {
+  return ViewletStates.getByUid(uid)?.moduleId
+}
+
 export const updateDynamicFocusContext = (commands) => {
-  updateDynamic(commands, 'Viewlet.setFocusContext', Focus.setFocus)
-  updateDynamic(commands, 'Viewlet.setAdditionalFocus', Focus.setAdditionalFocus)
-  updateDynamic(commands, 'Viewlet.unsetAdditionalFocus', Focus.removeAdditionalFocus)
+  updateDynamic(commands, 'Viewlet.setFocusContext', (command) => {
+    const [, uid, focusKey, additionalFocusKey] = command
+    Focus.setFocus(focusKey, additionalFocusKey, uid, getModuleId(uid))
+  })
+  updateDynamic(commands, 'Viewlet.setAdditionalFocus', (command) => {
+    const [, uid, focusKey] = command
+    Focus.setAdditionalFocus(focusKey, uid, getModuleId(uid))
+  })
+  updateDynamic(commands, 'Viewlet.unsetAdditionalFocus', (command) => {
+    Focus.removeAdditionalFocus(command[2])
+  })
 }
 
 export const updateDynamicKeyBindings = (commands) => {
-  updateDynamic(commands, 'Viewlet.setKeyBindings', (keyBindings) => {
+  updateDynamic(commands, 'Viewlet.setKeyBindings', (command) => {
     // TODO
   })
 }

--- a/packages/renderer-worker/test/UpdateDynamicFocusContext.test.ts
+++ b/packages/renderer-worker/test/UpdateDynamicFocusContext.test.ts
@@ -8,6 +8,16 @@ jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => {
+  return {
+    getByUid: jest.fn((uid: number) => {
+      return {
+        moduleId: uid === 1 ? 'EditorText' : 'Unknown',
+      }
+    }),
+  }
+})
+
 const Focus = await import('../src/parts/Focus/Focus.js')
 const UpdateDynamicFocusContext = await import('../src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js')
 const mockRemoveAdditionalFocus = jest.mocked(Focus.removeAdditionalFocus)
@@ -32,7 +42,13 @@ test('removes and applies all dynamic focus commands', () => {
   UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
 
   expect(commands).toEqual([['Viewlet.setDom2', 1, []]])
-  expect(mockSetFocus.mock.calls).toEqual([[10], [20]])
-  expect(mockSetAdditionalFocus.mock.calls).toEqual([[30], [40]])
+  expect(mockSetFocus.mock.calls).toEqual([
+    [10, undefined, 1, 'EditorText'],
+    [20, undefined, 1, 'EditorText'],
+  ])
+  expect(mockSetAdditionalFocus.mock.calls).toEqual([
+    [30, 1, 'EditorText'],
+    [40, 1, 'EditorText'],
+  ])
   expect(mockRemoveAdditionalFocus.mock.calls).toEqual([[50], [60]])
 })


### PR DESCRIPTION
## Summary
- retain the editor UID when applying dynamic focus commands
- resolve and retain the editor module ID for instance routing
- cover focus and additional-focus routing

## Validation
- renderer-worker type-check
- focused renderer-worker Jest test
- live browser multi-file rename verification