### PR TITLE
fix: open cli file paths in editor

### DIFF
--- a/packages/renderer-worker/src/parts/OpenInitialUri/OpenInitialUri.js
+++ b/packages/renderer-worker/src/parts/OpenInitialUri/OpenInitialUri.js
@@ -1,0 +1,9 @@
+import * as Command from '../Command/Command.js'
+
+export const openInitialUri = async (href) => {
+  const uri = new URL(href).searchParams.get('openUri')
+  if (!uri) {
+    return
+  }
+  await Command.execute('Main.openUri', uri)
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -22,6 +22,7 @@ import * as LifeCycle from '../LifeCycle/LifeCycle.js'
 import * as LifeCyclePhase from '../LifeCyclePhase/LifeCyclePhase.js'
 import * as Location from '../Location/Location.js'
 import * as Module from '../Module/Module.js'
+import * as OpenInitialUri from '../OpenInitialUri/OpenInitialUri.js'
 import * as Performance from '../Performance/Performance.js'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
@@ -236,6 +237,7 @@ export const startup = async (platform, assetDir) => {
   LifeCycle.mark(LifeCyclePhase.Five)
 
   await Promise.all(actions.map((action) => action(platform, assetDir)))
+  await OpenInitialUri.openInitialUri(initData.Location.href)
   await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
 
   LifeCycle.mark(LifeCyclePhase.Fifteen)

--- a/packages/renderer-worker/test/OpenInitialUri.test.ts
+++ b/packages/renderer-worker/test/OpenInitialUri.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const Command = await import('../src/parts/Command/Command.js')
+const OpenInitialUri = await import('../src/parts/OpenInitialUri/OpenInitialUri.js')
+const openUri = jest.fn()
+
+Command.register('Main.openUri', openUri)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('openInitialUri opens the file supplied in the application URL', async () => {
+  const uri = 'file:///tmp/example file.txt'
+  const url = new URL('lvce-oss://-/')
+  url.searchParams.set('openUri', uri)
+
+  await OpenInitialUri.openInitialUri(url.href)
+
+  expect(openUri).toHaveBeenCalledTimes(1)
+  expect(openUri).toHaveBeenCalledWith(uri)
+})
+
+test('openInitialUri does nothing when no file was supplied', async () => {
+  await OpenInitialUri.openInitialUri('lvce-oss://-/')
+
+  expect(openUri).not.toHaveBeenCalled()
+})

--- a/packages/shared-process/src/parts/AppWindow/AppWindow.ts
+++ b/packages/shared-process/src/parts/AppWindow/AppWindow.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, resolve } from 'node:path'
+import { stat } from 'node:fs/promises'
+import { dirname, isAbsolute, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import * as DefaultUrl from '../DefaultUrl/DefaultUrl.ts'
 import * as GetAppWindowOptions from '../GetAppWindowOptions/GetAppWindowOptions.ts'
@@ -25,29 +26,40 @@ const getValidatedAppUrl = (url: unknown): string => {
   return parsedUrl.toString()
 }
 
-const getWorkspaceUri = (parsedArgs: any, workingDirectory: any): string => {
+const getAbsolutePath = (parsedArgs: any, workingDirectory: any): string => {
   const path = parsedArgs?._?.at(-1)
   if (!path || typeof path !== 'string') {
     return ''
   }
   if (path.startsWith('file://')) {
-    return pathToFileURL(fileURLToPath(path)).toString()
+    return fileURLToPath(path)
   }
-  const absolutePath = isAbsolute(path) ? path : resolve(workingDirectory, path)
-  return pathToFileURL(absolutePath).toString()
+  return isAbsolute(path) ? path : resolve(workingDirectory, path)
 }
 
-const getAppWindowUrl = (url: unknown, parsedArgs: any, workingDirectory: any): string => {
+const getAppWindowUrl = async (url: unknown, parsedArgs: any, workingDirectory: any): Promise<string> => {
   const parsedUrl = new URL(getValidatedAppUrl(url))
-  const workspaceUri = getWorkspaceUri(parsedArgs, workingDirectory)
-  if (workspaceUri) {
-    parsedUrl.searchParams.set('workspace', workspaceUri)
+  const absolutePath = getAbsolutePath(parsedArgs, workingDirectory)
+  if (!absolutePath) {
+    return parsedUrl.toString()
   }
+  const uri = pathToFileURL(absolutePath).toString()
+  try {
+    const stats = await stat(absolutePath)
+    if (stats.isFile()) {
+      parsedUrl.searchParams.set('workspace', pathToFileURL(dirname(absolutePath)).toString())
+      parsedUrl.searchParams.set('openUri', uri)
+      return parsedUrl.toString()
+    }
+  } catch {
+    // Preserve the existing folder error for paths that do not exist.
+  }
+  parsedUrl.searchParams.set('workspace', uri)
   return parsedUrl.toString()
 }
 
 export const createAppWindow = async ({ parsedArgs, preferences, preloadUrl, url = DefaultUrl.defaultUrl, workingDirectory }: any): Promise<any> => {
-  const validatedUrl = getAppWindowUrl(url, parsedArgs, workingDirectory)
+  const validatedUrl = await getAppWindowUrl(url, parsedArgs, workingDirectory)
   const { height, width } = await Screen.getBounds()
   const windowOptions = await GetAppWindowOptions.getAppWindowOptions({
     preferences,

--- a/packages/shared-process/test/AppWindow.test.ts
+++ b/packages/shared-process/test/AppWindow.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
-import { resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 jest.unstable_mockModule('../src/parts/GetAppWindowOptions/GetAppWindowOptions.js', () => ({
   getAppWindowOptions: jest.fn(() => ({})),
@@ -90,4 +90,24 @@ test.each([
 
   expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
   expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, parsedArgs, workingDirectory, [], url.toString())
+})
+
+test('createAppWindow opens a file argument in its parent workspace', async () => {
+  const filePath = fileURLToPath(import.meta.url)
+  const fileUri = pathToFileURL(filePath).toString()
+  const workspaceUri = pathToFileURL(dirname(filePath)).toString()
+  const url = new URL('lvce-oss://-/')
+  url.searchParams.set('workspace', workspaceUri)
+  url.searchParams.set('openUri', fileUri)
+  const parsedArgs = { _: [filePath] }
+
+  await AppWindow.createAppWindow({
+    parsedArgs,
+    preferences: {},
+    preloadUrl: 'file:///preload.js',
+    workingDirectory: otherPath,
+  })
+
+  expect(ParentIpc.invoke).toHaveBeenCalledTimes(1)
+  expect(ParentIpc.invoke).toHaveBeenCalledWith('AppWindow.createAppWindow', {}, parsedArgs, otherPath, [], url.toString())
 })


### PR DESCRIPTION
Treat CLI file arguments as editor targets while opening their parent directory as the workspace. Consume the initial editor URI after startup and cover both launch URL construction and renderer command routing.