### PR TITLE
feature: update title-bar-worker to version 4.15.3

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -71,7 +71,7 @@
         "@lvce-editor/text-measurement-worker": "^1.21.0",
         "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
-        "@lvce-editor/title-bar-worker": "^4.15.2",
+        "@lvce-editor/title-bar-worker": "^4.15.3",
         "@lvce-editor/update-worker": "^2.12.0"
       },
       "devDependencies": {
@@ -1252,9 +1252,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/title-bar-worker": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/title-bar-worker/-/title-bar-worker-4.15.2.tgz",
-      "integrity": "sha512-OnFMpvWPjnboxVUawStCIf6SSb9xGSO13sdESeaXAW2hpl45J0rDZTcXKSsJ4rXZ3/LEgWblNA7dfwaNC7fARw==",
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/title-bar-worker/-/title-bar-worker-4.15.3.tgz",
+      "integrity": "sha512-SiBVuLIP12zY5aFxqBvmaeq+IxHZhHm0LtkS7MoiWzgP0iUGZsgepc9u/pOghnjAJD8c4X3X1NiMUPWeDnADwQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/update-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -103,7 +103,7 @@
     "@lvce-editor/text-measurement-worker": "^1.21.0",
     "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
-    "@lvce-editor/title-bar-worker": "^4.15.2",
+    "@lvce-editor/title-bar-worker": "^4.15.3",
     "@lvce-editor/update-worker": "^2.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- update `@lvce-editor/title-bar-worker` from 4.15.2 to 4.15.3
- integrate keyboard activation for focused open-menu items with Enter and Space

## Validation

- renderer-worker: 1,234 tests passed
- renderer-worker: type-check passed
- package integrity: `sha512-SiBVuLIP12zY5aFxqBvmaeq+IxHZhHm0LtkS7MoiWzgP0iUGZsgepc9u/pOghnjAJD8c4X3X1NiMUPWeDnADwQ==`