### PR TITLE
fix: accept resolved workspace path separator

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -28,10 +28,10 @@ export const setPath = async (path) => {
   await onWorkspaceChange()
 }
 
-export const setUri = async (uri) => {
+export const setUri = async (uri, providedPathSeparator) => {
   const protocol = GetProtocol.getProtocol(uri)
   const path = protocol === 'file' ? decodeURIComponent(uri.slice('file://'.length)) : uri
-  const pathSeparator = await FileSystem.getPathSeparator(uri)
+  const pathSeparator = providedPathSeparator ?? (await FileSystem.getPathSeparator(uri))
   if (path !== state.workspacePath) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -40,3 +40,12 @@ test('setUri preserves a custom uri as the workspace path', async () => {
   expect(Workspace.state.pathSeparator).toBe('\\')
   expect(getPathSeparator).toHaveBeenCalledWith('remote-ssh:///test-folder')
 })
+
+test('setUri uses a provided provider path separator', async () => {
+  await Workspace.setUri('remote-ssh:///test-folder', '\\')
+
+  expect(Workspace.getWorkspacePath()).toBe('remote-ssh:///test-folder')
+  expect(Workspace.getWorkspaceUri()).toBe('remote-ssh:///test-folder')
+  expect(Workspace.state.pathSeparator).toBe('\\')
+  expect(getPathSeparator).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

- let Workspace.setUri accept an already-resolved provider path separator
- retain file-system resolution when no separator is supplied
- avoid re-entering an isolated extension worker while it is switching to its own file-system scheme

## Validation

- WorkspaceSetUri test suite passes (3 tests)
- renderer worker type-check passes
- changed files pass Prettier