### PR TITLE
feature: update editor-worker to version 19.29.7

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -27,7 +27,7 @@
         "@lvce-editor/dialog-worker": "^1.1.2",
         "@lvce-editor/diff-view": "^3.32.1",
         "@lvce-editor/diff-worker": "^3.4.0",
-        "@lvce-editor/editor-worker": "^19.29.6",
+        "@lvce-editor/editor-worker": "^19.29.7",
         "@lvce-editor/embeds-worker": "^4.9.0",
         "@lvce-editor/error-worker": "^3.8.0",
         "@lvce-editor/explorer-view": "^7.21.0",
@@ -982,9 +982,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/editor-worker": {
-      "version": "19.29.6",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/editor-worker/-/editor-worker-19.29.6.tgz",
-      "integrity": "sha512-E7ROalszDox3n4poTWvIUCzOB7TdJq4xlHtSoSXA43oXETmlfMVoY6h11eB2RNnZW2PiG6Y4D5ymAngP2XQmTw==",
+      "version": "19.29.7",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/editor-worker/-/editor-worker-19.29.7.tgz",
+      "integrity": "sha512-kbt4UqqrGCXHMsn2VNs6PVECZSSURJyaBr5ztQaez1yZOtmJ1bNS7ZfnXqJSJW2J6n8sBnEmqUYCB4SelzcdGA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -59,7 +59,7 @@
     "@lvce-editor/dialog-worker": "^1.1.2",
     "@lvce-editor/diff-view": "^3.32.1",
     "@lvce-editor/diff-worker": "^3.4.0",
-    "@lvce-editor/editor-worker": "^19.29.6",
+    "@lvce-editor/editor-worker": "^19.29.7",
     "@lvce-editor/embeds-worker": "^4.9.0",
     "@lvce-editor/error-worker": "^3.8.0",
     "@lvce-editor/explorer-view": "^7.21.0",


### PR DESCRIPTION
## Details

Update `@lvce-editor/editor-worker` from `19.29.6` to `19.29.7`. The new version implements debounced `files.autoSave: afterDelay` persistence for focused document edits, including Undo/Redo.

Owning change: lvce-editor/editor-worker#1412

## Tests

- Renderer worker: 1,234 tests passed
- `npm run type-check` (all 6 projects)
- `npm run lint`
- `npm run build:static:ignore-icon-theme`
- Published package resolved locally as `19.29.7` with the lockfile integrity from npm