### PR TITLE
fix: preserve search editor query during navigation

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-keyboard-navigation.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-keyboard-navigation.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-keyboard-navigation'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ FileSystem, KeyBoard, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'needle')
+  await Workspace.setPath(tmpDir)
+  await Main.closeAllEditors()
+  await Main.openUri('search-editor://1/Search')
+
+  const input = Locator('.Main textarea[name="SearchValue"]')
+  await waitFor(() => expect(input).toBeVisible())
+  await input.click()
+  await input.type('needle')
+  await waitFor(() => expect(Locator('.Main .Search .TreeItem')).toHaveCount(2))
+
+  const results = Locator('.Main .Search [role="tree"]')
+  await results.dispatchEvent('focus', { bubbles: false } as unknown as string)
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  await KeyBoard.press('ArrowDown')
+
+  await waitFor(() => expect(input).toHaveValue('needle'))
+  await waitFor(() => expect(Locator('.Main .Search .TreeItemActive')).toHaveCount(1))
+}

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -69,7 +69,7 @@
         "@lvce-editor/terminal-worker": "^2.7.0",
         "@lvce-editor/test-worker": "^17.11.0",
         "@lvce-editor/text-measurement-worker": "^1.21.0",
-        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.2/lvce-editor-text-search-view-1.6.2.tgz",
+        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.3/lvce-editor-text-search-view-1.6.3.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
         "@lvce-editor/title-bar-worker": "^4.15.0",
         "@lvce-editor/update-worker": "^2.12.0"
@@ -1240,9 +1240,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-view": {
-      "version": "1.6.2",
-      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.2/lvce-editor-text-search-view-1.6.2.tgz",
-      "integrity": "sha512-pBfN46xM5G2+bEIc+J1qAsr47AQldT1j/DW9EsinSOqiaYxutePwMUNcfONUWJ6V294V8rFW9/6LYCnNySV+MQ==",
+      "version": "1.6.3",
+      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.3/lvce-editor-text-search-view-1.6.3.tgz",
+      "integrity": "sha512-uF97I/Q/PZWsxYCA9dJyl/Tkpf8PhXqLycXR6i53mfyF9uhbxHIFvszA6NaITehiegIGDhGBTjZ0OyL8Csugxg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -101,7 +101,7 @@
     "@lvce-editor/terminal-worker": "^2.7.0",
     "@lvce-editor/test-worker": "^17.11.0",
     "@lvce-editor/text-measurement-worker": "^1.21.0",
-    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.2/lvce-editor-text-search-view-1.6.2.tgz",
+    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.3/lvce-editor-text-search-view-1.6.3.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
     "@lvce-editor/title-bar-worker": "^4.15.0",
     "@lvce-editor/update-worker": "^2.12.0"


### PR DESCRIPTION
## Summary

- update text-search-view to v1.6.3
- add a Search Editor keyboard-navigation regression
- verify ArrowDown preserves the query and activates the first result after the result tree receives focus

## Test

- regression fails against text-search-view v1.6.2: expected one active row, found zero
- regression passes against v1.6.3 in 330 ms
- renderer-worker: 301 suites / 1203 tests passed
- extension-host-worker-tests type-check
- renderer-worker type-check
- npm run lint
- npm run build:server
- npm run test-static-export