### PR TITLE
fix: define drag overlay layout statically

### DIFF
--- a/static/css/parts/ViewletMainDragOverlay.css
+++ b/static/css/parts/ViewletMainDragOverlay.css
@@ -1,5 +1,9 @@
 .DragOverlay {
   position: absolute;
+  left: var(--DragOverlayLeft);
+  top: var(--DragOverlayTop);
+  width: var(--DragOverlayWidth);
+  height: var(--DragOverlayHeight);
   background: rgba(83, 89, 93, 0.5);
   z-index: 1;
   pointer-events: none;


### PR DESCRIPTION
Defines the drag overlay's invariant layout and visual CSS in lvce-editor, with its dynamic position and dimensions supplied through custom properties by main-area-worker.