### PR TITLE
Fix lazy loading of WebSocket capability commands

### DIFF
--- a/packages/shared-process/src/parts/WebSocketCapability/WebSocketCapability.ipc.ts
+++ b/packages/shared-process/src/parts/WebSocketCapability/WebSocketCapability.ipc.ts
@@ -2,7 +2,7 @@ import * as WebSocketCapability from './WebSocketCapability.ts'
 
 export const name = 'WebSocketCapability'
 
-export const commandMap = {
+export const Commands = {
   create: WebSocketCapability.create,
   createExtensionNodeRpc: WebSocketCapability.createExtensionNodeRpc,
   createLegacyExtensionNodeRpc: WebSocketCapability.createLegacyExtensionNodeRpc,

--- a/packages/shared-process/test/WebSocketCapability.test.ts
+++ b/packages/shared-process/test/WebSocketCapability.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from '@jest/globals'
-import * as WebSocketCapability from '../src/parts/WebSocketCapability/WebSocketCapability.ts'
 import * as WebSocketCapabilityIpc from '../src/parts/WebSocketCapability/WebSocketCapability.ipc.ts'
+import * as WebSocketCapability from '../src/parts/WebSocketCapability/WebSocketCapability.ts'
 import * as WebSocketCapabilityRegistry from '../src/parts/WebSocketCapabilityRegistry/WebSocketCapabilityRegistry.ts'
 
 afterEach(() => {

--- a/packages/shared-process/test/WebSocketCapability.test.ts
+++ b/packages/shared-process/test/WebSocketCapability.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from '@jest/globals'
 import * as WebSocketCapability from '../src/parts/WebSocketCapability/WebSocketCapability.ts'
+import * as WebSocketCapabilityIpc from '../src/parts/WebSocketCapability/WebSocketCapability.ipc.ts'
 import * as WebSocketCapabilityRegistry from '../src/parts/WebSocketCapabilityRegistry/WebSocketCapabilityRegistry.ts'
 
 afterEach(() => {
@@ -10,6 +11,14 @@ const consumeDescriptor = (descriptor: WebSocketCapability.WebSocketConnectionIn
   const tokenProtocol = descriptor.protocols.find((protocol) => protocol.startsWith(WebSocketCapabilityRegistry.capabilityProtocolPrefix)) || ''
   return WebSocketCapabilityRegistry.consume(tokenProtocol.slice(WebSocketCapabilityRegistry.capabilityProtocolPrefix.length))
 }
+
+test('exposes capability commands to the lazy command loader', () => {
+  expect(WebSocketCapabilityIpc.Commands).toEqual({
+    create: WebSocketCapability.create,
+    createExtensionNodeRpc: WebSocketCapability.createExtensionNodeRpc,
+    createLegacyExtensionNodeRpc: WebSocketCapability.createLegacyExtensionNodeRpc,
+  })
+})
 
 test('binds isolated node rpc identity and resolved module path into the capability', () => {
   const descriptor = WebSocketCapability.createExtensionNodeRpc('builtin.git', 'git-client', '/extensions/builtin.git/client.js')


### PR DESCRIPTION
Exports the WebSocket capability IPC map as `Commands`, matching the shared-process lazy command loader contract. Adds a regression test for the capability commands.\n\nThis fixes built-in extension Node RPC startup exposed while updating `lvce-editor/git` to server 0.96.12.