### PR TITLE
fix: load media files with spaces in their names

### DIFF
--- a/packages/shared-process/src/parts/GetElectronFileResponseRelativePath/GetElectronFileResponseRelativePath.ts
+++ b/packages/shared-process/src/parts/GetElectronFileResponseRelativePath/GetElectronFileResponseRelativePath.ts
@@ -27,7 +27,8 @@ export const getElectronFileResponseRelativePath = (requestUrl: any): any => {
   }
   if (requestUrl.startsWith('/')) {
     // TODO this should not be supported anymore and could probably be removed
-    return removeQueryParameters(requestUrl)
+    const pathName = removeQueryParameters(requestUrl)
+    return decodeURI(pathName)
   }
   console.log({ requestUrl })
   return ''

--- a/packages/shared-process/test/GetElectronFileResponseEncodedPath.test.ts
+++ b/packages/shared-process/test/GetElectronFileResponseEncodedPath.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, expect, test } from '@jest/globals'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as GetElectronFileResponse from '../src/parts/GetElectronFileResponse/GetElectronFileResponse.js'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  const directories = [...temporaryDirectories]
+  temporaryDirectories.length = 0
+  await Promise.all(directories.map((directory) => rm(directory, { force: true, recursive: true })))
+})
+
+test('serves a remote file whose name contains a space', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'lvce-remote-file-'))
+  temporaryDirectories.push(directory)
+  const filePath = join(directory, 'sample image.png')
+  const content = Buffer.from('sample image')
+  await writeFile(filePath, content)
+
+  const response = await GetElectronFileResponse.getElectronFileResponse(`/remote${encodeURI(filePath)}`, undefined)
+
+  expect(response.init.status).toBe(200)
+  expect(response.body).toEqual(content)
+})


### PR DESCRIPTION
Decode encoded HTTP file request paths before resolving them on disk. This lets media preview load files whose names contain spaces and includes a regression test using a real temporary image path.