### PR TITLE
fix: bridge current viewlet drag data

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -426,6 +426,7 @@ export const commandMap = {
   'Viewlet.focus': lazy('Viewlet.focus'),
   'Viewlet.resize': lazy('Viewlet.resize'),
   'Viewlet.getAllStates': lazy('Viewlet.getAllStates'),
+  'Viewlet.getDragData': lazy('Viewlet.getDragData'),
   'Viewlet.getTitle': lazy('Viewlet.getTitle'),
   'Viewlet.openWidget': lazy('Viewlet.openWidget'),
   'Viewlet.send': lazy('Viewlet.send'),

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
@@ -8,6 +8,7 @@ export const Commands = {
   executeViewletCommand: Viewlet.executeViewletCommand,
   focus: Viewlet.focus,
   getAllStates: Viewlet.getAllStates,
+  getDragData: Viewlet.getDragData,
   getTitle: Viewlet.getTitle,
   openWidget: Viewlet.openWidget,
   send: Viewlet.send,

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -27,6 +27,10 @@ export const getTitle = (id) => {
   return instance.factory.getTitle(instance.state.uid)
 }
 
+export const getDragData = () => {
+  return RendererProcess.invoke('Viewlet.getDragData')
+}
+
 export const focus = async (id) => {
   const instance = ViewletStates.getInstance(id)
   if (!instance) {

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -100,7 +100,7 @@ test('getDragData', async () => {
     ],
     label: '1',
   }
-  RendererProcess.invoke.mockResolvedValue(dragData)
+  jest.mocked(RendererProcess.invoke).mockResolvedValue(dragData)
 
   await expect(Viewlet.getDragData()).resolves.toBe(dragData)
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.getDragData')

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -90,6 +90,22 @@ test('getTitle', async () => {
   expect(getTitle).toHaveBeenCalledWith(1)
 })
 
+test('getDragData', async () => {
+  const dragData = {
+    items: [
+      {
+        data: 'file:///workspace/file.txt',
+        type: 'text/uri-list',
+      },
+    ],
+    label: '1',
+  }
+  RendererProcess.invoke.mockResolvedValue(dragData)
+
+  await expect(Viewlet.getDragData()).resolves.toBe(dragData)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.getDragData')
+})
+
 test('getFocusCommands returns focus render commands without sending them', async () => {
   const oldState = { uid: 2 }
   const newState = { focus: 1, uid: 2 }


### PR DESCRIPTION
Bridge the renderer process drag payload through renderer-worker so isolated view workers can resolve internal explorer drops.