### PR TITLE
fix: focus views opened from title menu

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletChat/ViewletChat.ts
+++ b/packages/renderer-worker/src/parts/ViewletChat/ViewletChat.ts
@@ -50,3 +50,10 @@ export const hotReload = async (state) => {
 export const saveState = (state) => {
   return ChatViewWorker.invoke('Chat.saveState', state.uid)
 }
+
+export const focus = (state: ChatState): ChatState => {
+  return {
+    ...state,
+    commands: [['Viewlet.focusSelector', '[name="composer"]']],
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletChat/ViewletChatCommands.ts
+++ b/packages/renderer-worker/src/parts/ViewletChat/ViewletChatCommands.ts
@@ -1,6 +1,6 @@
 import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import { wrapChatCommand } from '../WrapChatCommand/WrapChatCommand.ts'
-import { hotReload } from './ViewletChat.ts'
+import { focus, hotReload } from './ViewletChat.ts'
 
 export const Commands = {}
 
@@ -10,5 +10,6 @@ export const getCommands = async () => {
     Commands[command] = wrapChatCommand(command)
   }
   Commands['hotReload'] = hotReload
+  Commands['focus'] = focus
   return Commands
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.js
@@ -52,6 +52,13 @@ export const loadContent = async (state, savedState) => {
 
 export const dispose = () => {}
 
+export const focus = (state) => {
+  return {
+    ...state,
+    commands: [['Viewlet.focusSelector', '[name="extensions"]']],
+  }
+}
+
 // TODO lazyload this
 
 export const hotReload = async (state) => {

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensionsCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensionsCommands.js
@@ -10,6 +10,7 @@ export const getCommands = async () => {
     Commands[command] = WrapExtensionSearchCommand.wrapExtensionSearchCommand(command)
   }
   Commands['hotReload'] = ViewletExtensions.hotReload
+  Commands['focus'] = ViewletExtensions.focus
 
   return Commands
 }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -728,19 +728,21 @@ export const toggleSecondarySideBar = (state: LayoutState) => {
   return toggle(state, LayoutModules.SecondarySideBar)
 }
 
-export const openChat = async (state: LayoutState): Promise<LayoutStateResult> => {
+export const openChat = async (state: LayoutState, focus = false): Promise<LayoutStateResult> => {
   if (state.secondarySideBarVisible && state.secondarySideBarView === ViewletModuleId.Chat) {
+    const focusCommands = focus ? await Viewlet.getFocusCommands(ViewletModuleId.Chat) : []
     return {
       newState: state,
-      commands: [],
+      commands: focusCommands,
     }
   }
   // @ts-ignore
   const openResult = await openSecondarySideBarView(state, ViewletModuleId.Chat)
   const showResult = await showSecondarySideBar(openResult.newState)
+  const focusCommands = focus ? await Viewlet.getFocusCommands(ViewletModuleId.Chat) : []
   return {
     newState: showResult.newState,
-    commands: [...openResult.commands, ...showResult.commands],
+    commands: [...openResult.commands, ...showResult.commands, ...focusCommands],
   }
 }
 
@@ -2196,7 +2198,15 @@ export const getSideBarPosition = (state: LayoutState) => {
 }
 
 export const openSideBarView = async (state: LayoutState, moduleId, focus = false, args): Promise<LayoutStateResult> => {
-  return showSideBar(state, moduleId)
+  const result = await showSideBar(state, moduleId)
+  if (!focus) {
+    return result
+  }
+  const focusCommands = await Viewlet.getFocusCommands(moduleId)
+  return {
+    newState: result.newState,
+    commands: [...result.commands, ...focusCommands],
+  }
 }
 
 export const openSecondarySideBarView = async (state: LayoutState, moduleId, focus = false, args): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/src/parts/ViewletRunAndDebug/ViewletRunAndDebug.js
+++ b/packages/renderer-worker/src/parts/ViewletRunAndDebug/ViewletRunAndDebug.js
@@ -98,6 +98,13 @@ export const contentLoaded = async () => {
   return []
 }
 
+export const focus = (state) => {
+  return {
+    ...state,
+    commands: [['Viewlet.focusSelector', '.RunAndDebug']],
+  }
+}
+
 // TODO maybe store scope chain elements as tree
 // TODO when collapsing, store collapsed elements by parent id in cache
 // TODO when expanding, retrieve items from cache by parent id first

--- a/packages/renderer-worker/src/parts/ViewletRunAndDebug/ViewletRunAndDebugCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletRunAndDebug/ViewletRunAndDebugCommands.js
@@ -10,5 +10,6 @@ export const getCommands = async () => {
     Commands[command] = WrapRunAndDebugCommand.wrapRunAndDebugCommand(command)
   }
   Commands['hotReload'] = ViewletRunAndDebug.hotReload
+  Commands['focus'] = ViewletRunAndDebug.focus
   return Commands
 }

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -84,6 +84,13 @@ export const handleInput = (state, text) => {
   }
 }
 
+export const focus = (state) => {
+  return {
+    ...state,
+    commands: [['Viewlet.focusSelector', '.SourceControlHeader input']],
+  }
+}
+
 const updateIcon = (displayItem) => {
   if (displayItem.type === DirentType.File) {
     return {

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
@@ -12,5 +12,6 @@ export const getCommands = async () => {
   Commands['loadContentLater'] = ViewletSourceControl.loadContentLater
   Commands['hotReload'] = ViewletSourceControl.hotReload
   Commands['getInfo'] = ({ uid }) => SourceControlWorker.invoke('SourceControl.getInfo', uid)
+  Commands['focus'] = ViewletSourceControl.focus
   return Commands
 }

--- a/packages/renderer-worker/test/ViewMenuFocus.test.ts
+++ b/packages/renderer-worker/test/ViewMenuFocus.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletChat from '../src/parts/ViewletChat/ViewletChat.ts'
+import * as ViewletExtensions from '../src/parts/ViewletExtensions/ViewletExtensions.js'
+import * as ViewletRunAndDebug from '../src/parts/ViewletRunAndDebug/ViewletRunAndDebug.js'
+import * as ViewletSourceControl from '../src/parts/ViewletSourceControl/ViewletSourceControl.js'
+
+test.each([
+  ['Source Control', ViewletSourceControl.focus, '.SourceControlHeader input'],
+  ['Run and Debug', ViewletRunAndDebug.focus, '.RunAndDebug'],
+  ['Extensions', ViewletExtensions.focus, '[name="extensions"]'],
+  ['Chat', ViewletChat.focus, '[name="composer"]'],
+] as const)('%s focuses its primary interactive control', (name, focus, selector) => {
+  const state = { commands: [], id: 1 }
+
+  const result = focus(state as any)
+
+  expect(result).toEqual({
+    ...state,
+    commands: [['Viewlet.focusSelector', selector]],
+  })
+})

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -564,6 +564,89 @@ test('toggleSideBarView appends focus commands after showing the requested view'
   expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusElementByName', 12, 'SearchValue']])
 })
 
+test('openSideBarView appends focus commands when focus is requested', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="extensions"]']])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  }
+
+  const result = await ViewletLayout.openSideBarView(state, 'Extensions', true, undefined)
+
+  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Extensions')
+  expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusSelector', 12, '[name="extensions"]']])
+})
+
+test('openSideBarView does not request focus by default', async () => {
+  mockActivityBarRender()
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    sideBarView: 'Explorer',
+    sideBarVisible: true,
+  }
+
+  await ViewletLayout.openSideBarView(state, 'Extensions', false, undefined)
+
+  expect(Viewlet.getFocusCommands).not.toHaveBeenCalled()
+})
+
+test('openChat focuses an already open chat when requested', async () => {
+  // @ts-ignore
+  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="composer"]']])
+  const state = {
+    ...ViewletLayout.create(1),
+    secondarySideBarView: 'Chat',
+    secondarySideBarVisible: true,
+  }
+
+  const result = await ViewletLayout.openChat(state, true)
+
+  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Chat')
+  expect(result).toEqual({
+    newState: state,
+    commands: [['Viewlet.focusSelector', 12, '[name="composer"]']],
+  })
+})
+
+test('openChat focuses chat after opening the secondary side bar', async () => {
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([])
+  // @ts-ignore
+  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="composer"]']])
+  const state = {
+    ...ViewletLayout.create(1),
+    secondarySideBarView: '',
+    secondarySideBarVisible: false,
+  }
+
+  const result = await ViewletLayout.openChat(state, true)
+
+  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Chat')
+  expect(result.newState).toMatchObject({
+    secondarySideBarView: 'Chat',
+    secondarySideBarVisible: true,
+  })
+  expect(result.commands.at(-1)).toEqual(['Viewlet.focusSelector', 12, '[name="composer"]'])
+})
+
+test('openChat leaves an already open chat unfocused by default', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    secondarySideBarView: 'Chat',
+    secondarySideBarVisible: true,
+  }
+
+  const result = await ViewletLayout.openChat(state)
+
+  expect(Viewlet.getFocusCommands).not.toHaveBeenCalled()
+  expect(result).toEqual({ newState: state, commands: [] })
+})
+
 test('toggleSideBarView opens a preview-preferred extension view in the preview area', async () => {
   mockActivityBarRender()
   // @ts-ignore


### PR DESCRIPTION
## Summary

- focus Source Control, Run and Debug, and Extensions after their View-menu commands open the side bar
- focus Chat after initial open and when the already-open Chat view is selected again
- register explicit focus commands in each destination view and compose them through the layout commands

This completes the focus half of title-bar dogfood Issue 11. The title-bar-worker 4.15.6 command arguments and debug-worker 4.13.1 provider routing are already present on `main`.

## Validation

- focused renderer tests: 31 passed
- complete renderer suite: 310 suites / 1247 tests passed; 23 suites / 232 tests skipped
- renderer-worker type-check passed
- repository lint/knip passed
- full LVCE CI will additionally build and package Electron on Linux, macOS, and Windows