### PR TITLE
fix: align output source links to the right

### DIFF
--- a/static/css/parts/ViewletOutput.css
+++ b/static/css/parts/ViewletOutput.css
@@ -27,7 +27,7 @@
   overflow: auto;
 }
 
-.ViewletOutput .Line {
+.Output .Line {
   display: flex;
   align-items: center;
   box-sizing: border-box;
@@ -37,11 +37,11 @@
   padding-inline: 6px;
 }
 
-.ViewletOutput .Line.error {
+.Output .Line.error {
   background: color-mix(in srgb, var(--vscode-errorForeground, #f48771) 18%, var(--vscode-editor-background, #1e1e1e));
 }
 
-.ViewletOutput .Line.warning {
+.Output .Line.warning {
   background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 18%, var(--vscode-editor-background, #1e1e1e));
 }
 


### PR DESCRIPTION
Correct the output-line CSS selector so the flex layout applies to the real Output view DOM. Source and stack-trace links now consume the available space and align at the right edge.