### PR TITLE
fix: target focusable view menu controls

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletRunAndDebug/ViewletRunAndDebug.js
+++ b/packages/renderer-worker/src/parts/ViewletRunAndDebug/ViewletRunAndDebug.js
@@ -101,7 +101,7 @@ export const contentLoaded = async () => {
 export const focus = (state) => {
   return {
     ...state,
-    commands: [['Viewlet.focusSelector', '.RunAndDebug']],
+    commands: [['Viewlet.focus', state.uid]],
   }
 }
 

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -87,7 +87,7 @@ export const handleInput = (state, text) => {
 export const focus = (state) => {
   return {
     ...state,
-    commands: [['Viewlet.focusSelector', '.SourceControlHeader input']],
+    commands: [['Viewlet.focusSelector', '[name="SourceControlInput"]']],
   }
 }
 

--- a/packages/renderer-worker/test/ViewMenuFocus.test.ts
+++ b/packages/renderer-worker/test/ViewMenuFocus.test.ts
@@ -5,17 +5,17 @@ import * as ViewletRunAndDebug from '../src/parts/ViewletRunAndDebug/ViewletRunA
 import * as ViewletSourceControl from '../src/parts/ViewletSourceControl/ViewletSourceControl.js'
 
 test.each([
-  ['Source Control', ViewletSourceControl.focus, '.SourceControlHeader input'],
-  ['Run and Debug', ViewletRunAndDebug.focus, '.RunAndDebug'],
-  ['Extensions', ViewletExtensions.focus, '[name="extensions"]'],
-  ['Chat', ViewletChat.focus, '[name="composer"]'],
-] as const)('%s focuses its primary interactive control', (name, focus, selector) => {
-  const state = { commands: [], id: 1 }
+  ['Source Control', ViewletSourceControl.focus, ['Viewlet.focusSelector', '[name="SourceControlInput"]']],
+  ['Run and Debug', ViewletRunAndDebug.focus, ['Viewlet.focus', 7]],
+  ['Extensions', ViewletExtensions.focus, ['Viewlet.focusSelector', '[name="extensions"]']],
+  ['Chat', ViewletChat.focus, ['Viewlet.focusSelector', '[name="composer"]']],
+] as const)('%s focuses its primary interactive control', (name, focus, command) => {
+  const state = { commands: [], id: 1, uid: 7 }
 
   const result = focus(state as any)
 
   expect(result).toEqual({
     ...state,
-    commands: [['Viewlet.focusSelector', selector]],
+    commands: [command],
   })
 })


### PR DESCRIPTION
## Summary

- focus the actual Source Control textarea rendered as `SourceControlInput`
- focus the Run and Debug viewlet root through `Viewlet.focus`, because the root cannot match its own descendant selector
- keep Extensions and Chat targeting their primary inputs

## Acceptance finding

Official `v0.97.23` verified that all four title-menu destinations open and that Run no longer reports `Command not found ExtensionHostDebug.start`. It also exposed two selector mistakes: Source Control renders a textarea rather than an input, and `.RunAndDebug` is the focusable viewlet root rather than a descendant. This patch addresses those physical-Electron findings.

## Validation

- focused renderer tests: 47 passed, 2 skipped
- complete renderer suite: 310 suites / 1247 tests passed; 23 suites / 232 tests skipped
- renderer-worker type-check passed
- repository lint/knip passed