### PR TITLE
fix: use absolute search replacement columns

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -69,7 +69,7 @@
         "@lvce-editor/terminal-worker": "^2.7.0",
         "@lvce-editor/test-worker": "^17.11.0",
         "@lvce-editor/text-measurement-worker": "^1.21.0",
-        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.4/lvce-editor-text-search-view-1.6.4.tgz",
+        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
         "@lvce-editor/title-bar-worker": "^4.15.0",
         "@lvce-editor/update-worker": "^2.12.0"
@@ -1240,9 +1240,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-view": {
-      "version": "1.6.4",
-      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.4/lvce-editor-text-search-view-1.6.4.tgz",
-      "integrity": "sha512-vVlHzOyZnKe+/W12uV8ss44ZsiDYGsbNY/2MILB1n+c0zYd9zvtB0gUgX+WUtxnbqaB9ASPaOIOf2vGdb7c15Q==",
+      "version": "1.6.5",
+      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
+      "integrity": "sha512-6XLz/cDJ6HkvZL7fw2GnULntXxQS02A7g3gjiA4XC6sVFq+GIXmMRd4Z+CvOnBY3wcA6iFwRwKSR1eoCtLIX5g==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -101,7 +101,7 @@
     "@lvce-editor/terminal-worker": "^2.7.0",
     "@lvce-editor/test-worker": "^17.11.0",
     "@lvce-editor/text-measurement-worker": "^1.21.0",
-    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.4/lvce-editor-text-search-view-1.6.4.tgz",
+    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
     "@lvce-editor/title-bar-worker": "^4.15.0",
     "@lvce-editor/update-worker": "^2.12.0"


### PR DESCRIPTION
## Details

Search Editor Replace All used preview-relative match coordinates for long lines, so replacements could overwrite text before the actual match even though the UI reported success.

## Change

Update `@lvce-editor/text-search-view` from 1.6.4 to 1.6.5. The dependency now prefers the absolute columns already supplied by the search process and retains legacy coordinate fallback behavior.

Dependency release: https://github.com/lvce-editor/text-search-view/releases/tag/v1.6.5
Dependency fix: https://github.com/lvce-editor/text-search-view/pull/21

## Verification

- Renderer dependency integrity independently matches the published tarball
- All five project test targets passed (renderer: 305 suites / 1216 tests)
- Type-check
- Lint
- Static build
- Server build
- Static export
- Focused Search Editor Replace All accessibility e2e