### PR TITLE
fix: create terminal from title bar menu

### DIFF
--- a/packages/renderer-worker/src/parts/MenuEntriesTerminal/MenuEntriesTerminal.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesTerminal/MenuEntriesTerminal.js
@@ -1,7 +1,6 @@
 import * as MenuItemFlags from '../MenuItemFlags/MenuItemFlags.js'
 import * as TerminalStrings from '../TerminalStrings/TerminalStrings.js'
 import * as MenuEntryId from '../MenuEntryId/MenuEntryId.js'
-import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
 export const id = MenuEntryId.Terminal
 
@@ -11,8 +10,8 @@ export const getMenuEntries = () => {
       id: 'newTerminal',
       label: TerminalStrings.newTerminal(),
       flags: MenuItemFlags.None,
-      command: 'Layout.showPanel',
-      args: [ViewletModuleId.Terminals],
+      command: 'Layout.openIntegratedTerminal',
+      args: [''],
     },
   ]
 }

--- a/packages/renderer-worker/test/MenuEntriesTerminal.test.ts
+++ b/packages/renderer-worker/test/MenuEntriesTerminal.test.ts
@@ -4,8 +4,8 @@ import * as MenuEntriesTerminal from '../src/parts/MenuEntriesTerminal/MenuEntri
 test('getMenuEntries', () => {
   const menuEntries = MenuEntriesTerminal.getMenuEntries()
   expect(menuEntries).toContainEqual({
-    args: ['Terminals'],
-    command: 'Layout.showPanel',
+    args: [''],
+    command: 'Layout.openIntegratedTerminal',
     flags: 0,
     id: 'newTerminal',
     label: 'New Terminal',


### PR DESCRIPTION
## Summary
- route Terminal > New Terminal through the integrated-terminal command
- create a new terminal when the terminal panel is already active
- update the terminal menu regression expectation

## Tests
- npm test -- MenuEntriesTerminal.test.ts ViewletLayoutOpenIntegratedTerminal.test.ts --runInBand
- npm test -- --runInBand --silent
- npm run type-check
- npx prettier --check packages/renderer-worker/src/parts/MenuEntriesTerminal/MenuEntriesTerminal.js packages/renderer-worker/test/MenuEntriesTerminal.test.ts