### PR TITLE
fix: prefer linked extensions over bundled extensions

### DIFF
--- a/packages/shared-process/src/parts/ExtensionManagement/ExtensionManagement.ts
+++ b/packages/shared-process/src/parts/ExtensionManagement/ExtensionManagement.ts
@@ -111,7 +111,7 @@ export const getExtensions = (): any => {
       ...transientLinkedExtensions,
       {
         path: PlatformPaths.getLinkedExtensionsPath(),
-        type: ExtensionManifestInputType.Folder,
+        type: ExtensionManifestInputType.LinkedExtensionsFolder,
       },
       {
         path: PlatformPaths.getExtensionsPath(),
@@ -141,7 +141,7 @@ export const getExtensionsEtag = async (): Promise<any> => {
     ...transientLinkedExtensions,
     {
       path: PlatformPaths.getLinkedExtensionsPath(),
-      type: ExtensionManifestInputType.Folder,
+      type: ExtensionManifestInputType.LinkedExtensionsFolder,
     },
     {
       path: PlatformPaths.getExtensionsPath(),

--- a/packages/shared-process/src/parts/ExtensionManifests/ExtensionManifestsFromLinkedExtensionsFolder.ts
+++ b/packages/shared-process/src/parts/ExtensionManifests/ExtensionManifestsFromLinkedExtensionsFolder.ts
@@ -20,13 +20,17 @@ const readSymlinks = (absolutePaths: any): any => {
   return Promise.all(absolutePaths.map(readSymlink))
 }
 
+const isExtensionFolder = (dirent: any): any => {
+  return dirent.type === DirentType.Directory || dirent.type === DirentType.Symlink
+}
+
 export const getExtensionManifests = async (path: any): Promise<any> => {
   try {
     if (!path) {
       return []
     }
     const dirents = await FileSystem.readDirWithFileTypes(path)
-    const folderNames = dirents.filter((dirent: any) => dirent.type === DirentType.Directory).map((dirent: any) => dirent.name)
+    const folderNames = dirents.filter(isExtensionFolder).map((dirent: any) => dirent.name)
     const absolutePaths = ToAbsolutePaths.toAbsolutePaths(path, folderNames)
     const manifests = await Promise.all(absolutePaths.map(ExtensionManifest.get))
     const symlinks = await readSymlinks(absolutePaths)

--- a/packages/shared-process/src/parts/GetExtensionEtags/GetExtensionEtags.ts
+++ b/packages/shared-process/src/parts/GetExtensionEtags/GetExtensionEtags.ts
@@ -35,10 +35,14 @@ const getOnly = async (path: any): Promise<any> => {
   return getManifestStats(path)
 }
 
-const getFolder = async (path: any): Promise<any> => {
+const isExtensionFolder = (dirent: any, includeSymlinks: boolean): boolean => {
+  return dirent.type === DirentType.Directory || (includeSymlinks && dirent.type === DirentType.Symlink)
+}
+
+const getFolder = async (path: any, includeSymlinks: boolean = false): Promise<any> => {
   try {
     const dirents = await FileSystem.readDirWithFileTypes(path)
-    const folderNames = dirents.filter((dirent: any) => dirent.type === DirentType.Directory).map((dirent: any) => dirent.name)
+    const folderNames = dirents.filter((dirent: any) => isExtensionFolder(dirent, includeSymlinks)).map((dirent: any) => dirent.name)
     const stats = await Promise.all(
       folderNames.map(async (folderName: any) => {
         const extensionManifestPath = join(path, folderName, 'extension.json')
@@ -57,9 +61,11 @@ const getFolder = async (path: any): Promise<any> => {
 const get = (input: any): any => {
   switch (input.type) {
     case ExtensionManifestInputType.Folder:
-    case ExtensionManifestInputType.LinkedExtensionsFolder:
       return getFolder(input.path)
     case ExtensionManifestInputType.LinkedExtension:
+      return getOnly(input.path)
+    case ExtensionManifestInputType.LinkedExtensionsFolder:
+      return getFolder(input.path, true)
     case ExtensionManifestInputType.OnlyExtension:
       return getOnly(input.path)
     default:

--- a/packages/shared-process/test/ExtensionManagement.test.ts
+++ b/packages/shared-process/test/ExtensionManagement.test.ts
@@ -1,6 +1,6 @@
 import { expect, jest, test, beforeAll, afterAll, afterEach } from '@jest/globals'
 import { createWriteStream } from 'node:fs'
-import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import http from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -132,9 +132,7 @@ test("uninstall should fail when extension doesn't exist", async () => {
   const tmpDir = await getTmpDir()
   // @ts-ignore
   PlatformPaths.getExtensionsPath.mockImplementation(() => tmpDir)
-  await expect(ExtensionManagement.uninstall('test-author.test-extension')).rejects.toThrow(
-    uninstallMissingExtensionErrorRegex,
-  )
+  await expect(ExtensionManagement.uninstall('test-author.test-extension')).rejects.toThrow(uninstallMissingExtensionErrorRegex)
 })
 
 // TODO test for extension main not found (extension host)
@@ -281,6 +279,43 @@ test('getExtensions - includes transient linked extension from --link', async ()
       version: '1.0.0',
     },
   ])
+})
+
+test('getExtensions - linked extension overrides builtin extension', async () => {
+  const installedExtensionsPath = await getTmpDir()
+  const builtinExtensionsPath = await getTmpDir()
+  const linkedExtensionsPath = await getTmpDir()
+  const disabledExtensionsPath = await getTmpDir()
+  const linkedExtensionPath = await getTmpDir()
+  const extensionId = 'builtin.test-extension'
+  await mkdir(join(builtinExtensionsPath, extensionId))
+  await writeFile(join(builtinExtensionsPath, extensionId, 'extension.json'), JSON.stringify({ id: extensionId, name: 'Bundled Extension' }))
+  await writeFile(join(linkedExtensionPath, 'extension.json'), JSON.stringify({ id: extensionId, name: 'Linked Extension' }))
+  await symlink(linkedExtensionPath, join(linkedExtensionsPath, extensionId))
+  // @ts-ignore
+  PlatformPaths.getExtensionsPath.mockImplementation(() => installedExtensionsPath)
+  // @ts-ignore
+  PlatformPaths.getBuiltinExtensionsPath.mockImplementation(() => builtinExtensionsPath)
+  // @ts-ignore
+  PlatformPaths.getDisabledExtensionsPath.mockImplementation(() => disabledExtensionsPath)
+  // @ts-ignore
+  PlatformPaths.getDisabledExtensionsJsonPath.mockImplementation(() => join(disabledExtensionsPath, 'disabled-extensions.json'))
+  // @ts-ignore
+  PlatformPaths.getOnlyExtensionPath.mockImplementation(() => undefined)
+  // @ts-ignore
+  PlatformPaths.getLinkedExtensionsPath.mockImplementation(() => linkedExtensionsPath)
+
+  const extensions = await ExtensionManagement.getExtensions()
+
+  expect(extensions).toHaveLength(1)
+  expect(extensions[0]).toMatchObject({
+    disabled: false,
+    id: extensionId,
+    isBuiltin: true,
+    name: 'Linked Extension',
+    path: join(linkedExtensionsPath, extensionId),
+    symlink: linkedExtensionPath,
+  })
 })
 
 test('disable', async () => {

--- a/packages/shared-process/test/GetExtensionEtags.test.ts
+++ b/packages/shared-process/test/GetExtensionEtags.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals'
+import { mkdtemp, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as ExtensionManifestInputType from '../src/parts/ExtensionManifestInputType/ExtensionManifestInputType.js'
+import * as GetExtensionEtags from '../src/parts/GetExtensionEtags/GetExtensionEtags.js'
+
+const getTmpDir = (): Promise<string> => {
+  return mkdtemp(join(tmpdir(), 'linked-extension-etag-'))
+}
+
+test('getExtensionEtags includes linked extension symlinks', async () => {
+  const linkedExtensionsPath = await getTmpDir()
+  const extensionPath = await getTmpDir()
+  const manifestContent = JSON.stringify({ id: 'builtin.test-extension' })
+  await writeFile(join(extensionPath, 'extension.json'), manifestContent)
+  await symlink(extensionPath, join(linkedExtensionsPath, 'builtin.test-extension'))
+
+  const etags = await GetExtensionEtags.getExtensionEtags([
+    {
+      path: linkedExtensionsPath,
+      type: ExtensionManifestInputType.LinkedExtensionsFolder,
+    },
+  ])
+
+  expect(etags).toHaveLength(1)
+  expect(etags[0].size).toBe(manifestContent.length)
+  expect(etags[0].mtime.getTime()).toEqual(expect.any(Number))
+})


### PR DESCRIPTION
Make persistent linked-extension symlinks participate in extension discovery and etag collection so linked manifests take precedence over bundled copies with the same ID. Add regression coverage for linked-over-bundled selection and symlink etags.