### PR TITLE
fix: update quick-pick-worker to version 4.12.1

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -54,7 +54,7 @@
         "@lvce-editor/preview-worker": "^6.11.0",
         "@lvce-editor/problems-view": "^1.26.5",
         "@lvce-editor/process-explorer-worker": "^3.14.0",
-        "@lvce-editor/quick-pick-worker": "^4.12.0",
+        "@lvce-editor/quick-pick-worker": "^4.12.1",
         "@lvce-editor/references-view": "^2.14.0",
         "@lvce-editor/rename-worker": "^1.37.0",
         "@lvce-editor/renderer-process": "^30.23.1",
@@ -1147,9 +1147,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/quick-pick-worker": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/quick-pick-worker/-/quick-pick-worker-4.12.0.tgz",
-      "integrity": "sha512-U5pLtJkLolDDpTx5TecofPrRhsNIiVjCBmhBQR1HpvkJ1JEbuXb35lUr1xb/oD2boHV14+AIMw1Ee1iZLvby0A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/quick-pick-worker/-/quick-pick-worker-4.12.1.tgz",
+      "integrity": "sha512-ecL+LifmbaIv9LmkOvJHe0YjonUz+u+f0nEEpfXsyuQ6AvorVtB+RiGpcy1Y5GRtljErxTf8dB1x+FSS44PY6g==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/references-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -86,7 +86,7 @@
     "@lvce-editor/preview-worker": "^6.11.0",
     "@lvce-editor/problems-view": "^1.26.5",
     "@lvce-editor/process-explorer-worker": "^3.14.0",
-    "@lvce-editor/quick-pick-worker": "^4.12.0",
+    "@lvce-editor/quick-pick-worker": "^4.12.1",
     "@lvce-editor/references-view": "^2.14.0",
     "@lvce-editor/rename-worker": "^1.37.0",
     "@lvce-editor/renderer-process": "^30.23.1",


### PR DESCRIPTION
Integrates @lvce-editor/quick-pick-worker 4.12.1 so Escape dispatches the stateful close command for focused quick picks.\n\nValidated locally with all 1,234 renderer-worker tests and renderer-worker type checking.