### PR TITLE
fix: preserve media blob mime types

### DIFF
--- a/packages/renderer-worker/src/parts/BlobSrc/BlobSrc.js
+++ b/packages/renderer-worker/src/parts/BlobSrc/BlobSrc.js
@@ -1,9 +1,11 @@
 import * as Command from '../Command/Command.js'
 import * as FileSystem from '../FileSystem/FileSystem.js'
+import * as Mime from '../Mime/Mime.js'
 import * as Protocol from '../Protocol/Protocol.js'
 
 export const getSrc = (uri) => {
-  return FileSystem.getBlobUrl(uri)
+  const mimeType = Mime.getMediaMimeType(uri)
+  return FileSystem.getBlobUrl(uri, mimeType)
 }
 
 export const disposeSrc = async (src) => {

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -80,14 +80,14 @@ export const unwatchAll = () => {
   throw new Error('not implemented')
 }
 
-export const getBlobUrl = async (uri) => {
+export const getBlobUrl = async (uri, type = '') => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   if (fileSystem.getBlobSrc) {
-    return fileSystem.getBlobSrc(uri)
+    return fileSystem.getBlobSrc(uri, type)
   }
   if (fileSystem.getBlobUrl) {
-    return fileSystem.getBlobUrl(uri)
+    return fileSystem.getBlobUrl(uri, type)
   }
   throw new Error(`Filesystem doesn't support the getBlobUrl function`)
 }

--- a/packages/renderer-worker/test/BlobSrc.test.ts
+++ b/packages/renderer-worker/test/BlobSrc.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
-const getBlobUrl = jest.fn()
+const getBlobUrl = jest.fn<(uri: string, type: string) => Promise<string>>()
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   getBlobUrl,

--- a/packages/renderer-worker/test/BlobSrc.test.ts
+++ b/packages/renderer-worker/test/BlobSrc.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const getBlobUrl = jest.fn()
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  getBlobUrl,
+}))
+
+const BlobSrc = await import('../src/parts/BlobSrc/BlobSrc.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('getSrc creates an SVG blob with its media type', async () => {
+  getBlobUrl.mockResolvedValue('blob:https://example.com/image-id')
+
+  await expect(BlobSrc.getSrc('memfs:///workspace/image.svg')).resolves.toBe('blob:https://example.com/image-id')
+  expect(getBlobUrl).toHaveBeenCalledWith('memfs:///workspace/image.svg', 'image/svg+xml')
+})

--- a/packages/renderer-worker/test/FileSystem.test.ts
+++ b/packages/renderer-worker/test/FileSystem.test.ts
@@ -8,6 +8,7 @@ const readFile = jest.fn()
 const writeFile = jest.fn()
 const remove = jest.fn()
 const isReadonly = jest.fn()
+const getBlobUrl = jest.fn()
 
 FileSystemState.registerAll({
   test() {
@@ -16,6 +17,7 @@ FileSystemState.registerAll({
       writeFile,
       remove,
       isReadonly,
+      getBlobUrl,
     }
   },
 })
@@ -48,6 +50,13 @@ test('isReadonly', async () => {
   isReadonly.mockReturnValue(true)
   expect(await FileSystem.isReadonly('test://some-file.txt')).toBe(true)
   expect(isReadonly).toHaveBeenCalledWith('test://some-file.txt')
+})
+
+test('getBlobUrl forwards the media type', async () => {
+  getBlobUrl.mockReturnValue('blob:https://example.com/image-id')
+
+  await expect(FileSystem.getBlobUrl('test://some-file.svg', 'image/svg+xml')).resolves.toBe('blob:https://example.com/image-id')
+  expect(getBlobUrl).toHaveBeenCalledWith('test://some-file.svg', 'image/svg+xml')
 })
 
 test.skip('removeFile - error', async () => {


### PR DESCRIPTION
Infer media MIME types before creating blob URLs so memfs-backed previews, including SVG images, load correctly.