### PR TITLE
fix: cache built-in icon theme by content

### DIFF
--- a/packages/build/src/parts/BuildStatic/BuildStatic.ts
+++ b/packages/build/src/parts/BuildStatic/BuildStatic.ts
@@ -10,6 +10,7 @@ import * as CodiconsPath from '../CodiconsPath/CodiconsPath.ts'
 import * as CopySourceFiles from '../CopySourceFiles/CopySourceFiles.ts'
 import * as GetCommitDate from '../GetCommitDate/GetCommitDate.ts'
 import * as GetAllExtensionsJson from '../GetAllExtensionsJson/GetAllExtensionsJson.ts'
+import * as GetIconThemeEtag from '../GetIconThemeEtag/GetIconThemeEtag.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import { isWebCompatibleExtension } from '../IsWebCompatibleExtension/IsWebCompatibleExtension.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
@@ -392,7 +393,7 @@ const copyIconThemes = async ({ commitHash }) => {
   })
 }
 
-const bundleJs = async ({ commitHash, platform, assetDir, version, date, product }) => {
+const bundleJs = async ({ commitHash, platform, assetDir, version, date, product, iconThemeEtag }) => {
   const toRoot = `packages/build/.tmp/dist/${commitHash}`
   await BundleWorkers.bundleWorkers({
     commitHash,
@@ -402,6 +403,7 @@ const bundleJs = async ({ commitHash, platform, assetDir, version, date, product
     version,
     date,
     toRoot,
+    iconThemeEtag,
   })
 }
 
@@ -554,6 +556,7 @@ export const build = async ({ product }) => {
   const assetDir = `${pathPrefix}/${commitHash}`
   const platform = 'web'
   const version = await Version.getVersion()
+  const iconThemeEtag = ignoreIconTheme ? '' : await GetIconThemeEtag.getIconThemeEtag({ iconPath: '/file-icons' })
 
   Console.time('clean')
   await Remove.remove('packages/build/.tmp/dist')
@@ -580,7 +583,7 @@ export const build = async ({ product }) => {
   Console.timeEnd('applyJsOverrides')
 
   Console.time('bundleJs')
-  await bundleJs({ commitHash, platform, assetDir, version, date, product })
+  await bundleJs({ commitHash, platform, assetDir, version, date, product, iconThemeEtag })
   Console.timeEnd('bundleJs')
 
   Console.time('copyColorThemes')

--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
@@ -8,6 +8,7 @@ import * as Remove from '../Remove/Remove.ts'
 import * as Replace from '../Replace/Replace.ts'
 import * as BundleJs from '../BundleJsRollup/BundleJsRollup.ts'
 import * as GetStaticFiles from '../GetStaticFiles/GetStaticFiles.ts'
+import * as GetIconThemeEtag from '../GetIconThemeEtag/GetIconThemeEtag.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 
 const copyStaticFiles = async ({ commitHash }) => {
@@ -362,7 +363,7 @@ const { files, headers } = config;`,
   await Remove.remove('packages/build/.tmp/server/static-server/node_modules')
 }
 
-const bundleRendererWorkerAndRendererProcessJs = async ({ commitHash, version, date, product }) => {
+const bundleRendererWorkerAndRendererProcessJs = async ({ commitHash, version, date, product, iconThemeEtag }) => {
   const assetDir = `/${commitHash}`
   const platform = 'remote'
   const toRoot = `packages/build/.tmp/server/static-server/static/${commitHash}`
@@ -374,6 +375,7 @@ const bundleRendererWorkerAndRendererProcessJs = async ({ commitHash, version, d
     date,
     product,
     toRoot,
+    iconThemeEtag,
   })
 }
 
@@ -492,8 +494,9 @@ const copyExtensions = async ({ commitHash }) => {
 }
 
 export const buildStaticServer = async ({ product, commitHash, version, date }) => {
+  const iconThemeEtag = await GetIconThemeEtag.getIconThemeEtag()
   console.time('bundleRendererWorkerAndRendererProcessJs')
-  await bundleRendererWorkerAndRendererProcessJs({ commitHash, version, date, product })
+  await bundleRendererWorkerAndRendererProcessJs({ commitHash, version, date, product, iconThemeEtag })
   console.timeEnd('bundleRendererWorkerAndRendererProcessJs')
 
   console.time('copyExtensions')

--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -14,6 +14,7 @@ import * as CopyElectronIcons from '../CopyElectronIcons/CopyElectronIcons.ts'
 import * as CopyElectronLicense from '../CopyElectronLicense/CopyElectronLicense.ts'
 import * as GetCommitDate from '../GetCommitDate/GetCommitDate.ts'
 import * as GetElectronVersion from '../GetElectronVersion/GetElectronVersion.ts'
+import * as GetIconThemeEtag from '../GetIconThemeEtag/GetIconThemeEtag.ts'
 import * as Hash from '../Hash/Hash.ts'
 import * as Rename from '../Rename/Rename.ts'
 import * as Logger from '../Logger/Logger.ts'
@@ -316,6 +317,7 @@ export const build = async ({
 
   const assetDir = `/${commitHash}`
   const toRoot = `${resourcesPath}/app/static/${commitHash}`
+  const iconThemeEtag = await GetIconThemeEtag.getIconThemeEtag()
 
   await BundleWorkers.bundleWorkers({
     platform: 'electron',
@@ -325,6 +327,7 @@ export const build = async ({
     date,
     toRoot,
     product,
+    iconThemeEtag,
   })
 
   const etag = `W/"${commitHash}"`

--- a/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
+++ b/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
@@ -117,7 +117,7 @@ const replaceWorkerPaths = async (cachePath) => {
   }
 }
 
-export const bundleRendererWorker = async ({ cachePath, platform, commitHash, assetDir, version, date, product }) => {
+export const bundleRendererWorker = async ({ cachePath, platform, commitHash, assetDir, version, date, product, iconThemeEtag }) => {
   try {
     await Copy.copy({
       from: 'packages/renderer-worker/src',
@@ -156,6 +156,11 @@ export const bundleRendererWorker = async ({ cachePath, platform, commitHash, as
       path: `${cachePath}/src/parts/Commit/Commit.js`,
       occurrence: `const commit = 'unknown commit'`,
       replacement: `const commit = '${commitHash}'`,
+    })
+    await Replace.replace({
+      path: `${cachePath}/src/parts/IconThemeEtag/IconThemeEtag.js`,
+      occurrence: `etag = ''`,
+      replacement: `etag = ${JSON.stringify(iconThemeEtag)}`,
     })
     await Replace.replace({
       path: `${cachePath}/src/parts/AssetDir/AssetDir.js`,

--- a/packages/build/src/parts/BundleRendererWorkerCached/BundleRendererWorkerCached.ts
+++ b/packages/build/src/parts/BundleRendererWorkerCached/BundleRendererWorkerCached.ts
@@ -4,8 +4,8 @@ import * as Path from '../Path/Path.ts'
 import * as Remove from '../Remove/Remove.ts'
 import * as Logger from '../Logger/Logger.ts'
 
-export const bundleRendererWorkerCached = async ({ commitHash, platform, assetDir, version, date, product }) => {
-  const rendererWorkerCachePath = await CachePaths.getRendererWorkerCachePath([platform, commitHash, version, date, product])
+export const bundleRendererWorkerCached = async ({ commitHash, platform, assetDir, version, date, product, iconThemeEtag }) => {
+  const rendererWorkerCachePath = await CachePaths.getRendererWorkerCachePath([platform, commitHash, version, date, product, iconThemeEtag])
   if (existsSync(rendererWorkerCachePath)) {
     Logger.info('[build step skipped] bundleRendererWorker')
   } else {
@@ -20,6 +20,7 @@ export const bundleRendererWorkerCached = async ({ commitHash, platform, assetDi
       version,
       date,
       product,
+      iconThemeEtag,
     })
     console.timeEnd('bundleRendererWorker')
   }

--- a/packages/build/src/parts/BundleWorkers/BundleWorkers.ts
+++ b/packages/build/src/parts/BundleWorkers/BundleWorkers.ts
@@ -47,7 +47,7 @@ const copyWorkers = async ({ toRoot }) => {
   }
 }
 
-export const bundleWorkers = async ({ commitHash, platform, assetDir, version, date, product, toRoot }) => {
+export const bundleWorkers = async ({ commitHash, platform, assetDir, version, date, product, toRoot, iconThemeEtag }) => {
   const rendererProcessCachePath = await BundleRendererProcessCached.bundleRendererProcessCached({
     commitHash,
     platform,
@@ -68,6 +68,7 @@ export const bundleWorkers = async ({ commitHash, platform, assetDir, version, d
     version,
     date,
     product,
+    iconThemeEtag,
   })
   await Copy.copy({
     from: rendererWorkerCachePath,

--- a/packages/build/src/parts/GetIconThemeEtag/GetIconThemeEtag.ts
+++ b/packages/build/src/parts/GetIconThemeEtag/GetIconThemeEtag.ts
@@ -1,0 +1,10 @@
+import * as Hash from '../Hash/Hash.ts'
+import * as ReadFile from '../ReadFile/ReadFile.ts'
+
+const defaultIconThemePath = 'extensions/builtin.vscode-icons/icon-theme.json'
+
+export const getIconThemeEtag = async ({ iconThemePath = defaultIconThemePath, iconPath = '/icons' } = {}): Promise<string> => {
+  const content = await ReadFile.readFile(iconThemePath)
+  const builtContent = content.replaceAll('/icons', iconPath)
+  return Hash.computeHash(builtContent)
+}

--- a/packages/build/test/GetIconThemeEtag.test.ts
+++ b/packages/build/test/GetIconThemeEtag.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { getIconThemeEtag } from '../src/parts/GetIconThemeEtag/GetIconThemeEtag.ts'
+
+test('computes a stable etag from the icon theme contents', async () => {
+  const etag = await getIconThemeEtag({ iconThemePath: 'packages/build/test/fixtures/icon-theme.json' })
+
+  expect(etag).toBe('4c0017dd1a7f8d1806173fb908ea3a7baf4fd64e')
+})
+
+test('computes the etag after applying the production icon path', async () => {
+  const etag = await getIconThemeEtag({ iconThemePath: 'packages/build/test/fixtures/icon-theme.json', iconPath: '/file-icons' })
+
+  expect(etag).toBe('8e2de3f6057a56b20eff7ffbbb099bf7453d131c')
+})

--- a/packages/build/test/fixtures/icon-theme.json
+++ b/packages/build/test/fixtures/icon-theme.json
@@ -1,0 +1,1 @@
+{"iconDefinitions":{"file":{"iconPath":"/icons/file.svg"}}}

--- a/packages/renderer-worker/src/parts/GetIconThemeEtag/GetIconThemeEtag.js
+++ b/packages/renderer-worker/src/parts/GetIconThemeEtag/GetIconThemeEtag.js
@@ -1,0 +1,9 @@
+import * as IconThemeEtag from '../IconThemeEtag/IconThemeEtag.js'
+import * as IsProduction from '../IsProduction/IsProduction.js'
+
+export const getIconThemeEtag = (iconThemeId, isProduction = IsProduction.isProduction, etag = IconThemeEtag.etag) => {
+  if (!isProduction || iconThemeId !== 'vscode-icons') {
+    return ''
+  }
+  return etag
+}

--- a/packages/renderer-worker/src/parts/IconTheme/IconTheme.js
+++ b/packages/renderer-worker/src/parts/IconTheme/IconTheme.js
@@ -1,4 +1,5 @@
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as GetIconThemeEtag from '../GetIconThemeEtag/GetIconThemeEtag.js'
 import * as HandleIconThemeChange from '../HandleIconThemeChange/HandleIconThemeChange.js'
 import * as IconThemeWorker from '../IconThemeWorker/IconThemeWorker.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
@@ -18,7 +19,8 @@ export const setIconTheme = async (iconThemeId, platform, assetDir) => {
     const useCache = Preferences.get('icon-theme.cache') ?? true
     const extensions = await ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, platform)
     const iconThemePlatform = getIconThemePlatform(platform, assetDir)
-    await IconThemeWorker.invoke('IconTheme.getIconThemeJson', extensions, iconThemeId, assetDir, iconThemePlatform, useCache)
+    const etag = GetIconThemeEtag.getIconThemeEtag(iconThemeId)
+    await IconThemeWorker.invoke('IconTheme.getIconThemeJson', extensions, iconThemeId, assetDir, iconThemePlatform, useCache, etag)
     await HandleIconThemeChange.handleIconThemeChange()
   } catch (error) {
     if (Workspace.isTest()) {

--- a/packages/renderer-worker/src/parts/IconThemeEtag/IconThemeEtag.js
+++ b/packages/renderer-worker/src/parts/IconThemeEtag/IconThemeEtag.js
@@ -1,0 +1,1 @@
+export const etag = ''

--- a/packages/renderer-worker/test/GetIconThemeEtag.test.ts
+++ b/packages/renderer-worker/test/GetIconThemeEtag.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { getIconThemeEtag } from '../src/parts/GetIconThemeEtag/GetIconThemeEtag.js'
+
+test('returns the build-provided etag for the production built-in icon theme', () => {
+  expect(getIconThemeEtag('vscode-icons', true, 'content-hash')).toBe('content-hash')
+})
+
+test('returns no etag during development', () => {
+  expect(getIconThemeEtag('vscode-icons', false, 'content-hash')).toBe('')
+})
+
+test('returns no etag for extension-provided icon themes', () => {
+  expect(getIconThemeEtag('custom-icons', true, 'content-hash')).toBe('')
+})

--- a/packages/renderer-worker/test/IconTheme.test.ts
+++ b/packages/renderer-worker/test/IconTheme.test.ts
@@ -10,6 +10,10 @@ jest.unstable_mockModule('../src/parts/HandleIconThemeChange/HandleIconThemeChan
   handleIconThemeChange: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/GetIconThemeEtag/GetIconThemeEtag.js', () => ({
+  getIconThemeEtag: jest.fn(() => ''),
+}))
+
 jest.unstable_mockModule('../src/parts/IconThemeWorker/IconThemeWorker.js', () => ({
   invoke: jest.fn(),
 }))
@@ -19,6 +23,7 @@ jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
 }))
 
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const GetIconThemeEtag = await import('../src/parts/GetIconThemeEtag/GetIconThemeEtag.js')
 const IconTheme = await import('../src/parts/IconTheme/IconTheme.js')
 const IconThemeWorker = await import('../src/parts/IconThemeWorker/IconThemeWorker.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
@@ -26,18 +31,35 @@ const Preferences = await import('../src/parts/Preferences/Preferences.js')
 beforeEach(() => {
   jest.resetAllMocks()
   ExtensionManagementWorker.invoke.mockResolvedValue([])
+  GetIconThemeEtag.getIconThemeEtag.mockReturnValue('')
 })
 
 test('setIconTheme uses remote icon paths in the Electron development server', async () => {
   await IconTheme.setIconTheme('vscode-icons', PlatformType.Electron, '')
 
-  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '', PlatformType.Remote, true)
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '', PlatformType.Remote, true, '')
 })
 
 test('setIconTheme keeps optimized icon paths in a packaged Electron app', async () => {
   await IconTheme.setIconTheme('vscode-icons', PlatformType.Electron, '/static/commit')
 
-  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '/static/commit', PlatformType.Electron, true)
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '/static/commit', PlatformType.Electron, true, '')
+})
+
+test('setIconTheme passes the production icon theme content etag to the worker', async () => {
+  GetIconThemeEtag.getIconThemeEtag.mockReturnValue('content-hash')
+
+  await IconTheme.setIconTheme('vscode-icons', PlatformType.Web, '/static/commit')
+
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith(
+    'IconTheme.getIconThemeJson',
+    [],
+    'vscode-icons',
+    '/static/commit',
+    PlatformType.Web,
+    true,
+    'content-hash',
+  )
 })
 
 test('hydrate uses the configured workbench icon theme', async () => {
@@ -51,5 +73,5 @@ test('hydrate uses the configured workbench icon theme', async () => {
   await IconTheme.hydrate(PlatformType.Remote, '/static')
 
   expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.getAllExtensions', '/static', PlatformType.Remote)
-  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'custom-icons', '/static', PlatformType.Remote, true)
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'custom-icons', '/static', PlatformType.Remote, true, '')
 })


### PR DESCRIPTION
Compute the built-in icon theme ETag from its final production JSON at build time and inject it into the renderer. Production cache entries are now reused across deployments when the icon theme is unchanged, without adding runtime hashing or a config fetch.