### PR TITLE
fix: filter eager CSS from worker viewlet config

### DIFF
--- a/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
+++ b/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
@@ -2,6 +2,7 @@ import { VError } from '@lvce-editor/verror'
 import { readFile, readdir, writeFile } from 'node:fs/promises'
 import * as BundleJs from '../BundleJsRollup/BundleJsRollup.ts'
 import * as Copy from '../Copy/Copy.ts'
+import * as FilterWorkerViewletCss from '../FilterWorkerViewletCss/FilterWorkerViewletCss.ts'
 import * as GetCssDeclarationFiles from '../GetCssDeclarationFiles/GetCssDeclarationFiles.ts'
 import * as GetFilteredCssDeclarations from '../GetFilteredCssDeclarations/GetFilteredCssDeclarations.ts'
 import * as Path from '../Path/Path.ts'
@@ -83,6 +84,14 @@ const getWorkerPathReplacements = async (cachePath) => {
     })
 }
 
+const filterWorkerViewletCss = async (cachePath) => {
+  const workersJsonPath = Path.join(cachePath, 'src', 'parts', 'Workers', 'Workers.json')
+  const content = await readFile(workersJsonPath, 'utf8')
+  const workers = JSON.parse(content)
+  const filteredWorkers = FilterWorkerViewletCss.filterWorkerViewletCss(workers)
+  await writeFile(workersJsonPath, `${JSON.stringify(filteredWorkers, undefined, 2)}\n`)
+}
+
 const getSourceFiles = async (path) => {
   const entries = await readdir(path, { withFileTypes: true })
   const files: any[] = []
@@ -123,6 +132,7 @@ export const bundleRendererWorker = async ({ cachePath, platform, commitHash, as
       from: 'packages/renderer-worker/src',
       to: Path.join(cachePath, 'src'),
     })
+    await filterWorkerViewletCss(cachePath)
     const cssDeclarationFiles = await GetCssDeclarationFiles.getCssDeclarationFiles(cachePath)
     for (const file of cssDeclarationFiles) {
       const content = await readFile(file, 'utf8')

--- a/packages/build/src/parts/CachePaths/CachePaths.ts
+++ b/packages/build/src/parts/CachePaths/CachePaths.ts
@@ -34,7 +34,9 @@ const getRendererWorkerCacheHash = async (extraContents) => {
       'packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts',
       'packages/build/src/parts/BundleRendererWorkerCached/BundleRendererWorkerCached.ts',
       'packages/build/src/parts/EagerLoadedCss/EagerLoadedCss.ts',
+      'packages/build/src/parts/FilterWorkerViewletCss/FilterWorkerViewletCss.ts',
       'packages/build/src/parts/GetCssDeclarationFiles/GetCssDeclarationFiles.ts',
+      'packages/build/src/parts/GetFilteredCssDeclarations/GetFilteredCssDeclarations.ts',
     ],
     extraContents,
   )

--- a/packages/build/src/parts/FilterWorkerViewletCss/FilterWorkerViewletCss.ts
+++ b/packages/build/src/parts/FilterWorkerViewletCss/FilterWorkerViewletCss.ts
@@ -1,0 +1,16 @@
+import * as GetFilteredCssDeclarations from '../GetFilteredCssDeclarations/GetFilteredCssDeclarations.ts'
+
+export const filterWorkerViewletCss = (workers) => {
+  return workers.map((worker) => {
+    if (!Array.isArray(worker.viewlet?.css)) {
+      return worker
+    }
+    return {
+      ...worker,
+      viewlet: {
+        ...worker.viewlet,
+        css: GetFilteredCssDeclarations.getFilteredCssDeclarations(worker.viewlet.css),
+      },
+    }
+  })
+}

--- a/packages/build/test/FilterWorkerViewletCss.test.ts
+++ b/packages/build/test/FilterWorkerViewletCss.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@jest/globals'
+import { filterWorkerViewletCss } from '../src/parts/FilterWorkerViewletCss/FilterWorkerViewletCss.ts'
+
+test('removes CSS that is already bundled into App.css', () => {
+  const workers = [
+    {
+      id: 'statusBarWorker',
+      viewlet: {
+        css: ['/css/parts/ViewletStatusBar.css', '/css/parts/Markdown.css'],
+        name: 'StatusBar',
+      },
+    },
+  ]
+
+  expect(filterWorkerViewletCss(workers)).toEqual([
+    {
+      id: 'statusBarWorker',
+      viewlet: {
+        css: ['/css/parts/Markdown.css'],
+        name: 'StatusBar',
+      },
+    },
+  ])
+})
+
+test('preserves workers without viewlet CSS', () => {
+  const workers = [{ id: 'fileSystemWorker' }, { id: 'aboutWorker', viewlet: { name: 'About' } }]
+
+  expect(filterWorkerViewletCss(workers)).toEqual(workers)
+})


### PR DESCRIPTION
Filters worker-viewlet CSS entries that are already bundled into App.css during production renderer builds. This restores packaged startup after generic worker viewlets began consuming JSON CSS declarations. Adds regression coverage and includes the filter inputs in the renderer-worker cache key.