### PR TITLE
fix: forward diagnostics change events

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -534,6 +534,7 @@ export const commandMap = {
   'Layout.handleBlur': lazy('Layout.handleBlur'),
   'Layout.handleColorThemeChanged': lazy('Layout.handleColorThemeChanged'),
   'Layout.handleContextMenu': lazy('Layout.handleContextMenu'),
+  'Layout.handleDiagnosticsChange': lazy('Layout.handleDiagnosticsChange'),
   'Layout.handleExtensionsChanged': lazy('Layout.handleExtensionsChanged'),
   'Layout.handleFocus': lazy('Layout.handleFocus'),
   'Layout.handleResize': lazy('Layout.handleResize'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2076,6 +2076,10 @@ export const handleActiveEditorChange = async (state: LayoutState, activeUri: st
   return callGlobalEvent(state, 'handleActiveEditorChange', activeUri)
 }
 
+export const handleDiagnosticsChange = async (state: LayoutState, uri: string) => {
+  return callGlobalEvent(state, 'handleDiagnosticsChange', uri)
+}
+
 export const handleSettingsChanged = async (state: LayoutState) => {
   await Preferences.hydrate()
   return callGlobalEvent(state, 'handleSettingsChanged')

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -31,6 +31,7 @@ export const CommandsWithSideEffects = {
   handleExtensionsChanged: ViewletLayout.handleExtensionsChanged,
   handleBlur: ViewletLayout.handleBlur,
   handleContextMenu: ViewletLayout.handleContextMenu,
+  handleDiagnosticsChange: ViewletLayout.handleDiagnosticsChange,
   handleFocus: ViewletLayout.handleFocus,
   handleResize: ViewletLayout.handleResize,
   handleSashDoubleClick: ViewletLayout.handleSashDoubleClick,

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -177,6 +177,28 @@ test('handleActiveEditorChange ignores viewlets that are not loaded', async () =
   })
 })
 
+test('handleDiagnosticsChange forwards the changed uri to loaded viewlets', async () => {
+  const handler = jest.fn((state: { uid: number }, uri: string) => {
+    return {
+      ...state,
+      refreshedUri: uri,
+    }
+  })
+  ViewletStates.set('problems', createInstance(1, 'handleDiagnosticsChange', handler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleDiagnosticsChange(state, 'file:///test.ts')
+
+  expect(handler).toHaveBeenCalledWith({ uid: 1 }, 'file:///test.ts')
+  expect(ViewletManager.render).toHaveBeenCalledTimes(1)
+  expect(result).toEqual({
+    commands: [['render.1']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
 test('handleSettingsChanged hydrates preferences and updates viewlet state', async () => {
   const calls: string[] = []
   hydratePreferences.mockImplementation(async () => {


### PR DESCRIPTION
Forwards editor diagnostic-change notifications to loaded viewlets so consumers such as the Problems panel can refresh immediately.