### PR TITLE
fix: inject websocket issuer into test pages

### DIFF
--- a/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
+++ b/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
@@ -151,8 +151,15 @@ export const getExtraHeaders = ({ pathName, fileExtension }) => {
   })
   await WriteFile.writeFile({
     to: `${cachePath}/src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.js`,
-    content: `export const addCustomPathsToIndexHtml = async (content) => {
+    content: `export const addCustomPathsToIndexHtml = async (content, additionalConfig = {}) => {
+  if (Object.keys(additionalConfig).length === 0) {
     return content
+  }
+  const stringifiedConfig = JSON.stringify(additionalConfig, null, 2)
+  return content.toString().replace(
+    '</title>',
+    '</title>\\n    <script type="application/json" id="Config">' + stringifiedConfig + '</script>',
+  )
 }
 `,
   })

--- a/packages/shared-process/src/parts/GetTestRequestResponse/GetTestRequestResponse.ts
+++ b/packages/shared-process/src/parts/GetTestRequestResponse/GetTestRequestResponse.ts
@@ -13,13 +13,19 @@ import * as GetTestPath from '../GetTestPath/GetTestPath.ts'
 import * as HttpHeader from '../HttpHeader/HttpHeader.ts'
 import * as HttpStatusCode from '../HttpStatusCode/HttpStatusCode.ts'
 import * as Logger from '../Logger/Logger.ts'
+import * as WebSocketIssuerRegistry from '../WebSocketIssuerRegistry/WebSocketIssuerRegistry.ts'
+
+const getTestPageContent = async (indexHtmlPath: string): Promise<string> => {
+  const body = await readFile(indexHtmlPath, 'utf8')
+  const webSocketIssuer = WebSocketIssuerRegistry.create()
+  return AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(body, { webSocketIssuer })
+}
 
 export const getTestRequestResponse = async (request: any, indexHtmlPath: any): Promise<any> => {
   try {
     const pathName = GetPathName.getPathName(request)
     if (pathName === '/tests/_all.html') {
-      const body = await readFile(indexHtmlPath, 'utf8')
-      const content = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(body)
+      const content = await getTestPageContent(indexHtmlPath)
       const headers = {
         [HttpHeader.ContentSecurityPolicy]: ContentSecurityPolicyDocument.value,
         [HttpHeader.ContentType]: 'text/html',
@@ -30,8 +36,7 @@ export const getTestRequestResponse = async (request: any, indexHtmlPath: any): 
       return GetContentResponse.getContentResponse(content, headers)
     }
     if (pathName.endsWith('.html')) {
-      const body = await readFile(indexHtmlPath, 'utf8')
-      const content = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(body)
+      const content = await getTestPageContent(indexHtmlPath)
       const headers = {
         [HttpHeader.ContentSecurityPolicy]: ContentSecurityPolicyDocument.value,
         [HttpHeader.ContentType]: 'text/html',

--- a/packages/shared-process/test/GetTestRequestResponse.test.ts
+++ b/packages/shared-process/test/GetTestRequestResponse.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+const webSocketIssuerRegex = /"webSocketIssuer": "[A-Za-z0-9_-]{43}"/
+
 beforeEach(() => {
   jest.resetAllMocks()
 })
@@ -89,6 +91,32 @@ test('getTestRequestResponse - _all.html serves index html', async () => {
     },
   })
   expect(result.body).toContain('<title>Tests</title>')
+  expect(result.body).toMatch(webSocketIssuerRegex)
+})
+
+test('getTestRequestResponse - individual test serves index html with websocket issuer', async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'lvce-test-request-'))
+  temporaryDirectories.push(tmpDir)
+  const indexHtmlPath = join(tmpDir, 'index.html')
+  await writeFile(indexHtmlPath, '<!doctype html><title>Tests</title>')
+  const request = {
+    url: '/tests/example.html',
+  }
+  jest.spyOn(GetPathName, 'getPathName').mockReturnValue('/tests/example.html')
+
+  const result = await GetTestRequestResponse.getTestRequestResponse(request, indexHtmlPath)
+
+  expect(result).toMatchObject({
+    init: {
+      headers: {
+        'Content-Security-Policy': expect.stringContaining(`style-src 'self' 'unsafe-inline'`),
+        'Content-Type': 'text/html',
+      },
+      status: 200,
+    },
+  })
+  expect(result.body).toContain('<title>Tests</title>')
+  expect(result.body).toMatch(webSocketIssuerRegex)
 })
 
 test('getTestRequestResponse - error in createTestOverview', async () => {


### PR DESCRIPTION
Fix test-page startup after WebSocket RPC capabilities were introduced.

- inject a fresh WebSocket issuer into individual and reuse-page test HTML
- preserve additional config injection in production server bundles
- keep production responses unchanged when no additional config is supplied
- cover both `/tests/_all.html` and individual test pages

Verified with focused shared-process tests, type checks, generated production-bundle validation, and the extension-search built-in detail e2e against the patched published layout.