### PR TITLE
fix: support extension view image context menus

### DIFF
--- a/packages/renderer-worker/src/parts/ClipBoard/ClipBoard.ipc.js
+++ b/packages/renderer-worker/src/parts/ClipBoard/ClipBoard.ipc.js
@@ -12,6 +12,7 @@ export const Commands = {
   readNativeFiles: ClipBoard.readNativeFiles,
   readText: ClipBoard.readText,
   writeImage: ClipBoard.writeImage,
+  writeImageUrl: ClipBoard.writeImageUrl,
   writeNativeFiles: ClipBoard.writeNativeFiles,
   writeText: ClipBoard.writeText,
 }

--- a/packages/renderer-worker/src/parts/ClipBoard/ClipBoard.js
+++ b/packages/renderer-worker/src/parts/ClipBoard/ClipBoard.js
@@ -46,6 +46,14 @@ export const writeImage = async (blob) => {
   }
 }
 
+export const writeImageUrl = async (url, fetchImage = globalThis.fetch) => {
+  const response = await fetchImage(url)
+  if (!response.ok) {
+    throw new Error(response.statusText)
+  }
+  return writeImage(await response.blob())
+}
+
 export const execCopy = async () => {
   try {
     return await RendererProcess.invoke('ClipBoard.execCopy')

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -38,6 +38,7 @@ export const commandMap = {
   'ClipBoard.readNativeFiles': lazy('ClipBoard.readNativeFiles'),
   'ClipBoard.readText': lazy('ClipBoard.readText'),
   'ClipBoard.writeImage': lazy('ClipBoard.writeImage'),
+  'ClipBoard.writeImageUrl': lazy('ClipBoard.writeImageUrl'),
   'ClipBoard.writeNativeFiles': lazy('ClipBoard.writeNativeFiles'),
   'ClipBoard.writeText': lazy('ClipBoard.writeText'),
   'ClipBoard.getSelectionText': lazy('ClipBoard.getSelectionText'),

--- a/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagement/ExtensionManagement.js
@@ -47,7 +47,7 @@ export const handleViewContextChange = (uid, viewId, context) => {
 }
 
 export const showViewContextMenu = async (uid, viewId, menuId, x, y) => {
-  await ContextMenu.show2(uid, MenuEntryId.ExtensionView, x, y, false, {
+  await ContextMenu.show2(uid, MenuEntryId.ExtensionView, x, y, {
     menuId,
     viewId,
   })

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewMenuEntries.ts
@@ -6,15 +6,23 @@ import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 interface ContextMenuProps {
   readonly menuId?: string
+  readonly viewId?: string
 }
 
 const getMenuEntries = async (uid: number, props: ContextMenuProps = {}): Promise<readonly unknown[]> => {
-  const instance = ViewletStates.getByUid(uid)
-  const state = instance?.state
-  if (!state || typeof state.uri !== 'string' || typeof props.menuId !== 'string') {
+  if (typeof props.menuId !== 'string') {
     return []
   }
-  const viewId = typeof state.viewId === 'string' ? state.viewId : state.uri
+  const instance = ViewletStates.getByUid(uid)
+  const state = instance?.state
+  const { uri, viewId: stateViewId } = state || {}
+  let { viewId } = props
+  if (typeof viewId !== 'string') {
+    viewId = typeof stateViewId === 'string' ? stateViewId : uri
+  }
+  if (typeof viewId !== 'string') {
+    return []
+  }
   return ExtensionManagementWorker.invoke('Extensions.getViewMenuEntries', viewId, uid, props.menuId, assetDir, getPlatform()) as Promise<
     readonly unknown[]
   >

--- a/packages/renderer-worker/test/ClipBoard.test.ts
+++ b/packages/renderer-worker/test/ClipBoard.test.ts
@@ -170,6 +170,25 @@ test.skip('writeImage', async () => {
   })
 })
 
+test('writeImageUrl fetches and writes the image blob', async () => {
+  const blob = new Blob(['image'], { type: 'image/png' })
+  const fetchImage = jest.fn<typeof fetch>(async () => new Response(blob))
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+
+  await ClipBoard.writeImageUrl('https://example.com/image.png', fetchImage)
+
+  expect(fetchImage).toHaveBeenCalledWith('https://example.com/image.png')
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('ClipBoard.writeImage', blob)
+})
+
+test('writeImageUrl rejects unsuccessful responses', async () => {
+  const fetchImage = jest.fn<typeof fetch>(async () => new Response(null, { status: 404, statusText: 'Not Found' }))
+
+  await expect(ClipBoard.writeImageUrl('https://example.com/missing.png', fetchImage)).rejects.toThrow('Not Found')
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
 test.skip('execCopy - error', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockImplementation(() => {

--- a/packages/renderer-worker/test/ExtensionManagement.test.ts
+++ b/packages/renderer-worker/test/ExtensionManagement.test.ts
@@ -106,7 +106,7 @@ test.skip('install', async () => {
 test('showViewContextMenu opens extension view context menu', async () => {
   await ExtensionManagement.showViewContextMenu(1, 'sample.views.testing', 'sample.card', 10, 20)
 
-  expect(ContextMenu.show2).toHaveBeenCalledWith(1, 30, 10, 20, false, {
+  expect(ContextMenu.show2).toHaveBeenCalledWith(1, 30, 10, 20, {
     menuId: 'sample.card',
     viewId: 'sample.views.testing',
   })

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
@@ -567,6 +567,20 @@ test('extension view menu entries delegate to extension management worker', asyn
   ViewletStates.remove(1)
 })
 
+test('extension view menu entries use the supplied view id without a renderer viewlet instance', async () => {
+  // @ts-ignore
+  ExtensionManagementWorker.invoke.mockResolvedValueOnce([])
+
+  await expect(
+    ViewletExtensionViewMenuEntries.menus[0].getMenuEntries(1, {
+      menuId: 'sample.card',
+      viewId: 'sample.views.testing',
+    }),
+  ).resolves.toEqual([])
+
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.getViewMenuEntries', 'sample.views.testing', 1, 'sample.card', '', 4)
+})
+
 test('loadContent ignores css load errors', async () => {
   globalThis.fetch = jest.fn(async () => {
     throw new Error('not found')


### PR DESCRIPTION
Fix extension-view context menu argument routing for main-area previews.

Add a clipboard command that fetches an image URL before writing the blob, with focused regression coverage.