### PR TITLE
fix: improve editor error formatting

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.main-open-not-found.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-open-not-found.ts
@@ -14,5 +14,7 @@ export const test = async ({ FileSystem, Workspace, Main, Locator, expect, SideB
   await expect(errorEditor).toHaveCSS('flex-grow', '1')
   const errorMessage = Locator('.TextEditorErrorMessage')
   await expect(errorMessage).toBeVisible()
+  await expect(errorMessage).toHaveCSS('overflow-x', 'auto')
+  await expect(errorMessage).toHaveCSS('white-space', 'pre')
   await expect(errorMessage).toHaveText('The editor could not be opened because the file was not found')
 }

--- a/static/css/parts/ViewletEditorError.css
+++ b/static/css/parts/ViewletEditorError.css
@@ -21,7 +21,10 @@
 }
 
 .TextEditorErrorMessage {
-  white-space: pre-wrap;
+  max-width: 100%;
+  overflow: auto;
+  font-family: var(--EditorFontFamily);
+  white-space: pre;
 }
 
 .EditorTextIcon {


### PR DESCRIPTION
Keep editor error code frames and stack traces on single lines with preserved whitespace, using a bounded scrollable message area. Adds browser coverage for the computed error-message formatting.