### PR TITLE
fix: open output stack trace links

### DIFF
--- a/packages/renderer-worker/src/parts/ResolveInternalSourceUri/ResolveInternalSourceUri.ts
+++ b/packages/renderer-worker/src/parts/ResolveInternalSourceUri/ResolveInternalSourceUri.ts
@@ -1,0 +1,14 @@
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+const internalSourcePrefixes = ['lvce://', 'lvce-oss://']
+
+interface Invoke {
+  (method: string, uri: string): Promise<string>
+}
+
+export const resolveInternalSourceUri = async (uri: string, invoke: Invoke = SharedProcess.invoke): Promise<string> => {
+  if (internalSourcePrefixes.every((prefix) => !uri.startsWith(prefix))) {
+    return uri
+  }
+  return invoke('GetElectronFileResponse.resolveElectronFileUri', uri)
+}

--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMainOpenUri.ts
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMainOpenUri.ts
@@ -2,6 +2,7 @@ import * as Assert from '../Assert/Assert.ts'
 import * as Id from '../Id/Id.js'
 import * as MeasureTabWidth from '../MeasureTabWidth/MeasureTabWidth.js'
 import * as PathDisplay from '../PathDisplay/PathDisplay.js'
+import { resolveInternalSourceUri } from '../ResolveInternalSourceUri/ResolveInternalSourceUri.ts'
 import * as TabFlags from '../TabFlags/TabFlags.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
@@ -13,13 +14,14 @@ import * as ViewletMainFocusIndex from './ViewletMainFocusIndex.js'
 export const openUri = async (state, uri, focus = true, { preview = false, ...context } = {}) => {
   Assert.object(state)
   Assert.string(uri)
+  const resolvedUri = await resolveInternalSourceUri(uri)
   const { tabFontWeight, tabFontSize, tabFontFamily, tabLetterSpacing, groups, activeGroupIndex, tabHeight } = state
   const x = state.x
   const y = state.y + tabHeight
   const width = state.width
   const contentHeight = state.height - tabHeight
   // @ts-ignore
-  const moduleId = await ViewletMap.getModuleId(uri, context.opener)
+  const moduleId = await ViewletMap.getModuleId(resolvedUri, context.opener)
   let activeGroup = groups[activeGroupIndex]
   activeGroup ||= {
     uid: Id.create(),
@@ -37,7 +39,7 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
   const previousEditor = editors[activeIndex]
   let disposeCommands
   // @ts-ignore
-  if (previousEditor && previousEditor.uri === uri && previousEditor.opener === context.opener) {
+  if (previousEditor && previousEditor.uri === resolvedUri && previousEditor.opener === context.opener) {
     return {
       newState: state,
       commands: [],
@@ -45,7 +47,7 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
   }
   for (let i = 0; i < editors.length; i++) {
     const editor = editors[i]
-    if (editor.uri === uri) {
+    if (editor.uri === resolvedUri) {
       // @ts-ignore
       if (editor.opener === context.opener) {
         return ViewletMainFocusIndex.focusIndex(state, i)
@@ -59,15 +61,15 @@ export const openUri = async (state, uri, focus = true, { preview = false, ...co
     disposeCommands = Viewlet.hideFunctional(previousUid)
   }
   const instanceUid = Id.create()
-  const instance = ViewletManager.create(ViewletModule.load, moduleId, state.uid, uri, activeGroup.x, y, activeGroup.width, contentHeight)
+  const instance = ViewletManager.create(ViewletModule.load, moduleId, state.uid, resolvedUri, activeGroup.x, y, activeGroup.width, contentHeight)
   instance.uid = instanceUid
   // const oldActiveIndex = state.activeIndex
-  const tabLabel = PathDisplay.getLabel(uri)
+  const tabLabel = PathDisplay.getLabel(resolvedUri)
   const tabWidth = MeasureTabWidth.measureTabWidth(tabLabel, tabFontWeight, tabFontSize, tabFontFamily, tabLetterSpacing)
-  const tabTitle = PathDisplay.getTitle(uri)
-  const icon = await PathDisplay.getFileIcon(uri)
+  const tabTitle = PathDisplay.getTitle(resolvedUri)
+  const icon = await PathDisplay.getFileIcon(resolvedUri)
   const newEditor = {
-    uri,
+    uri: resolvedUri,
     uid: instanceUid,
     label: tabLabel,
     title: tabTitle,

--- a/packages/renderer-worker/test/ResolveInternalSourceUri.test.ts
+++ b/packages/renderer-worker/test/ResolveInternalSourceUri.test.ts
@@ -1,0 +1,26 @@
+import { expect, jest, test } from '@jest/globals'
+import { resolveInternalSourceUri } from '../src/parts/ResolveInternalSourceUri/ResolveInternalSourceUri.ts'
+
+test('resolveInternalSourceUri - resolves an lvce uri on disk', async () => {
+  const invoke = jest.fn(async (_method: string, _uri: string) => 'file:///usr/lib/lvce/resources/app/static/abc123/rendererWorkerMain.js')
+
+  await expect(resolveInternalSourceUri('lvce://-/abc123/rendererWorkerMain.js', invoke)).resolves.toBe(
+    'file:///usr/lib/lvce/resources/app/static/abc123/rendererWorkerMain.js',
+  )
+  expect(invoke).toHaveBeenCalledWith('GetElectronFileResponse.resolveElectronFileUri', 'lvce://-/abc123/rendererWorkerMain.js')
+})
+
+test('resolveInternalSourceUri - resolves an lvce oss uri on disk', async () => {
+  const invoke = jest.fn(async (_method: string, _uri: string) => 'file:///home/test/lvce-editor/packages/rendererWorkerMain.js')
+
+  await expect(resolveInternalSourceUri('lvce-oss://-/packages/rendererWorkerMain.js', invoke)).resolves.toBe(
+    'file:///home/test/lvce-editor/packages/rendererWorkerMain.js',
+  )
+})
+
+test('resolveInternalSourceUri - keeps a file uri unchanged', async () => {
+  const invoke = jest.fn(async (_method: string, _uri: string) => '')
+
+  await expect(resolveInternalSourceUri('file:///tmp/test.js', invoke)).resolves.toBe('file:///tmp/test.js')
+  expect(invoke).not.toHaveBeenCalled()
+})

--- a/packages/shared-process/src/parts/GetElectronFileResponse/GetElectronFileResponse.ipc.ts
+++ b/packages/shared-process/src/parts/GetElectronFileResponse/GetElectronFileResponse.ipc.ts
@@ -4,4 +4,5 @@ export const name = 'GetElectronFileResponse'
 
 export const Commands = {
   getElectronFileResponse: GetElectronFileResponse.getElectronFileResponse,
+  resolveElectronFileUri: GetElectronFileResponse.resolveElectronFileUri,
 }

--- a/packages/shared-process/src/parts/GetElectronFileResponse/GetElectronFileResponse.ts
+++ b/packages/shared-process/src/parts/GetElectronFileResponse/GetElectronFileResponse.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import * as GetContentResponse from '../GetContentResponse/GetContentResponse.ts'
 import * as GetElectronFileResponseAbsolutePath from '../GetElectronFileResponseAbsolutePath/GetElectronFileResponseAbsolutePath.ts'
 import * as GetElectronFileResponseContent from '../GetElectronFileResponseContent/GetElectronFileResponseContent.ts'
@@ -12,6 +13,12 @@ import * as HttpHeader from '../HttpHeader/HttpHeader.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import * as IsTypeScriptSyntaxError from '../IsTypeScriptSyntaxError/IsTypeScriptSyntaxError.ts'
 import * as Logger from '../Logger/Logger.ts'
+
+export const resolveElectronFileUri = (url: string): string => {
+  const pathName = GetElectronFileResponseRelativePath.getElectronFileResponseRelativePath(url)
+  const absolutePath = GetElectronFileResponseAbsolutePath.getElectronFileResponseAbsolutePath(pathName)
+  return pathToFileURL(absolutePath).toString()
+}
 
 // TODO maybe handle app responses and webview responses separately
 // maybe send webview requests directly to preview process

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -158,6 +158,7 @@ export const getModuleId = (commandId: any): any => {
     case 'FirefoxCookieImport.importCookies':
       return ModuleId.FirefoxCookieImport
     case 'GetElectronFileResponse.getElectronFileResponse':
+    case 'GetElectronFileResponse.resolveElectronFileUri':
       return ModuleId.GetElectronFileResponse
     case 'GetExtensions.getExtensions':
       return ModuleId.GetExtensions

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -21,3 +21,7 @@ test('getModuleId - ChromeCookieImport.importCookies', () => {
 test('getModuleId - FirefoxCookieImport.importCookies', () => {
   expect(ModuleMap.getModuleId('FirefoxCookieImport.importCookies')).toBe(ModuleId.FirefoxCookieImport)
 })
+
+test('getModuleId - GetElectronFileResponse.resolveElectronFileUri', () => {
+  expect(ModuleMap.getModuleId('GetElectronFileResponse.resolveElectronFileUri')).toBe(ModuleId.GetElectronFileResponse)
+})

--- a/packages/shared-process/test/ResolveElectronFileUri.test.ts
+++ b/packages/shared-process/test/ResolveElectronFileUri.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@jest/globals'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import * as GetElectronFileResponse from '../src/parts/GetElectronFileResponse/GetElectronFileResponse.ts'
+import * as Root from '../src/parts/Root/Root.ts'
+
+test('resolveElectronFileUri - resolves a development source uri', () => {
+  const uri = GetElectronFileResponse.resolveElectronFileUri('lvce-oss://-/packages/renderer-worker/dist/rendererWorkerMain.js')
+
+  expect(uri).toBe(pathToFileURL(join(Root.root, 'packages', 'renderer-worker', 'dist', 'rendererWorkerMain.js')).toString())
+})
+
+test('resolveElectronFileUri - resolves a built source uri', () => {
+  const uri = GetElectronFileResponse.resolveElectronFileUri('lvce-oss://-/abc123/packages/renderer-worker/dist/rendererWorkerMain.js')
+
+  expect(uri).toBe(pathToFileURL(join(Root.root, 'static', 'abc123', 'packages', 'renderer-worker', 'dist', 'rendererWorkerMain.js')).toString())
+})


### PR DESCRIPTION
Resolve internal LVCE asset URLs through the shared-process protocol mapping before opening them in the main-area editor. This makes Window output stack-frame links target the corresponding file on disk in both development and packaged builds.