### PR TITLE
fix: detect navigation without fetch destination

### DIFF
--- a/packages/shared-process/src/parts/GetElectronFileResponse/GetElectronFileResponse.ts
+++ b/packages/shared-process/src/parts/GetElectronFileResponse/GetElectronFileResponse.ts
@@ -10,6 +10,7 @@ import * as GetPathEtag from '../GetPathEtag/GetPathEtag.ts'
 import * as GetServerErrorResponse from '../GetServerErrorResponse/GetServerErrorResponse.ts'
 import * as GetTypeScriptSyntaxErrorResponse from '../GetTypeScriptSyntaxErrorResponse/GetTypeScriptSyntaxErrorResponse.ts'
 import * as HttpHeader from '../HttpHeader/HttpHeader.ts'
+import * as IsDocumentNavigation from '../IsDocumentNavigation/IsDocumentNavigation.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import * as IsTypeScriptSyntaxError from '../IsTypeScriptSyntaxError/IsTypeScriptSyntaxError.ts'
 import * as Logger from '../Logger/Logger.ts'
@@ -24,9 +25,8 @@ export const resolveElectronFileUri = (url: string): string => {
 // maybe send webview requests directly to preview process
 export const getElectronFileResponse = async (url: any, request: any): Promise<any> => {
   try {
-    const fetchDestination = request?.headers?.['sec-fetch-dest']
     const isRootDocument = url === '/' || url.startsWith('/?')
-    const isSecretDocument = isRootDocument && fetchDestination === 'document'
+    const isSecretDocument = isRootDocument && IsDocumentNavigation.isDocumentNavigation(request)
     const pathName = GetElectronFileResponseRelativePath.getElectronFileResponseRelativePath(url)
     let absolutePath = GetElectronFileResponseAbsolutePath.getElectronFileResponseAbsolutePath(pathName)
     let etag

--- a/packages/shared-process/src/parts/GetElectronFileResponseContent/GetElectronFileResponseContent.ts
+++ b/packages/shared-process/src/parts/GetElectronFileResponseContent/GetElectronFileResponseContent.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import * as AddCustomPathsToIndexHtml from '../AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.ts'
+import * as IsDocumentNavigation from '../IsDocumentNavigation/IsDocumentNavigation.ts'
 import * as Platform from '../Platform/Platform.ts'
 import * as ShouldTranspileTypescript from '../ShouldTranspileTypescript/ShouldTranspileTypescript.ts'
 import * as TranspileTypeScript from '../TranspileTypeScript/TranspileTypeScript.ts'
@@ -25,9 +26,7 @@ export const getElectronFileResponseContent = async (request: any, absolutePath:
     content = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(content)
   }
   if (url === '/' || url.startsWith('/?')) {
-    const fetchDestination = request?.headers?.['sec-fetch-dest']
-    const isDocumentNavigation = fetchDestination === 'document'
-    const additionalConfig = isDocumentNavigation ? { webSocketIssuer: WebSocketIssuerRegistry.create() } : {}
+    const additionalConfig = IsDocumentNavigation.isDocumentNavigation(request) ? { webSocketIssuer: WebSocketIssuerRegistry.create() } : {}
     content = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(content, additionalConfig)
   }
   if (typeof content === 'string') {

--- a/packages/shared-process/src/parts/IsDocumentNavigation/IsDocumentNavigation.ts
+++ b/packages/shared-process/src/parts/IsDocumentNavigation/IsDocumentNavigation.ts
@@ -1,0 +1,4 @@
+export const isDocumentNavigation = (request: any): boolean => {
+  const headers = request?.headers
+  return headers?.['sec-fetch-dest'] === 'document' || headers?.['sec-fetch-mode'] === 'navigate'
+}

--- a/packages/shared-process/test/GetElectronFileResponse.test.ts
+++ b/packages/shared-process/test/GetElectronFileResponse.test.ts
@@ -78,3 +78,17 @@ test('getElectronFileResponse - secret document is never cached or returned as 3
   expect(response.init.status).toBe(200)
   expect(response.init.headers['Cache-Control']).toBe('no-store')
 })
+
+test('getElectronFileResponse - navigation without a fetch destination is never cached or returned as 304', async () => {
+  jest.mocked(GetElectronFileResponseContent.getElectronFileResponseContent).mockResolvedValue(Buffer.from('html'))
+
+  const response = await GetElectronFileResponse.getElectronFileResponse('/', {
+    headers: {
+      'if-none-match': 'etag',
+      'sec-fetch-mode': 'navigate',
+    },
+  })
+
+  expect(response.init.status).toBe(200)
+  expect(response.init.headers['Cache-Control']).toBe('no-store')
+})

--- a/packages/shared-process/test/GetElectronFileResponseContent.test.ts
+++ b/packages/shared-process/test/GetElectronFileResponseContent.test.ts
@@ -41,6 +41,15 @@ test('injects an issuer only for a top-level document navigation', async () => {
   )
 })
 
+test('injects an issuer when a navigation omits the fetch destination', async () => {
+  await GetElectronFileResponseContent.getElectronFileResponseContent({ headers: { 'sec-fetch-mode': 'navigate' } }, '/index.html', '/')
+
+  expect(addCustomPathsToIndexHtml).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ webSocketIssuer: expect.stringMatching(issuerRegex) }),
+  )
+})
+
 test('generates a fresh issuer for each navigation', async () => {
   const request = { headers: { 'sec-fetch-dest': 'document' } }
   await GetElectronFileResponseContent.getElectronFileResponseContent(request, '/index.html', '/')
@@ -52,7 +61,11 @@ test('generates a fresh issuer for each navigation', async () => {
 })
 
 test('does not expose an issuer when an extension fetches the application root', async () => {
-  await GetElectronFileResponseContent.getElectronFileResponseContent({ headers: { 'sec-fetch-dest': 'empty' } }, '/index.html', '/')
+  await GetElectronFileResponseContent.getElectronFileResponseContent(
+    { headers: { 'sec-fetch-dest': 'empty', 'sec-fetch-mode': 'cors' } },
+    '/index.html',
+    '/',
+  )
 
   expect(addCustomPathsToIndexHtml).toHaveBeenCalledWith(expect.anything(), {})
 })


### PR DESCRIPTION
Fix dev-server startup when a document navigation omits Sec-Fetch-Dest by recognizing Sec-Fetch-Mode: navigate. Keep websocket issuers unavailable to ordinary fetch requests and ensure navigation responses remain non-cacheable.