### PR TITLE
Update LVCE Editor server to 0.96.12

### DIFF
--- a/packages/build/files/docker/alpine/Dockerfile
+++ b/packages/build/files/docker/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.11.0-alpine
 
-RUN npm install --global @lvce-editor/server@0.24.1
+RUN npm install --global @lvce-editor/server@0.96.12
 
 EXPOSE 3000
 

--- a/packages/build/files/docker/debian/Dockerfile
+++ b/packages/build/files/docker/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24.11.0
 
-RUN npm install --global @lvce-editor/server@0.24.1
+RUN npm install --global @lvce-editor/server@0.96.12
 
 EXPOSE 3000
 


### PR DESCRIPTION
Updates the Docker images to use `@lvce-editor/server` 0.96.12, the frozen latest published version for this rollout.