### PR TITLE
fix: keep terminal panel open from title menu

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -71,7 +71,7 @@
         "@lvce-editor/text-measurement-worker": "^1.21.0",
         "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
-        "@lvce-editor/title-bar-worker": "^4.15.0",
+        "@lvce-editor/title-bar-worker": "^4.15.1",
         "@lvce-editor/update-worker": "^2.12.0"
       },
       "devDependencies": {
@@ -1252,9 +1252,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/title-bar-worker": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/title-bar-worker/-/title-bar-worker-4.15.0.tgz",
-      "integrity": "sha512-AYEwFCe7BDCtNhrNzijOX7tMSUA70H+BJQKanFCDhot/+v7nCWwJCc3+N+8VBaeFqFHpsggau/rPi+sbiAsImg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/title-bar-worker/-/title-bar-worker-4.15.1.tgz",
+      "integrity": "sha512-D2MeQK/XxqFk4wqPjKvgv0JERq9Ck3uokDUQOoNbd8v+Ta7R3rsWYxuchWfqt4Kkzzsblf4C4STs8qwWd2gH8Q==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/update-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -103,7 +103,7 @@
     "@lvce-editor/text-measurement-worker": "^1.21.0",
     "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
-    "@lvce-editor/title-bar-worker": "^4.15.0",
+    "@lvce-editor/title-bar-worker": "^4.15.1",
     "@lvce-editor/update-worker": "^2.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Update `@lvce-editor/title-bar-worker` to 4.15.1 so **Terminal > New Terminal** uses `Layout.openIntegratedTerminal` instead of toggling the panel. The action now opens the terminal panel when hidden and creates/focuses another terminal without collapsing a visible terminal panel.

Upstream worker fix: https://github.com/lvce-editor/title-bar-worker/pull/644

## Tests

- renderer focused tests: 2 suites, 3 tests passed
- renderer full suite: 308 suites / 1234 tests passed; 23 suites / 232 tests skipped
- renderer type-check
- root lint
- local Electron acceptance using the published 4.15.1 package with the panel hidden and visible

## Note

The renderer package's direct `npm run lint` currently reports the existing repository-wide XO baseline (100316 findings); the root lint command passes and this dependency-only diff introduces no source lint changes.