### PR TITLE
fix: cover running extension disable from search

### DIFF
--- a/packages/extension-host-worker-tests/src/extension-search.disable-removes-running-extension.ts
+++ b/packages/extension-host-worker-tests/src/extension-search.disable-removes-running-extension.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import { addLifecycleExtension, extensionId, runningExtensionSelector } from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension-search.disable-removes-running-extension'
+
+export const test: Test = async ({ expect, ExtensionSearch, Locator, RunningExtensions, ...api }) => {
+  await addLifecycleExtension(api)
+  await RunningExtensions.show()
+  const runningExtensionsView = Locator('.RunningExtensions')
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+  await expect(runningExtensionsView).toBeVisible()
+  await expect(runningExtension).toBeVisible()
+
+  await ExtensionSearch.open()
+  await ExtensionSearch.handleInput(extensionId)
+  const disableButton = Locator('.ExtensionActionButton', { hasText: 'Disable' })
+  await expect(disableButton).toBeVisible()
+  // eslint-disable-next-line e2e/no-direct-click -- exercise the extension search action while the running view remains open
+  await disableButton.click()
+
+  await expect(runningExtensionsView).toBeVisible()
+  await expect(runningExtension).toBeHidden()
+
+  const enableButton = Locator('.ExtensionActionButton', { hasText: 'Enable' })
+  await expect(enableButton).toBeVisible()
+  // eslint-disable-next-line e2e/no-direct-click -- restore the fixture through the same extension search action
+  await enableButton.click()
+}


### PR DESCRIPTION
Summary:

Add an extension-host regression test that keeps Running Extensions open, disables an active extension from Extension Search, and verifies the running entry disappears immediately. The test also restores the fixture by enabling the extension again.