### PR TITLE
fix: pass editor context to created viewlets

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1091,7 +1091,15 @@ export const setActionsDom = (
   }
 }
 
-export const createViewlet = async (state: LayoutState, viewletModuleId: string, editorUid: number, tabId: number, bounds: any, uri: string) => {
+export const createViewlet = async (
+  state: LayoutState,
+  viewletModuleId: string,
+  editorUid: number,
+  tabId: number,
+  bounds: any,
+  uri: string,
+  args: readonly any[] = [],
+) => {
   const commands = await ViewletManager.load(
     {
       getModule: ViewletModule.load,
@@ -1109,7 +1117,7 @@ export const createViewlet = async (state: LayoutState, viewletModuleId: string,
       height: bounds.height,
       parentUid: -1,
       append: false,
-      args: [],
+      args,
     },
     false,
     true,

--- a/packages/renderer-worker/test/ViewletLayoutCreateViewlet.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutCreateViewlet.test.ts
@@ -1,0 +1,34 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => {
+  return {
+    load: jest.fn(async () => []),
+  }
+})
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+
+test('passes editor context to the created viewlet', async () => {
+  const state = ViewletLayout.create(1)
+  const bounds = { height: 600, width: 800, x: 0, y: 35 }
+  const editorContext = {
+    endColumnIndex: 17,
+    endRowIndex: 42,
+    startColumnIndex: 12,
+    startRowIndex: 42,
+  }
+
+  await ViewletLayout.createViewlet(state, 'EditorText', 2, 3, bounds, 'file:///definition.ts', [editorContext])
+
+  expect(ViewletManager.load).toHaveBeenCalledWith(
+    expect.objectContaining({
+      args: [editorContext],
+      id: 'EditorText',
+      uri: 'file:///definition.ts',
+      uid: 2,
+    }),
+    false,
+    true,
+  )
+})


### PR DESCRIPTION
## Description

Allow main-area viewlet creation to provide editor arguments and retain them on the created renderer viewlet. This completes definition-range propagation into a newly opened text editor.

## Tests

- renderer-worker: 312 suites, 1,282 tests
- `npm run type-check`
- `npm run lint`
- `npm run build:server`