### PR TITLE
fix: refresh extension search disabled state

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, handleExtensionsChanged, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'extensionSearch' })

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -652,6 +652,7 @@
           { "source": "state", "name": "platform" }, { "source": "state", "name": "assetDir" }, { "source": "state", "name": "parentUid" }
         ] },
         "loadContent": { "name": "SearchExtensions.loadContent", "parameters": [{ "source": "state", "name": "id" }, { "source": "argument", "name": "savedState" }] },
+        "handleExtensionsChanged": { "name": "SearchExtensions.handleExtensionsChanged", "parameters": [{ "source": "state", "name": "id" }] },
         "diff": { "name": "SearchExtensions.diff2", "parameters": [{ "source": "state", "name": "id" }] },
         "render": { "name": "SearchExtensions.render3", "parameters": [{ "source": "state", "name": "id" }, { "source": "result", "name": "diff" }] },
         "saveState": { "name": "SearchExtensions.saveState", "parameters": [{ "source": "state", "name": "id" }] },
@@ -662,6 +663,7 @@
         "getMenuEntries": { "name": "SearchExtensions.getMenuEntries2", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
         "renderEventListeners": { "name": "SearchExtensions.renderEventListeners", "parameters": [] }
       },
+      "extraCommands": [{ "name": "handleExtensionsChanged", "method": "handleExtensionsChanged" }],
       "title": "Extensions: Installed",
       "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
     }

--- a/packages/renderer-worker/test/ViewletExtensions.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensions.test.ts
@@ -10,6 +10,9 @@ jest.unstable_mockModule('../src/parts/ExtensionSearchViewWorker/ExtensionSearch
     if (command === 'SearchExtensions.render3') {
       return renderCommands
     }
+    if (command === 'SearchExtensions.getCommandIds') {
+      return []
+    }
     return undefined
   }),
   restart: jest.fn(),
@@ -72,4 +75,25 @@ test('forwards the parent view uid to the extension search worker', async () => 
     '/test-assets',
     42,
   )
+})
+
+test('handleExtensionsChanged refreshes and renders the extension search view', async () => {
+  const state = ViewletExtensions.create(1, 'extensions://', 10, 20, 800, 600, [], 42)
+
+  const result = await ViewletExtensions.handleExtensionsChanged(state, 'builtin.language-features-typescript', true)
+
+  expect(ExtensionSearchViewWorker.invoke).toHaveBeenNthCalledWith(1, 'SearchExtensions.handleExtensionsChanged', 1)
+  expect(ExtensionSearchViewWorker.invoke).toHaveBeenNthCalledWith(2, 'SearchExtensions.diff2', 1)
+  expect(ExtensionSearchViewWorker.invoke).toHaveBeenNthCalledWith(3, 'SearchExtensions.render3', 1, [])
+  expect(result).toEqual({
+    ...state,
+    commands: [],
+    title: 'Extensions: Installed',
+  })
+})
+
+test('getCommands includes the extension change handler', async () => {
+  await ViewletExtensions.getCommands()
+
+  expect(typeof ViewletExtensions.Commands['handleExtensionsChanged']).toBe('function')
 })


### PR DESCRIPTION
Refresh the open extension search view when extension state changes so disabled extensions, including TypeScript language features, immediately show their disabled styling and Enable action.

Adds renderer regression coverage for the extension-change event wiring.