### PR TITLE
fix: reject renderer worker GitHub tarballs

### DIFF
--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -3,6 +3,7 @@ import * as ExitCode from './parts/ExitCode/ExitCode.ts'
 import * as Logger from './parts/Logger/Logger.ts'
 import * as SetStackTraceLimit from './parts/SetStackTraceLimit/SetStackTraceLimit.ts'
 import * as Process from './parts/Process/Process.ts'
+import * as ValidateRendererWorkerPackageJson from './parts/ValidateRendererWorkerPackageJson/ValidateRendererWorkerPackageJson.ts'
 
 const getProduct = (productName) => {
   switch (productName) {
@@ -76,6 +77,7 @@ const main = async () => {
     Process.exit(ExitCode.Error)
   }
   SetStackTraceLimit.setStackTraceLimit(100)
+  await ValidateRendererWorkerPackageJson.validateRendererWorkerPackageJson()
   const product = await getProduct(argv.product)
   const module = await getBuildModule(target)
   try {

--- a/packages/build/src/parts/ValidateRendererWorkerPackageJson/ValidateRendererWorkerPackageJson.ts
+++ b/packages/build/src/parts/ValidateRendererWorkerPackageJson/ValidateRendererWorkerPackageJson.ts
@@ -1,0 +1,21 @@
+import * as JsonFile from '../JsonFile/JsonFile.ts'
+
+const dependencySections = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']
+
+const githubTarballPattern = /^https:\/\/github\.com\/.+\.(?:tar\.gz|tgz)(?:[?#].*)?$/i
+
+export const validatePackageJson = (packageJson) => {
+  for (const section of dependencySections) {
+    const dependencies = packageJson[section] || {}
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (typeof version === 'string' && githubTarballPattern.test(version)) {
+        throw new Error(`renderer-worker package.json dependency "${name}" must use an npm version instead of a GitHub tarball`)
+      }
+    }
+  }
+}
+
+export const validateRendererWorkerPackageJson = async () => {
+  const packageJson = await JsonFile.readJson('packages/renderer-worker/package.json')
+  validatePackageJson(packageJson)
+}

--- a/packages/build/test/ValidateRendererWorkerPackageJson.test.ts
+++ b/packages/build/test/ValidateRendererWorkerPackageJson.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@jest/globals'
+import { validatePackageJson } from '../src/parts/ValidateRendererWorkerPackageJson/ValidateRendererWorkerPackageJson.ts'
+
+test('accepts npm dependency versions', () => {
+  expect(() =>
+    validatePackageJson({
+      dependencies: {
+        '@lvce-editor/text-search-view': '^1.6.5',
+      },
+    }),
+  ).not.toThrow()
+})
+
+test.each([
+  'https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz',
+  'https://github.com/lvce-editor/text-search-view/archive/refs/tags/v1.6.5.tar.gz',
+])('rejects GitHub tarball dependency %s', (version) => {
+  expect(() =>
+    validatePackageJson({
+      dependencies: {
+        '@lvce-editor/text-search-view': version,
+      },
+    }),
+  ).toThrow('must use an npm version instead of a GitHub tarball')
+})
+
+test('checks every dependency section', () => {
+  expect(() =>
+    validatePackageJson({
+      devDependencies: {
+        '@lvce-editor/text-search-view': 'https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/text-search-view.tgz',
+      },
+    }),
+  ).toThrow('must use an npm version instead of a GitHub tarball')
+})

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -69,7 +69,7 @@
         "@lvce-editor/terminal-worker": "^2.7.0",
         "@lvce-editor/test-worker": "^17.11.0",
         "@lvce-editor/text-measurement-worker": "^1.21.0",
-        "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
+        "@lvce-editor/text-search-view": "^1.6.5",
         "@lvce-editor/text-search-worker": "^7.13.2",
         "@lvce-editor/title-bar-worker": "^4.15.6",
         "@lvce-editor/update-worker": "^2.12.0"
@@ -1241,7 +1241,7 @@
     },
     "node_modules/@lvce-editor/text-search-view": {
       "version": "1.6.5",
-      "resolved": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/text-search-view/-/text-search-view-1.6.5.tgz",
       "integrity": "sha512-6XLz/cDJ6HkvZL7fw2GnULntXxQS02A7g3gjiA4XC6sVFq+GIXmMRd4Z+CvOnBY3wcA6iFwRwKSR1eoCtLIX5g==",
       "license": "MIT"
     },

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -101,7 +101,7 @@
     "@lvce-editor/terminal-worker": "^2.7.0",
     "@lvce-editor/test-worker": "^17.11.0",
     "@lvce-editor/text-measurement-worker": "^1.21.0",
-    "@lvce-editor/text-search-view": "https://github.com/lvce-editor/text-search-view/releases/download/v1.6.5/lvce-editor-text-search-view-1.6.5.tgz",
+    "@lvce-editor/text-search-view": "^1.6.5",
     "@lvce-editor/text-search-worker": "^7.13.2",
     "@lvce-editor/title-bar-worker": "^4.15.6",
     "@lvce-editor/update-worker": "^2.12.0"


### PR DESCRIPTION
Replace the text search view release tarball with its npm version and fail builds when renderer-worker dependencies use GitHub tarball URLs.