### PR TITLE
fix: align panel sash highlight

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -104,7 +104,7 @@ test('bundleCss keeps the panel and panel sash within the non-preview area', asy
   width: var(--PanelWidth);
 }`)
     expect(css).toContain(`.SashPanel {
-  top: var(--SashPanelTop);
+  top: calc(var(--SashPanelTop) - 2px);
   width: var(--PanelWidth);
 }`)
   } finally {

--- a/static/css/parts/ViewletSash.css
+++ b/static/css/parts/ViewletSash.css
@@ -66,7 +66,7 @@
 }
 
 .SashPanel {
-  top: var(--SashPanelTop);
+  top: calc(var(--SashPanelTop) - 2px);
   width: var(--PanelWidth);
 }
 


### PR DESCRIPTION
Moves the panel resize sash up by 2px so its active highlight and hit area are centered on the panel border.