### PR TITLE
fix: update extension search heading

### DIFF
--- a/packages/extension-host-worker-tests/src/extension-search.heading-updates.ts
+++ b/packages/extension-host-worker-tests/src/extension-search.heading-updates.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'extension-search.heading-updates'
+
+export const test: Test = async ({ expect, ExtensionSearch, Locator }) => {
+  await ExtensionSearch.open()
+  const heading = Locator('.SideBarTitleAreaTitle')
+  await expect(heading).toHaveText('Extensions: Installed')
+
+  await ExtensionSearch.handleInput('atom')
+  await expect(heading).toHaveText('Extensions: Marketplace')
+
+  await ExtensionSearch.handleInput('@disabled')
+  await expect(heading).toHaveText('Extensions: Disabled')
+}

--- a/packages/renderer-worker/src/parts/UpdateExtensionSearchRenderState/UpdateExtensionSearchRenderState.js
+++ b/packages/renderer-worker/src/parts/UpdateExtensionSearchRenderState/UpdateExtensionSearchRenderState.js
@@ -1,0 +1,18 @@
+const isSetTitleCommand = (command) => {
+  return command[0] === 'Viewlet.send' && command[2] === 'setTitle'
+}
+
+export const updateExtensionSearchRenderState = (state, commands) => {
+  const titleCommand = commands.findLast(isSetTitleCommand)
+  if (!titleCommand) {
+    return {
+      ...state,
+      commands,
+    }
+  }
+  return {
+    ...state,
+    commands: commands.filter((command) => !isSetTitleCommand(command)),
+    title: titleCommand[3],
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
@@ -1,6 +1,7 @@
 import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as ExtensionSearchViewWorker from '../ExtensionSearchViewWorker/ExtensionSearchViewWorker.js'
 import * as Platform from '../Platform/Platform.js'
+import * as UpdateExtensionSearchRenderState from '../UpdateExtensionSearchRenderState/UpdateExtensionSearchRenderState.js'
 
 // then state can be recycled by Viewlet when there is only a single ViewletExtensions instance
 
@@ -9,17 +10,19 @@ export const saveState = async (state) => {
   return savedState
 }
 
-export const create = (id, uri, x, y, width, height) => {
+export const create = (id, uri, x, y, width, height, _args, parentUid) => {
   return {
     id,
     uid: id,
     searchValue: '',
+    title: '',
     width,
     height,
     x,
     y,
     platform: Platform.getPlatform(),
     assetDir: AssetDir.assetDir,
+    parentUid,
   }
 }
 
@@ -34,14 +37,16 @@ export const loadContent = async (state, savedState) => {
     state.height,
     state.platform,
     state.assetDir,
+    state.parentUid,
   )
 
   await ExtensionSearchViewWorker.invoke('SearchExtensions.loadContent', state.id, savedState)
   const diffResult = await ExtensionSearchViewWorker.invoke('SearchExtensions.diff2', state.id)
   const commands = await ExtensionSearchViewWorker.invoke('SearchExtensions.render3', state.id, diffResult)
+  const renderState = UpdateExtensionSearchRenderState.updateExtensionSearchRenderState(state, commands)
   return {
-    ...state,
-    commands,
+    ...renderState,
+    title: renderState.title || 'Extensions: Installed',
   }
 }
 
@@ -73,13 +78,16 @@ export const hotReload = async (state) => {
     state.height,
     state.platform,
     state.assetDir,
+    state.parentUid,
   )
   await ExtensionSearchViewWorker.invoke('SearchExtensions.loadContent', state.id, savedState)
   const diffResult = await ExtensionSearchViewWorker.invoke('SearchExtensions.diff2', state.id)
   const commands = await ExtensionSearchViewWorker.invoke('SearchExtensions.render3', oldState.id, diffResult)
-  return {
-    ...oldState,
+  return UpdateExtensionSearchRenderState.updateExtensionSearchRenderState(
+    {
+      ...oldState,
+      isHotReloading: false,
+    },
     commands,
-    isHotReloading: false,
-  }
+  )
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensionsRenderTitle.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensionsRenderTitle.js
@@ -1,11 +1,8 @@
 export const renderTitle = {
   isEqual(oldState, newState) {
-    return oldState === newState
+    return oldState.title === newState.title
   },
   apply(oldState, newState) {
-    const prefix = `Extensions`
-    const postfix = `Installed`
-    const title = `${prefix}: ${postfix}`
-    return title
+    return newState.title || 'Extensions: Installed'
   },
 }

--- a/packages/renderer-worker/src/parts/WrapExtensionSearchCommand/WrapExtensionSearchCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapExtensionSearchCommand/WrapExtensionSearchCommand.ts
@@ -1,14 +1,12 @@
 import * as ExtensionSearchViewWorker from '../ExtensionSearchViewWorker/ExtensionSearchViewWorker.js'
+import * as UpdateExtensionSearchRenderState from '../UpdateExtensionSearchRenderState/UpdateExtensionSearchRenderState.js'
 
 export const wrapExtensionSearchCommand = (key) => {
   const wrapped = async (state, ...args) => {
     await ExtensionSearchViewWorker.invoke(`SearchExtensions.${key}`, state.uid, ...args)
     const diffResult = await ExtensionSearchViewWorker.invoke(`SearchExtensions.diff2`, state.uid)
     const commands = await ExtensionSearchViewWorker.invoke('SearchExtensions.render3', state.uid, diffResult)
-    return {
-      ...state,
-      commands,
-    }
+    return UpdateExtensionSearchRenderState.updateExtensionSearchRenderState(state, commands)
   }
   return wrapped
 }

--- a/packages/renderer-worker/test/ViewletExtensions.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensions.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+let renderCommands: readonly any[] = []
+
+jest.unstable_mockModule('../src/parts/ExtensionSearchViewWorker/ExtensionSearchViewWorker.js', () => ({
+  invoke: jest.fn(async (command: string) => {
+    if (command === 'SearchExtensions.diff2') {
+      return []
+    }
+    if (command === 'SearchExtensions.render3') {
+      return renderCommands
+    }
+    return undefined
+  }),
+  restart: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 2),
+}))
+
+jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
+  assetDir: '/test-assets',
+}))
+
+const ExtensionSearchViewWorker = await import('../src/parts/ExtensionSearchViewWorker/ExtensionSearchViewWorker.js')
+const ViewletExtensions = await import('../src/parts/ViewletExtensions/ViewletExtensions.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  renderCommands = []
+})
+
+test('moves the worker title command into wrapper state', async () => {
+  renderCommands = [
+    ['Viewlet.send', 42, 'setTitle', 'Extensions: Marketplace'],
+    ['Viewlet.setDom2', 1, []],
+  ]
+  const state = ViewletExtensions.create(1, 'extensions://', 10, 20, 800, 600, [], 42)
+
+  const result = await ViewletExtensions.loadContent(state)
+
+  expect(result.title).toBe('Extensions: Marketplace')
+  expect(result.commands).toEqual([['Viewlet.setDom2', 1, []]])
+})
+
+test('sets the default title when the worker has no title command', async () => {
+  const state = ViewletExtensions.create(1, 'extensions://', 10, 20, 800, 600, [], 42)
+
+  const result = await ViewletExtensions.loadContent(state)
+
+  expect(state.title).toBe('')
+  expect(result.title).toBe('Extensions: Installed')
+})
+
+test('forwards the parent view uid to the extension search worker', async () => {
+  const state = ViewletExtensions.create(1, 'extensions://', 10, 20, 800, 600, [], 42)
+
+  await ViewletExtensions.loadContent(state)
+
+  expect(state.parentUid).toBe(42)
+  expect(ExtensionSearchViewWorker.invoke).toHaveBeenNthCalledWith(
+    1,
+    'SearchExtensions.create',
+    1,
+    undefined,
+    10,
+    20,
+    800,
+    600,
+    2,
+    '/test-assets',
+    42,
+  )
+})


### PR DESCRIPTION
Fix the Extensions sidebar heading so it follows the active search mode.

The integration now forwards the parent view ID to the extension search worker and translates worker title updates into parent view state. The initial installed heading is also applied after content loads.

Adds focused renderer unit coverage and an end-to-end test for Installed, Marketplace, and Disabled headings.