### PR TITLE
fix: align search field actions right

### DIFF
--- a/static/css/parts/SearchField.css
+++ b/static/css/parts/SearchField.css
@@ -31,6 +31,7 @@
   contain: content;
   display: flex;
   gap: 2px;
+  order: 1;
 }
 
 .SearchFieldButton {


### PR DESCRIPTION
Keep search field action icons aligned to the right edge even when incremental DOM updates leave the input and action group in an unexpected sibling order.