### PR TITLE
fix: make macOS release signing optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,19 +209,37 @@ jobs:
       #     asset_path: ${{ env.ASSET_DMG_X64 }}
       #     asset_name: ${{ env.ASSET_DMG_X64 }}
       #     asset_content_type: application/octet-stream
-      - name: Prepare Apple API key
+      - name: Configure optional macOS signing
+        id: macos-signing
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
         shell: bash
         env:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
         run: |
+          for secret in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID MAC_CSC_LINK MAC_CSC_KEY_PASSWORD; do
+            if [ -z "${!secret}" ]; then
+              echo "macOS signing is disabled because one or more signing secrets are unavailable."
+              echo "enabled=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
           api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
           printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
           chmod 600 "$api_key_path"
           echo "APPLE_API_KEY_PATH=$api_key_path" >> $GITHUB_ENV
-      - name: Build Electron App (Macos dmg, arm64)
-        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+      - name: Build Electron App (Macos dmg, arm64, unsigned)
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled != 'true'
+        run: npm run build:electron:mac:arm64 -- --product=lvce
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+      - name: Build Electron App (Macos dmg, arm64, signed)
+        if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         run: npm run build:electron:mac:arm64 -- --product=lvce
         env:
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}


### PR DESCRIPTION
Allow release builds to publish the macOS arm64 DMG unsigned when Apple signing credentials are unavailable, while retaining the signed path when credentials are configured.