### PR TITLE
fix: restore editor history after reopen

### DIFF
--- a/packages/renderer-worker/src/parts/SaveState/SaveState.js
+++ b/packages/renderer-worker/src/parts/SaveState/SaveState.js
@@ -26,7 +26,9 @@ const saveViewletStateAs = async (instanceId, storageId) => {
 }
 
 export const saveViewletState = async (id) => {
-  return saveViewletStateAs(id, id)
+  const instance = ViewletStates.getInstance(id)
+  const storageId = instance?.factory.getStorageKey ? instance.factory.getStorageKey(instance.state) : id
+  return saveViewletStateAs(id, storageId)
 }
 
 export const saveViewletStateWithStorageId = async (instanceId, storageId) => {

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -6,6 +6,7 @@ import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 import * as LayoutWidgets from '../LayoutWidgets/LayoutWidgets.ts'
 import * as Logger from '../Logger/Logger.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as SaveState from '../SaveState/SaveState.js'
 import * as SimpleBrowserOverlay from '../SimpleBrowserOverlay/SimpleBrowserOverlay.js'
 import * as UpdateDynamicFocusContext from '../UpdateDynamicFocusContext/UpdateDynamicFocusContext.js'
 import { VError } from '../VError/VError.js'
@@ -138,6 +139,9 @@ export const dispose = async (id) => {
       throw new Error(`${id} is missing a factory function`)
     }
     const widgetDisposeCommands = LayoutWidgets.removeOwnedWidgets(instanceUid)
+    if (instance.factory.saveState) {
+      await SaveState.saveViewletState(id)
+    }
     if (instance.factory.dispose) {
       await instance.factory.dispose(instance.state)
     }

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -150,7 +150,7 @@ export const loadContent = async (state, savedState, context) => {
     const tokenizePath = GetTokenizePath.getTokenizePath(languageId)
     const useCache = Preferences.get('editor.cache') ?? true
     await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath, useCache)
-    await EditorWorker.invoke('Editor.loadContent', id)
+    await EditorWorker.invoke('Editor.loadContent', id, savedState?.editorState)
     const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)
     const selectionRender = await rerender(newState2)

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextSaveState.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextSaveState.js
@@ -1,9 +1,17 @@
-export const saveState = (state) => {
+import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
+
+export const getStorageKey = (state) => {
+  return `Editor:${state.uri}`
+}
+
+export const saveState = async (state) => {
   // @ts-ignore
-  const { selections, focused, deltaY, minLineY, differences } = state
+  const { selections, focused, deltaY, id } = state
+  const editorState = await EditorWorker.invoke('Editor.saveState', id)
   return {
     selections: Array.from(selections),
     focused,
     deltaY,
+    editorState,
   }
 }

--- a/packages/renderer-worker/test/SaveState.test.ts
+++ b/packages/renderer-worker/test/SaveState.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const getInstance = jest.fn<() => any>(() => ({ factory: {}, state: {} }))
+
 jest.unstable_mockModule('../src/parts/InstanceStorage/InstanceStorage.js', () => ({
   getJson: jest.fn(async () => undefined),
   setJson: jest.fn(async () => {}),
@@ -10,7 +12,7 @@ jest.unstable_mockModule('../src/parts/SerializeViewlet/SerializeViewlet.js', ()
 }))
 
 jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({
-  getInstance: jest.fn(() => ({ factory: {}, state: {} })),
+  getInstance,
 }))
 
 jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
@@ -24,12 +26,28 @@ const SaveStateIpc = await import('../src/parts/SaveState/SaveState.ipc.js')
 
 beforeEach(() => {
   jest.clearAllMocks()
+  getInstance.mockReturnValue({ factory: {}, state: {} })
 })
 
 test('saves viewlet state under the current workspace key', async () => {
   await SaveState.saveViewletState('Explorer')
 
   expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:file:///workspace:Explorer', { value: 1 })
+})
+
+test('saves viewlet state under its instance storage key', async () => {
+  getInstance.mockReturnValue({
+    factory: {
+      getStorageKey: (state: { uri: string }) => `Editor:${state.uri}`,
+    },
+    state: {
+      uri: 'file:///workspace/file.txt',
+    },
+  })
+
+  await SaveState.saveViewletState(7)
+
+  expect(InstanceStorage.setJson).toHaveBeenCalledWith('viewlet:file:///workspace:Editor:file:///workspace/file.txt', { value: 1 })
 })
 
 test('saves layout state under its global key', async () => {

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -42,9 +42,13 @@ jest.unstable_mockModule('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay
     show: jest.fn(),
   }
 })
+jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => ({
+  saveViewletState: jest.fn(),
+}))
 
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 
@@ -233,6 +237,27 @@ test('dispose - disposes the rendered viewlet when the factory has no dispose fu
 
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.dispose', 2)
   expect(ViewletStates.getInstance(2)).toBeUndefined()
+})
+
+test('dispose - saves persistent state before disposing the viewlet', async () => {
+  const factoryDispose = jest.fn()
+  const factorySaveState = jest.fn()
+  ViewletStates.set(2, {
+    state: { uid: 2 },
+    renderedState: { uid: 2 },
+    moduleId: 'EditorText',
+    factory: {
+      dispose: factoryDispose,
+      saveState: factorySaveState,
+    },
+  })
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+
+  await Viewlet.dispose(2)
+
+  expect(SaveState.saveViewletState).toHaveBeenCalledWith(2)
+  expect(jest.mocked(SaveState.saveViewletState).mock.invocationCallOrder[0]).toBeLessThan(factoryDispose.mock.invocationCallOrder[0])
 })
 
 test('dispose - removes Layout references before recursively disposing owned widgets', async () => {

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -44,6 +44,7 @@ jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
 }))
 
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+const ViewletEditorTextSaveState = await import('../src/parts/ViewletEditorText/ViewletEditorTextSaveState.js')
 const Languages = await import('../src/parts/Languages/Languages.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
@@ -84,6 +85,7 @@ test('loadContent - restores the selection supplied by the opener', async () => 
     '/tokenize-typescript.js',
     true,
   )
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.loadContent', 1, undefined)
   expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.setSelections2', 1, selections)
   const editorMethods = editorWorkerInvoke.mock.calls
     .map(([method]) => method)
@@ -100,6 +102,52 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   const createCall = editorWorkerInvoke.mock.calls.find(([method]) => method === 'Editor.create2')
   expect(createCall?.at(-1)).toBe(true)
   expect(newState.commands).toEqual([...initialCommands, ...selectionCommands])
+})
+
+test('loadContent - restores the editor worker state', async () => {
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.diff2':
+      case 'Editor.render2':
+        return []
+      default:
+        return undefined
+    }
+  })
+  const state = ViewletEditorText.create(1, '/test/file.txt', 0, 0, 800, 600)
+  const editorState = {
+    lines: ['saved content'],
+    redoStack: [['redo']],
+    undoStack: [['undo']],
+  }
+
+  await ViewletEditorText.loadContent(state, { editorState }, {})
+
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.loadContent', 1, editorState)
+})
+
+test('saveState - saves editor history under a URI-scoped key', async () => {
+  const editorState = {
+    lines: ['saved content'],
+    redoStack: [['redo']],
+    undoStack: [['undo']],
+  }
+  editorWorkerInvoke.mockResolvedValue(editorState as never)
+  const state = {
+    ...ViewletEditorText.create(1, 'file:///test/file.txt', 0, 0, 800, 600),
+    deltaY: 20,
+    focused: true,
+    selections: new Uint32Array([1, 2, 1, 4]),
+  }
+
+  await expect(ViewletEditorTextSaveState.saveState(state)).resolves.toEqual({
+    deltaY: 20,
+    editorState,
+    focused: true,
+    selections: [1, 2, 1, 4],
+  })
+  expect(ViewletEditorTextSaveState.getStorageKey(state)).toBe('Editor:file:///test/file.txt')
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.saveState', 1)
 })
 
 test('loadContent - restores the definition range supplied by the opener', async () => {


### PR DESCRIPTION
## Summary

- persist viewlet state before disposal
- scope editor snapshots by URI instead of sharing one generic key
- pass the saved editor-worker state back during editor load
- preserve explicit storage-key overrides for other viewlets

## Validation

- 315 renderer-worker test suites passed (1,295 tests; 23 suites and 231 tests skipped)
- renderer-worker TypeScript and Prettier checks passed
- source-built Electron UI: saved edit undoes after tab close/reopen
- source-built Electron UI: explicitly persisted history survives an application process restart

The editor-worker behavior change is tracked in the companion editor-worker PR; its release and dependency update are intentionally deferred to the consolidated release phase.