### PR TITLE
fix: constrain panel to preview boundary

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -86,7 +86,7 @@ test('bundleCss keeps the preview sash transparent', async () => {
   }
 }, 30_000)
 
-test('bundleCss keeps the panel sash within the non-preview area', async () => {
+test('bundleCss keeps the panel and panel sash within the non-preview area', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 
   try {
@@ -98,6 +98,11 @@ test('bundleCss keeps the panel sash within the non-preview area', async () => {
     const css = await readFile(join(dir, 'App.css'), 'utf8')
 
     expect(css).toContain('contain: size layout style;')
+    expect(css).toContain(`.Panel {
+  background: var(--PanelBackground);
+  height: var(--PanelHeight);
+  width: var(--PanelWidth);
+}`)
     expect(css).toContain(`.SashPanel {
   top: var(--SashPanelTop);
   width: var(--PanelWidth);

--- a/static/css/parts/ViewletLayout.css
+++ b/static/css/parts/ViewletLayout.css
@@ -57,4 +57,5 @@
 .Panel {
   background: var(--PanelBackground);
   height: var(--PanelHeight);
+  width: var(--PanelWidth);
 }


### PR DESCRIPTION
The panel now uses the computed non-preview width, so it stops at the preview area instead of stretching behind it. Adds bundled CSS regression coverage for both the panel and its sash.