### PR TITLE
fix: install terminal unicode fonts on Debian

### DIFF
--- a/packages/build/src/parts/LinuxDependencies/LinuxDependencies.ts
+++ b/packages/build/src/parts/LinuxDependencies/LinuxDependencies.ts
@@ -8,6 +8,8 @@ export const defaultDepends = [
   'libgtk-3-0 (>= 3.10.0)',
   'libxss1',
   'libgbm1',
+  'fonts-noto-cjk',
+  'fonts-noto-color-emoji',
 ]
 
 export const recommends = ['ripgrep']

--- a/packages/build/test/LinuxDependencies.test.ts
+++ b/packages/build/test/LinuxDependencies.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals'
+import * as LinuxDependencies from '../src/parts/LinuxDependencies/LinuxDependencies.ts'
+
+test('Debian package installs terminal Unicode fallback fonts', () => {
+  expect(LinuxDependencies.defaultDepends).toContain('fonts-noto-cjk')
+  expect(LinuxDependencies.defaultDepends).toContain('fonts-noto-color-emoji')
+})


### PR DESCRIPTION
## Summary

- install Noto CJK and color emoji fonts as required Debian dependencies
- add a regression test for the generated dependency source

## Root cause

The terminal receives and exposes the correct UTF-8 text, but a minimal Debian installation has no font covering the tested CJK and emoji code points. Chromium therefore renders tofu squares. An isolated fontconfig probe with `fonts-noto-cjk` and `fonts-noto-color-emoji` made the unchanged official renderer display both glyph classes correctly.

## Verification

- regression test failed before the dependency change and passes afterward
- `packages/build`: 20 suites / 67 tests pass
- `packages/build` type-check passes
- root lint passes
- locally built `lvce` 0.97.14 amd64 Debian metadata includes both dependencies
- installing the candidate pulls both font packages; real Electron terminal renders `日本語 🚀`; console/error logs are empty