### PR TITLE
fix: update preview action event listeners

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1039,7 +1039,10 @@ export const setActionsDom = (
   }
   if (state.previewActionsUid !== -1) {
     return {
-      commands: [['Viewlet.setDom2', state.previewActionsUid, actionsDom]],
+      commands: [
+        ['Viewlet.registerEventListeners', state.previewActionsUid, eventListeners],
+        ['Viewlet.setDom2', state.previewActionsUid, actionsDom],
+      ],
       handled: true,
       renderParent: false,
       statePatch: {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -100,21 +100,25 @@ test('setActionsDom creates preview actions with the child event listeners', () 
   ])
 })
 
-test('setActionsDom updates existing preview actions', () => {
+test('setActionsDom updates existing preview actions and event listeners', () => {
   const state = {
     ...ViewletLayout.create(12),
+    previewActionsEventListeners: ['old-click'],
     previewActionsUid: 8,
     previewId: 7,
   }
 
-  const result = ViewletLayout.setActionsDom(state, ['updated-actions'], 7)
+  const result = ViewletLayout.setActionsDom(state, ['updated-actions'], 7, ['new-click'])
 
   expect(result).toEqual({
-    commands: [['Viewlet.setDom2', 8, ['updated-actions']]],
+    commands: [
+      ['Viewlet.registerEventListeners', 8, ['new-click']],
+      ['Viewlet.setDom2', 8, ['updated-actions']],
+    ],
     handled: true,
     renderParent: false,
     statePatch: {
-      previewActionsEventListeners: [],
+      previewActionsEventListeners: ['new-click'],
     },
   })
 })


### PR DESCRIPTION
## Summary
- replace the event-listener map when a reused preview action root receives a new child toolbar
- keep the listener update ordered before the corresponding DOM update
- cover switching an existing preview action root from old to new listeners

## Tests
- renderer-worker focused regression (22 tests)
- renderer-worker full suite (304 suites, 1213 tests)
- renderer-worker type-check
- root lint