### PR TITLE
fix: expose all editor providers

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -496,6 +496,7 @@ export const commandMap = {
   'WebView.compatRendererProcessInvokeAndTransfer': lazy('WebView.compatRendererProcessInvokeAndTransfer'),
   'WebView.compatSharedProcessInvoke': lazy('WebView.compatSharedProcessInvoke'),
   'WebView.createWebViewWorkerRpc2': lazy('WebView.createWebViewWorkerRpc2'),
+  'WebView.getEditorProviders': lazy('WebView.getEditorProviders'),
   'WebView.getSavedState': lazy('WebView.getSavedState'),
   'WebView.getSecret': lazy('WebView.getSecret'),
   'WebView.getRpcInfo': lazy('WebView.getRpcInfo'),

--- a/packages/renderer-worker/src/parts/GetEditorProviders/GetEditorProviders.ts
+++ b/packages/renderer-worker/src/parts/GetEditorProviders/GetEditorProviders.ts
@@ -1,0 +1,27 @@
+import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
+import * as GetWebViews from '../GetWebViews/GetWebViews.ts'
+
+interface EditorProvider {
+  readonly id: string
+  readonly type?: string
+}
+
+export const mergeEditorProviders = (webViews: readonly EditorProvider[], extensionViews: readonly EditorProvider[]): readonly EditorProvider[] => {
+  const providers = new Map<string, EditorProvider>()
+  for (const provider of webViews) {
+    if (provider?.id) {
+      providers.set(provider.id, provider)
+    }
+  }
+  for (const provider of extensionViews) {
+    if (provider?.id && provider.type === 'preview') {
+      providers.set(provider.id, provider)
+    }
+  }
+  return [...providers.values()]
+}
+
+export const getEditorProviders = async (): Promise<readonly EditorProvider[]> => {
+  const [webViews, extensionViews] = await Promise.all([GetWebViews.getWebViews(), GetExtensionViews.getExtensionViews()])
+  return mergeEditorProviders(webViews, extensionViews)
+}

--- a/packages/renderer-worker/src/parts/WebView/WebView.ipc.ts
+++ b/packages/renderer-worker/src/parts/WebView/WebView.ipc.ts
@@ -8,6 +8,7 @@ export const Commands = {
   compatRendererProcessInvoke: WebView.compat.rendererProcessInvoke,
   compatRendererProcessInvokeAndTransfer: WebView.compat.rendererProcessInvokeAndTransfer,
   compatSharedProcessInvoke: WebView.compat.sharedProcessInvoke,
+  getEditorProviders: WebView.getEditorProviders,
   getSavedState: WebView.compat.getSavedState,
   getWebViewInfo: WebView.getWebViewInfo,
   getWebViewInfo2: WebView.getWebViewInfo2,

--- a/packages/renderer-worker/src/parts/WebView/WebView.ts
+++ b/packages/renderer-worker/src/parts/WebView/WebView.ts
@@ -1,6 +1,7 @@
 import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as ExtensionHostState from '../ExtensionHost/ExtensionHostState.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as GetEditorProviders from '../GetEditorProviders/GetEditorProviders.ts'
 import * as GetWebViews from '../GetWebViews/GetWebViews.ts'
 import * as IframeWorker from '../IframeWorker/IframeWorker.js'
 import * as IsGitpod from '../IsGitpod/IsGitpod.ts'
@@ -23,6 +24,10 @@ export const getWebViewInfo = (providerId: string) => {
 
 export const getWebViewInfo2 = (providerId: string) => {
   return GetWebViews.getWebViews().then((webViews) => webViews.find((webView) => webView.id === providerId))
+}
+
+export const getEditorProviders = (): Promise<readonly unknown[]> => {
+  return GetEditorProviders.getEditorProviders()
 }
 
 export const create3 = async (uri: string, id: number): Promise<void> => {

--- a/packages/renderer-worker/test/GetEditorProviders.test.ts
+++ b/packages/renderer-worker/test/GetEditorProviders.test.ts
@@ -1,0 +1,36 @@
+import { expect, jest, test } from '@jest/globals'
+
+const state = {
+  extensionViews: [] as any[],
+  webViews: [] as any[],
+}
+
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => ({
+  getExtensionViews: jest.fn(async () => state.extensionViews),
+}))
+
+jest.unstable_mockModule('../src/parts/GetWebViews/GetWebViews.ts', () => ({
+  getWebViews: jest.fn(async () => state.webViews),
+}))
+
+const { getEditorProviders } = await import('../src/parts/GetEditorProviders/GetEditorProviders.ts')
+
+test('returns legacy webviews and modern preview views', async () => {
+  state.webViews = [{ id: 'builtin.markdown-preview', selector: ['.md'] }]
+  state.extensionViews = [
+    { id: 'builtin.media-preview', selector: ['.png'], title: 'Media Preview', type: 'preview' },
+    { id: 'sample.sidebar', selector: ['.png'], title: 'Sidebar' },
+  ]
+
+  await expect(getEditorProviders()).resolves.toEqual([
+    { id: 'builtin.markdown-preview', selector: ['.md'] },
+    { id: 'builtin.media-preview', selector: ['.png'], title: 'Media Preview', type: 'preview' },
+  ])
+})
+
+test('uses the modern preview contribution when provider ids overlap', async () => {
+  state.webViews = [{ id: 'builtin.media-preview', name: 'Legacy Media Preview', selector: ['.png'] }]
+  state.extensionViews = [{ id: 'builtin.media-preview', selector: ['.png'], title: 'Media Preview', type: 'preview' }]
+
+  await expect(getEditorProviders()).resolves.toEqual([{ id: 'builtin.media-preview', selector: ['.png'], title: 'Media Preview', type: 'preview' }])
+})


### PR DESCRIPTION
Expose a renderer command that combines legacy webviews with modern preview view contributions. This lets consumers discover providers such as Media Preview while excluding sidebar-only views and duplicate provider IDs.