### PR TITLE
Restore shared-process release headers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -44,7 +44,13 @@
       "project": ["index.js", "bin/**/*.js", "src/**/*.js"]
     },
     "packages/shared-process": {
-      "entry": ["bin/sharedProcess.ts", "src/sharedProcessMain.ts", "test/**/*.test.ts"],
+      "entry": [
+        "bin/sharedProcess.ts",
+        "src/sharedProcessMain.ts",
+        "src/parts/GetHeadersDefault/GetHeadersDefault.ts",
+        "src/parts/GetHeadersOtherWorker/GetHeadersOtherWorker.ts",
+        "test/**/*.test.ts"
+      ],
       "project": ["bin/**/*.ts", "src/**/*.ts", "test/**/*.ts"],
       "ignoreDependencies": ["@lvce-editor/static-server"]
     },

--- a/packages/shared-process/src/parts/GetHeadersDefault/GetHeadersDefault.ts
+++ b/packages/shared-process/src/parts/GetHeadersDefault/GetHeadersDefault.ts
@@ -1,0 +1,3 @@
+export const getHeadersDefault = (): any => {
+  return {}
+}

--- a/packages/shared-process/src/parts/GetHeadersOtherWorker/GetHeadersOtherWorker.ts
+++ b/packages/shared-process/src/parts/GetHeadersOtherWorker/GetHeadersOtherWorker.ts
@@ -1,0 +1,14 @@
+import * as ContentSecurityPolicyState from '../ContentSecurityPolicyState/ContentSecurityPolicyState.ts'
+import * as CrossOriginEmbedderPolicy from '../CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicy.ts'
+import * as HttpHeader from '../HttpHeader/HttpHeader.ts'
+
+export const getHeadersOtherWorker = (url: any): any => {
+  const headers: Record<string, any> = {
+    [HttpHeader.CrossOriginEmbedderPolicy]: CrossOriginEmbedderPolicy.value,
+  }
+  const dynamicCsp = ContentSecurityPolicyState.get(url)
+  if (dynamicCsp) {
+    headers[HttpHeader.ContentSecurityPolicy] = dynamicCsp
+  }
+  return headers
+}


### PR DESCRIPTION
Restore the two build-only header modules referenced by the shared-process release bundle and register them as explicit Knip entry points. This fixes the published server failing at startup after the Knip cleanup.