### PR TITLE
fix: keep terminal panel open from menu

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-panel-actions.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-panel-actions.ts
@@ -21,8 +21,16 @@ export const test: Test = async (api) => {
   await api.expect(terminals).toHaveCount(1)
   await api.expect(terminals.locator('.xterm-helper-textarea')).toBeFocused()
 
-  await api.Locator('#Panel .IconButton[title="New Terminal"]').click()
+  await api.Locator('.TitleBarTopLevelEntry[aria-label="More ..."]').click()
+  await api.Locator('#Menu-0 .MenuItem', { hasText: 'Terminal' }).hover()
+  await api.expect(api.Locator('#Menu-1')).toBeVisible()
+  await api.Locator('#Menu-1 .MenuItem', { hasText: 'New Terminal' }).click()
   await api.expect(api.Locator('.TerminalTab')).toHaveCount(2)
+  await api.expect(terminals).toHaveCount(1)
+  await api.expect(terminals.locator('.xterm-helper-textarea')).toBeFocused()
+
+  await api.Locator('#Panel .IconButton[title="New Terminal"]').click()
+  await api.expect(api.Locator('.TerminalTab')).toHaveCount(3)
   await api.expect(terminals).toHaveCount(1)
   await runCommand('echo left-terminal')
   await api.expect(terminals).toContainText('left-terminal')

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -797,12 +797,18 @@ export const showPanel = async (state: LayoutState, moduleId = state.panelView, 
 }
 
 export const openIntegratedTerminal = async (state: LayoutState, cwd: string): Promise<LayoutStateResult> => {
-  const terminalsActive = state.panelView === ViewletModuleId.Terminals && Boolean(ViewletStates.getInstance(ViewletModuleId.Terminals))
-  const result = await showPanel(state, ViewletModuleId.Terminals, terminalsActive ? '' : cwd)
+  const terminalsActive = state.panelVisible && Boolean(ViewletStates.getInstance(ViewletModuleId.Terminals))
   if (terminalsActive) {
     await Command.execute('Terminals.addTerminal', cwd)
+    return {
+      newState: {
+        ...state,
+        panelView: ViewletModuleId.Terminals,
+      },
+      commands: [],
+    }
   }
-  return result
+  return showPanel(state, ViewletModuleId.Terminals, cwd)
 }
 
 export const hidePanel = (state: LayoutState) => {

--- a/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
@@ -59,7 +59,7 @@ test('opens a new terminal panel view with the requested cwd', async () => {
   expect(commandExecute).not.toHaveBeenCalled()
 })
 
-test('adds a focused terminal when the terminal panel view is already active', async () => {
+test('adds a focused terminal without reselecting the active terminal panel view', async () => {
   ViewletStates.set('Terminals', {
     factory: {},
     moduleId: 'Terminals',
@@ -68,15 +68,13 @@ test('adds a focused terminal when the terminal panel view is already active', a
   })
   const state = {
     ...ViewletLayout.create(1),
-    panelView: 'Terminals',
+    panelView: 'Problems',
     panelVisible: true,
   }
 
-  await ViewletLayout.openIntegratedTerminal(state, 'file:///workspace/folder')
+  const result = await ViewletLayout.openIntegratedTerminal(state, 'file:///workspace/folder')
 
-  expect(panelWorkerInvocations).toEqual([
-    ['Panel.toggleView', 77, 'Terminals', ''],
-    ['Panel.diff2', 77],
-  ])
+  expect(result.newState.panelView).toBe('Terminals')
+  expect(panelWorkerInvocations).toEqual([])
   expect(commandExecute).toHaveBeenCalledWith('Terminals.addTerminal', 'file:///workspace/folder')
 })


### PR DESCRIPTION
## Summary
- add a terminal directly when its live panel viewlet already exists
- avoid reselecting the active panel through Panel.toggleView when layout panelView is stale
- cover Terminal > New Terminal in the panel actions e2e scenario

## Context
Official v0.97.12 acceptance of #13481 showed that routing the menu to Layout.openIntegratedTerminal was necessary but insufficient: the active branch still reselected the panel and the panel disappeared.

## Tests
- npm test -- ViewletLayoutOpenIntegratedTerminal.test.ts MenuEntriesTerminal.test.ts --runInBand
- npm test -- --runInBand --silent
- npm run type-check (renderer-worker and extension-host-worker-tests)
- npm run lint
- npx prettier --check affected files

The source-mode terminal-panel-actions e2e runner currently stops at its pre-existing initial terminal-count assertion before reaching the new menu steps; official Debian UI acceptance remains the release gate.