### PR TITLE
fix: update panel view actions

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1124,6 +1124,7 @@ export const createPanelViewlet = async (
       // @ts-ignore
       uri,
       uid: editorUid,
+      actionsUid,
       show: false,
       focus,
       setBounds: false,

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -262,11 +262,13 @@ export const create = (getModule, id, parentUid, uri, x, y, width, height) => {
   }
 }
 
-const getRenderCommands = (module, oldState, newState, uid = newState.uid || module.name, parentId, eventListeners) => {
+const getRenderCommands = (module, oldState, newState, uid = newState.uid || module.name, parentId, eventListeners, actionsUid) => {
   const commands = []
   if (module.renderActions && !module.renderActions.isEqual(oldState, newState)) {
     const actionsCommands = module.renderActions.apply(oldState, newState)
-    if (parentId) {
+    if (typeof actionsUid === 'number' && actionsUid > 0) {
+      commands.push(['Viewlet.setDom2', actionsUid, actionsCommands])
+    } else if (parentId) {
       const parentInstance = ViewletStates.getInstance(parentId)
       if (parentInstance?.factory?.setActionsDom) {
         const result = parentInstance.factory.setActionsDom(parentInstance.state, actionsCommands, uid, eventListeners)
@@ -630,6 +632,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
 
     if (viewlet.id === ViewletModuleId.Layout) {
       ViewletStates.set(viewletUid, {
+        actionsUid: viewlet.actionsUid,
         state: newState,
         renderedState: viewletState,
         factory: module,
@@ -701,6 +704,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     }
 
     const instance = {
+      actionsUid: viewlet.actionsUid,
       state: newState,
       renderedState: viewletState,
       factory: module,
@@ -860,7 +864,8 @@ export const mutate = async (id, fn) => {
 }
 
 export const render = (module, oldState, newState, uid = newState.uid || module.name, parentUid = newState.parentUid) => {
-  const commands = getRenderCommands(module, oldState, newState, uid, parentUid)
+  const actionsUid = ViewletStates.getInstance(uid)?.actionsUid
+  const commands = getRenderCommands(module, oldState, newState, uid, parentUid, undefined, actionsUid)
   return LayoutWidgets.reconcile(commands)
 }
 

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -404,6 +404,13 @@ test('createPanelViewlet creates a linked actions root for child-contributed act
   )
 
   expect(ViewletManager.load).toHaveBeenCalledTimes(1)
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      actionsUid: 33,
+    }),
+    false,
+    true,
+  )
   expect(result).toEqual({
     newState: state,
     commands: [

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -110,6 +110,38 @@ test('render adds uid to setPatches command', () => {
   expect(commands).toEqual([['Viewlet.setPatches', 42, patches]])
 })
 
+test('render sends action updates to a linked actions root', () => {
+  const oldState = {
+    uid: 42,
+    viewMode: 1,
+  }
+  const newState = {
+    ...oldState,
+    viewMode: 2,
+  }
+  const mockModule = {
+    render: [],
+    renderActions: {
+      apply() {
+        return ['updated-actions']
+      },
+      isEqual() {
+        return false
+      },
+    },
+  }
+  ViewletStates.set(42, {
+    actionsUid: 99,
+    factory: mockModule,
+    renderedState: oldState,
+    state: newState,
+  })
+
+  const commands = ViewletManager.render(mockModule, oldState, newState, 42, -1)
+
+  expect(commands).toEqual([['Viewlet.setDom2', 99, ['updated-actions']]])
+})
+
 test('load omits empty event listener registration for a new root', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValue(undefined)


### PR DESCRIPTION
Retain panel toolbar root ownership on renderer viewlet instances so later action renders update the attached toolbar directly. Adds regression coverage for panel action-root linkage and subsequent action updates.