### PR TITLE
fix: include bundled main process dependencies

### DIFF
--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -29,7 +29,7 @@ import * as Root from '../Root/Root.ts'
 import * as WriteFile from '../WriteFile/WriteFile.ts'
 import { generateConfigJson } from '../GenerateConfigJson/GenerateConfigJson.ts'
 
-const getDependencyCacheHash = async ({ electronVersion, arch, supportsAutoUpdate, isMacos, isArchLinux, isAppImage }) => {
+const getDependencyCacheHash = async ({ electronVersion, arch, supportsAutoUpdate, isMacos, isArchLinux, isAppImage, bundleMainProcess }) => {
   const files = [
     'packages/main-process/package-lock.json',
     'packages/shared-process/package-lock.json',
@@ -41,6 +41,7 @@ const getDependencyCacheHash = async ({ electronVersion, arch, supportsAutoUpdat
     'packages/build/src/parts/FilterSharedProcessDependencies/FilterSharedProcessDependencies.ts',
     'packages/build/src/parts/CopyDependencies/CopyDependencies.ts',
     'packages/build/src/parts/BundleMainProcessDependencies/BundleMainProcessDependencies.ts',
+    'packages/build/src/parts/FilterMainProcessDependencies/FilterMainProcessDependencies.ts',
     'packages/build/src/parts/NodeModulesIgnoredFiles/NodeModulesIgnoredFiles.ts',
     'packages/build/src/parts/NpmDependencies/NpmDependencies.ts',
     'packages/build/src/parts/WalkDependencies/WalkDependencies.ts',
@@ -49,7 +50,14 @@ const getDependencyCacheHash = async ({ electronVersion, arch, supportsAutoUpdat
   const absolutePaths = files.map(Path.absolute)
   const contents = await Promise.all(absolutePaths.map(ReadFile.readFile))
   const hash = Hash.computeHash(
-    contents + electronVersion + arch + String(supportsAutoUpdate) + String(isMacos) + String(isArchLinux) + String(isAppImage),
+    contents +
+      electronVersion +
+      arch +
+      String(supportsAutoUpdate) +
+      String(isMacos) +
+      String(isArchLinux) +
+      String(isAppImage) +
+      String(bundleMainProcess),
   )
   return hash
 }
@@ -180,6 +188,7 @@ export const build = async ({
   Assert.object(product)
   Assert.string(version)
   const { electronVersion, isInstalled, installedArch, installedPlatform } = await GetElectronVersion.getElectronVersion()
+  const bundleMainProcess = BundleOptions.bundleMainProcess
   const dependencyCacheHash = await getDependencyCacheHash({
     electronVersion,
     arch,
@@ -187,12 +196,12 @@ export const build = async ({
     isMacos,
     isArchLinux,
     isAppImage,
+    bundleMainProcess,
   })
   const dependencyCachePath = Path.join(Path.absolute('packages/build/.tmp/cachedDependencies'), dependencyCacheHash)
   const dependencyCachePathFinished = Path.join(dependencyCachePath, 'finished')
   const commitHash = await CommitHash.getCommitHash()
   const date = await GetCommitDate.getCommitDate(commitHash)
-  const bundleMainProcess = BundleOptions.bundleMainProcess
   const bundleSharedProcess = BundleOptions.bundleSharedProcess
   const isLinux = Platform.isLinux()
   // Language-basics extensions are now copied individually

--- a/packages/build/src/parts/BundleElectronAppDependencies/BundleElectronAppDependencies.ts
+++ b/packages/build/src/parts/BundleElectronAppDependencies/BundleElectronAppDependencies.ts
@@ -20,12 +20,13 @@ const copySharedProcessFiles = async ({ cachePath, arch, electronVersion, platfo
   })
 }
 
-const copyMainProcessFiles = async ({ arch, electronVersion, cachePath, supportsAutoUpdate }) => {
+const copyMainProcessFiles = async ({ arch, electronVersion, cachePath, supportsAutoUpdate, bundleMainProcess }) => {
   await BundleMainProcessDependencies.bundleMainProcessDependencies({
     electronVersion,
     arch,
     to: `${cachePath}/main-process`,
     supportsAutoUpdate,
+    bundleMainProcess,
   })
 }
 
@@ -54,14 +55,13 @@ export const bundleElectronAppDependencies = async ({
   })
   console.timeEnd('copySharedProcessFiles')
 
-  if (!bundleMainProcess) {
-    console.time('copyMainProcessFiles')
-    await copyMainProcessFiles({
-      arch,
-      electronVersion,
-      cachePath,
-      supportsAutoUpdate,
-    })
-    console.timeEnd('copyMainProcessFiles')
-  }
+  console.time('copyMainProcessFiles')
+  await copyMainProcessFiles({
+    arch,
+    electronVersion,
+    cachePath,
+    supportsAutoUpdate,
+    bundleMainProcess,
+  })
+  console.timeEnd('copyMainProcessFiles')
 }

--- a/packages/build/src/parts/BundleMainProcessDependencies/BundleMainProcessDependencies.ts
+++ b/packages/build/src/parts/BundleMainProcessDependencies/BundleMainProcessDependencies.ts
@@ -7,19 +7,25 @@ import * as Platform from '../Platform/Platform.ts'
 import * as Remove from '../Remove/Remove.ts'
 import * as RemoveSourceMaps from '../RemoveSourceMaps/RemoveSourceMaps.ts'
 
-export const bundleMainProcessDependencies = async ({ to, arch, electronVersion, supportsAutoUpdate }) => {
+export const bundleMainProcessDependencies = async ({ to, arch, electronVersion, supportsAutoUpdate, bundleMainProcess }) => {
   const mainProcessPath = Path.absolute('packages/main-process')
-  const packageJson = await JsonFile.readJson('packages/main-process/package.json')
+  const packageJsonPath = bundleMainProcess
+    ? 'packages/main-process/node_modules/@lvce-editor/main-process/package.json'
+    : 'packages/main-process/package.json'
+  const packageJson = await JsonFile.readJson(packageJsonPath)
+  const dependencies = bundleMainProcess
+    ? Object.fromEntries(Object.entries(packageJson.dependencies).filter(([name]) => name !== 'electron'))
+    : packageJson.dependencies
   await JsonFile.writeJson({
     to: `${to}/package.json`,
     value: {
       name: packageJson.name,
       type: packageJson.type,
-      dependencies: packageJson.dependencies,
+      dependencies,
     },
   })
   const npmDependenciesRaw = await NpmDependencies.getNpmDependenciesRawJson('packages/main-process')
-  const npmDependencies = FilterMainProcessDependencies.filterDependencies(npmDependenciesRaw, supportsAutoUpdate)
+  const npmDependencies = FilterMainProcessDependencies.filterDependencies(npmDependenciesRaw, supportsAutoUpdate, bundleMainProcess)
   await CopyDependencies.copyDependencies(mainProcessPath, to, npmDependencies)
   if (Platform.isWindows()) {
     const Rebuild = await import('../Rebuild/Rebuild.ts')

--- a/packages/build/src/parts/FilterMainProcessDependencies/FilterMainProcessDependencies.ts
+++ b/packages/build/src/parts/FilterMainProcessDependencies/FilterMainProcessDependencies.ts
@@ -1,6 +1,6 @@
 import * as WalkDependencies from '../WalkDependencies/WalkDependencies.ts'
 
-export const filterDependencies = (rawDependencies, supportsAutoUpdate) => {
+export const filterDependencies = (rawDependencies, supportsAutoUpdate, bundleMainProcess) => {
   const dependencyPaths: any[] = []
   const handleDependency = (dependency) => {
     if (!dependency.path) {
@@ -16,6 +16,12 @@ export const filterDependencies = (rawDependencies, supportsAutoUpdate) => {
       return false
     }
     if (dependency.name === 'electron-unhandled') {
+      return false
+    }
+    if (bundleMainProcess && dependency.name === '@lvce-editor/main-process') {
+      return true
+    }
+    if (bundleMainProcess && dependency.name === 'electron') {
       return false
     }
     dependencyPaths.push(dependency.path)

--- a/packages/build/test/BundleElectronAppDependencies.test.ts
+++ b/packages/build/test/BundleElectronAppDependencies.test.ts
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/BundleExtensionHostHelperProcessDependencies/BundleExtensionHostHelperProcessDependencies.ts', () => ({
+  bundleExtensionHostHelperProcessDependencies: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/BundleSharedProcessDependencies/BundleSharedProcessDependencies.ts', () => ({
+  bundleSharedProcessDependencies: jest.fn(),
+}))
+
+const { bundleElectronAppDependencies } = await import('../src/parts/BundleElectronAppDependencies/BundleElectronAppDependencies.ts')
+
+test('bundled main process includes external runtime dependencies', async () => {
+  const cachePath = await mkdtemp(join(tmpdir(), 'lvce-electron-dependencies-'))
+  try {
+    await bundleElectronAppDependencies({
+      cachePath,
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      product: {},
+      supportsAutoUpdate: false,
+      bundleMainProcess: true,
+      platform: 'linux',
+      target: 'electron-deb',
+    })
+
+    const packagedMainProcessPath = join(cachePath, 'main-process', 'dist', 'mainProcessMain.js')
+    expect(createRequire(packagedMainProcessPath).resolve('dbus-native')).toBe(
+      join(cachePath, 'main-process', 'node_modules', 'dbus-native', 'index.js'),
+    )
+  } finally {
+    await rm(cachePath, { recursive: true, force: true })
+  }
+})

--- a/packages/build/test/BundleElectronAppDependencies.test.ts
+++ b/packages/build/test/BundleElectronAppDependencies.test.ts
@@ -35,4 +35,4 @@ test('bundled main process includes external runtime dependencies', async () => 
   } finally {
     await rm(cachePath, { recursive: true, force: true })
   }
-})
+}, 30_000)

--- a/packages/build/test/BundleElectronAppDependencies.test.ts
+++ b/packages/build/test/BundleElectronAppDependencies.test.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, realpath, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, jest, test } from '@jest/globals'
@@ -29,8 +29,8 @@ test('bundled main process includes external runtime dependencies', async () => 
     })
 
     const packagedMainProcessPath = join(cachePath, 'main-process', 'dist', 'mainProcessMain.js')
-    expect(createRequire(packagedMainProcessPath).resolve('dbus-native')).toBe(
-      join(cachePath, 'main-process', 'node_modules', 'dbus-native', 'index.js'),
+    expect(await realpath(createRequire(packagedMainProcessPath).resolve('dbus-native'))).toBe(
+      await realpath(join(cachePath, 'main-process', 'node_modules', 'dbus-native', 'index.js')),
     )
   } finally {
     await rm(cachePath, { recursive: true, force: true })


### PR DESCRIPTION
Fix the Linux desktop startup crash caused by the bundled main process importing `dbus-native` without packaging it.

Copy external runtime dependencies for bundled main-process builds while excluding the already bundled package and Electron itself, and cover module resolution with a regression test.