### PR TITLE
feature: support extension file system workspaces

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -129,6 +129,7 @@ export const commandMap = {
   'ExtensionHostHover.executeHoverProvider': lazy('ExtensionHostHover.executeHoverProvider'),
   'ExtensionHostOrganizeImports.organizeImports': lazy('ExtensionHostOrganizeImports.organizeImports'),
   'ExtensionHostQuickPick.show': lazy('ExtensionHostQuickPick.show'),
+  'ExtensionHostQuickPick.showQuickInput': lazy('ExtensionHostQuickPick.showQuickInput'),
   'ExtensionHostQuickPick.showQuickPick': lazy('ExtensionHostQuickPick.showQuickPick'),
   'ExtensionHostSelection.executeGrowSelection': lazy('ExtensionHostSelection.executeGrowSelection'),
   'ExtensionHostState.getSavedState': lazy('ExtensionHostState.getSavedState'),

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
@@ -1,43 +1,60 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as ExtensionHostCommandType from '../ExtensionHostCommandType/ExtensionHostCommandType.js'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as FileSystemProtocol from '../FileSystemProtocol/FileSystemProtocol.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as ExtensionHostShared from './ExtensionHostShared.js'
 
-const getProviderProtocolAndPath = (uri) => {
+const getProviderProtocolPathAndUri = (uri) => {
   const protocol = GetProtocol.getProtocol(uri)
   if (protocol !== FileSystemProtocol.ExtensionHost) {
     return {
-      protocol,
       path: GetProtocol.getPath(protocol, uri),
+      protocol,
+      uri,
     }
   }
   const providerUri = GetProtocol.getPath(protocol, uri)
   const providerProtocol = GetProtocol.getProtocol(providerUri)
   return {
-    protocol: providerProtocol,
     path: GetProtocol.getPath(providerProtocol, providerUri),
+    protocol: providerProtocol,
+    uri: providerUri,
   }
 }
 
-export const readFile = (uri) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  // TODO there shouldn't be multiple file system providers for the same protocol
+const executeProvider = async ({ isolatedMethod, isolatedParams, legacyMethod, legacyParams, protocol }) => {
+  const { found, result } = await ExtensionManagementWorker.invoke(isolatedMethod, protocol, ...isolatedParams)
+  if (found) {
+    return result
+  }
   return ExtensionHostShared.executeProvider({
     event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemReadFile,
-    params: [protocol, path],
+    method: legacyMethod,
     noProviderFoundMessage: 'no file system provider found',
+    params: [protocol, ...legacyParams],
+  })
+}
+
+export const readFile = (uri) => {
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderReadFile',
+    isolatedParams: [providerUri],
+    legacyMethod: ExtensionHostCommandType.FileSystemReadFile,
+    legacyParams: [path],
+    protocol,
   })
 }
 
 export const remove = (uri) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemRemove,
-    params: [protocol, path],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderRemove',
+    isolatedParams: [providerUri],
+    legacyMethod: ExtensionHostCommandType.FileSystemRemove,
+    legacyParams: [path],
+    protocol,
   })
 }
 
@@ -47,84 +64,92 @@ export const remove = (uri) => {
  * @param {string} newUri
  */
 export const rename = (oldUri, newUri) => {
-  const { protocol, path: oldPath } = getProviderProtocolAndPath(oldUri)
-  const { path: newPath } = getProviderProtocolAndPath(newUri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemRename,
-    params: [protocol, oldPath, newPath],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path: oldPath, uri: providerOldUri } = getProviderProtocolPathAndUri(oldUri)
+  const { path: newPath, uri: providerNewUri } = getProviderProtocolPathAndUri(newUri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderRename',
+    isolatedParams: [providerOldUri, providerNewUri],
+    legacyMethod: ExtensionHostCommandType.FileSystemRename,
+    legacyParams: [oldPath, newPath],
+    protocol,
   })
 }
 
 export const mkdir = (uri) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemMkdir,
-    params: [protocol, path],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderMkdir',
+    isolatedParams: [providerUri],
+    legacyMethod: ExtensionHostCommandType.FileSystemMkdir,
+    legacyParams: [path],
+    protocol,
   })
 }
 
 export const createFile = (uri) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemWriteFile,
-    params: [protocol, path, ''],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderWriteFile',
+    isolatedParams: [providerUri, ''],
+    legacyMethod: ExtensionHostCommandType.FileSystemWriteFile,
+    legacyParams: [path, ''],
+    protocol,
   })
 }
 
 export const createFolder = (uri) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemCreateFolder,
-    params: [protocol, path],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderMkdir',
+    isolatedParams: [providerUri],
+    legacyMethod: ExtensionHostCommandType.FileSystemCreateFolder,
+    legacyParams: [path],
+    protocol,
   })
 }
 
 export const writeFile = (uri, content) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemWriteFile,
-    params: [protocol, path, content],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderWriteFile',
+    isolatedParams: [providerUri, content],
+    legacyMethod: ExtensionHostCommandType.FileSystemWriteFile,
+    legacyParams: [path, content],
+    protocol,
   })
 }
 
 export const readDirWithFileTypes = (uri) => {
-  const { protocol, path } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemReadDirWithFileTypes,
-    params: [protocol, path],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderReadDirWithFileTypes',
+    isolatedParams: [providerUri],
+    legacyMethod: ExtensionHostCommandType.FileSystemReadDirWithFileTypes,
+    legacyParams: [path],
+    protocol,
   })
 }
 
 export const getPathSeparator = async (uri) => {
-  const { protocol } = getProviderProtocolAndPath(uri)
-  const pathSeparator = await ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemGetPathSeparator,
-    params: [protocol],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol } = getProviderProtocolPathAndUri(uri)
+  const pathSeparator = await executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderGetPathSeparator',
+    isolatedParams: [],
+    legacyMethod: ExtensionHostCommandType.FileSystemGetPathSeparator,
+    legacyParams: [],
+    protocol,
   })
   Assert.string(pathSeparator)
   return pathSeparator
 }
 
 export const isReadonly = async (uri) => {
-  const { protocol } = getProviderProtocolAndPath(uri)
-  return ExtensionHostShared.executeProvider({
-    event: `onFileSystem:${protocol}`,
-    method: ExtensionHostCommandType.FileSystemIsReadonly,
-    params: [protocol],
-    noProviderFoundMessage: 'no file system provider found',
+  const { protocol } = getProviderProtocolPathAndUri(uri)
+  return executeProvider({
+    isolatedMethod: 'Extensions.executeFileSystemProviderIsReadonly',
+    isolatedParams: [],
+    legacyMethod: ExtensionHostCommandType.FileSystemIsReadonly,
+    legacyParams: [],
+    protocol,
   })
 }

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.ipc.js
@@ -5,5 +5,6 @@ export const name = 'ExtensionHostQuickPick'
 // prettier-ignore
 export const Commands = {
   show: ExtensionHostQuickPick.show,
+  showQuickInput: ExtensionHostQuickPick.showQuickInput,
   showQuickPick: ExtensionHostQuickPick.showQuickPick,
 }

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostQuickPick.js
@@ -11,3 +11,14 @@ export const show = async (picks) => {
 export const showQuickPick = (options) => {
   return QuickPickWorker.invoke('QuickPick.showQuickPick', options)
 }
+
+export const showQuickInput = async (options = {}) => {
+  const result = await QuickPickWorker.invoke('QuickPick.showQuickInput', {
+    initialValue: options.value,
+    placeholder: options.placeholder,
+  })
+  if (!result || result.canceled) {
+    return undefined
+  }
+  return result.inputValue
+}

--- a/packages/renderer-worker/src/parts/GetFileSystem/GetFileSystem.js
+++ b/packages/renderer-worker/src/parts/GetFileSystem/GetFileSystem.js
@@ -1,4 +1,5 @@
 import * as FileSystemState from '../FileSystemState/FileSystemState.js'
+import * as FileSystemProtocol from '../FileSystemProtocol/FileSystemProtocol.js'
 
 // TODO when it rejects, it should throw a custom error,
 // FileSystemError
@@ -8,7 +9,7 @@ import * as FileSystemState from '../FileSystemState/FileSystemState.js'
 // TODO extension host should be able to register arbitrary protocols (except app, http, https, file, )
 
 export const getFileSystem = (protocol) => {
-  const fn = FileSystemState.get(protocol)
+  const fn = FileSystemState.get(protocol) || FileSystemState.get(FileSystemProtocol.ExtensionHost)
   if (!fn) {
     throw new Error(`file system for protocol ${protocol} not found`)
   }

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -3,6 +3,7 @@ import * as Character from '../Character/Character.js'
 import * as FileSystem from '../FileSystem/FileSystem.js'
 import * as GetResolvedRoot from '../GetResolvedRoot/GetResolvedRoot.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
+import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as Location from '../Location/Location.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
@@ -28,12 +29,15 @@ export const setPath = async (path) => {
 }
 
 export const setUri = async (uri) => {
-  const path = decodeURIComponent(uri.slice('file://'.length))
+  const protocol = GetProtocol.getProtocol(uri)
+  const path = protocol === 'file' ? decodeURIComponent(uri.slice('file://'.length)) : uri
+  const pathSeparator = await FileSystem.getPathSeparator(uri)
   if (path !== state.workspacePath) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }
   state.workspacePath = path
   state.workspaceUri = uri
+  state.pathSeparator = pathSeparator
   await onWorkspaceChange()
 }
 

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -1,9 +1,16 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as DirentType from '../src/parts/DirentType/DirentType.js'
 
+const invoke = jest.fn<(...args: readonly any[]) => Promise<any>>()
+
 beforeEach(() => {
   jest.resetAllMocks()
+  invoke.mockResolvedValue({ found: false })
 })
+
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
+  invoke,
+}))
 
 jest.unstable_mockModule('../src/parts/ExtensionHost/ExtensionHostShared.js', () => {
   return {
@@ -215,4 +222,51 @@ test('isReadonly', async () => {
     noProviderFoundMessage: 'no file system provider found',
     params: ['xyz'],
   })
+})
+
+test('isolated provider dispatch uses full provider uris', async () => {
+  invoke.mockImplementation(async (method) => ({
+    found: true,
+    result: method,
+  }))
+
+  await expect(ExtensionHostFileSystem.readFile('remote-ssh:///test-folder/README.md')).resolves.toBe('Extensions.executeFileSystemProviderReadFile')
+  await expect(ExtensionHostFileSystem.readDirWithFileTypes('remote-ssh:///test-folder')).resolves.toBe(
+    'Extensions.executeFileSystemProviderReadDirWithFileTypes',
+  )
+  await expect(ExtensionHostFileSystem.mkdir('remote-ssh:///test-folder/new-folder')).resolves.toBe('Extensions.executeFileSystemProviderMkdir')
+  await expect(ExtensionHostFileSystem.writeFile('remote-ssh:///test-folder/new.txt', 'content')).resolves.toBe(
+    'Extensions.executeFileSystemProviderWriteFile',
+  )
+  await expect(ExtensionHostFileSystem.rename('remote-ssh:///test-folder/new.txt', 'remote-ssh:///test-folder/renamed.txt')).resolves.toBe(
+    'Extensions.executeFileSystemProviderRename',
+  )
+  await expect(ExtensionHostFileSystem.remove('remote-ssh:///test-folder/renamed.txt')).resolves.toBe('Extensions.executeFileSystemProviderRemove')
+  await expect(ExtensionHostFileSystem.getPathSeparator('remote-ssh:///test-folder')).resolves.toBe(
+    'Extensions.executeFileSystemProviderGetPathSeparator',
+  )
+  await expect(ExtensionHostFileSystem.isReadonly('remote-ssh:///test-folder')).resolves.toBe('Extensions.executeFileSystemProviderIsReadonly')
+
+  expect(invoke.mock.calls).toEqual([
+    ['Extensions.executeFileSystemProviderReadFile', 'remote-ssh', 'remote-ssh:///test-folder/README.md'],
+    ['Extensions.executeFileSystemProviderReadDirWithFileTypes', 'remote-ssh', 'remote-ssh:///test-folder'],
+    ['Extensions.executeFileSystemProviderMkdir', 'remote-ssh', 'remote-ssh:///test-folder/new-folder'],
+    ['Extensions.executeFileSystemProviderWriteFile', 'remote-ssh', 'remote-ssh:///test-folder/new.txt', 'content'],
+    ['Extensions.executeFileSystemProviderRename', 'remote-ssh', 'remote-ssh:///test-folder/new.txt', 'remote-ssh:///test-folder/renamed.txt'],
+    ['Extensions.executeFileSystemProviderRemove', 'remote-ssh', 'remote-ssh:///test-folder/renamed.txt'],
+    ['Extensions.executeFileSystemProviderGetPathSeparator', 'remote-ssh'],
+    ['Extensions.executeFileSystemProviderIsReadonly', 'remote-ssh'],
+  ])
+  expect(ExtensionHostShared.executeProvider).not.toHaveBeenCalled()
+})
+
+test('isolated provider dispatch unwraps extension host uris', async () => {
+  invoke.mockResolvedValue({
+    found: true,
+    result: 'content',
+  })
+
+  await expect(ExtensionHostFileSystem.readFile('extension-host://remote-ssh:///test-folder/README.md')).resolves.toBe('content')
+
+  expect(invoke).toHaveBeenCalledWith('Extensions.executeFileSystemProviderReadFile', 'remote-ssh', 'remote-ssh:///test-folder/README.md')
 })

--- a/packages/renderer-worker/test/ExtensionHostQuickPick.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostQuickPick.test.ts
@@ -1,6 +1,6 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
-const invoke = jest.fn(async (..._args) => 'main')
+const invoke = jest.fn<(...args: readonly any[]) => Promise<any>>()
 
 jest.unstable_mockModule('../src/parts/QuickPickWorker/QuickPickWorker.js', () => ({
   invoke,
@@ -8,7 +8,12 @@ jest.unstable_mockModule('../src/parts/QuickPickWorker/QuickPickWorker.js', () =
 
 const ExtensionHostQuickPick = await import('../src/parts/ExtensionHost/ExtensionHostQuickPick.js')
 
+beforeEach(() => {
+  invoke.mockReset()
+})
+
 test('showQuickPick forwards options to the quick pick worker', async () => {
+  invoke.mockResolvedValue('main')
   const options = {
     items: [
       {
@@ -21,4 +26,32 @@ test('showQuickPick forwards options to the quick pick worker', async () => {
   await expect(ExtensionHostQuickPick.showQuickPick(options)).resolves.toBe('main')
 
   expect(invoke).toHaveBeenCalledWith('QuickPick.showQuickPick', options)
+})
+
+test('showQuickInput forwards placeholder and value and returns accepted input', async () => {
+  invoke.mockResolvedValue({
+    canceled: false,
+    inputValue: 'user@example.com',
+  })
+
+  await expect(
+    ExtensionHostQuickPick.showQuickInput({
+      placeholder: 'Enter SSH host',
+      value: 'user@',
+    }),
+  ).resolves.toBe('user@example.com')
+
+  expect(invoke).toHaveBeenCalledWith('QuickPick.showQuickInput', {
+    initialValue: 'user@',
+    placeholder: 'Enter SSH host',
+  })
+})
+
+test('showQuickInput returns undefined when canceled', async () => {
+  invoke.mockResolvedValue({
+    canceled: true,
+    inputValue: '',
+  })
+
+  await expect(ExtensionHostQuickPick.showQuickInput({ placeholder: 'Enter SSH host' })).resolves.toBeUndefined()
 })

--- a/packages/renderer-worker/test/GetFileSystem.test.ts
+++ b/packages/renderer-worker/test/GetFileSystem.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@jest/globals'
+import * as FileSystemState from '../src/parts/FileSystemState/FileSystemState.js'
+import * as GetFileSystem from '../src/parts/GetFileSystem/GetFileSystem.js'
+
+test('registered built-in file systems take precedence', async () => {
+  const builtin = { name: 'builtin' }
+  const extensionHost = { name: 'extension-host' }
+  FileSystemState.registerAll({
+    'extension-host': async () => extensionHost,
+    'test-builtin': async () => builtin,
+  })
+
+  await expect(GetFileSystem.getFileSystem('test-builtin')).resolves.toBe(builtin)
+})
+
+test('unknown schemes use the extension host file system', async () => {
+  const extensionHost = { name: 'extension-host' }
+  FileSystemState.registerAll({
+    'extension-host': async () => extensionHost,
+  })
+
+  await expect(GetFileSystem.getFileSystem('remote-ssh')).resolves.toBe(extensionHost)
+})

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const getPathSeparator = jest.fn<(uri: string) => Promise<string>>(async () => '/')
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  getPathSeparator,
+}))
+
 jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
   set: jest.fn(async () => {}),
 }))
@@ -8,6 +14,7 @@ const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
+  getPathSeparator.mockClear()
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = ''
@@ -19,4 +26,17 @@ test('setUri preserves the uri and decodes the workspace path', async () => {
 
   expect(Workspace.getWorkspacePath()).toBe('/home/test/my folder/#project?')
   expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/my%20folder/%23project%3F')
+  expect(Workspace.state.pathSeparator).toBe('/')
+  expect(getPathSeparator).toHaveBeenCalledWith('file:///home/test/my%20folder/%23project%3F')
+})
+
+test('setUri preserves a custom uri as the workspace path', async () => {
+  getPathSeparator.mockResolvedValue('\\')
+
+  await Workspace.setUri('remote-ssh:///test-folder')
+
+  expect(Workspace.getWorkspacePath()).toBe('remote-ssh:///test-folder')
+  expect(Workspace.getWorkspaceUri()).toBe('remote-ssh:///test-folder')
+  expect(Workspace.state.pathSeparator).toBe('\\')
+  expect(getPathSeparator).toHaveBeenCalledWith('remote-ssh:///test-folder')
 })


### PR DESCRIPTION
## Summary

- preserve custom workspace URIs and resolve their path separators
- route unknown file-system schemes to isolated providers before legacy providers
- bridge isolated extension quick input to the quick-pick worker

## Tests

- renderer-worker focused tests: 25 passed
- renderer-worker full suite: 1,227 passed, 232 skipped
- renderer-worker type-check
- repository lint