### PR TITLE
fix: include extension host worker in static build

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -34,6 +34,7 @@
         "@lvce-editor/explorer-view": "^7.21.0",
         "@lvce-editor/extension-detail-view": "^7.29.2",
         "@lvce-editor/extension-host-sub-worker": "^3.14.0",
+        "@lvce-editor/extension-host-worker": "^8.74.0",
         "@lvce-editor/extension-management-worker": "^4.52.6",
         "@lvce-editor/extension-search-view": "^7.13.3",
         "@lvce-editor/file-search-worker": "^8.9.0",
@@ -1027,6 +1028,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@lvce-editor/extension-host-worker": {
+      "version": "8.74.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-worker/-/extension-host-worker-8.74.0.tgz",
+      "integrity": "sha512-wBc4OIDB0DFFLyUjboc7YFGo0NpDnN46ou5OEFA6ZdL6HvFMbADZethzHOM5FB2mqTnrb57cT3D7hLbM0lZSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/virtual-dom-worker": "^11.0.0"
+      }
+    },
     "node_modules/@lvce-editor/extension-management-worker": {
       "version": "4.53.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/extension-management-worker/-/extension-management-worker-4.53.0.tgz",
@@ -1268,6 +1278,21 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/update-worker/-/update-worker-2.13.0.tgz",
       "integrity": "sha512-FcvNmuh1PEBUEFpo3RSWD5WsVPH9pPXcjL+BMBiTlM0F2VcwRtlI7/KX4Sn5a/kmWCT8NfHN1Q4j+cZKJ9FJkA==",
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/virtual-dom-worker": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.12.0.tgz",
+      "integrity": "sha512-b48eaCCD5605Fsw5Z3ZH5UH9Ae1i8L9dR/6Y2swlqbSyTprRSaESyv1qNUw0bH/hcZuz+Uc7g2FIOOSWc5AFjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/constants": "^5.25.0"
+      }
+    },
+    "node_modules/@lvce-editor/virtual-dom-worker/node_modules/@lvce-editor/constants": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
+      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
       "license": "MIT"
     },
     "node_modules/@pkgr/core": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -66,6 +66,7 @@
     "@lvce-editor/explorer-view": "^7.21.0",
     "@lvce-editor/extension-detail-view": "^7.29.2",
     "@lvce-editor/extension-host-sub-worker": "^3.14.0",
+    "@lvce-editor/extension-host-worker": "^8.74.0",
     "@lvce-editor/extension-management-worker": "^4.52.6",
     "@lvce-editor/extension-search-view": "^7.13.3",
     "@lvce-editor/file-search-worker": "^8.9.0",

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -609,6 +609,15 @@
     }
   },
   {
+    "id": "extensionHostWorker",
+    "fileName": "extensionHostWorkerMain.js",
+    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self'", "script-src 'self'", "font-src 'self'"],
+    "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/extension-host-worker/dist/extensionHostWorkerMain.js",
+    "productionPath": "/packages/extension-host-worker/dist/extensionHostWorkerMain.js",
+    "settingName": "develop.extensionHostWorkerPath",
+    "hotReloadCommand": ""
+  },
+  {
     "id": "extensionHostSubWorker",
     "fileName": "extensionHostSubWorkerMain.js",
     "contentSecurityPolicy": ["default-src 'none'", "connect-src *", "script-src 'self'", "font-src 'self'"],


### PR DESCRIPTION
## Summary

- restore the extension-host worker dependency to renderer-worker
- declare its production artifact in Workers.json so static builds copy it
- fix static-server exports consumed by worker e2e repositories

## Validation

- npm run build:static
- verified extensionHostWorkerMain.js exists in the static artifact
- npm run build:server
- npm run test-static-export
- renderer-worker type-check
- build package tests