### PR TITLE
fix: resize activity bar with panel

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-panel-resize.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-panel-resize.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.activity-bar-panel-resize'
+
+export const test: Test = async ({ Command, Locator, expect }) => {
+  const additionalViews = Locator('.ActivityBarItem[title="Additional Views"]')
+  const search = Locator('.ActivityBarItem[title="Search"]')
+
+  await Command.execute('Layout.handleResize', 800, 720)
+  await Command.execute('Layout.showPanel', 'Problems')
+  await Command.execute('Layout.handleSashPointerDown', 'Panel')
+  await Command.execute('Layout.handleSashPointerMove', 0, 180)
+
+  await expect(additionalViews).toBeVisible()
+  await expect(search).toHaveCount(0)
+
+  await Command.execute('Layout.handleSashPointerMove', 0, 600)
+
+  await expect(additionalViews).toHaveCount(0)
+  await expect(search).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -100,7 +100,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
     const destinationActivityBarLeft = p8
     const destinationActivityBarTop = p2
     const destinationActivityBarWidth = 48
-    const destinationActivityBarHeight = p4 - p2
+    const destinationActivityBarHeight = p3 - p2
     const destinationActivityBarVisible = activityBarVisible
 
     // Calculate sidebar width for left section
@@ -241,7 +241,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
     const destinationActivityBarLeft = p6
     const destinationActivityBarTop = p2
     const destinationActivityBarWidth = 48
-    const destinationActivityBarHeight = p4 - p2
+    const destinationActivityBarHeight = p3 - p2
     const destinationActivityBarVisible = activityBarVisible
 
     const maxSecondarySideBarWidth = Math.max(0, availableWidth - p8 - mainMinWidth)

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1446,38 +1446,41 @@ const getNewStatePointerMoveActivityBar = async (state: LayoutState, x: number, 
 const getNewStatePointerMovePanel = async (state: LayoutState, x: number, y: number): Promise<{ newState: LayoutState; commands: any[] }> => {
   const windowHeight = state[LayoutKeys.WindowHeight]
   const statusBarHeight = state[LayoutKeys.StatusBarHeight]
-  const titleBarHeight = state[LayoutKeys.TitleBarHeight]
-  const activityBarHeight = state[LayoutKeys.ActivityBarHeight]
   const panelMinHeight = state[LayoutKeys.PanelMinHeight]
   const newPanelHeight = windowHeight - statusBarHeight - y
   if (newPanelHeight < panelMinHeight / 2) {
     return {
-      newState: {
-        ...state,
-        panelVisible: false,
-        mainHeight: windowHeight - statusBarHeight - titleBarHeight,
-      },
+      newState: getPoints(
+        {
+          ...state,
+          panelVisible: false,
+        },
+        state.sideBarLocation,
+      ),
       commands: [],
     }
   } else if (newPanelHeight <= panelMinHeight) {
     return {
-      newState: {
-        ...state,
-        panelVisible: true,
-        panelHeight: panelMinHeight,
-        mainHeight: windowHeight - activityBarHeight - panelMinHeight,
-      },
+      newState: getPoints(
+        {
+          ...state,
+          panelVisible: true,
+          panelHeight: panelMinHeight,
+        },
+        state.sideBarLocation,
+      ),
       commands: [],
     }
   } else {
     return {
-      newState: {
-        ...state,
-        panelVisible: true,
-        mainHeight: y - titleBarHeight,
-        panelTop: y,
-        panelHeight: windowHeight - statusBarHeight - y,
-      },
+      newState: getPoints(
+        {
+          ...state,
+          panelVisible: true,
+          panelHeight: newPanelHeight,
+        },
+        state.sideBarLocation,
+      ),
       commands: [],
     }
   }

--- a/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
@@ -25,6 +25,7 @@ jest.unstable_mockModule('../src/parts/PanelWorker/PanelWorker.js', () => {
 })
 
 const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+const LayoutPoints = await import('../src/parts/ViewletLayout/LayoutPoints.ts')
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 beforeEach(() => {
@@ -134,6 +135,35 @@ test('create initializes panelHeightBeforeMaximize to 0', () => {
   const state = ViewletLayout.create(1)
 
   expect(state.panelHeightBeforeMaximize).toBe(0)
+})
+
+test('resizing the panel updates the activity bar height', async () => {
+  createActivityBarInstance()
+  const state = LayoutPoints.getPoints({
+    ...ViewletLayout.create(1),
+    activityBarVisible: true,
+    panelHeight: 200,
+    panelMaxHeight: 600,
+    panelMinHeight: 150,
+    panelVisible: true,
+    sashId: 'Panel',
+    statusBarHeight: 20,
+    statusBarVisible: true,
+    titleBarHeight: 0,
+    titleBarVisible: false,
+    windowHeight: 800,
+    windowWidth: 1200,
+  })
+
+  const shrunken = await ViewletLayout.handleSashPointerMove(state, 0, 400)
+
+  expect(shrunken.newState.activityBarHeight).toBe(400)
+  expect(shrunken.commands).toContainEqual(['Viewlet.setBounds', 88, 1152, 0, 48, 400])
+
+  const expanded = await ViewletLayout.handleSashPointerMove(shrunken.newState, 0, 600)
+
+  expect(expanded.newState.activityBarHeight).toBe(600)
+  expect(expanded.commands).toContainEqual(['Viewlet.setBounds', 88, 1152, 0, 48, 600])
 })
 
 test('maximizePanel enlarges panel and sets panelMaximized to true', async () => {


### PR DESCRIPTION
Updates activity-bar bounds while the panel sash moves so overflow items recalculate immediately. Adds focused unit and e2e coverage for shrinking and expanding the available activity-bar space.