### PR TITLE
feature: include eslint as builtin extension

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -48,6 +48,12 @@
     "created": "2022-12-15"
   },
   {
+    "name": "builtin.eslint",
+    "repository": "github.com/lvce-editor/eslint",
+    "version": "1.0.2",
+    "created": "2026-08-01"
+  },
+  {
     "name": "builtin.rest-client",
     "repository": "github.com/lvce-editor/rest-client",
     "version": "1.4.0",


### PR DESCRIPTION
Add the ESLint extension to the built-in extension catalog so JavaScript and TypeScript diagnostics are available without a separate installation.