### PR TITLE
fix: route server documents through shared process

### DIFF
--- a/packages/build/src/parts/BuildServer/BuildServer.ts
+++ b/packages/build/src/parts/BuildServer/BuildServer.ts
@@ -19,6 +19,22 @@ const getObjectDependencies = (obj) => {
   return [obj, ...Object.values(obj.dependencies).flatMap(getObjectDependencies)]
 }
 
+export const getServerIsStaticReplacement = (commitHash: string): string => `const isStatic = (url) => {
+  if (url.startsWith('/${commitHash}')) {
+    return true
+  }
+  if (url.startsWith('/favicon.ico')) {
+    return true
+  }
+  if (url === '/auth/callback' || url.startsWith('/auth/callback?')) {
+    return true
+  }
+  if (url.startsWith('/manifest.ico')) {
+    return true
+  }
+  return false
+}`
+
 const copyServerFiles = async ({ commitHash }) => {
   await Copy.copy({
     from: 'packages/server',
@@ -87,24 +103,7 @@ const copyServerFiles = async ({ commitHash }) => {
   }
   return false
 }`,
-    replacement: `const isStatic = (url) => {
-  if(url === '/'){
-    return true
-  }
-  if (url.startsWith('/${commitHash}')) {
-    return true
-  }
-  if (url.startsWith('/favicon.ico')) {
-    return true
-  }
-  if (url === '/auth/callback' || url.startsWith('/auth/callback?')) {
-    return true
-  }
-  if (url.startsWith('/manifest.ico')) {
-    return true
-  }
-  return false
-}`,
+    replacement: getServerIsStaticReplacement(commitHash),
   })
   await Replace.replace({
     path: 'packages/build/.tmp/server/server/src/server.js',

--- a/packages/build/test/BuildServer.test.ts
+++ b/packages/build/test/BuildServer.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { runInNewContext } from 'node:vm'
 import { expect, test } from '@jest/globals'
-import { setVersionsAndDependencies } from '../src/parts/BuildServer/BuildServer.ts'
+import { getServerIsStaticReplacement, setVersionsAndDependencies } from '../src/parts/BuildServer/BuildServer.ts'
 
 const writeJson = async (path: string, value: unknown): Promise<void> => {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
@@ -11,6 +12,15 @@ const writeJson = async (path: string, value: unknown): Promise<void> => {
 const readJson = async (path: string): Promise<any> => {
   return JSON.parse(await readFile(path, 'utf8'))
 }
+
+test('generated server sends the root document through the shared process', () => {
+  const replacement = getServerIsStaticReplacement('abcdefg')
+  const isStatic = runInNewContext(`${replacement}; isStatic`) as (url: string) => boolean
+
+  expect(isStatic('/')).toBe(false)
+  expect(isStatic('/?workspace=/test')).toBe(false)
+  expect(isStatic('/abcdefg/packages/renderer-worker.js')).toBe(true)
+})
 
 test('setVersionsAndDependencies includes process explorer as shared-process dependency', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-build-server-'))


### PR DESCRIPTION
Route published server document requests through the shared process so navigation responses receive a fresh WebSocket issuer. Keep commit-hashed assets on the static server path and cover the generated routing behavior.