### PR TITLE
fix: route extension host ports to management

### DIFF
--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -12,7 +12,6 @@ import * as ChatViewModelWorker from '../ChatViewModelWorker/ChatViewModelWorker
 import * as ClipBoardWorker from '../ClipBoardWorker/ClipBoardWorker.js'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as ErrorWorker from '../ErrorWorker/ErrorWorker.ts'
-import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as FileSearchWorker from '../FileSearchWorker/FileSearchWorker.js'
 import * as FileSystemWorker from '../FileSystemWorker/FileSystemWorker.js'
@@ -31,8 +30,7 @@ import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
 export const sendMessagePortToExtensionHostWorker = async (port, initialCommand, rpcId) => {
   Assert.object(port)
   Assert.string(initialCommand)
-  HandleIpc.handleIpc(port)
-  port.start?.()
+  await ExtensionManagementWorker.invokeAndTransfer('Extensions.handleMessagePort', port, rpcId)
 }
 
 export const sendMessagePortToSharedProcess = async (port, initialCommand, rpcId) => {

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -16,7 +16,14 @@ jest.unstable_mockModule('../src/parts/DialogWorker/DialogWorker.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => {
+  return {
+    invokeAndTransfer: jest.fn(),
+  }
+})
+
 const DialogWorker = await import('../src/parts/DialogWorker/DialogWorker.js')
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const SendMessagePortToExtensionHostWorker = await import('../src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js')
 
@@ -36,4 +43,13 @@ test('sendMessagePortToDialogWorker', async () => {
 
   expect(DialogWorker.invokeAndTransfer).toHaveBeenCalledTimes(1)
   expect(DialogWorker.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', port)
+})
+
+test('sendMessagePortToExtensionHostWorker forwards to extension management worker', async () => {
+  const port = {}
+
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToExtensionHostWorker(port, 'HandleMessagePort.handleMessagePort2', 42)
+
+  expect(ExtensionManagementWorker.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(ExtensionManagementWorker.invokeAndTransfer).toHaveBeenCalledWith('Extensions.handleMessagePort', port, 42)
 })


### PR DESCRIPTION
The deprecated extension-host message-port command now forwards the port to extension-management-worker using `Extensions.handleMessagePort`. It no longer installs the port in renderer-worker as a local RPC and never launches or contacts extension-host-worker.

A focused regression test verifies the exact management-worker transfer and preserved RPC id.

Validated with:
- renderer-worker focused regression test
- renderer-worker full suite (296 suites, 1,186 tests passed)
- renderer-worker type-check
- root lint/knip