### PR TITLE
fix: restore definition range when opening editor

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -67,6 +67,14 @@ const getSavedSelections = (savedState, context) => {
   if (context?.selections) {
     return new Uint32Array(context.selections)
   }
+  if (
+    typeof context?.startRowIndex === 'number' &&
+    typeof context?.startColumnIndex === 'number' &&
+    typeof context?.endRowIndex === 'number' &&
+    typeof context?.endColumnIndex === 'number'
+  ) {
+    return new Uint32Array([context.startRowIndex, context.startColumnIndex, context.endRowIndex, context.endColumnIndex])
+  }
   if (savedState && savedState.selections) {
     return new Uint32Array(savedState.selections)
   }

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -102,6 +102,33 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   expect(newState.commands).toEqual([...initialCommands, ...selectionCommands])
 })
 
+test('loadContent - restores the definition range supplied by the opener', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.diff2':
+      case 'Editor.render2':
+        return []
+      default:
+        return undefined
+    }
+  })
+  const state = ViewletEditorText.create(1, '/test/lib.es5.d.ts', 0, 0, 800, 600)
+
+  await ViewletEditorText.loadContent(
+    state,
+    { selections: [0, 0, 0, 0] },
+    {
+      endColumnIndex: 9,
+      endRowIndex: 592,
+      languageId: 'typescript',
+      startColumnIndex: 4,
+      startRowIndex: 592,
+    },
+  )
+
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, new Uint32Array([592, 4, 592, 9]))
+})
+
 test('loadContent - disables the editor file cache through preferences', async () => {
   Preferences.state['editor.cache'] = false
   editorWorkerInvoke.mockImplementation((method) => {


### PR DESCRIPTION
## Summary

- translate go-to-definition range coordinates into the editor selection restored during load
- keep explicit opener selections as the highest-priority restore source
- add a regression test for opening a TypeScript library definition away from line 1

## Tests

- `npm test -- --runInBand ViewletEditorText.test.ts`
- `npm test -- --runInBand` (renderer-worker: 312 suites, 1283 tests)
- `npm run type-check` (renderer-worker)
- `npm run build:server`
- `npm run lint` (root)
- `npx prettier --check packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js packages/renderer-worker/test/ViewletEditorText.test.ts`