### PR TITLE
fix: expose search editor replace all as a button

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-editor-replace-all-accessibility.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-editor-replace-all-accessibility.ts
@@ -1,0 +1,38 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-editor-replace-all-accessibility'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'needle')
+  await Workspace.setPath(tmpDir)
+  await Main.closeAllEditors()
+  await Main.openUri('search-editor://1/Search')
+
+  const input = Locator('.Main textarea[name="SearchValue"]')
+  await waitFor(() => expect(input).toBeVisible())
+  await input.type('needle')
+  await waitFor(() => expect(Locator('.Main .Search .TreeItem')).toHaveCount(2))
+
+  await Locator('.Main button[title="Toggle Replace"]').click()
+  const replaceInput = Locator('.Main textarea[name="ReplaceValue"]')
+  await waitFor(() => expect(replaceInput).toBeVisible())
+  await replaceInput.type('pin')
+  const replaceAll = Locator('.Main button[name="ReplaceAll"]')
+  await expect(replaceAll).toHaveAttribute('role', null)
+  await expect(replaceAll).toHaveAttribute('aria-checked', null)
+}

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -69,7 +69,7 @@
         "@lvce-editor/terminal-worker": "^2.7.0",
         "@lvce-editor/test-worker": "^17.11.0",
         "@lvce-editor/text-measurement-worker": "^1.21.0",
-        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.3/lvce-editor-text-search-view-1.6.3.tgz",
+        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.4/lvce-editor-text-search-view-1.6.4.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
         "@lvce-editor/title-bar-worker": "^4.15.0",
         "@lvce-editor/update-worker": "^2.12.0"
@@ -1240,9 +1240,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-view": {
-      "version": "1.6.3",
-      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.3/lvce-editor-text-search-view-1.6.3.tgz",
-      "integrity": "sha512-uF97I/Q/PZWsxYCA9dJyl/Tkpf8PhXqLycXR6i53mfyF9uhbxHIFvszA6NaITehiegIGDhGBTjZ0OyL8Csugxg==",
+      "version": "1.6.4",
+      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.4/lvce-editor-text-search-view-1.6.4.tgz",
+      "integrity": "sha512-vVlHzOyZnKe+/W12uV8ss44ZsiDYGsbNY/2MILB1n+c0zYd9zvtB0gUgX+WUtxnbqaB9ASPaOIOf2vGdb7c15Q==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -101,7 +101,7 @@
     "@lvce-editor/terminal-worker": "^2.7.0",
     "@lvce-editor/test-worker": "^17.11.0",
     "@lvce-editor/text-measurement-worker": "^1.21.0",
-    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.3/lvce-editor-text-search-view-1.6.3.tgz",
+    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.4/lvce-editor-text-search-view-1.6.4.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
     "@lvce-editor/title-bar-worker": "^4.15.0",
     "@lvce-editor/update-worker": "^2.12.0"


### PR DESCRIPTION
## Summary
- update text-search-view to v1.6.4
- expose enabled Search Editor Replace All actions with native button semantics
- add an end-to-end accessibility regression test

## Test Plan
- targeted Search Editor Replace All accessibility e2e
- npm test (303 renderer suites / 1,210 renderer tests; all five project targets pass)
- npm run type-check
- npm run lint
- npm run build:static
- npm run build:server
- npm run test-static-export