### PR TITLE
fix: align preferred preview layout

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -105,7 +105,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
 
     // Calculate sidebar width for left section
     const maxSideBarWidth = Math.max(0, availableWidth - 48 - mainMinWidth)
-    const adjustedSideBarWidth = Math.min(newSideBarWidth, maxSideBarWidth)
+    const adjustedSideBarWidth = sideBarVisible ? Math.min(newSideBarWidth, maxSideBarWidth) : 0
     let p7 = p8 - adjustedSideBarWidth
     if (sideBarVisible && p7 < 0) {
       p7 = 0
@@ -129,7 +129,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
 
     const destinationSideBarLeft = p7
     const destinationSideBarTop = p2
-    const destinationSideBarWidth = adjustedSideBarWidth
+    const destinationSideBarWidth = sideBarVisible ? adjustedSideBarWidth : newSideBarWidth
     const destinationSideBarHeight = p3 - p2
     const destinationSideBarVisible = sideBarVisible
 
@@ -265,7 +265,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = SideBarLocation
 
     const destinationSideBarLeft = p7
     const destinationSideBarTop = p2
-    const destinationSideBarWidth = p8 - p7
+    const destinationSideBarWidth = sideBarVisible ? p8 - p7 : newSideBarWidth
     const destinationSideBarHeight = p3 - p2
     const destinationSideBarVisible = sideBarVisible
 

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -375,7 +375,7 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
     previewViewletId,
     restore,
     sideBarLocation,
-    sideBarSashVisible: true,
+    sideBarSashVisible: sideBarVisible,
     sideBarFocusMode: false,
     sideBarFocusModeLayout: undefined,
     sideBarFocusModeTarget: 'primary',
@@ -409,6 +409,7 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
     ...state,
     [kVisible]: true,
     ...(module === LayoutModules.Preview ? { previewSashVisible: true } : {}),
+    ...(module === LayoutModules.SideBar ? { sideBarSashVisible: true } : {}),
   })
   const x = intermediateState[kLeft]
   const y = intermediateState[kTop]
@@ -626,6 +627,7 @@ const hide = async (state: LayoutState, module): Promise<{ newState: LayoutState
           previewSashVisible: false,
         }
       : {}),
+    ...(module === LayoutModules.SideBar ? { sideBarSashVisible: false } : {}),
   })
   // TODO save state to local storage after rending (in background)
   if (isPreview) {
@@ -681,7 +683,14 @@ export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<L
       return hidePreview(state)
     }
     const sideBarResult = state.sideBarVisible ? await hideSideBar(state) : { newState: state, commands: [] }
-    const previewResult = await showPreview(sideBarResult.newState, sideBarView, ViewletModuleId.ExtensionView)
+    const previewState = getPoints(
+      {
+        ...sideBarResult.newState,
+        previewWidth: sideBarResult.newState.windowWidth / 2,
+      },
+      sideBarResult.newState.sideBarLocation,
+    )
+    const previewResult = await showPreview(previewState, sideBarView, ViewletModuleId.ExtensionView)
     const focusCommands = await Viewlet.getFocusCommands(sideBarView)
     return {
       newState: previewResult.newState,
@@ -1488,12 +1497,15 @@ const getNewStatePointerMovePanel = async (state: LayoutState, x: number, y: num
 
 const getNewStatePointerMovePreview = async (state: LayoutState, x: number): Promise<{ newState: LayoutState; commands: any[] }> => {
   const windowWidth = state.windowWidth
+  const previewWidth = Math.max(state.previewMinWidth, windowWidth - x)
   return {
-    newState: {
-      ...state,
-      previewLeft: x,
-      previewWidth: windowWidth - x,
-    },
+    newState: getPoints(
+      {
+        ...state,
+        previewWidth,
+      },
+      state.sideBarLocation,
+    ),
     commands: [],
   }
 }

--- a/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
@@ -125,7 +125,7 @@ test('setExplicitBounds enables explicit bounds and resizes layout', async () =>
     windowHeight: 320,
     mainLeft: 0,
     mainTop: 35,
-    mainWidth: 262,
+    mainWidth: 432,
     mainHeight: 265,
   })
   expect(result.commands).toEqual([['Viewlet.setBounds', 88, 432, 35, 48, 265]])

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -327,18 +327,30 @@ test('showPreview replaces an open file preview with the simple browser', async 
   })
 })
 
-test('resizing the preview preserves its vertical position', async () => {
+test('resizing the preview updates the adjoining layout and preserves its vertical position', async () => {
   const state = {
     ...ViewletLayout.create(1),
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    mainWidth: 752,
+    panelVisible: true,
+    panelWidth: 800,
     previewHeight: 745,
     previewId: 7,
     previewLeft: 800,
+    previewMinWidth: 100,
     previewTop: 35,
     previewUri: 'simple-browser://',
     previewViewletId: 'SimpleBrowser',
     previewVisible: true,
     previewWidth: 400,
     sashId: 'Preview',
+    sideBarVisible: false,
+    statusBarHeight: 20,
+    statusBarVisible: true,
+    statusBarWidth: 800,
+    titleBarHeight: 35,
+    titleBarVisible: true,
     windowHeight: 800,
     windowWidth: 1200,
   }
@@ -346,10 +358,14 @@ test('resizing the preview preserves its vertical position', async () => {
   const result = await ViewletLayout.handleSashPointerMove(state, 700, 400)
 
   expect(result.newState).toMatchObject({
-    previewHeight: 745,
+    activityBarLeft: 652,
+    mainWidth: 652,
+    panelWidth: 700,
+    previewHeight: 765,
     previewLeft: 700,
     previewTop: 35,
     previewWidth: 500,
+    statusBarWidth: 700,
   })
 })
 

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -174,6 +174,7 @@ test('showSideBar shows hidden side bar with requested viewlet', async () => {
   expect(result).toEqual({
     commands: [['Viewlet.createFunctionalRoot', 'SideBar', 1, true], ['activity-bar.render2']],
     newState: expect.objectContaining({
+      sideBarSashVisible: true,
       sideBarView: 'SourceControl',
       sideBarVisible: true,
     }),
@@ -340,6 +341,7 @@ test('hideSideBar updates activity bar through shared sidebar render helper', as
   expect(result).toEqual({
     commands: [['activity-bar.render2']],
     newState: expect.objectContaining({
+      sideBarSashVisible: false,
       sideBarView: 'Explorer',
       sideBarVisible: false,
     }),
@@ -566,26 +568,36 @@ test('toggleSideBarView opens a preview-preferred extension view in the preview 
     activityBarVisible: true,
     activityBarWidth: 48,
     sideBarId: 12,
+    sideBarSashVisible: true,
     sideBarView: 'Explorer',
     sideBarVisible: true,
+    sideBarWidth: 240,
     statusBarHeight: 20,
     titleBarHeight: 0,
     windowHeight: 800,
     windowWidth: 1200,
+    previewMinWidth: 100,
+    previewWidth: 320,
   }
 
   const result = await ViewletLayout.toggleSideBarView(state, 'sample.views.preview')
 
   expect(result.newState).toMatchObject({
+    mainWidth: 552,
+    previewLeft: 600,
     previewUri: 'sample.views.preview',
     previewViewletId: 'ExtensionView',
     previewVisible: true,
+    previewWidth: 600,
+    sideBarSashVisible: false,
     sideBarVisible: false,
   })
   expect(ViewletManager.load).toHaveBeenCalledWith(
     expect.objectContaining({
       id: 'ExtensionView',
       uri: 'sample.views.preview',
+      width: 600,
+      x: 600,
     }),
     false,
     true,


### PR DESCRIPTION
Fix preferred preview views such as Trello so they open in a true 50/50 split.

Keep sidebar and preview sash visibility and geometry synchronized, including while resizing the preview.