### PR TITLE
fix: render problems action-only updates

### DIFF
--- a/packages/renderer-worker/src/parts/WrapProblemsCommand/WrapProblemsCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapProblemsCommand/WrapProblemsCommand.ts
@@ -1,27 +1,56 @@
-import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
-import * as ViewletStates from '../ViewletStates/ViewletStates.js'
-import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as NameAnonymousFunction from '../NameAnonymousFunction/NameAnonymousFunction.js'
+import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
-export const wrapProblemsCommand = (key: string) => {
-  const fn = async (state, ...args) => {
-    await ProblemsWorker.invoke(`Problems.${key}`, state.uid, ...args)
-    const diffResult = await ProblemsWorker.invoke('Problems.diff2', state.uid)
-    if (diffResult.length === 0) {
+interface ProblemsCommandDependencies {
+  readonly getState: () => ProblemsViewState
+  readonly invoke: (command: string, ...args: readonly unknown[]) => Promise<unknown>
+}
+
+interface ProblemsViewState {
+  readonly actionsDom?: readonly unknown[]
+  readonly [key: string]: unknown
+  readonly uid: number
+}
+
+type ProblemsCommand = (state: ProblemsViewState, ...args: readonly unknown[]) => Promise<ProblemsViewState>
+
+const defaultDependencies: ProblemsCommandDependencies = {
+  getState: () => ViewletStates.getState(ViewletModuleId.Problems) as ProblemsViewState,
+  invoke: ProblemsWorker.invoke,
+}
+
+const areActionsEqual = (oldActionsDom: readonly unknown[] | undefined, newActionsDom: readonly unknown[]): boolean => {
+  return JSON.stringify(oldActionsDom) === JSON.stringify(newActionsDom)
+}
+
+export const wrapProblemsCommandWithDependencies = (key: string, dependencies: ProblemsCommandDependencies): ProblemsCommand => {
+  const { getState, invoke } = dependencies
+  const fn: ProblemsCommand = async (state, ...args) => {
+    const { actionsDom: oldActionsDom, uid } = state
+    await invoke(`Problems.${key}`, uid, ...args)
+    const diffResult = (await invoke('Problems.diff2', uid)) as readonly unknown[]
+    const actionsDom = (await invoke('Problems.renderActions', uid)) as readonly unknown[]
+    const actionsChanged = !areActionsEqual(oldActionsDom, actionsDom)
+    if (diffResult.length === 0 && !actionsChanged) {
       return state
     }
-    const commands = await ProblemsWorker.invoke('Problems.render2', state.uid, diffResult)
-    const actionsDom = await ProblemsWorker.invoke('Problems.renderActions', state.uid)
-    if (commands.length === 0) {
+    const commands = diffResult.length === 0 ? [] : ((await invoke('Problems.render2', uid, diffResult)) as readonly unknown[])
+    if (commands.length === 0 && !actionsChanged) {
       return state
     }
-    const latest = ViewletStates.getState(ViewletModuleId.Problems)
+    const latest = getState()
     return {
       ...latest,
-      commands,
       actionsDom,
+      commands,
     }
   }
   NameAnonymousFunction.nameAnonymousFunction(fn, `Problems/${key}`)
   return fn
+}
+
+export const wrapProblemsCommand = (key: string): ProblemsCommand => {
+  return wrapProblemsCommandWithDependencies(key, defaultDependencies)
 }

--- a/packages/renderer-worker/test/WrapProblemsCommand.test.ts
+++ b/packages/renderer-worker/test/WrapProblemsCommand.test.ts
@@ -1,0 +1,74 @@
+import { expect, jest, test } from '@jest/globals'
+import { wrapProblemsCommandWithDependencies } from '../src/parts/WrapProblemsCommand/WrapProblemsCommand.ts'
+
+test('returns updated actions when the problems body has no diff', async () => {
+  const invoke = jest.fn(async (command: string, ..._args: readonly unknown[]): Promise<unknown> => {
+    if (command === 'Problems.diff2') {
+      return []
+    }
+    if (command === 'Problems.renderActions') {
+      return [{ title: 'View as List' }]
+    }
+    return undefined
+  })
+  const command = wrapProblemsCommandWithDependencies('viewAsTable', {
+    getState: () => ({ marker: 'latest', uid: 7 }),
+    invoke,
+  })
+
+  const result = await command({ actionsDom: [{ title: 'View as Table' }], uid: 7 })
+
+  expect(result).toEqual({
+    actionsDom: [{ title: 'View as List' }],
+    commands: [],
+    marker: 'latest',
+    uid: 7,
+  })
+  expect(invoke).not.toHaveBeenCalledWith('Problems.render2', 7, [])
+})
+
+test('returns updated body commands and actions when both changed', async () => {
+  const invoke = jest.fn(async (command: string, ..._args: readonly unknown[]): Promise<unknown> => {
+    if (command === 'Problems.diff2') {
+      return [1]
+    }
+    if (command === 'Problems.render2') {
+      return [['Viewlet.setDom2']]
+    }
+    if (command === 'Problems.renderActions') {
+      return [{ title: 'View as List' }]
+    }
+    return undefined
+  })
+  const command = wrapProblemsCommandWithDependencies('viewAsTable', {
+    getState: () => ({ marker: 'latest', uid: 7 }),
+    invoke,
+  })
+
+  const result = await command({ actionsDom: [{ title: 'View as Table' }], uid: 7 })
+
+  expect(result.actionsDom).toEqual([{ title: 'View as List' }])
+  expect(result.commands).toEqual([['Viewlet.setDom2']])
+})
+
+test('preserves state when neither body nor actions changed', async () => {
+  const actionsDom = [{ title: 'View as Table' }]
+  const state = { actionsDom, uid: 7 }
+  const invoke = jest.fn(async (command: string, ..._args: readonly unknown[]): Promise<unknown> => {
+    if (command === 'Problems.diff2') {
+      return []
+    }
+    if (command === 'Problems.renderActions') {
+      return actionsDom
+    }
+    return undefined
+  })
+  const command = wrapProblemsCommandWithDependencies('handleBlur', {
+    getState: () => state,
+    invoke,
+  })
+
+  const result = await command(state)
+
+  expect(result).toBe(state)
+})


### PR DESCRIPTION
## Summary

- keep Problems toolbar actions in sync when a worker command changes only the actions DOM
- skip body rendering when there is no body diff while still returning changed actions
- preserve the previous no-op fast path when neither body nor actions changed

## Tests

- `npm run lint`
- `npx tsc -b packages/renderer-worker --pretty false --force`
- renderer Jest suite: 304 passed suites, 1,213 passed tests (existing skips unchanged)
- focused `WrapProblemsCommand` tests: action-only update, body-plus-action update, unchanged no-op
