### PR TITLE
fix: update search context dependencies

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -69,7 +69,7 @@
         "@lvce-editor/terminal-worker": "^2.7.0",
         "@lvce-editor/test-worker": "^17.10.1",
         "@lvce-editor/text-measurement-worker": "^1.21.0",
-        "@lvce-editor/text-search-view": "^1.5.0",
+        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.1/lvce-editor-text-search-view-1.6.1.tgz",
         "@lvce-editor/text-search-worker": "^7.13.1",
         "@lvce-editor/title-bar-worker": "^4.15.0",
         "@lvce-editor/update-worker": "^2.12.0"
@@ -1240,9 +1240,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-view": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/text-search-view/-/text-search-view-1.5.0.tgz",
-      "integrity": "sha512-XMaZ3rCgfclBQloN+2oUHi7gpFA9PFnVstfNjByIWRz7kcs25OQy0jNbGT9OA4FDIRKUcGjPXdwYK2T3mxIE/w==",
+      "version": "1.6.1",
+      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.1/lvce-editor-text-search-view-1.6.1.tgz",
+      "integrity": "sha512-aOtq3OXzeaxvqwGbWAMWs7GVsnXuXiwUD4M6shOvZrIbPwG2jSepnvSaayVMuETKHxwPbN81KPDNwrTdb00mFA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -101,7 +101,7 @@
     "@lvce-editor/terminal-worker": "^2.7.0",
     "@lvce-editor/test-worker": "^17.10.1",
     "@lvce-editor/text-measurement-worker": "^1.21.0",
-    "@lvce-editor/text-search-view": "^1.5.0",
+    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.1/lvce-editor-text-search-view-1.6.1.tgz",
     "@lvce-editor/text-search-worker": "^7.13.1",
     "@lvce-editor/title-bar-worker": "^4.15.0",
     "@lvce-editor/update-worker": "^2.12.0"

--- a/packages/shared-process/package-lock.json
+++ b/packages/shared-process/package-lock.json
@@ -41,7 +41,7 @@
         "@lvce-editor/preview-process": "^11.0.0",
         "@lvce-editor/process-explorer": "^3.14.0",
         "@lvce-editor/pty-host": "^8.7.0",
-        "@lvce-editor/search-process": "^15.6.0",
+        "@lvce-editor/search-process": "^15.6.1",
         "@lvce-editor/typescript-compile-process": "^5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.0.tgz",
-      "integrity": "sha512-l6qJZAPFSWxgOyaE21D949s4R7X/cJax7mNH4S09N/TaUqHYnT8ScR5P9lihpn1tDXlI1tAZKC9TZuwhTalOjw==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.1.tgz",
+      "integrity": "sha512-XQfgR8TK0NN5tnkPnu5mlf7oEe66PwxbfJCCxjFD+XbXRtmYJZpUPitAjkZE5p1awl7RrQMJFUin8uC3mfulig==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/packages/shared-process/package.json
+++ b/packages/shared-process/package.json
@@ -43,7 +43,7 @@
     "@lvce-editor/preview-process": "^11.0.0",
     "@lvce-editor/process-explorer": "^3.14.0",
     "@lvce-editor/pty-host": "^8.7.0",
-    "@lvce-editor/search-process": "^15.6.0",
+    "@lvce-editor/search-process": "^15.6.1",
     "@lvce-editor/typescript-compile-process": "^5.8.0",
     "open": "^11.0.0",
     "tail": "^2.2.6",


### PR DESCRIPTION
## Summary

- update `@lvce-editor/search-process` to 15.6.1 so ripgrep context records reach the editor
- update `@lvce-editor/text-search-view` to 1.6.1 so context rows render without inflating match counts or replacements
- consume the CI-produced text-search-view tarball from its GitHub release because that repository's package-scoped npm credential cannot publish the newly created package version

`@lvce-editor/text-search-worker` 7.13.1 was already merged separately by the trusted dependency bot in #13432.

## Release provenance

- search-process v15.6.1: https://github.com/lvce-editor/search-process/releases/tag/v15.6.1
- text-search-view v1.6.1: https://github.com/lvce-editor/text-search-view/releases/tag/v1.6.1
- text-search-view asset SHA-256: `caf9bfc5de170feee2e4d831b0f51b969f119e7ba0dbccce0d0e6ff28e4290fe`
- npm integrity: `sha512-aOtq3OXzeaxvqwGbWAMWs7GVsnXuXiwUD4M6shOvZrIbPwG2jSepnvSaayVMuETKHxwPbN81KPDNwrTdb00mFA==`

## Test

- `npm ci --ignore-scripts` in `packages/renderer-worker` installs `@lvce-editor/text-search-view@1.6.1`
- `npm ci --ignore-scripts` in `packages/shared-process` installs `@lvce-editor/search-process@15.6.1`
- `git diff --check`