### PR TITLE
fix: make macOS signing optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Build Electron App (deb, armhf)
         if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'armhf'
         run: npm run build:electron:deb:armhf
-      - name: Prepare Apple API key
+      - name: Configure optional macOS signing
+        id: macos-signing
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
         shell: bash
         env:
@@ -120,14 +121,24 @@ jobs:
           MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
         run: |
           for secret in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID MAC_CSC_LINK MAC_CSC_KEY_PASSWORD; do
-            test -n "${!secret}" || { echo "Required macOS signing secret is missing: $secret"; exit 1; }
+            if [ -z "${!secret}" ]; then
+              echo "macOS signing is disabled because one or more signing secrets are unavailable."
+              echo "enabled=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           done
           api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
           printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
           chmod 600 "$api_key_path"
-          echo "APPLE_API_KEY_PATH=$api_key_path" >> $GITHUB_ENV
-      - name: Build Electron App (Macos dmg, arm64)
-        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+          echo "APPLE_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+      - name: Build Electron App (Macos dmg, arm64, unsigned)
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled != 'true'
+        run: npm run build:electron:mac:arm64
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+      - name: Build Electron App (Macos dmg, arm64, signed)
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         run: npm run build:electron:mac:arm64
         env:
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
@@ -137,7 +148,7 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       - name: Verify signed and notarized macOS installer
-        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         shell: bash
         run: |
           app_path="$(find packages/build/.tmp/electron-builder/dist -maxdepth 3 -name '*.app' -print -quit)"
@@ -149,7 +160,7 @@ jobs:
           xcrun stapler validate "$app_path"
           xcrun stapler validate "$dmg_path"
       - name: Upload signed macOS installer
-        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: lvce-macos-arm64


### PR DESCRIPTION
## Summary

- allow the macOS CI job to build unsigned when signing credentials are unavailable or incomplete
- preserve certificate signing, notarization verification, and signed artifact upload when the full credential set is available
- continue failing for malformed or invalid configured credentials instead of silently falling back

## Root cause and impact

The macOS arm64 job failed before building because its signing setup required every Apple secret, even in environments where signing credentials are intentionally unavailable. This keeps ordinary CI builds working while retaining the release-grade signed path whenever credentials are configured.

## Validation

- workflow formatting with Prettier
- YAML syntax parsing
- whitespace and diff checks
- Bash simulations for both missing-credential and complete-credential branches
