### PR TITLE
fix: improve title bar styling on macOS

### DIFF
--- a/static/css/parts/TitleBarEntry.css
+++ b/static/css/parts/TitleBarEntry.css
@@ -1,4 +1,5 @@
 .TitleBarTopLevelEntry {
+  appearance: none;
   display: flex;
   align-items: center;
   padding: 0 8px;

--- a/static/css/parts/ViewletTitleBar.css
+++ b/static/css/parts/ViewletTitleBar.css
@@ -1,5 +1,7 @@
 .TitleBar {
   display: flex;
+  box-sizing: border-box;
+  padding-left: env(titlebar-area-x, 0px);
   color: var(--TitleBarForeground, rgba(204, 204, 204, 0.6));
   -webkit-app-region: no-drag;
   app-region: no-drag;


### PR DESCRIPTION
Resets native appearance for title-bar entries and respects the title-bar safe-area inset. This keeps custom controls and layout consistent on macOS.