### PR TITLE
fix: expose panel child state saving

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -343,6 +343,7 @@ export const commandMap = {
   'SaveFileAs.saveFileAs': lazy('SaveFileAs.saveFileAs'),
   'SaveState.handleVisibilityChange': lazy('SaveState.handleVisibilityChange'),
   'SaveState.hydrate': lazy('SaveState.hydrate'),
+  'SaveState.saveViewletStateWithStorageId': lazy('SaveState.saveViewletStateWithStorageId'),
   'SearchProcess.invoke': lazy('SearchProcess.invoke'),
   'SendMessagePortToElectron.sendMessagePortToElectron': lazy('SendMessagePortToElectron.sendMessagePortToElectron'),
   'SendMessagePortToExtensionHostWorker.sendMessagePortToEditorWorker': lazy('SendMessagePortToExtensionHostWorker.sendMessagePortToEditorWorker'),

--- a/packages/renderer-worker/src/parts/SaveState/SaveState.ipc.js
+++ b/packages/renderer-worker/src/parts/SaveState/SaveState.ipc.js
@@ -6,4 +6,5 @@ export const name = 'SaveState'
 export const Commands = {
   handleVisibilityChange: SaveState.handleVisibilityChange,
   hydrate: SaveState.hydrate,
+  saveViewletStateWithStorageId: SaveState.saveViewletStateWithStorageId,
 }

--- a/packages/renderer-worker/src/parts/ViewletPanel/ViewletPanel.ts
+++ b/packages/renderer-worker/src/parts/ViewletPanel/ViewletPanel.ts
@@ -28,6 +28,10 @@ export const loadContent = async (state: any): Promise<any> => {
   }
 }
 
+export const saveState = (state: any): Promise<any> => {
+  return PanelWorker.invoke('Panel.saveState', state.uid)
+}
+
 export const hotReload = async (state) => {
   if (state.isHotReloading) {
     return state

--- a/packages/renderer-worker/test/SaveState.test.ts
+++ b/packages/renderer-worker/test/SaveState.test.ts
@@ -20,6 +20,7 @@ jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
 
 const InstanceStorage = await import('../src/parts/InstanceStorage/InstanceStorage.js')
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
+const SaveStateIpc = await import('../src/parts/SaveState/SaveState.ipc.js')
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -41,6 +42,12 @@ test('saves an instance under a different storage id', async () => {
   await SaveState.saveViewletStateWithStorageId(7, 'SimpleBrowser')
 
   expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:file:///workspace:SimpleBrowser', { value: 1 })
+})
+
+test('exposes workspace-scoped instance saving over renderer rpc', async () => {
+  await SaveStateIpc.Commands.saveViewletStateWithStorageId(7, 'Problems')
+
+  expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:file:///workspace:Problems', { value: 1 })
 })
 
 test('loads viewlet state from the current workspace key', async () => {

--- a/packages/renderer-worker/test/ViewletPanel.test.ts
+++ b/packages/renderer-worker/test/ViewletPanel.test.ts
@@ -1,0 +1,16 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/PanelWorker/PanelWorker.js', () => ({
+  invoke: jest.fn(async () => ({ currentViewletId: 'Problems' })),
+  restart: jest.fn(),
+}))
+
+const PanelWorker = await import('../src/parts/PanelWorker/PanelWorker.js')
+const ViewletPanel = await import('../src/parts/ViewletPanel/ViewletPanel.ts')
+
+test('saveState lets the panel worker save its active child', async () => {
+  const result = await ViewletPanel.saveState({ uid: 13 })
+
+  expect(PanelWorker.invoke).toHaveBeenCalledWith('Panel.saveState', 13)
+  expect(result).toEqual({ currentViewletId: 'Problems' })
+})


### PR DESCRIPTION
## Summary

- expose workspace-scoped viewlet state saving to worker RPC callers
- let the panel viewlet delegate state persistence to panel-worker
- cover both RPC boundaries with focused tests

## Testing

- renderer-worker type-check
- focused SaveState and ViewletPanel tests
- Prettier check for touched files