### PR TITLE
Fix color theme link contrast

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -170,6 +170,25 @@ test('bundleCss preserves the extension detail sash divider', async () => {
   }
 }, 30_000)
 
+test('bundleCss preserves the color theme link foreground', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'Features.css'), 'utf8')
+
+    expect(css).toContain(`.ColorThemeLink {
+  color: var(--LinkForeground, #3794ff);
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss preserves the extension runtime status layout', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/Features.css
+++ b/static/css/parts/Features.css
@@ -41,6 +41,10 @@
   color: var(--WorkbenchForeground);
 }
 
+.ColorThemeLink {
+  color: var(--LinkForeground, #3794ff);
+}
+
 .DefinitionListItemHeading {
   font-size: 12px;
   white-space: pre;


### PR DESCRIPTION
Style extension detail color-theme links with the editor's theme-aware link foreground and a readable fallback. Add CSS bundle regression coverage.