### PR TITLE
feature: add static main area css

### DIFF
--- a/static/css/parts/ViewletMain.css
+++ b/static/css/parts/ViewletMain.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   flex: 1;
   contain: strict;
+  position: relative;
 }
 
 .TextEditor {

--- a/static/css/parts/ViewletMainEditorGroup.css
+++ b/static/css/parts/ViewletMainEditorGroup.css
@@ -9,6 +9,7 @@
   height: 100%;
   width: 100%;
   contain: strict;
+  overflow: auto;
 }
 
 .EditorGroupsVertical {
@@ -22,10 +23,11 @@
 .EditorGroup {
   contain: strict;
   display: flex;
-  width: 100%;
   height: 100%;
   flex-direction: column;
+  min-width: 250px;
   outline: none;
+  width: var(--EditorGroupWidth, auto);
 }
 
 .EditorGroupEmpty {

--- a/static/css/parts/ViewletSash.css
+++ b/static/css/parts/ViewletSash.css
@@ -75,3 +75,40 @@
   width: 1px;
   background: var(--SashBorder, gray);
 }
+
+.SashBorderHorizontal {
+  width: 100%;
+  height: 1px;
+}
+
+.SashBorderVertical {
+  width: 1px;
+  height: 100%;
+}
+
+.SashCorner {
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: all-scroll;
+  transform: translate(-50%, -50%);
+}
+
+.SashCorner::after {
+  content: '';
+  width: 4px;
+  height: 4px;
+  background: var(--SashBorder, gray);
+}
+
+.SashCorner:hover::after,
+.SashCorner:active::after {
+  background: var(--SashHoverBorder, #3d5252);
+}


### PR DESCRIPTION
Moves invariant main-area, editor-group, sash, and sash-corner declarations into the existing lvce-editor stylesheets so the main-area worker only needs to emit state-dependent CSS.