### PR TITLE
fix: support Command+S in Electron on macOS

### DIFF
--- a/packages/main-process/src/handleMacOsSaveShortcut.js
+++ b/packages/main-process/src/handleMacOsSaveShortcut.js
@@ -1,0 +1,22 @@
+const isMacOsSaveShortcut = (input, platform) => {
+  return platform === 'darwin' && input.type === 'keyDown' && input.meta && !input.control && !input.shift && input.key?.toLowerCase() === 's'
+}
+
+export const handleMacOsSaveShortcut = (event, input, webContents, platform = process.platform) => {
+  if (!isMacOsSaveShortcut(input, platform)) {
+    return
+  }
+  event.preventDefault()
+  queueMicrotask(() => {
+    webContents.sendInputEvent({
+      keyCode: 'S',
+      modifiers: ['control'],
+      type: 'keyDown',
+    })
+    webContents.sendInputEvent({
+      keyCode: 'S',
+      modifiers: ['control'],
+      type: 'keyUp',
+    })
+  })
+}

--- a/packages/main-process/src/mainProcessMain.js
+++ b/packages/main-process/src/mainProcessMain.js
@@ -1,5 +1,6 @@
 import { app } from 'electron'
 import { join } from 'node:path'
+import { handleMacOsSaveShortcut } from './handleMacOsSaveShortcut.js'
 
 const root = process.env.LVCE_ROOT || process.cwd()
 const iconPath = join(root, 'packages', 'build', 'files', 'icon.png')
@@ -13,6 +14,9 @@ if (isPromptMode) {
 app.setName('Lvce Editor')
 app.on('browser-window-created', (_event, window) => {
   window.setIcon(iconPath)
+  window.webContents.on('before-input-event', (event, input) => {
+    handleMacOsSaveShortcut(event, input, window.webContents)
+  })
 })
 
 await import('@lvce-editor/main-process')

--- a/packages/main-process/test/HandleMacOsSaveShortcut.test.js
+++ b/packages/main-process/test/HandleMacOsSaveShortcut.test.js
@@ -1,0 +1,79 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { handleMacOsSaveShortcut } from '../src/handleMacOsSaveShortcut.js'
+
+const event = {
+  preventDefault: jest.fn(),
+}
+
+const webContents = {
+  sendInputEvent: jest.fn(),
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('translates Command+S to the existing Control+S save binding on macOS', async () => {
+  handleMacOsSaveShortcut(
+    event,
+    {
+      control: false,
+      key: 's',
+      meta: true,
+      shift: false,
+      type: 'keyDown',
+    },
+    webContents,
+    'darwin',
+  )
+  await Promise.resolve()
+
+  expect(event.preventDefault).toHaveBeenCalledTimes(1)
+  expect(webContents.sendInputEvent).toHaveBeenNthCalledWith(1, {
+    keyCode: 'S',
+    modifiers: ['control'],
+    type: 'keyDown',
+  })
+  expect(webContents.sendInputEvent).toHaveBeenNthCalledWith(2, {
+    keyCode: 'S',
+    modifiers: ['control'],
+    type: 'keyUp',
+  })
+})
+
+test('leaves Command+Shift+S unchanged', async () => {
+  handleMacOsSaveShortcut(
+    event,
+    {
+      control: false,
+      key: 'S',
+      meta: true,
+      shift: true,
+      type: 'keyDown',
+    },
+    webContents,
+    'darwin',
+  )
+  await Promise.resolve()
+
+  expect(event.preventDefault).not.toHaveBeenCalled()
+  expect(webContents.sendInputEvent).not.toHaveBeenCalled()
+})
+
+test('leaves other input unchanged', () => {
+  handleMacOsSaveShortcut(
+    event,
+    {
+      control: false,
+      key: 's',
+      meta: true,
+      shift: false,
+      type: 'keyDown',
+    },
+    webContents,
+    'linux',
+  )
+
+  expect(event.preventDefault).not.toHaveBeenCalled()
+  expect(webContents.sendInputEvent).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Adds a macOS Command+S handler in Electron that forwards to the editor’s existing Control+S save binding. Includes regression coverage for translated and ignored shortcuts.