### PR TITLE
feature: update title-bar-worker to version 4.15.6

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -71,7 +71,7 @@
         "@lvce-editor/text-measurement-worker": "^1.21.0",
         "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
         "@lvce-editor/text-search-worker": "^7.13.2",
-        "@lvce-editor/title-bar-worker": "^4.15.5",
+        "@lvce-editor/title-bar-worker": "^4.15.6",
         "@lvce-editor/update-worker": "^2.12.0"
       },
       "devDependencies": {
@@ -1252,9 +1252,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/title-bar-worker": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/title-bar-worker/-/title-bar-worker-4.15.5.tgz",
-      "integrity": "sha512-cBLmVopScWjRqofA1FKTcyL5WAg4Y40we+3cKU/6UbS4SEOGvHA6/SWULbCdjIBw1WAm4MXs1DzUoGYsvdi8vQ==",
+      "version": "4.15.6",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/title-bar-worker/-/title-bar-worker-4.15.6.tgz",
+      "integrity": "sha512-oChqLmsMb+86fN+CfPCcy8eUcxiBoNEeQjtVLUpyE9Qylr6ielJzjvcR8SX/MxZB3Svcl0+E5pzlO/7mZeVt3A==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/update-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -103,7 +103,7 @@
     "@lvce-editor/text-measurement-worker": "^1.21.0",
     "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
     "@lvce-editor/text-search-worker": "^7.13.2",
-    "@lvce-editor/title-bar-worker": "^4.15.5",
+    "@lvce-editor/title-bar-worker": "^4.15.6",
     "@lvce-editor/update-worker": "^2.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update @lvce-editor/title-bar-worker to 4.15.6
- include View-menu focus requests for Source Control, Run, Extensions, and Chat