### PR TITLE
fix: resolve internal URIs before opening editors

### DIFF
--- a/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
@@ -2,6 +2,7 @@ import * as Assert from '../Assert/Assert.ts'
 import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import { resolveInternalSourceUri } from '../ResolveInternalSourceUri/ResolveInternalSourceUri.ts'
 
 const loadingDelay = 500
 const loadingTimeout = Symbol('loadingTimeout')
@@ -9,6 +10,26 @@ const commandsThatOpenEditors = new Set(['handleClickTab', 'openInput', 'openUri
 
 const shouldRenderLoadingState = (key: string): boolean => {
   return commandsThatOpenEditors.has(key) && Preferences.get('workbench.editor.showTabsWhileLoading') === true
+}
+
+const resolveOpenUriArgs = async (key: string, args: readonly any[]): Promise<readonly any[]> => {
+  if (key !== 'openUri' || args.length === 0) {
+    return args
+  }
+  const [options, ...rest] = args
+  if (typeof options === 'string') {
+    return [await resolveInternalSourceUri(options), ...rest]
+  }
+  if (typeof options?.uri === 'string') {
+    return [
+      {
+        ...options,
+        uri: await resolveInternalSourceUri(options.uri),
+      },
+      ...rest,
+    ]
+  }
+  return args
 }
 
 const renderPendingState = async (uid: number): Promise<void> => {
@@ -24,7 +45,8 @@ const renderPendingState = async (uid: number): Promise<void> => {
 }
 
 const invokeMainAreaCommand = async (key: string, uid: number, args: readonly any[]): Promise<void> => {
-  const commandPromise = MainAreaWorker.invoke(`MainArea.${key}`, uid, ...args)
+  const resolvedArgs = await resolveOpenUriArgs(key, args)
+  const commandPromise = MainAreaWorker.invoke(`MainArea.${key}`, uid, ...resolvedArgs)
   if (!shouldRenderLoadingState(key)) {
     await commandPromise
     return

--- a/packages/renderer-worker/test/WrapMainAreaCommand.test.ts
+++ b/packages/renderer-worker/test/WrapMainAreaCommand.test.ts
@@ -18,9 +18,16 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
   }
 })
 
+jest.unstable_mockModule('../src/parts/ResolveInternalSourceUri/ResolveInternalSourceUri.ts', () => {
+  return {
+    resolveInternalSourceUri: jest.fn(async (uri: string) => uri),
+  }
+})
+
 const MainAreaWorker = await import('../src/parts/MainAreaWorker/MainAreaWorker.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const ResolveInternalSourceUri = await import('../src/parts/ResolveInternalSourceUri/ResolveInternalSourceUri.ts')
 const { wrapMainAreaCommand } = await import('../src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts')
 
 const state = {
@@ -34,6 +41,8 @@ beforeEach(() => {
   Preferences.get.mockReturnValue(false)
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValue(undefined)
+  // @ts-ignore
+  ResolveInternalSourceUri.resolveInternalSourceUri.mockImplementation(async (uri: string) => uri)
 })
 
 afterEach(() => {
@@ -63,6 +72,27 @@ test('returns final render commands for a fast open', async () => {
     commands: finalCommands,
   })
   expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('resolves an internal URI before opening it in the main area worker', async () => {
+  const options = {
+    focus: true,
+    uri: 'lvce://-/abc123/extensions/typescript/lib/lib.es5.d.ts',
+  }
+  // @ts-ignore
+  ResolveInternalSourceUri.resolveInternalSourceUri.mockResolvedValue(
+    'file:///usr/lib/lvce/resources/app/static/abc123/extensions/typescript/lib/lib.es5.d.ts',
+  )
+  // @ts-ignore
+  MainAreaWorker.invoke.mockResolvedValue([])
+
+  await wrapMainAreaCommand('openUri')(state, options)
+
+  expect(ResolveInternalSourceUri.resolveInternalSourceUri).toHaveBeenCalledWith(options.uri)
+  expect(MainAreaWorker.invoke).toHaveBeenNthCalledWith(1, 'MainArea.openUri', state.uid, {
+    ...options,
+    uri: 'file:///usr/lib/lvce/resources/app/static/abc123/extensions/typescript/lib/lib.es5.d.ts',
+  })
 })
 
 test('renders a pending loading state after 500ms and returns the final render', async () => {


### PR DESCRIPTION
Resolves internal source URIs before forwarding openUri commands to the main-area worker, so bundled TypeScript library definitions open through the installed file-system provider. Adds regression coverage for object-form openUri arguments.