### PR TITLE
feature: update debug-worker to version 4.13.1

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -23,7 +23,7 @@
         "@lvce-editor/clipboard-worker": "^1.26.0",
         "@lvce-editor/color-picker-worker": "^3.12.0",
         "@lvce-editor/completion-worker": "^4.17.0",
-        "@lvce-editor/debug-worker": "^4.12.0",
+        "@lvce-editor/debug-worker": "^4.13.1",
         "@lvce-editor/dialog-worker": "^1.1.2",
         "@lvce-editor/diff-view": "^3.32.1",
         "@lvce-editor/diff-worker": "^3.4.0",
@@ -958,9 +958,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/debug-worker": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/debug-worker/-/debug-worker-4.13.0.tgz",
-      "integrity": "sha512-YUUdDacqYWneEJW4CCTPgT8UICcpPH0omNp6Stg7SZBVHT5c19B5f7uV2137+akLHFgt1KDF3+KO5zpQAsHfRg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/debug-worker/-/debug-worker-4.13.1.tgz",
+      "integrity": "sha512-HHca1c0Xue3py6/90ILkgm9kTMgUv7gC4CnQ13IVMIcdmc3gbMOLanRMtWc5fIBA0OD7IfFo7PtNySEYfCcZkQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/dialog-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -55,7 +55,7 @@
     "@lvce-editor/clipboard-worker": "^1.26.0",
     "@lvce-editor/color-picker-worker": "^3.12.0",
     "@lvce-editor/completion-worker": "^4.17.0",
-    "@lvce-editor/debug-worker": "^4.12.0",
+    "@lvce-editor/debug-worker": "^4.13.1",
     "@lvce-editor/dialog-worker": "^1.1.2",
     "@lvce-editor/diff-view": "^3.32.1",
     "@lvce-editor/diff-worker": "^3.4.0",


### PR DESCRIPTION
## Summary

- update `@lvce-editor/debug-worker` to 4.13.1
- route Run and Debug provider execution through extension event activation instead of sending an unregistered extension-host command

## Validation

- debug-worker 4.13.1 release passed tests, type-check, lint, and builds on Linux, macOS, and Windows
- verified the lockfile integrity against the published npm package
- LVCE CI will exercise lint, type-check, tests, static/server builds, extension-host tests, and Electron packaging on all supported CI platforms