### PR TITLE
Restore shared-process bin resolution

### DIFF
--- a/packages/shared-process/src/parts/ResolveBin/ResolveBin.ts
+++ b/packages/shared-process/src/parts/ResolveBin/ResolveBin.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url'
+
+export const resolveBin = (name: any): any => {
+  try {
+    const uri = import.meta.resolve(name)
+    const path = fileURLToPath(uri)
+    return path
+  } catch {
+    return ''
+  }
+}

--- a/packages/shared-process/test/ResolveBin.test.ts
+++ b/packages/shared-process/test/ResolveBin.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import * as ResolveBin from '../src/parts/ResolveBin/ResolveBin.js'
+
+test('resolveBin - existing package', () => {
+  expect(ResolveBin.resolveBin('@lvce-editor/assert')).toContain('assert')
+})
+
+test('resolveBin - missing package', () => {
+  expect(ResolveBin.resolveBin('@lvce-editor/does-not-exist')).toBe('')
+})


### PR DESCRIPTION
Restore the build-only ResolveBin module used by packaged server process paths and cover both successful and missing package resolution. This completes the runtime modules removed by the Knip cleanup.