### PR TITLE
fix: resize problems worker with panel

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletProblems/ViewletProblemsResize.js
+++ b/packages/renderer-worker/src/parts/ViewletProblems/ViewletProblemsResize.js
@@ -1,8 +1,19 @@
+import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
+
 export const hasFunctionalResize = true
 
-export const resize = (state, dimensions) => {
+export const resizeWithDependencies = async (state, dimensions, invoke) => {
+  const { uid } = state
+  await invoke('Problems.resize', uid, dimensions)
+  const diffResult = await invoke('Problems.diff2', uid)
+  const commands = await invoke('Problems.render2', uid, diffResult)
   return {
     ...state,
     ...dimensions,
+    commands,
   }
+}
+
+export const resize = (state, dimensions) => {
+  return resizeWithDependencies(state, dimensions, ProblemsWorker.invoke)
 }

--- a/packages/renderer-worker/test/ViewletProblemsResize.test.ts
+++ b/packages/renderer-worker/test/ViewletProblemsResize.test.ts
@@ -1,0 +1,38 @@
+import { expect, jest, test } from '@jest/globals'
+import { resizeWithDependencies } from '../src/parts/ViewletProblems/ViewletProblemsResize.js'
+
+const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
+  if (method === 'Problems.diff2') {
+    return [1, 2]
+  }
+  if (method === 'Problems.render2') {
+    return [['Viewlet.setDom2', []]]
+  }
+  return undefined
+})
+
+test('resize forwards current dimensions to the problems worker and renders the result', async () => {
+  const state = {
+    commands: [],
+    height: 0,
+    uid: 42,
+    width: 0,
+    x: 0,
+    y: 0,
+  }
+  const dimensions = {
+    height: 200,
+    width: 800,
+    x: 10,
+    y: 20,
+  }
+
+  await expect(resizeWithDependencies(state, dimensions, invoke)).resolves.toEqual({
+    ...state,
+    ...dimensions,
+    commands: [['Viewlet.setDom2', []]],
+  })
+  expect(invoke).toHaveBeenNthCalledWith(1, 'Problems.resize', 42, dimensions)
+  expect(invoke).toHaveBeenNthCalledWith(2, 'Problems.diff2', 42)
+  expect(invoke).toHaveBeenNthCalledWith(3, 'Problems.render2', 42, [1, 2])
+})


### PR DESCRIPTION
## Summary

- forward panel resize dimensions to the Problems worker
- recompute and render its virtual-list range after resizing
- add focused regression coverage

## Verification

- renderer-worker full suite: 299 passed, 24 skipped
- focused regression test passed after rebasing onto main
- renderer-worker type-check passed
- focused ESLint checks passed