### PR TITLE
fix: preserve title across workspace transitions

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -7,6 +7,7 @@ import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as Location from '../Location/Location.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as Product from '../Product/Product.js'
 import * as WindowTitle from '../WindowTitle/WindowTitle.js'
 import { state } from '../WorkspaceState/WorkspaceState.js'
 
@@ -57,7 +58,7 @@ export { isTest } from '../IsTest/IsTest.js'
 
 const getTitle = (workspacePath) => {
   if (!workspacePath) {
-    return ''
+    return Product.getProductNameLong()
   }
   const pathSeparator = state.pathSeparator
   return workspacePath.slice(workspacePath.lastIndexOf(pathSeparator) + 1)

--- a/packages/renderer-worker/test/Workspace.test.ts
+++ b/packages/renderer-worker/test/Workspace.test.ts
@@ -5,8 +5,11 @@ import * as GlobalEventBus from '../src/parts/GlobalEventBus/GlobalEventBus.js'
 import * as ModuleId from '../src/parts/ModuleId/ModuleId.js'
 
 beforeEach(() => {
-  jest.resetAllMocks()
+  jest.clearAllMocks()
+  Workspace.state.isTest = false
   Workspace.state.workspacePath = ''
+  Workspace.state.workspaceUri = ''
+  Workspace.state.pathSeparator = ''
 })
 
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
@@ -16,6 +19,11 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
     }),
   }
 })
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  canBeRestored: jest.fn(() => true),
+  getPathSeparator: jest.fn(async () => '/'),
+}))
 
 jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
   return {
@@ -52,6 +60,9 @@ test('hydrate', async () => {
         return {
           path: '/tmp/some-folder',
           homeDir: '~',
+          pathSeparator: '/',
+          source: 'shared-process',
+          uri: 'file:///tmp/some-folder',
         }
 
       default:
@@ -63,11 +74,11 @@ test('hydrate', async () => {
   await Workspace.hydrate({ href: 'http://localhost:3000' })
   expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
   expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot', 'http://localhost:3000')
-  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
-  expect(RendererProcess.invoke).toHaveBeenNthCalledWith(2, 'WindowTitle.set', '/tmp/some-folder')
+  const windowTitleCalls = jest.mocked(RendererProcess.invoke).mock.calls.filter(([method]) => method === 'WindowTitle.set')
+  expect(windowTitleCalls).toEqual([['WindowTitle.set', 'some-folder']])
 })
 
-test.skip('hydrate - path changed in the meantime', async () => {
+test('hydrate - path changed in the meantime', async () => {
   let _resolve: () => void = () => {}
   // @ts-ignore
   // @ts-ignore
@@ -80,9 +91,10 @@ test.skip('hydrate - path changed in the meantime', async () => {
         return {
           path: '/tmp/some-folder',
           homeDir: '~',
+          pathSeparator: '/',
+          source: 'shared-process',
+          uri: 'file:///tmp/some-folder',
         }
-      case 'FileSystem.getPathSeparator':
-        return '/'
       default:
         throw new Error('unexpected message')
     }
@@ -96,9 +108,10 @@ test.skip('hydrate - path changed in the meantime', async () => {
   _resolve()
   await promise1
   expect(Workspace.state.workspacePath).toBe('/test')
-  expect(SharedProcess.invoke).toHaveBeenCalledTimes(2)
+  expect(SharedProcess.invoke).toHaveBeenCalledTimes(1)
   expect(SharedProcess.invoke).toHaveBeenCalledWith('Workspace.resolveRoot', 'http://localhost:3000')
-  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
+  const windowTitleCalls = jest.mocked(RendererProcess.invoke).mock.calls.filter(([method]) => method === 'WindowTitle.set')
+  expect(windowTitleCalls).toEqual([['WindowTitle.set', 'test']])
 })
 
 test('hydrate - error', async () => {

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const getPathSeparator = jest.fn<(uri: string) => Promise<string>>(async () => '/')
+const setWindowTitle = jest.fn<(title: string) => Promise<void>>(async () => {})
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   getPathSeparator,
 }))
 
 jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
-  set: jest.fn(async () => {}),
+  set: setWindowTitle,
+}))
+
+jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({
+  getProductNameLong: () => 'Lvce Editor',
 }))
 
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
@@ -15,10 +20,23 @@ const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
   getPathSeparator.mockClear()
+  setWindowTitle.mockClear()
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = ''
   Workspace.state.workspaceUri = ''
+})
+
+test('setPath uses the product name for an empty workspace', async () => {
+  await Workspace.setPath('')
+
+  expect(setWindowTitle).toHaveBeenCalledWith('Lvce Editor')
+})
+
+test('setPath uses the folder name for a workspace', async () => {
+  await Workspace.setPath('/home/test/project')
+
+  expect(setWindowTitle).toHaveBeenCalledWith('project')
 })
 
 test('setUri preserves the uri and decodes the workspace path', async () => {


### PR DESCRIPTION
## Summary

- use the configured product name when no workspace is open
- preserve folder-name titles for loaded workspaces
- restore the pending-hydration regression covering an Open Recent selection during startup

## Validation

- `npm test -- --runInBand test/WorkspaceSetUri.test.ts test/Workspace.test.ts` (8 passed, 3 pre-existing skips)
- `npm run type-check`
- `git diff --check`

Package-wide lint currently reports the repository baseline of approximately 98,000 violations in untouched renderer-worker files. The local minimal-build script could not start because `microbundle` is absent from the installed workspace; GitHub CI and the official release build remain the build gates.