### PR TITLE
fix: preserve search editor toolbar action

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-new-each-time.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-new-each-time.ts
@@ -5,10 +5,16 @@ export const name = 'viewlet.search-editor-new-each-time'
 export const test: Test = async ({ expect, Locator, Main }) => {
   await Main.closeAllEditors()
   await Locator('.ActivityBarItem[title="Search"]').click()
+  await new Promise((resolve) => setTimeout(resolve, 500))
 
-  const searchEditorButton = Locator('#SideBar button[title="Open New Search Editor"]')
+  const searchEditorButton = Locator('button[title="Open New Search Editor"]')
+  await expect(searchEditorButton).toBeVisible()
   await searchEditorButton.click()
-  await searchEditorButton.click()
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const searchEditorButtonAfterFirstOpen = Locator('button[title="Open New Search Editor"]')
+  await expect(searchEditorButtonAfterFirstOpen).toHaveCount(1)
+  await searchEditorButtonAfterFirstOpen.click()
+  await new Promise((resolve) => setTimeout(resolve, 50))
 
   const tabs = Locator('.MainTab')
   await expect(tabs).toHaveCount(2)

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -57,7 +57,7 @@
         "@lvce-editor/quick-pick-worker": "^4.10.0",
         "@lvce-editor/references-view": "^2.14.0",
         "@lvce-editor/rename-worker": "^1.37.0",
-        "@lvce-editor/renderer-process": "^30.23.0",
+        "@lvce-editor/renderer-process": "^30.23.1",
         "@lvce-editor/running-extensions-view": "^1.19.0",
         "@lvce-editor/settings-view": "^2.18.0",
         "@lvce-editor/settings-worker": "^1.11.0",
@@ -1165,9 +1165,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/renderer-process": {
-      "version": "30.23.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/renderer-process/-/renderer-process-30.23.0.tgz",
-      "integrity": "sha512-Qls69u4wEW6pfLnMSXaXyIyxT4rRDyTn1a6rgj2WK+5mSj6fzoy6vXDqHXuivezsteDZIxJe6YnaRykjE7teLQ==",
+      "version": "30.23.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/renderer-process/-/renderer-process-30.23.1.tgz",
+      "integrity": "sha512-pp1F1Ni9NCVJdzW4tlwOy9B/kq1jt3TIPZsVWUKrpsmVTsHTheL2xm8SPydG2+GskgDmmZg1cPY/drLUGlPrFw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/running-extensions-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -89,7 +89,7 @@
     "@lvce-editor/quick-pick-worker": "^4.10.0",
     "@lvce-editor/references-view": "^2.14.0",
     "@lvce-editor/rename-worker": "^1.37.0",
-    "@lvce-editor/renderer-process": "^30.23.0",
+    "@lvce-editor/renderer-process": "^30.23.1",
     "@lvce-editor/running-extensions-view": "^1.19.0",
     "@lvce-editor/settings-view": "^2.18.0",
     "@lvce-editor/settings-worker": "^1.11.0",


### PR DESCRIPTION
## Summary

- update renderer-process to 30.23.1, incorporating virtual-dom 11.11.4
- preserve focused actions that belong to referenced subtrees during Workbench rerenders
- strengthen the existing Search Editor e2e scenario by asserting the toolbar action remains after the first open and resolving it again before the second click

## Root cause

Opening a Search Editor rerenders the Workbench while the clicked toolbar action is focused. Focus preservation detached that action before the render; because the Search actions are reused as a referenced subtree, the new Workbench received the temporarily incomplete action list and cleanup removed the detached button.

## Validation

- focused Search Editor e2e passes with two Search tabs
- published fixed virtual-DOM signature is present in the built static renderer
- extension-host-worker-tests type check
- renderer-worker: 301 suites and 1,201 tests passed
- renderer-worker type check
- repository lint
- static build and static export verification
- server build

Dependency PRs: lvce-editor/virtual-dom#548, lvce-editor/renderer-process#754, lvce-editor/renderer-process#755