### PR TITLE
fix: add output channel scrollbars

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/viewlet.output-scrolling/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/viewlet.output-scrolling/extension.json
@@ -1,0 +1,5 @@
+{
+  "browser": "main.js",
+  "main": "main.js",
+  "activation": ["onOutput"]
+}

--- a/packages/extension-host-worker-tests/fixtures/viewlet.output-scrolling/main.js
+++ b/packages/extension-host-worker-tests/fixtures/viewlet.output-scrolling/main.js
@@ -1,0 +1,17 @@
+const outputChannelProvider = {
+  id: 'scrolling',
+  label: 'Scrolling',
+}
+
+const getContent = () => {
+  const lines = []
+  for (let index = 1; index <= 100; index++) {
+    lines.push(`line ${index} ${'content '.repeat(30)}`)
+  }
+  return lines.join('\n')
+}
+
+export const activate = () => {
+  const channel = vscode.registerOutputChannel(outputChannelProvider)
+  channel.append(getContent())
+}

--- a/packages/extension-host-worker-tests/src/viewlet.output-scrolling.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.output-scrolling.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.output-scrolling'
+
+export const test: Test = async ({ Command, expect, Extension, FileSystem, KeyBoard, Locator, Output, Panel }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await FileSystem.writeFile(`${tmpDir}/test.txt`, '')
+  const extensionUri = import.meta.resolve('../fixtures/viewlet.output-scrolling')
+  await Extension.addWebExtension(extensionUri)
+  await Panel.open('Output')
+  await Command.execute('Panel.selectIndex', 1)
+  await Output.selectChannel('scrolling')
+
+  const outputContent = Locator('.OutputContent')
+  const lines = Locator('.OutputContent .Line')
+  const firstLine = lines.nth(0)
+  const lastLine = lines.nth(99)
+  await expect(outputContent).toHaveCSS('overflow-x', 'auto')
+  await expect(outputContent).toHaveCSS('overflow-y', 'auto')
+  await expect(firstLine).toBeVisible()
+  await expect(lastLine).not.toBeVisible()
+
+  await outputContent.click()
+  await expect(outputContent).toBeFocused()
+  await KeyBoard.press('End')
+
+  await expect(lastLine).toBeVisible()
+}

--- a/static/css/parts/ViewletOutput.css
+++ b/static/css/parts/ViewletOutput.css
@@ -1,5 +1,9 @@
 .Output {
+  display: flex;
+  flex-direction: column;
   flex: 1;
+  min-width: 0;
+  min-height: 0;
 }
 
 .Output:focus {
@@ -14,10 +18,13 @@
 }
 
 .OutputContent {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
   white-space: pre;
   user-select: text;
   cursor: text;
-  overflow-y: auto;
+  overflow: auto;
 }
 
 .ViewletOutput .Line {


### PR DESCRIPTION
Fix output channels so overflowing content stays within the panel and exposes vertical and horizontal browser scrollbars. Add an end-to-end regression covering keyboard scrolling to the final output line.