### PR TITLE
fix: focus title menu views after loading

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -730,19 +730,25 @@ export const toggleSecondarySideBar = (state: LayoutState) => {
 
 export const openChat = async (state: LayoutState, focus = false): Promise<LayoutStateResult> => {
   if (state.secondarySideBarVisible && state.secondarySideBarView === ViewletModuleId.Chat) {
-    const focusCommands = focus ? await Viewlet.getFocusCommands(ViewletModuleId.Chat) : []
+    if (focus) {
+      await ViewletManager.waitForLoadContentLater(ViewletModuleId.Chat)
+      await Viewlet.focus(ViewletModuleId.Chat)
+    }
     return {
       newState: state,
-      commands: focusCommands,
+      commands: [],
     }
   }
   // @ts-ignore
   const openResult = await openSecondarySideBarView(state, ViewletModuleId.Chat)
   const showResult = await showSecondarySideBar(openResult.newState)
-  const focusCommands = focus ? await Viewlet.getFocusCommands(ViewletModuleId.Chat) : []
+  if (focus) {
+    await ViewletManager.waitForLoadContentLater(ViewletModuleId.Chat)
+    await Viewlet.focus(ViewletModuleId.Chat)
+  }
   return {
     newState: showResult.newState,
-    commands: [...openResult.commands, ...showResult.commands, ...focusCommands],
+    commands: [...openResult.commands, ...showResult.commands],
   }
 }
 
@@ -2202,11 +2208,9 @@ export const openSideBarView = async (state: LayoutState, moduleId, focus = fals
   if (!focus) {
     return result
   }
-  const focusCommands = await Viewlet.getFocusCommands(moduleId)
-  return {
-    newState: result.newState,
-    commands: [...result.commands, ...focusCommands],
-  }
+  await ViewletManager.waitForLoadContentLater(moduleId)
+  await Viewlet.focus(moduleId)
+  return result
 }
 
 export const openSecondarySideBarView = async (state: LayoutState, moduleId, focus = false, args): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -40,10 +40,17 @@ export const runLoadContentLater = (uid) => {
   const instance = ViewletStates.getInstance(uid)
   const loadContentLater = instance?.factory?.Commands?.loadContentLater
   if (!loadContentLater || instance.loadContentLaterStarted) {
-    return
+    return instance?.loadContentLaterPromise
   }
   instance.loadContentLaterStarted = true
-  void runLoadContentLaterWithErrorHandling(loadContentLater, instance.state)
+  instance.loadContentLaterPromise = runLoadContentLaterWithErrorHandling(loadContentLater, instance.state)
+  void instance.loadContentLaterPromise
+  return instance.loadContentLaterPromise
+}
+
+export const waitForLoadContentLater = async (uid) => {
+  const instance = ViewletStates.getInstance(uid)
+  await instance?.loadContentLaterPromise
 }
 
 export const runLoadContentLaterForCreatedViewlets = (commands) => {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -19,6 +19,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
     load: jest.fn(() => {
       throw new Error('not implemented')
     }),
+    waitForLoadContentLater: jest.fn(() => undefined),
   }
 })
 
@@ -32,6 +33,7 @@ jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
 jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
   return {
     disposeFunctional: jest.fn(() => []),
+    focus: jest.fn(() => undefined),
     getFocusCommands: jest.fn(() => []),
     resize: jest.fn(() => []),
   }
@@ -69,9 +71,13 @@ beforeEach(() => {
   // @ts-ignore
   Viewlet.disposeFunctional.mockReturnValue([])
   // @ts-ignore
+  Viewlet.focus.mockResolvedValue(undefined)
+  // @ts-ignore
   Viewlet.getFocusCommands.mockResolvedValue([])
   // @ts-ignore
   Viewlet.resize.mockResolvedValue([])
+  // @ts-ignore
+  ViewletManager.waitForLoadContentLater.mockResolvedValue(undefined)
   // @ts-ignore
   ViewletStates.getAllInstances.mockReturnValue({})
   // @ts-ignore
@@ -564,10 +570,8 @@ test('toggleSideBarView appends focus commands after showing the requested view'
   expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusElementByName', 12, 'SearchValue']])
 })
 
-test('openSideBarView appends focus commands when focus is requested', async () => {
+test('openSideBarView waits for deferred content and focuses the mounted view when requested', async () => {
   mockActivityBarRender()
-  // @ts-ignore
-  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="extensions"]']])
   const state = {
     ...ViewletLayout.create(1),
     activityBarId: 7,
@@ -577,8 +581,9 @@ test('openSideBarView appends focus commands when focus is requested', async () 
 
   const result = await ViewletLayout.openSideBarView(state, 'Extensions', true, undefined)
 
-  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Extensions')
-  expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusSelector', 12, '[name="extensions"]']])
+  expect(ViewletManager.waitForLoadContentLater).toHaveBeenCalledWith('Extensions')
+  expect(Viewlet.focus).toHaveBeenCalledWith('Extensions')
+  expect(result.commands).toEqual([['activity-bar.render2']])
 })
 
 test('openSideBarView does not request focus by default', async () => {
@@ -592,12 +597,11 @@ test('openSideBarView does not request focus by default', async () => {
 
   await ViewletLayout.openSideBarView(state, 'Extensions', false, undefined)
 
-  expect(Viewlet.getFocusCommands).not.toHaveBeenCalled()
+  expect(ViewletManager.waitForLoadContentLater).not.toHaveBeenCalled()
+  expect(Viewlet.focus).not.toHaveBeenCalled()
 })
 
 test('openChat focuses an already open chat when requested', async () => {
-  // @ts-ignore
-  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="composer"]']])
   const state = {
     ...ViewletLayout.create(1),
     secondarySideBarView: 'Chat',
@@ -606,18 +610,17 @@ test('openChat focuses an already open chat when requested', async () => {
 
   const result = await ViewletLayout.openChat(state, true)
 
-  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Chat')
+  expect(ViewletManager.waitForLoadContentLater).toHaveBeenCalledWith('Chat')
+  expect(Viewlet.focus).toHaveBeenCalledWith('Chat')
   expect(result).toEqual({
     newState: state,
-    commands: [['Viewlet.focusSelector', 12, '[name="composer"]']],
+    commands: [],
   })
 })
 
 test('openChat focuses chat after opening the secondary side bar', async () => {
   // @ts-ignore
   ViewletManager.load.mockResolvedValue([])
-  // @ts-ignore
-  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="composer"]']])
   const state = {
     ...ViewletLayout.create(1),
     secondarySideBarView: '',
@@ -626,12 +629,13 @@ test('openChat focuses chat after opening the secondary side bar', async () => {
 
   const result = await ViewletLayout.openChat(state, true)
 
-  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Chat')
+  expect(ViewletManager.waitForLoadContentLater).toHaveBeenCalledWith('Chat')
+  expect(Viewlet.focus).toHaveBeenCalledWith('Chat')
   expect(result.newState).toMatchObject({
     secondarySideBarView: 'Chat',
     secondarySideBarVisible: true,
   })
-  expect(result.commands.at(-1)).toEqual(['Viewlet.focusSelector', 12, '[name="composer"]'])
+  expect(result.commands).toEqual([])
 })
 
 test('openChat leaves an already open chat unfocused by default', async () => {
@@ -643,7 +647,8 @@ test('openChat leaves an already open chat unfocused by default', async () => {
 
   const result = await ViewletLayout.openChat(state)
 
-  expect(Viewlet.getFocusCommands).not.toHaveBeenCalled()
+  expect(ViewletManager.waitForLoadContentLater).not.toHaveBeenCalled()
+  expect(Viewlet.focus).not.toHaveBeenCalled()
   expect(result).toEqual({ newState: state, commands: [] })
 })
 

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -70,6 +70,37 @@ test('runLoadContentLater starts deferred loading once', async () => {
   expect(loadContentLater).toHaveBeenCalledWith(viewletState)
 })
 
+test('waitForLoadContentLater waits for deferred loading to finish', async () => {
+  let finishLoading: () => void = () => {}
+  const loading = new Promise<void>((resolve) => {
+    finishLoading = resolve
+  })
+  const loadContentLater = jest.fn(() => loading)
+  const viewletState = { uid: 42 }
+  ViewletStates.set(42, {
+    factory: {
+      Commands: {
+        loadContentLater,
+      },
+    },
+    renderedState: viewletState,
+    state: viewletState,
+  })
+
+  ViewletManager.runLoadContentLater(42)
+  let finished = false
+  const waiting = ViewletManager.waitForLoadContentLater(42).then(() => {
+    finished = true
+  })
+  await Promise.resolve()
+  expect(finished).toBe(false)
+
+  finishLoading()
+  await waiting
+
+  expect(finished).toBe(true)
+})
+
 test('runLoadContentLaterForCreatedViewlets starts deferred loading for newly rendered viewlets', async () => {
   const loadContentLater = jest.fn(async (_state: unknown) => {})
   const viewletState = { uid: 42 }


### PR DESCRIPTION
## Summary

- retain the promise for deferred viewlet content loading and expose an awaitable lifecycle hook
- wait for deferred content before focusing a View-menu destination
- focus mounted side-bar and Chat viewlets directly instead of deriving render commands from an intermediate state

## Acceptance finding

Official `v0.97.24` confirmed that the corrected selectors exist, but Source Control and Run still ended on `<body>`. Source Control completes `loadContentLater` after the title command returns and replaces the focused DOM, while the command-derived focus path can run against an intermediate render. Waiting for the actual load promise makes focus the final lifecycle operation.

## Validation

- focused lifecycle/layout/view tests: 71 passed, 10 skipped
- complete renderer suite: 310 suites / 1248 tests passed; 23 suites / 232 tests skipped
- renderer-worker type-check passed
- repository lint/knip passed