### PR TITLE
feature: wrap source control filenames

### DIFF
--- a/packages/renderer-worker/src/parts/GetSourceControlItemVirtualDom/GetSourceControlItemVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSourceControlItemVirtualDom/GetSourceControlItemVirtualDom.js
@@ -104,7 +104,14 @@ const createItemOther = (item) => {
     className: labelClassName,
     childCount: 1,
   }
-  dom.push(labelDom, text(label))
+  dom.push(
+    labelDom,
+    {
+      type: VirtualDomElements.Span,
+      childCount: 1,
+    },
+    text(label),
+  )
 
   if (detail) {
     labelDom.childCount++

--- a/packages/renderer-worker/test/GetSourceControlItemVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSourceControlItemVirtualDom.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@jest/globals'
+import * as DirentType from '../src/parts/DirentType/DirentType.js'
+import * as EmptySourceControlButtons from '../src/parts/EmptySourceControlButtons/EmptySourceControlButton.js'
+import * as GetSourceControlItemVirtualDom from '../src/parts/GetSourceControlItemVirtualDom/GetSourceControlItemVirtualDom.js'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
+
+test('wraps the filename in a separate span', () => {
+  const dom = GetSourceControlItemVirtualDom.getSourceControlItemVirtualDom({
+    posInSet: 1,
+    setSize: 1,
+    icon: '/file-icon.svg',
+    file: '/workspace/src/file.js',
+    label: 'file.js',
+    decorationIcon: '/modified.svg',
+    decorationIconTitle: 'Modified',
+    decorationStrikeThrough: false,
+    detail: 'src/',
+    buttons: EmptySourceControlButtons.emptySourceControlButtons,
+    type: DirentType.File,
+  })
+
+  expect(dom.slice(2, 7)).toEqual([
+    {
+      type: VirtualDomElements.Div,
+      className: 'Label Grow',
+      childCount: 2,
+    },
+    {
+      type: VirtualDomElements.Span,
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Text,
+      text: 'file.js',
+      childCount: 0,
+    },
+    {
+      type: VirtualDomElements.Span,
+      className: 'LabelDetail',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Text,
+      text: 'src/',
+      childCount: 0,
+    },
+  ])
+})


### PR DESCRIPTION
Wrap each source-control filename in its own span while keeping the path detail in its existing sibling span. Adds focused virtual-DOM regression coverage for the resulting label structure.