### PR TITLE
Fix initial widget render command reconciliation

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -727,7 +727,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     const instanceNow = ViewletStates.getInstance(viewletUid)
     viewletState = instanceNow.renderedState
     if (module.hasFunctionalRender && shouldRender) {
-      const renderCommands = getRenderCommands(module, viewletState, newState, viewletUid, parentUid, eventListeners)
+      const renderCommands = LayoutWidgets.reconcile(getRenderCommands(module, viewletState, newState, viewletUid, parentUid, eventListeners))
       ViewletStates.setRenderedState(viewletUid, newState)
       commands.push(...renderCommands)
       if (viewlet.show === false) {

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -197,6 +197,49 @@ test('load retains non-empty event listener registration for a new root', async 
   ])
 })
 
+test('load reconciles widget declarations before returning initial render commands', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const layoutState = ViewletLayout.create(1)
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'Layout',
+    renderedState: layoutState,
+    state: layoutState,
+  })
+  ViewletStates.set('Layout', ViewletStates.getInstance(1))
+  const mockModule = {
+    create: jest.fn(() => ({ uid: 9 })),
+    hasFunctionalEvents: true,
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state) => state),
+    render: [
+      {
+        apply: jest.fn(() => [['Viewlet.setWidgets', 9, 1, [20]]]),
+        isEqual: jest.fn(() => false),
+        multiple: true,
+      },
+    ],
+    renderEventListeners: jest.fn(() => []),
+  }
+  const viewlet = {
+    disposed: false,
+    getModule: async () => mockModule,
+    id: 'WidgetOwnerTest',
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid: 9,
+    uri: '',
+  }
+
+  const commands = await ViewletManager.load(viewlet)
+
+  expect(commands.some((command) => command[0] === 'Viewlet.setWidgets')).toBe(false)
+  expect(ViewletStates.getState('Layout').widgetReferences).toEqual([{ parentUid: 9, uid: 20 }])
+})
+
 test('extension view render supports functional events', () => {
   expect(ViewletExtensionViewRender.hasFunctionalEvents).toBe(true)
 })


### PR DESCRIPTION
Reconcile widget ownership declarations during the initial functional render so internal Viewlet.setWidgets commands never reach the renderer process. Adds regression coverage for loading a widget-owning view.