### PR TITLE
fix: preserve content around bulk replacements

### DIFF
--- a/packages/renderer-worker/src/parts/BulkReplacementContent/BulkReplacementContent.ts
+++ b/packages/renderer-worker/src/parts/BulkReplacementContent/BulkReplacementContent.ts
@@ -16,12 +16,12 @@ export const getNewContent = (oldContent: string, changes: readonly TextEdit[]):
       newLineIndex = GetNewLineIndex.getNewLineIndex(oldContent, newLineIndex + 1)
       rowIndex++
     }
-    if (copiedContentIndex <= newLineIndex) {
-      newContent += oldContent.slice(copiedContentIndex, newLineIndex + 1)
-      copiedContentIndex = newLineIndex + 1
-    }
+    const lineStartIndex = newLineIndex + 1
+    const startContentIndex = lineStartIndex + startColumnIndex
+    const endContentIndex = lineStartIndex + endColumnIndex
+    newContent += oldContent.slice(copiedContentIndex, startContentIndex)
     newContent += text
-    copiedContentIndex += endColumnIndex - startColumnIndex
+    copiedContentIndex = endContentIndex
   }
-  return newContent
+  return newContent + oldContent.slice(copiedContentIndex)
 }

--- a/packages/renderer-worker/test/BulkReplacementContent.test.ts
+++ b/packages/renderer-worker/test/BulkReplacementContent.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@jest/globals'
+import * as BulkReplacementContent from '../src/parts/BulkReplacementContent/BulkReplacementContent.ts'
+
+test('getNewContent - preserves text around a replacement', () => {
+  const oldContent = "export const alpha = 'needle'\n"
+  const changes = [
+    {
+      endColumnIndex: 28,
+      endRowIndex: 1,
+      startColumnIndex: 22,
+      startRowIndex: 0,
+      text: 'pin',
+    },
+  ]
+
+  expect(BulkReplacementContent.getNewContent(oldContent, changes)).toBe("export const alpha = 'pin'\n")
+})
+
+test('getNewContent - replaces matches on multiple lines', () => {
+  const oldContent = "export const alpha = 'needle'\nexport const beta = 'NEEDLE'\nexport const phrase = 'needle in TypeScript'\n"
+  const changes = [
+    {
+      endColumnIndex: 28,
+      endRowIndex: 1,
+      startColumnIndex: 22,
+      startRowIndex: 0,
+      text: 'pin',
+    },
+    {
+      endColumnIndex: 27,
+      endRowIndex: 2,
+      startColumnIndex: 21,
+      startRowIndex: 1,
+      text: 'pin',
+    },
+    {
+      endColumnIndex: 29,
+      endRowIndex: 3,
+      startColumnIndex: 23,
+      startRowIndex: 2,
+      text: 'pin',
+    },
+  ]
+
+  expect(BulkReplacementContent.getNewContent(oldContent, changes)).toBe(
+    "export const alpha = 'pin'\nexport const beta = 'pin'\nexport const phrase = 'pin in TypeScript'\n",
+  )
+})
+
+test('getNewContent - replaces multiple matches on one line', () => {
+  const oldContent = 'needle and needle remain on one line'
+  const changes = [
+    {
+      endColumnIndex: 6,
+      endRowIndex: 1,
+      startColumnIndex: 0,
+      startRowIndex: 0,
+      text: 'pin',
+    },
+    {
+      endColumnIndex: 17,
+      endRowIndex: 1,
+      startColumnIndex: 11,
+      startRowIndex: 0,
+      text: 'pin',
+    },
+  ]
+
+  expect(BulkReplacementContent.getNewContent(oldContent, changes)).toBe('pin and pin remain on one line')
+})


### PR DESCRIPTION
## Summary
- copy source text up to each bulk replacement range
- advance to each absolute replacement end instead of the prior relative length
- preserve trailing source content after the final replacement
- cover non-zero columns, multiple lines, and multiple matches on one line

## Test Plan
- focused BulkReplacementContent tests (red before fix, 3/3 green after)
- npm test (305 renderer suites / 1,216 renderer tests; all five project targets pass)
- npm run type-check
- npm run lint
- npm run build:static:ignore-icon-theme
- npm run build:server
- npm run test-static-export