### PR TITLE
feature: add remote ssh builtin extension

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -60,6 +60,12 @@
     "created": "2024-09-24"
   },
   {
+    "name": "builtin.remote-ssh",
+    "repository": "github.com/lvce-editor/remote-ssh",
+    "version": "0.1.0",
+    "created": "2026-08-03"
+  },
+  {
     "name": "builtin.language-basics-coffeescript",
     "repository": "github.com/lvce-editor/language-basics-coffeescript",
     "version": "0.0.5",


### PR DESCRIPTION
## Details

Add `builtin.remote-ssh` version `0.1.0` to the built-in extension inventory.

## Validation

- downloaded and extracted the published `remote-ssh-v0.1.0.tar.br` asset
- `npm run lint`
- `npm run type-check`
- `npm run build:static`
- `npm run build:server`
- `npm run test-static-export`
- verified the generated tree contains the extension manifest, README, and worker bundle