### PR TITLE
fix: pass test mode to explorer worker

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -525,7 +525,7 @@
           { "source": "state", "name": "uid" }, { "source": "state", "name": "uri" }, { "source": "state", "name": "x" },
           { "source": "state", "name": "y" }, { "source": "state", "name": "width" }, { "source": "state", "name": "height" },
           { "source": "literal", "value": null }, { "source": "state", "name": "parentUid" }, { "source": "state", "name": "platform" },
-          { "source": "state", "name": "assetDir" }
+          { "source": "state", "name": "assetDir" }, { "source": "context", "name": "isTest" }
         ] },
         "loadContent": { "name": "Explorer.loadContent", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "savedState" }] },
         "diff": { "name": "Explorer.diff2", "parameters": [{ "source": "state", "name": "uid" }] },

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -64,6 +64,25 @@ test('runs configured legacy lifecycle methods with positional parameters', asyn
   expect(result).toEqual({ ...state, commands: [['setText', 'ready']] })
 })
 
+test('passes test mode to the explorer worker', async () => {
+  const invoke = jest.fn(async (method: string) => {
+    if (method === 'Explorer.diff2' || method === 'Explorer.render2') {
+      return []
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    config: getWorkerViewletConfig('explorer'),
+    context: { assetDir: 'test://assets', isTest: true, platform: 2 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const state = viewlet.create(7, 'test://explorer', 1, 2, 300, 200, undefined, 5)
+
+  await viewlet.loadContent(state, undefined)
+
+  expect(invoke.mock.calls[0]).toEqual(['Explorer.create', 7, 'test://explorer', 1, 2, 300, 200, null, 5, 2, 'test://assets', true])
+})
+
 test('creates command wrappers through the same lifecycle seam', async () => {
   const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
     if (method === 'Example.getCommandIds') {


### PR DESCRIPTION
## Summary

- pass the renderer test-mode context into Explorer.create
- verify the configured Explorer lifecycle invocation includes the test flag

## Context

Required for lvce-editor/explorer-view#1782 so direct dialog-worker calls remain compatible with the existing renderer confirmation mock in e2e tests.