### PR TITLE
fix: show process explorer web fallback

### DIFF
--- a/packages/renderer-worker/src/parts/GetProcessExplorerUnsupportedVirtualDom/GetProcessExplorerUnsupportedVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetProcessExplorerUnsupportedVirtualDom/GetProcessExplorerUnsupportedVirtualDom.js
@@ -1,0 +1,18 @@
+import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
+import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
+
+export const getProcessExplorerUnsupportedVirtualDom = (message) => {
+  return [
+    {
+      type: VirtualDomElements.Div,
+      className: 'ProcessExplorer',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Div,
+      className: 'ProcessExplorerMessage',
+      childCount: 1,
+    },
+    text(message),
+  ]
+}

--- a/packages/renderer-worker/src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js
+++ b/packages/renderer-worker/src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js
@@ -1,0 +1,9 @@
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+
+export const loadProcessExplorerViewletModule = (platform = Platform.getPlatform()) => {
+  if (platform === PlatformType.Web) {
+    return import('../ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.ipc.js')
+  }
+  return import('../ViewletProcessExplorer/ViewletProcessExplorer.ipc.js')
+}

--- a/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
@@ -1,3 +1,4 @@
+import * as LoadProcessExplorerViewletModule from '../LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
 export const map = {
@@ -37,7 +38,7 @@ export const map = {
   [ViewletModuleId.Output]: () => import('../ViewletOutput/ViewletOutput.ipc.ts'),
   [ViewletModuleId.Panel]: () => import('../ViewletPanel/ViewletPanel.ipc.ts'),
   [ViewletModuleId.Problems]: () => import('../ViewletProblems/ViewletProblems.ipc.js'),
-  [ViewletModuleId.ProcessExplorer]: () => import('../ViewletProcessExplorer/ViewletProcessExplorer.ipc.js'),
+  [ViewletModuleId.ProcessExplorer]: LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule,
   [ViewletModuleId.QuickPick]: () => import('../ViewletQuickPick/ViewletQuickPick.ipc.js'),
   [ViewletModuleId.References]: () => import('../ViewletReferences/ViewletReferences.ipc.js'),
   [ViewletModuleId.RunAndDebug]: () => import('../ViewletRunAndDebug/ViewletRunAndDebug.ipc.js'),

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.ipc.js
@@ -1,0 +1,7 @@
+export const name = 'ProcessExplorer'
+
+export const Commands = {}
+
+export * from './ViewletProcessExplorerUnsupported.js'
+export * from './ViewletProcessExplorerUnsupportedCss.js'
+export * from './ViewletProcessExplorerUnsupportedRender.js'

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.js
@@ -1,0 +1,23 @@
+const unsupportedMessage = 'Process Explorer is not supported on web.'
+
+export const create = (id, uri, x, y, width, height) => {
+  return {
+    id,
+    uid: id,
+    uri,
+    x,
+    y,
+    width,
+    height,
+    message: '',
+  }
+}
+
+export const loadContent = (state) => {
+  return {
+    ...state,
+    message: unsupportedMessage,
+  }
+}
+
+export const dispose = () => {}

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.js
@@ -20,4 +20,8 @@ export const loadContent = (state) => {
   }
 }
 
+export const getCommands = () => ({})
+
+export const getKeyBindings = () => []
+
 export const dispose = () => {}

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupportedCss.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupportedCss.js
@@ -1,0 +1,1 @@
+export const Css = ['/css/parts/ViewletProcessExplorer.css']

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupportedRender.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupportedRender.js
@@ -1,0 +1,17 @@
+import * as GetProcessExplorerUnsupportedVirtualDom from '../GetProcessExplorerUnsupportedVirtualDom/GetProcessExplorerUnsupportedVirtualDom.js'
+
+export const hasFunctionalRender = true
+
+export const hasFunctionalRootRender = true
+
+const renderMessage = {
+  isEqual(oldState, newState) {
+    return oldState.message === newState.message
+  },
+  apply(oldState, newState) {
+    const dom = GetProcessExplorerUnsupportedVirtualDom.getProcessExplorerUnsupportedVirtualDom(newState.message)
+    return ['Viewlet.setDom2', dom]
+  },
+}
+
+export const render = [renderMessage]

--- a/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
+++ b/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@jest/globals'
+import * as LoadProcessExplorerViewletModule from '../src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+test('loads unsupported viewlet on web', async () => {
+  const module = await LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule(PlatformType.Web)
+
+  const state = module.create(7, 'process-explorer://', 1, 2, 3, 4)
+  expect(module.loadContent(state)).toEqual({
+    ...state,
+    message: 'Process Explorer is not supported on web.',
+  })
+})
+
+test.each([PlatformType.Electron, PlatformType.Remote])('loads worker-backed viewlet on platform %s', async (platform) => {
+  const module = await LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule(platform)
+
+  expect(typeof module.getCommands).toBe('function')
+  expect(typeof module.getKeyBindings).toBe('function')
+})

--- a/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
+++ b/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
@@ -10,6 +10,8 @@ test('loads unsupported viewlet on web', async () => {
     ...state,
     message: 'Process Explorer is not supported on web.',
   })
+  expect(module.getCommands()).toEqual({})
+  expect(module.getKeyBindings()).toEqual([])
 })
 
 test.each([PlatformType.Electron, PlatformType.Remote])('loads worker-backed viewlet on platform %s', async (platform) => {

--- a/packages/renderer-worker/test/ViewletProcessExplorerUnsupported.test.ts
+++ b/packages/renderer-worker/test/ViewletProcessExplorerUnsupported.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@jest/globals'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
+import * as ViewletProcessExplorerUnsupported from '../src/parts/ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.ipc.js'
+
+test('renders unsupported message', () => {
+  const oldState = ViewletProcessExplorerUnsupported.create(7, 'process-explorer://', 1, 2, 3, 4)
+  const newState = ViewletProcessExplorerUnsupported.loadContent(oldState)
+  const command = ViewletProcessExplorerUnsupported.render[0].apply(oldState, newState)
+
+  expect(command).toEqual([
+    'Viewlet.setDom2',
+    [
+      {
+        type: VirtualDomElements.Div,
+        className: 'ProcessExplorer',
+        childCount: 1,
+      },
+      {
+        type: VirtualDomElements.Div,
+        className: 'ProcessExplorerMessage',
+        childCount: 1,
+      },
+      {
+        type: VirtualDomElements.Text,
+        text: 'Process Explorer is not supported on web.',
+        childCount: 0,
+      },
+    ],
+  ])
+})

--- a/static/css/parts/ViewletProcessExplorer.css
+++ b/static/css/parts/ViewletProcessExplorer.css
@@ -49,3 +49,8 @@
   color: var(--ErrorForeground, #f48771);
   user-select: text;
 }
+
+.ProcessExplorerMessage {
+  padding: 8px;
+  user-select: text;
+}


### PR DESCRIPTION
Render a clear unsupported message when Process Explorer is opened in the web editor, while preserving the existing worker-backed view for Electron and remote environments.