### PR TITLE
fix: apply search editor filters

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -69,7 +69,7 @@
         "@lvce-editor/terminal-worker": "^2.7.0",
         "@lvce-editor/test-worker": "^17.10.1",
         "@lvce-editor/text-measurement-worker": "^1.21.0",
-        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.1/lvce-editor-text-search-view-1.6.1.tgz",
+        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.2/lvce-editor-text-search-view-1.6.2.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
         "@lvce-editor/title-bar-worker": "^4.15.0",
         "@lvce-editor/update-worker": "^2.12.0"
@@ -1240,9 +1240,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-view": {
-      "version": "1.6.1",
-      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.1/lvce-editor-text-search-view-1.6.1.tgz",
-      "integrity": "sha512-aOtq3OXzeaxvqwGbWAMWs7GVsnXuXiwUD4M6shOvZrIbPwG2jSepnvSaayVMuETKHxwPbN81KPDNwrTdb00mFA==",
+      "version": "1.6.2",
+      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.2/lvce-editor-text-search-view-1.6.2.tgz",
+      "integrity": "sha512-pBfN46xM5G2+bEIc+J1qAsr47AQldT1j/DW9EsinSOqiaYxutePwMUNcfONUWJ6V294V8rFW9/6LYCnNySV+MQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -101,7 +101,7 @@
     "@lvce-editor/terminal-worker": "^2.7.0",
     "@lvce-editor/test-worker": "^17.10.1",
     "@lvce-editor/text-measurement-worker": "^1.21.0",
-    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.1/lvce-editor-text-search-view-1.6.1.tgz",
+    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.2/lvce-editor-text-search-view-1.6.2.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
     "@lvce-editor/title-bar-worker": "^4.15.0",
     "@lvce-editor/update-worker": "^2.12.0"

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -210,6 +210,7 @@ export const commandMap = {
   'Focus.setAdditionalFocus': lazy('Focus.setAdditionalFocus'),
   'Focus.setFocus': lazy('Focus.setFocus'),
   'GetActiveEditor.getActiveEditorId': lazy('GetActiveEditor.getActiveEditorId'),
+  'GetActiveEditor.getOpenEditorUris': lazy('GetActiveEditor.getOpenEditorUris'),
   'GetActiveEditor.updateAllDiagnostics': lazy('GetActiveEditor.updateAllDiagnostics'),
   'GetActiveEditor.updateDiagnostics': lazy('GetActiveEditor.updateDiagnostics'),
   'GetEditorSourceActions.getEditorSourceActions': lazy('GetEditorSourceActions.getEditorSourceActions'),

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
@@ -4,6 +4,7 @@ export const name = 'GetActiveEditor'
 
 export const Commands = {
   getActiveEditorId: GetActiveEditor.getActiveEditorId,
+  getOpenEditorUris: GetActiveEditor.getOpenEditorUris,
   updateAllDiagnostics: GetActiveEditor.updateAllDiagnostics,
   updateDiagnostics: GetActiveEditor.updateDiagnostics,
 }

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -1,5 +1,6 @@
 import * as Command from '../Command/Command.js'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
+import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
@@ -13,6 +14,19 @@ export const getActiveEditorId = () => {
     return -1
   }
   return instance.state.id
+}
+
+export const getOpenEditorUrisWithInvoke = async (invoke) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.Main)
+  if (!instance) {
+    return []
+  }
+  const savedState = await invoke('MainArea.saveState', instance.state.uid)
+  return savedState.layout.groups.flatMap((group) => group.tabs.map((tab) => tab.uri).filter((uri) => typeof uri === 'string'))
+}
+
+export const getOpenEditorUris = () => {
+  return getOpenEditorUrisWithInvoke(MainAreaWorker.invoke)
 }
 
 export const updateDiagnosticsWithCommand = async (executeCommand) => {

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -36,3 +36,33 @@ test('updateAllDiagnostics refreshes diagnostics for every open editor', async (
 
   expect(executeCommand).toHaveBeenCalledWith('Editor.updateDiagnosticsAll')
 })
+
+test('getOpenEditorUris returns tabs from every editor group', async () => {
+  ViewletStates.set('Main', {
+    factory: {},
+    moduleId: 'Main',
+    renderedState: { uid: 1 },
+    state: { uid: 1 },
+  })
+  const invoke = jest.fn(async () => ({
+    layout: {
+      groups: [
+        { tabs: [{ uri: 'file:///workspace/src/app.ts' }, { uri: 'search-editor://1/Search' }] },
+        { tabs: [{ uri: 'file:///workspace/README.md' }, { label: 'untitled' }] },
+      ],
+    },
+  }))
+
+  await expect(GetActiveEditor.getOpenEditorUrisWithInvoke(invoke)).resolves.toEqual([
+    'file:///workspace/src/app.ts',
+    'search-editor://1/Search',
+    'file:///workspace/README.md',
+  ])
+  expect(invoke).toHaveBeenCalledWith('MainArea.saveState', 1)
+})
+
+test('getOpenEditorUris returns an empty array without a main area', async () => {
+  const invoke = jest.fn()
+  await expect(GetActiveEditor.getOpenEditorUrisWithInvoke(invoke)).resolves.toEqual([])
+  expect(invoke).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

- expose open editor URIs from the main area to the Search view
- update Text Search View to request open editors when the filter is enabled
- update Text Search Worker so include patterns and open editor paths constrain ripgrep

## Dependencies

- https://github.com/lvce-editor/text-search-worker/pull/1482 (7.13.2)
- https://github.com/lvce-editor/text-search-view/pull/18 (1.6.2)

## Testing

- renderer-worker: 301 suites / 1,203 tests
- renderer-worker type-check
- root type-check
- root lint
- static and server builds
- direct ripgrep integration against the frozen Search Editor fixture