### PR TITLE
feature: verify signed macOS CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,53 @@ jobs:
       - name: Build Electron App (deb, armhf)
         if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'armhf'
         run: npm run build:electron:deb:armhf
+      - name: Prepare Apple API key
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+        shell: bash
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+        run: |
+          for secret in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID MAC_CSC_LINK MAC_CSC_KEY_PASSWORD; do
+            test -n "${!secret}" || { echo "Required macOS signing secret is missing: $secret"; exit 1; }
+          done
+          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
+          chmod 600 "$api_key_path"
+          echo "APPLE_API_KEY_PATH=$api_key_path" >> $GITHUB_ENV
       - name: Build Electron App (Macos dmg, arm64)
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
         run: npm run build:electron:mac:arm64
+        env:
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: Verify signed and notarized macOS installer
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+        shell: bash
+        run: |
+          app_path="$(find packages/build/.tmp/electron-builder/dist -maxdepth 3 -name '*.app' -print -quit)"
+          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
+          test -n "$app_path"
+          test -f "$dmg_path"
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          spctl --assess --type execute --verbose "$app_path"
+          xcrun stapler validate "$app_path"
+          xcrun stapler validate "$dmg_path"
+      - name: Upload signed macOS installer
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: lvce-macos-arm64
+          path: packages/build/.tmp/releases/lvce-arm64.dmg
+          if-no-files-found: error
       - name: Cache Electron Builder Dependencies (Windows)
         uses: actions/cache@v6
         id: electron-builder-cache-windows

--- a/packages/build/Build-Macos.md
+++ b/packages/build/Build-Macos.md
@@ -8,7 +8,7 @@ node bin/build.js --target=electron-builder-mac
 
 ## Code signing and notarization
 
-Release DMGs are signed and notarized by the GitHub Actions release workflow when the macOS signing secrets are present. PR and normal CI builds do not receive these secrets.
+Release DMGs and builds from the trusted `main` CI workflow are signed and notarized when the macOS signing secrets are present. The CI workflow verifies the signature and notarization ticket before uploading the arm64 DMG as an artifact. Pull-request builds intentionally remain unsigned because repository secrets are not exposed to untrusted pull-request code.
 
 ### Apple setup
 


### PR DESCRIPTION
Prepares Apple signing credentials for trusted main CI, verifies the signed and notarized arm64 app and DMG, and uploads the installer artifact. Updates the macOS build documentation to match.