### PR TITLE
feature: update all editor diagnostics

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -209,6 +209,7 @@ export const commandMap = {
   'Focus.setAdditionalFocus': lazy('Focus.setAdditionalFocus'),
   'Focus.setFocus': lazy('Focus.setFocus'),
   'GetActiveEditor.getActiveEditorId': lazy('GetActiveEditor.getActiveEditorId'),
+  'GetActiveEditor.updateAllDiagnostics': lazy('GetActiveEditor.updateAllDiagnostics'),
   'GetActiveEditor.updateDiagnostics': lazy('GetActiveEditor.updateDiagnostics'),
   'GetEditorSourceActions.getEditorSourceActions': lazy('GetEditorSourceActions.getEditorSourceActions'),
   'GetWindowId.getWindowId': lazy('GetWindowId.getWindowId'),

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
@@ -4,5 +4,6 @@ export const name = 'GetActiveEditor'
 
 export const Commands = {
   getActiveEditorId: GetActiveEditor.getActiveEditorId,
+  updateAllDiagnostics: GetActiveEditor.updateAllDiagnostics,
   updateDiagnostics: GetActiveEditor.updateDiagnostics,
 }

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -1,4 +1,5 @@
 import * as Command from '../Command/Command.js'
+import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
@@ -24,4 +25,12 @@ export const updateDiagnosticsWithCommand = async (executeCommand) => {
 
 export const updateDiagnostics = async () => {
   await updateDiagnosticsWithCommand(Command.execute)
+}
+
+export const updateAllDiagnosticsWithCommand = async (invoke) => {
+  await invoke('Editor.updateDiagnosticsAll')
+}
+
+export const updateAllDiagnostics = async () => {
+  await updateAllDiagnosticsWithCommand(EditorWorker.invoke)
 }

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -30,3 +30,9 @@ test('updateDiagnostics refreshes diagnostics for the active editor', async () =
 
   expect(executeCommand).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'updateDiagnostics')
 })
+
+test('updateAllDiagnostics refreshes diagnostics for every open editor', async () => {
+  await GetActiveEditor.updateAllDiagnosticsWithCommand(executeCommand)
+
+  expect(executeCommand).toHaveBeenCalledWith('Editor.updateDiagnosticsAll')
+})


### PR DESCRIPTION
## Summary

- expose a renderer command that asks the editor worker to refresh every open editor
- keep the existing active-editor diagnostic refresh unchanged
- provide the command needed by config-aware diagnostic extensions such as ESLint

## Tests

- `npm test -- --runTestsByPath test/GetActiveEditor.test.ts` in `packages/renderer-worker`
- `npm run type-check`
- `npm run lint`