### PR TITLE
fix: restore editor focus after menu commands

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.quick-pick-escape-restores-editor-focus.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.quick-pick-escape-restores-editor-focus.ts
@@ -1,0 +1,37 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.quick-pick-escape-restores-editor-focus'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ Command, expect, FileSystem, KeyBoard, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const fileUri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(fileUri, '')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(fileUri)
+
+  await Command.execute('QuickPick.showCommands')
+
+  const quickPick = Locator('#QuickPick')
+  await expect(quickPick).toBeVisible()
+  const quickPickInput = Locator('#QuickPick .InputBox')
+  await expect(quickPickInput).toBeFocused()
+  await KeyBoard.press('Escape')
+  await waitFor(() => expect(quickPick).toBeHidden())
+
+  const editorInput = Locator('[name="editor"]')
+  await waitFor(() => expect(editorInput).toBeFocused())
+}

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-view-license.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-view-license.ts
@@ -1,6 +1,8 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
 export const name = 'viewlet.title-bar-view-license'
 
-export const test = async ({ TitleBarMenuBar, Locator, expect }) => {
+export const test: Test = async ({ expect, Locator, TitleBarMenuBar }) => {
   await TitleBarMenuBar.focus()
   await TitleBarMenuBar.handleKeyEnd()
   await TitleBarMenuBar.handleKeyArrowDown()
@@ -13,4 +15,6 @@ export const test = async ({ TitleBarMenuBar, Locator, expect }) => {
   await expect(tabTitle).toHaveText('LICENSE')
   const editor = Locator('.Editor')
   await expect(editor).toContainText('The MIT License (MIT)')
+  const editorInput = Locator('[name="editor"]')
+  await expect(editorInput).toBeFocused()
 }

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -450,6 +450,7 @@ export const commandMap = {
   'Viewlet.dispose': lazy('Viewlet.dispose'),
   'Viewlet.executeViewletCommand': lazy('Viewlet.executeViewletCommand'),
   'Viewlet.focus': lazy('Viewlet.focus'),
+  'Viewlet.focusSelector': lazy('Viewlet.focusSelector'),
   'Viewlet.resize': lazy('Viewlet.resize'),
   'Viewlet.getAllStates': lazy('Viewlet.getAllStates'),
   'Viewlet.getDragData': lazy('Viewlet.getDragData'),

--- a/packages/renderer-worker/src/parts/RestoreMainFocus/RestoreMainFocus.js
+++ b/packages/renderer-worker/src/parts/RestoreMainFocus/RestoreMainFocus.js
@@ -1,0 +1,10 @@
+import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+
+export const restoreMainFocus = async (invoke = MainAreaWorker.invoke) => {
+  const mainInstance = ViewletStates.getInstance(ViewletModuleId.Main)
+  if (mainInstance) {
+    await invoke('MainArea.focus', mainInstance.state.uid)
+  }
+}

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
@@ -7,6 +7,7 @@ export const Commands = {
   closeWidget: Viewlet.closeWidget,
   executeViewletCommand: Viewlet.executeViewletCommand,
   focus: Viewlet.focus,
+  focusSelector: Viewlet.focusSelector,
   getAllStates: Viewlet.getAllStates,
   getDragData: Viewlet.getDragData,
   getTitle: Viewlet.getTitle,

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -31,6 +31,10 @@ export const getDragData = () => {
   return RendererProcess.invoke('Viewlet.getDragData')
 }
 
+export const focusSelector = (id, selector) => {
+  return RendererProcess.invoke('Viewlet.focusSelector', id, selector)
+}
+
 export const focus = async (id) => {
   const instance = ViewletStates.getInstance(id)
   if (!instance) {
@@ -366,7 +370,7 @@ export const openWidget = async (moduleId, ...args) => {
   if (ElectronBrowserView.isOpen() && moduleId === ViewletModuleId.QuickPick) {
     // TODO recycle quickpick instance
     if (hasInstance) {
-      await ViewletElectron.closeWidgetElectronQuickPick()
+      await ViewletElectron.closeWidgetElectronQuickPick(false)
     }
     return ViewletElectron.openElectronQuickPick(...args)
   }
@@ -441,7 +445,12 @@ export const closeWidget = async (id) => {
         await SimpleBrowserOverlay.hide('quick-pick')
       }
     }
-    // TODO restore focus
+    if (hasSimpleBrowserOverlay) {
+      const mainInstance = ViewletStates.getInstance(ViewletModuleId.Main)
+      if (mainInstance) {
+        await executeViewletCommand(mainInstance.state.uid, 'focus')
+      }
+    }
   } catch (error) {
     throw new VError(error, `Failed to close widget ${id}`)
   }

--- a/packages/renderer-worker/src/parts/Viewlet/ViewletElectron.js
+++ b/packages/renderer-worker/src/parts/Viewlet/ViewletElectron.js
@@ -6,6 +6,7 @@ import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as RestoreMainFocus from '../RestoreMainFocus/RestoreMainFocus.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
 import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
@@ -80,7 +81,7 @@ export const openWidget = async (id, ...args) => {
   if (ElectronBrowserView.isOpen() && id === 'QuickPick') {
     // TODO recycle quickpick instance
     if (hasInstance) {
-      await closeWidgetElectronQuickPick()
+      await closeWidgetElectronQuickPick(false)
     }
     return openElectronQuickPick(...args)
   }
@@ -110,11 +111,13 @@ export const openWidget = async (id, ...args) => {
   //
 }
 
-export const closeWidgetElectronQuickPick = async () => {
+export const closeWidgetElectronQuickPick = async (restoreFocus = true) => {
   const id = ViewletModuleId.QuickPick
   state.isQuickPickOpen = false
   ViewletStates.remove(id)
   await ElectronBrowserViewQuickPick.disposeBrowserViewQuickPick()
-  // TODO restore focus to previously focused element
   await ElectronWindow.focus()
+  if (restoreFocus) {
+    await RestoreMainFocus.restoreMainFocus()
+  }
 }

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -4,3 +4,7 @@ import { commandMap } from '../src/parts/CommandMap/CommandMap.js'
 test('registers the go-to-line quick pick command', () => {
   expect(commandMap['QuickPick.openGoToLine']).toBeDefined()
 })
+
+test('registers the viewlet focus-selector bridge command', () => {
+  expect(commandMap['Viewlet.focusSelector']).toBeDefined()
+})

--- a/packages/renderer-worker/test/RestoreMainFocus.test.ts
+++ b/packages/renderer-worker/test/RestoreMainFocus.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { restoreMainFocus } from '../src/parts/RestoreMainFocus/RestoreMainFocus.js'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+beforeEach(() => {
+  ViewletStates.reset()
+})
+
+test('restoreMainFocus focuses the active main-area editor', async () => {
+  const invoke = jest.fn(async (_method: string, _uid: number) => {})
+  ViewletStates.set(3, {
+    factory: {},
+    moduleId: 'Main',
+    renderedState: { uid: 3 },
+    state: { uid: 3 },
+  })
+
+  await restoreMainFocus(invoke)
+
+  expect(invoke).toHaveBeenCalledWith('MainArea.focus', 3)
+})
+
+test('restoreMainFocus does nothing without a main-area instance', async () => {
+  const invoke = jest.fn(async () => {})
+
+  await restoreMainFocus(invoke)
+
+  expect(invoke).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -106,6 +106,14 @@ test('getDragData', async () => {
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.getDragData')
 })
 
+test('focusSelector forwards focus to the renderer process', async () => {
+  jest.mocked(RendererProcess.invoke).mockResolvedValue(undefined)
+
+  await Viewlet.focusSelector(7, '[name="editor"]')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.focusSelector', 7, '[name="editor"]')
+})
+
 test('disposeFunctional disposes owned runtime viewlets', () => {
   const childFactory = {}
   ViewletStates.set(11, {
@@ -349,11 +357,22 @@ test('openWidget - declares DefineKeyBinding as an owned widget', async () => {
 })
 
 test('closeWidget restores Simple Browser after closing Quick Pick', async () => {
+  const focus = jest.fn((state: Readonly<{ readonly uid: number }>): Readonly<{ readonly uid: number }> => state)
   ViewletStates.set(2, {
-    state: { uid: 2 },
-    renderedState: { uid: 2 },
-    moduleId: 'QuickPick',
     factory: {},
+    moduleId: 'QuickPick',
+    renderedState: { uid: 2 },
+    state: { uid: 2 },
+  })
+  ViewletStates.set(3, {
+    factory: {
+      Commands: {
+        focus,
+      },
+    },
+    moduleId: 'Main',
+    renderedState: { uid: 3 },
+    state: { uid: 3 },
   })
   // @ts-ignore
   RendererProcess.invoke.mockImplementation(() => {})
@@ -361,6 +380,7 @@ test('closeWidget restores Simple Browser after closing Quick Pick', async () =>
   await Viewlet.closeWidget(2)
 
   expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('quick-pick')
+  expect(focus).toHaveBeenCalledWith({ uid: 3 })
 })
 
 test('openWidget - should not open again when already open', async () => {


### PR DESCRIPTION
## Summary

- restore the active editor after ordinary title-menu commands and canceled quick picks
- restore focus after Electron BrowserView quick-pick teardown without briefly focusing during picker replacement
- expose the renderer focus-selector bridge used by the main-area worker
- add unit, command-map, title-menu, and Escape focus regressions

## Dependencies

- `@lvce-editor/title-bar-worker@4.15.5` (PR #648) marks ordinary Edit, Selection, and View License commands for focus restoration
- `@lvce-editor/main-area-worker@9.37.2` (PRs #692 and #693) focuses the authoritative active editor through the `Main.focus` and `MainArea.focus` bridge aliases

Both dependency updates are already present on `main`.

## Validation

- renderer-worker: 309 suites passed, 1,238 tests passed
- renderer-worker and extension-host-worker-tests type checks passed
- focused ESLint passed for all new files and command-map/IPC changes
- static and server builds passed
- static export validation passed
- development and exported-static Escape regressions passed, including editor focus restoration
