### PR TITLE
fix: refresh active editor diagnostics

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -209,6 +209,7 @@ export const commandMap = {
   'Focus.setAdditionalFocus': lazy('Focus.setAdditionalFocus'),
   'Focus.setFocus': lazy('Focus.setFocus'),
   'GetActiveEditor.getActiveEditorId': lazy('GetActiveEditor.getActiveEditorId'),
+  'GetActiveEditor.updateDiagnostics': lazy('GetActiveEditor.updateDiagnostics'),
   'GetEditorSourceActions.getEditorSourceActions': lazy('GetEditorSourceActions.getEditorSourceActions'),
   'GetWindowId.getWindowId': lazy('GetWindowId.getWindowId'),
   'IconTheme.getFileIcon': lazy('IconTheme.getFileIcon'),

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
@@ -4,4 +4,5 @@ export const name = 'GetActiveEditor'
 
 export const Commands = {
   getActiveEditorId: GetActiveEditor.getActiveEditorId,
+  updateDiagnostics: GetActiveEditor.updateDiagnostics,
 }

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -1,3 +1,4 @@
+import * as Command from '../Command/Command.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
@@ -11,4 +12,16 @@ export const getActiveEditorId = () => {
     return -1
   }
   return instance.state.id
+}
+
+export const updateDiagnosticsWithCommand = async (executeCommand) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
+  if (!instance) {
+    return
+  }
+  await executeCommand('Viewlet.executeViewletCommand', instance.state.id, 'updateDiagnostics')
+}
+
+export const updateDiagnostics = async () => {
+  await updateDiagnosticsWithCommand(Command.execute)
 }

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const GetActiveEditor = await import('../src/parts/GetActiveEditor/GetActiveEditor.js')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
+const executeCommand = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ViewletStates.reset()
+})
+
+test('updateDiagnostics does nothing when there is no active editor', async () => {
+  await expect(GetActiveEditor.updateDiagnosticsWithCommand(executeCommand)).resolves.toBeUndefined()
+  expect(executeCommand).not.toHaveBeenCalled()
+})
+
+test('updateDiagnostics refreshes diagnostics for the active editor', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.js',
+    },
+  })
+
+  await GetActiveEditor.updateDiagnosticsWithCommand(executeCommand)
+
+  expect(executeCommand).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'updateDiagnostics')
+})


### PR DESCRIPTION
Expose a renderer command that refreshes diagnostics for the active text editor. This gives contributed lint commands a safe way to run the existing editor diagnostics pipeline, with regression coverage for active and missing editor states.