### PR TITLE
fix: clear simple browser loading state

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -212,8 +212,7 @@ export const setUrl = async (state, value) => {
   const newState1 = await handleInput(state, value)
   const { inputValue, browserViewId, shortcuts } = newState1
   const iframeSrc = IframeSrc.toIframeSrc(inputValue, shortcuts)
-  // TODO await promises
-  await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
+  void ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
 
   return {
     ...newState1,

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -138,6 +138,28 @@ test('handleWillNavigate', () => {
   })
 })
 
+test('setUrl applies the loading state before navigation completes', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockReturnValue({
+    then() {
+      throw new Error('navigation should not be awaited')
+    },
+  })
+  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12 }
+
+  const loadingState = await ViewletSimpleBrowser.setUrl(state, 'https://example.com')
+
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, 'https://example.com')
+  expect(loadingState).toMatchObject({
+    iframeSrc: 'https://example.com',
+    inputValue: 'https://example.com',
+    isLoading: true,
+  })
+  expect(ViewletSimpleBrowser.handleDidNavigate(loadingState, 'https://example.com')).toMatchObject({
+    isLoading: false,
+  })
+})
+
 test('handleDidNavigate', () => {
   const state = { ...ViewletSimpleBrowser.create(), isLoading: true }
   // @ts-ignore


### PR DESCRIPTION
Fix the integrated browser loading indicator remaining active after a programmatic navigation has completed. Apply the loading state before navigation events so the completion event can reliably clear it, with focused regression coverage.