### PR TITLE
fix: render editor content before diagnostics

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -522,6 +522,7 @@ export const commandMap = {
   'Layout.attachViewlet': lazy('Layout.attachViewlet'),
   'Layout.createPanelViewlet': lazy('Layout.createPanelViewlet'),
   'Layout.createViewlet': lazy('Layout.createViewlet'),
+  'Layout.renderMainAreaPending': lazy('Layout.renderMainAreaPending'),
   'Layout.getActiveSideBarView': lazy('Layout.getActiveSideBarView'),
   'Layout.getActiveSecondarySideBarView': lazy('Layout.getActiveSecondarySideBarView'),
   'Layout.getSecondarySideBarVisible': lazy('Layout.getSecondarySideBarVisible'),

--- a/packages/renderer-worker/src/parts/RenderMainAreaPending/RenderMainAreaPending.ts
+++ b/packages/renderer-worker/src/parts/RenderMainAreaPending/RenderMainAreaPending.ts
@@ -1,0 +1,14 @@
+import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+
+export const renderMainAreaPending = async (uid: number): Promise<void> => {
+  const diffResult = await MainAreaWorker.invoke('MainArea.diff2', uid)
+  if (diffResult.length === 0) {
+    return
+  }
+  const commands = await MainAreaWorker.invoke('MainArea.render2', uid, diffResult)
+  if (commands.length === 0) {
+    return
+  }
+  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -20,6 +20,7 @@ import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as Product from '../Product/Product.js'
+import * as RenderMainAreaPending from '../RenderMainAreaPending/RenderMainAreaPending.ts'
 import { reorderCommands } from '../ReorderCommands/ReorderCommands.js'
 import * as SashType from '../SashType/SashType.js'
 import * as SaveState from '../SaveState/SaveState.js'
@@ -1125,6 +1126,14 @@ export const createViewlet = async (
   return {
     newState: state,
     commands: commands,
+  }
+}
+
+export const renderMainAreaPending = async (state: LayoutState, uid: number) => {
+  await RenderMainAreaPending.renderMainAreaPending(uid)
+  return {
+    newState: state,
+    commands: [],
   }
 }
 

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -45,6 +45,7 @@ export const CommandsWithSideEffects = {
   handleSettingsChanged: ViewletLayout.handleSettingsChanged,
   handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
   refreshSourceControlBadgeCount: ViewletLayout.refreshSourceControlBadgeCount,
+  renderMainAreaPending: ViewletLayout.renderMainAreaPending,
   setMountedViewlets: ViewletLayout.setMountedViewlets,
   reset: ResetLayout.reset,
   resetViewLocations: ResetLayout.resetViewLocations,

--- a/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
@@ -1,7 +1,7 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
 import * as Preferences from '../Preferences/Preferences.js'
-import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import { renderMainAreaPending } from '../RenderMainAreaPending/RenderMainAreaPending.ts'
 import { resolveInternalSourceUri } from '../ResolveInternalSourceUri/ResolveInternalSourceUri.ts'
 
 const loadingDelay = 500
@@ -32,18 +32,6 @@ const resolveOpenUriArgs = async (key: string, args: readonly any[]): Promise<re
   return args
 }
 
-const renderPendingState = async (uid: number): Promise<void> => {
-  const diffResult = await MainAreaWorker.invoke('MainArea.diff2', uid)
-  if (diffResult.length === 0) {
-    return
-  }
-  const commands = await MainAreaWorker.invoke('MainArea.render2', uid, diffResult)
-  if (commands.length === 0) {
-    return
-  }
-  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
-}
-
 const invokeMainAreaCommand = async (key: string, uid: number, args: readonly any[]): Promise<void> => {
   const resolvedArgs = await resolveOpenUriArgs(key, args)
   const commandPromise = MainAreaWorker.invoke(`MainArea.${key}`, uid, ...resolvedArgs)
@@ -60,7 +48,7 @@ const invokeMainAreaCommand = async (key: string, uid: number, args: readonly an
   try {
     const result = await Promise.race([commandPromise, timeoutPromise])
     if (result === loadingTimeout) {
-      await Promise.all([commandPromise, renderPendingState(uid)])
+      await Promise.all([commandPromise, renderMainAreaPending(uid)])
     }
   } finally {
     clearTimeout(timeoutId)

--- a/packages/renderer-worker/test/RenderMainAreaPending.test.ts
+++ b/packages/renderer-worker/test/RenderMainAreaPending.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const mainAreaWorkerInvoke = jest.fn()
+const rendererProcessInvoke = jest.fn()
+
+jest.unstable_mockModule('../src/parts/MainAreaWorker/MainAreaWorker.js', () => ({
+  invoke: mainAreaWorkerInvoke,
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: rendererProcessInvoke,
+}))
+
+const { renderMainAreaPending } = await import('../src/parts/RenderMainAreaPending/RenderMainAreaPending.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('renders the pending main area state', async () => {
+  const diffResult = [1, 2]
+  const commands = [['Viewlet.setDom2', 7, ['content']]]
+  mainAreaWorkerInvoke.mockImplementation((method) => {
+    if (method === 'MainArea.diff2') {
+      return diffResult
+    }
+    if (method === 'MainArea.render2') {
+      return commands
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  await renderMainAreaPending(7)
+
+  expect(mainAreaWorkerInvoke).toHaveBeenNthCalledWith(1, 'MainArea.diff2', 7)
+  expect(mainAreaWorkerInvoke).toHaveBeenNthCalledWith(2, 'MainArea.render2', 7, diffResult)
+  expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.sendMultiple', commands)
+})
+
+test('does not render when the pending state has no diff', async () => {
+  mainAreaWorkerInvoke.mockImplementation(() => [])
+
+  await renderMainAreaPending(7)
+
+  expect(mainAreaWorkerInvoke).toHaveBeenCalledTimes(1)
+  expect(rendererProcessInvoke).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

- add a renderer command that flushes pending main-area state on demand
- reuse the pending-render helper for delayed main-area commands
- cover immediate rendering and the no-diff case