### PR TITLE
fix: load icon themes in Electron development

### DIFF
--- a/packages/renderer-worker/src/parts/IconTheme/IconTheme.js
+++ b/packages/renderer-worker/src/parts/IconTheme/IconTheme.js
@@ -1,15 +1,24 @@
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as HandleIconThemeChange from '../HandleIconThemeChange/HandleIconThemeChange.js'
 import * as IconThemeWorker from '../IconThemeWorker/IconThemeWorker.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import { VError } from '../VError/VError.js'
 import * as Workspace from '../Workspace/Workspace.js'
+
+export const getIconThemePlatform = (platform, assetDir) => {
+  if (platform === PlatformType.Electron && !assetDir) {
+    return PlatformType.Remote
+  }
+  return platform
+}
 
 export const setIconTheme = async (iconThemeId, platform, assetDir) => {
   try {
     const useCache = Preferences.get('icon-theme.cache') ?? true
     const extensions = await ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, platform)
-    await IconThemeWorker.invoke('IconTheme.getIconThemeJson', extensions, iconThemeId, assetDir, platform, useCache)
+    const iconThemePlatform = getIconThemePlatform(platform, assetDir)
+    await IconThemeWorker.invoke('IconTheme.getIconThemeJson', extensions, iconThemeId, assetDir, iconThemePlatform, useCache)
     await HandleIconThemeChange.handleIconThemeChange()
   } catch (error) {
     if (Workspace.isTest()) {
@@ -22,7 +31,7 @@ export const setIconTheme = async (iconThemeId, platform, assetDir) => {
 
 export const hydrate = async (platform, assetDir) => {
   // TODO do this all in worker
-  const iconThemeId = Preferences.get('icon-theme') || 'vscode-icons'
+  const iconThemeId = Preferences.get('workbench.iconTheme') || 'vscode-icons'
   await setIconTheme(iconThemeId, platform, assetDir)
 }
 

--- a/packages/renderer-worker/test/IconTheme.test.ts
+++ b/packages/renderer-worker/test/IconTheme.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/HandleIconThemeChange/HandleIconThemeChange.js', () => ({
+  handleIconThemeChange: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/IconThemeWorker/IconThemeWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  get: jest.fn(),
+}))
+
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const IconTheme = await import('../src/parts/IconTheme/IconTheme.js')
+const IconThemeWorker = await import('../src/parts/IconThemeWorker/IconThemeWorker.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  ExtensionManagementWorker.invoke.mockResolvedValue([])
+})
+
+test('setIconTheme uses remote icon paths in the Electron development server', async () => {
+  await IconTheme.setIconTheme('vscode-icons', PlatformType.Electron, '')
+
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '', PlatformType.Remote, true)
+})
+
+test('setIconTheme keeps optimized icon paths in a packaged Electron app', async () => {
+  await IconTheme.setIconTheme('vscode-icons', PlatformType.Electron, '/static/commit')
+
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '/static/commit', PlatformType.Electron, true)
+})
+
+test('hydrate uses the configured workbench icon theme', async () => {
+  Preferences.get.mockImplementation((key) => {
+    if (key === 'workbench.iconTheme') {
+      return 'custom-icons'
+    }
+    return undefined
+  })
+
+  await IconTheme.hydrate(PlatformType.Remote, '/static')
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.getAllExtensions', '/static', PlatformType.Remote)
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'custom-icons', '/static', PlatformType.Remote, true)
+})


### PR DESCRIPTION
Loads remote icon paths when Electron runs without a packaged asset directory, while preserving packaged paths. Also reads the configured workbench.iconTheme preference and adds regression coverage.