### PR TITLE
fix: isolate search editor state

### DIFF
--- a/packages/renderer-worker/src/parts/SerializeViewlet/SerializeViewlet.js
+++ b/packages/renderer-worker/src/parts/SerializeViewlet/SerializeViewlet.js
@@ -11,7 +11,7 @@ export const serializeInstances = async (instances) => {
   for (const value of Object.values(instances)) {
     const serializedInstance = await serializeInstance(value)
     if (serializedInstance) {
-      const storageKey = value.factory.StorageKey || value.moduleId
+      const storageKey = value.factory.getStorageKey ? value.factory.getStorageKey(value.state) : value.factory.StorageKey || value.moduleId
       serialized[storageKey] = serializedInstance
     }
   }

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -600,7 +600,8 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     const oldVersion = viewletState.version === undefined ? undefined : ++viewletState.version
     let instanceSavedState
     if (restore) {
-      instanceSavedState = await SaveState.getSavedViewletState(viewlet.id)
+      const storageKey = module.getStorageKey ? module.getStorageKey(viewletState) : viewlet.id
+      instanceSavedState = await SaveState.getSavedViewletState(storageKey)
     } else if (restoreState) {
       instanceSavedState = restoreState
     }

--- a/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearch.ts
+++ b/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearch.ts
@@ -7,6 +7,7 @@ import type { SearchState } from './ViewletSearchTypes.ts'
 export const create = (id: any, uri: string, x: number, y: number, width: number, height: number): SearchState => {
   return {
     uid: id,
+    uri,
     x,
     y,
     width,
@@ -17,6 +18,10 @@ export const create = (id: any, uri: string, x: number, y: number, width: number
     isSearchEditor: uri.startsWith('search-editor://'),
     platform: Platform.getPlatform(),
   }
+}
+
+export const getStorageKey = (state: SearchState): string => {
+  return state.uri
 }
 
 const doCreate = async (state: any): Promise<void> => {

--- a/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearchTypes.ts
+++ b/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearchTypes.ts
@@ -1,5 +1,6 @@
 export interface SearchState {
   readonly uid: number
+  readonly uri: string
   readonly commands: readonly any[]
   readonly x: number
   readonly y: number

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -130,9 +130,10 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     return state
   }
   // TODO set it in layout
-  const { currentViewletId } = state
+  const { childUid: currentChildUid, currentViewletId } = state
   const requestId = state.currentViewletRequestId + 1
-  const savePromise = restore ? SaveState.saveViewletState(currentViewletId) : undefined
+  const savePromise =
+    restore && currentChildUid !== -1 ? SaveState.saveViewletStateWithStorageId(currentChildUid, currentViewletId) : undefined
   state.currentViewletRequestId = requestId
   state.currentViewletId = moduleId
 

--- a/packages/renderer-worker/test/SerializeViewlet.test.ts
+++ b/packages/renderer-worker/test/SerializeViewlet.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@jest/globals'
+import * as SerializeViewlet from '../src/parts/SerializeViewlet/SerializeViewlet.js'
+
+test('serializeInstances keeps viewlet instances with distinct storage keys isolated', async () => {
+  const factory = {
+    getStorageKey: (state) => state.uri,
+    saveState: (state) => ({ value: state.value }),
+  }
+  const instances = {
+    1: {
+      factory,
+      moduleId: 'Search',
+      state: { uri: 'search-editor://1/Search', value: 'needle' },
+    },
+    2: {
+      factory,
+      moduleId: 'Search',
+      state: { uri: 'search-editor://2/Search', value: 'alpha' },
+    },
+  }
+
+  await expect(SerializeViewlet.serializeInstances(instances)).resolves.toEqual({
+    'search-editor://1/Search': { value: 'needle' },
+    'search-editor://2/Search': { value: 'alpha' },
+  })
+})

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -197,6 +197,41 @@ test('load retains non-empty event listener registration for a new root', async 
   ])
 })
 
+test('load restores state from a viewlet instance storage key', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation((command, _storageType, key) => {
+    if (command === 'WebStorage.getItem') {
+      expect(key).toBe('viewlet::search-editor://1/Search')
+      return JSON.stringify({ value: 'needle' })
+    }
+    return undefined
+  })
+  const mockModule = {
+    create: jest.fn(() => ({ uid: 12, uri: 'search-editor://1/Search' })),
+    getStorageKey: (state) => state.uri,
+    hasFunctionalEvents: true,
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state, _savedState) => state),
+    render: [],
+    renderEventListeners: jest.fn(() => []),
+  }
+  const viewlet = {
+    disposed: false,
+    getModule: async () => mockModule,
+    id: 'Search',
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid: 12,
+    uri: 'search-editor://1/Search',
+  }
+
+  await ViewletManager.load(viewlet, false, true)
+
+  expect(mockModule.loadContent).toHaveBeenCalledWith(expect.objectContaining({ uri: 'search-editor://1/Search' }), { value: 'needle' })
+})
+
 test('load reconciles widget declarations before returning initial render commands', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValue(undefined)

--- a/packages/renderer-worker/test/ViewletSearch.test.ts
+++ b/packages/renderer-worker/test/ViewletSearch.test.ts
@@ -35,12 +35,16 @@ test('create identifies sidebar search', () => {
   const state = ViewletSearch.create(1, 'Search', 10, 20, 800, 600)
 
   expect(state.isSearchEditor).toBe(false)
+  expect(state.uri).toBe('Search')
+  expect(ViewletSearch.getStorageKey(state)).toBe('Search')
 })
 
 test('create identifies search editors', () => {
   const state = ViewletSearch.create(1, 'search-editor://1/Search', 10, 20, 800, 600)
 
   expect(state.isSearchEditor).toBe(true)
+  expect(state.uri).toBe('search-editor://1/Search')
+  expect(ViewletSearch.getStorageKey(state)).toBe('search-editor://1/Search')
 })
 
 test('loadContent passes search editor mode to the text search view', async () => {

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -23,6 +23,7 @@ jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', 
 jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
   return {
     saveViewletState: jest.fn(() => undefined),
+    saveViewletStateWithStorageId: jest.fn(() => undefined),
   }
 })
 
@@ -47,6 +48,7 @@ beforeEach(() => {
   Command.execute.mockResolvedValue('Search')
   RendererProcess.invoke.mockResolvedValue(undefined)
   SaveState.saveViewletState.mockResolvedValue(undefined)
+  SaveState.saveViewletStateWithStorageId.mockResolvedValue(undefined)
   ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'Explorer', 2, true]])
   ViewletManager.runLoadContentLater.mockReturnValue(undefined)
   GetExtensionViews.getExtensionView.mockResolvedValue(undefined)
@@ -157,6 +159,19 @@ test('handleSideBarViewletChange uses child title', async () => {
     currentViewletId: 'Explorer',
     title: 'workspace-name',
   })
+})
+
+test('handleSideBarViewletChange saves the concrete sidebar child under the viewlet storage id', async () => {
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    childUid: 99,
+    currentViewletId: 'Search',
+  }
+
+  await ViewletSideBar.handleSideBarViewletChange(state, 'Explorer')
+
+  expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(99, 'Search')
+  expect(SaveState.saveViewletState).not.toHaveBeenCalled()
 })
 
 test('handleSideBarViewletChange gives an opted-out extension view the full sidebar', async () => {


### PR DESCRIPTION
## Summary

- persist each Search Editor instance under its stable editor URI
- restore Search Editor state from that per-instance key
- save the sidebar's concrete child instance under the sidebar view key
- add regression coverage for serialization, restoration, and sidebar switching

## Validation

- renderer worker: 302 suites, 1,208 tests passed
- focused regression suites: 48 tests passed
- full repository type-check passed
- root lint passed
- server build passed
- static export validation passed

## Reproduction

Before this change, two Search Editor tabs containing different queries collapse to the last-created query after restart, and switching the sidebar away from Search and back can load an editor query into the sidebar. Search sidebar and editor instances now remain isolated.