### PR TITLE
feature: make nvmrc language features builtin

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -360,6 +360,12 @@
     "created": "2024-02-28"
   },
   {
+    "name": "builtin.language-features-nvmrc",
+    "repository": "github.com/lvce-editor/language-features-nvmrc",
+    "version": "1.4.0",
+    "created": "2026-07-09"
+  },
+  {
     "name": "builtin.language-features-typescript",
     "repository": "github.com/lvce-editor/language-features-typescript",
     "version": "5.14.0",


### PR DESCRIPTION
Adds the NVMRC language-features extension to the default built-in extension catalog at its current v1.4.0 release.