### PR TITLE
feature: import Firefox cookies in simple browser

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -454,6 +454,10 @@ export const getQuickPickMenuEntries = () => {
       label: 'Simple Browser: Import Cookies from Chrome',
     },
     {
+      id: 'SimpleBrowser.importFirefoxCookies',
+      label: 'Simple Browser: Import Cookies from Firefox',
+    },
+    {
       id: 'Workspace.close',
       label: 'Workspace: Close',
     },

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -28,6 +28,7 @@ export const LazyCommands = {
   backward: () => import('./ViewletSimpleBrowserBackward.js'),
   forward: () => import('./ViewletSimpleBrowserForward.js'),
   importChromeCookies: () => import('./ViewletSimpleBrowserImportChromeCookies.js'),
+  importFirefoxCookies: () => import('./ViewletSimpleBrowserImportFirefoxCookies.js'),
   openDevtools: () => import('./ViewletSimpleBrowserOpenDevtools.js'),
   reload: () => import('./ViewletSimpleBrowserReload.js'),
   cancelNavigation: () => import('./ViewletSimpleBrowserCancelNavigation.js'),

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserImportFirefoxCookies.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserImportFirefoxCookies.js
@@ -1,0 +1,42 @@
+import * as ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt.js'
+import * as ElectronBrowserViewFunctions from '../ElectronBrowserViewFunctions/ElectronBrowserViewFunctions.js'
+import * as Notification from '../Notification/Notification.js'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+const getConfirmationMessage = ({ cookieCount, profileDirectory, profileName }) => {
+  const cookieLabel = cookieCount === 1 ? 'cookie' : 'cookies'
+  return `Import ${cookieCount} ${cookieLabel} from Firefox profile "${profileName}" (${profileDirectory})? This gives Simple Browser the same website access as Firefox.`
+}
+
+const getResultMessage = ({ failed, imported, skipped }) => {
+  return `Imported ${imported} Firefox cookies (${skipped} skipped, ${failed} failed).`
+}
+
+const getErrorMessage = (error) => {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export const importFirefoxCookies = async (state) => {
+  try {
+    const { browserViewId } = state
+    const info = await SharedProcess.invoke('FirefoxCookieImport.getInfo')
+    const confirmed = await ConfirmPrompt.prompt(getConfirmationMessage(info), {
+      confirmMessage: 'Import',
+      title: 'Import Firefox Cookies',
+    })
+    if (!confirmed) {
+      return state
+    }
+    const result = await SharedProcess.invoke('FirefoxCookieImport.importCookies')
+    await ElectronBrowserViewFunctions.reload(browserViewId)
+    const notificationType = result.failed > 0 ? 'warning' : 'info'
+    await Notification.create(notificationType, getResultMessage(result))
+    return {
+      ...state,
+      isLoading: true,
+    }
+  } catch (error) {
+    await Notification.create('error', `Failed to import Firefox cookies: ${getErrorMessage(error)}`)
+    return state
+  }
+}

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -87,6 +87,15 @@ test('getQuickPickMenuEntries includes Chrome cookie import command', () => {
   })
 })
 
+test('getQuickPickMenuEntries includes Firefox cookie import command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'SimpleBrowser.importFirefoxCookies',
+    label: 'Simple Browser: Import Cookies from Firefox',
+  })
+})
+
 test('getQuickPickMenuEntries includes close all editors command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowserImportFirefoxCookies.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserImportFirefoxCookies.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ConfirmPrompt/ConfirmPrompt.js', () => ({
+  prompt: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/ElectronBrowserViewFunctions/ElectronBrowserViewFunctions.js', () => ({
+  reload: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Notification/Notification.js', () => ({
+  create: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const ConfirmPrompt = await import('../src/parts/ConfirmPrompt/ConfirmPrompt.js')
+const ElectronBrowserViewFunctions = await import('../src/parts/ElectronBrowserViewFunctions/ElectronBrowserViewFunctions.js')
+const Notification = await import('../src/parts/Notification/Notification.js')
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const ViewletSimpleBrowserImportFirefoxCookies = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserImportFirefoxCookies.js')
+
+const state = {
+  browserViewId: 12,
+  isLoading: false,
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('asks for confirmation and imports Firefox cookies', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValueOnce({
+    cookieCount: 12,
+    profileDirectory: 'Profiles/abc.default-release',
+    profileName: 'default-release',
+  })
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValueOnce({
+    failed: 0,
+    imported: 10,
+    skipped: 2,
+  })
+  // @ts-ignore
+  ConfirmPrompt.prompt.mockResolvedValue(true)
+
+  await expect(ViewletSimpleBrowserImportFirefoxCookies.importFirefoxCookies(state)).resolves.toEqual({
+    ...state,
+    isLoading: true,
+  })
+  expect(ConfirmPrompt.prompt).toHaveBeenCalledWith(
+    'Import 12 cookies from Firefox profile "default-release" (Profiles/abc.default-release)? This gives Simple Browser the same website access as Firefox.',
+    {
+      confirmMessage: 'Import',
+      title: 'Import Firefox Cookies',
+    },
+  )
+  expect(SharedProcess.invoke).toHaveBeenNthCalledWith(1, 'FirefoxCookieImport.getInfo')
+  expect(SharedProcess.invoke).toHaveBeenNthCalledWith(2, 'FirefoxCookieImport.importCookies')
+  expect(ElectronBrowserViewFunctions.reload).toHaveBeenCalledWith(12)
+  expect(Notification.create).toHaveBeenCalledWith('info', 'Imported 10 Firefox cookies (2 skipped, 0 failed).')
+})
+
+test('does not import when confirmation is canceled', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockResolvedValue({
+    cookieCount: 1,
+    profileDirectory: 'Profiles/abc.default-release',
+    profileName: 'default-release',
+  })
+  // @ts-ignore
+  ConfirmPrompt.prompt.mockResolvedValue(false)
+
+  await expect(ViewletSimpleBrowserImportFirefoxCookies.importFirefoxCookies(state)).resolves.toBe(state)
+  expect(ConfirmPrompt.prompt).toHaveBeenCalledWith(
+    'Import 1 cookie from Firefox profile "default-release" (Profiles/abc.default-release)? This gives Simple Browser the same website access as Firefox.',
+    {
+      confirmMessage: 'Import',
+      title: 'Import Firefox Cookies',
+    },
+  )
+  expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(ElectronBrowserViewFunctions.reload).not.toHaveBeenCalled()
+  expect(Notification.create).not.toHaveBeenCalled()
+})
+
+test('shows an actionable import error', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockRejectedValue(new Error('Firefox cookie database is busy. Close Firefox and try again.'))
+
+  await expect(ViewletSimpleBrowserImportFirefoxCookies.importFirefoxCookies(state)).resolves.toBe(state)
+  expect(Notification.create).toHaveBeenCalledWith(
+    'error',
+    'Failed to import Firefox cookies: Firefox cookie database is busy. Close Firefox and try again.',
+  )
+  expect(ElectronBrowserViewFunctions.reload).not.toHaveBeenCalled()
+})

--- a/packages/shared-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ipc.ts
+++ b/packages/shared-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ipc.ts
@@ -1,0 +1,8 @@
+import * as FirefoxCookieImport from './FirefoxCookieImport.ts'
+
+export const name = 'FirefoxCookieImport'
+
+export const Commands = {
+  getInfo: FirefoxCookieImport.getInfo,
+  importCookies: FirefoxCookieImport.importCookies,
+}

--- a/packages/shared-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ts
+++ b/packages/shared-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ts
@@ -1,0 +1,9 @@
+import * as MainProcess from '../MainProcess/MainProcess.ts'
+
+export const getInfo = (): any => {
+  return MainProcess.invoke('FirefoxCookieImport.getInfo')
+}
+
+export const importCookies = (): any => {
+  return MainProcess.invoke('FirefoxCookieImport.importCookies')
+}

--- a/packages/shared-process/src/parts/Module/Module.ts
+++ b/packages/shared-process/src/parts/Module/Module.ts
@@ -64,6 +64,8 @@ export const load = (moduleId: any): any => {
       return import('../FileSystemDisk/FileSystemDisk.ipc.ts')
     case ModuleId.FileWatcher:
       return import('../FileWatcher/FileWatcher.ipc.ts')
+    case ModuleId.FirefoxCookieImport:
+      return import('../FirefoxCookieImport/FirefoxCookieImport.ipc.ts')
     case ModuleId.GetElectronFileResponse:
       return import('../GetElectronFileResponse/GetElectronFileResponse.ipc.ts')
     case ModuleId.GetExtensions:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.ts
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.ts
@@ -81,3 +81,4 @@ export const LanguageServer = 87
 export const SendMessagePortToMainProcess = 88
 export const SecretStorage = 89
 export const ChromeCookieImport = 90
+export const FirefoxCookieImport = 91

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -154,6 +154,9 @@ export const getModuleId = (commandId: any): any => {
     case 'FileWatcher.watch':
     case 'FileWatcher.watchFile2':
       return ModuleId.FileWatcher
+    case 'FirefoxCookieImport.getInfo':
+    case 'FirefoxCookieImport.importCookies':
+      return ModuleId.FirefoxCookieImport
     case 'GetElectronFileResponse.getElectronFileResponse':
       return ModuleId.GetElectronFileResponse
     case 'GetExtensions.getExtensions':

--- a/packages/shared-process/test/FirefoxCookieImport.test.ts
+++ b/packages/shared-process/test/FirefoxCookieImport.test.ts
@@ -1,0 +1,34 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.ts', () => ({
+  invoke: jest.fn(),
+}))
+
+const FirefoxCookieImport = await import('../src/parts/FirefoxCookieImport/FirefoxCookieImport.ts')
+const MainProcess = await import('../src/parts/MainProcess/MainProcess.ts')
+
+test('getInfo', async () => {
+  const info = {
+    cookieCount: 12,
+    profileDirectory: 'Profiles/abc.default-release',
+    profileName: 'default-release',
+  }
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(info)
+
+  await expect(FirefoxCookieImport.getInfo()).resolves.toEqual(info)
+  expect(MainProcess.invoke).toHaveBeenCalledWith('FirefoxCookieImport.getInfo')
+})
+
+test('importCookies', async () => {
+  const result = {
+    failed: 0,
+    imported: 10,
+    skipped: 2,
+  }
+  // @ts-ignore
+  MainProcess.invoke.mockResolvedValue(result)
+
+  await expect(FirefoxCookieImport.importCookies()).resolves.toEqual(result)
+  expect(MainProcess.invoke).toHaveBeenCalledWith('FirefoxCookieImport.importCookies')
+})

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -17,3 +17,7 @@ test('getModuleId - SecretStorage.get', () => {
 test('getModuleId - ChromeCookieImport.importCookies', () => {
   expect(ModuleMap.getModuleId('ChromeCookieImport.importCookies')).toBe(ModuleId.ChromeCookieImport)
 })
+
+test('getModuleId - FirefoxCookieImport.importCookies', () => {
+  expect(ModuleMap.getModuleId('FirefoxCookieImport.importCookies')).toBe(ModuleId.FirefoxCookieImport)
+})


### PR DESCRIPTION
Adds a Simple Browser command to import cookies from the active Firefox profile, with confirmation, reload, result notifications, and focused coverage.