### PR TITLE
fix: ignore late blur events for disposed viewlets

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
 import * as ElectronBrowserView from '../ElectronBrowserView/ElectronBrowserView.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as Id from '../Id/Id.js'
@@ -517,7 +518,9 @@ export const getFocusCommands = async (id) => {
 export const executeViewletCommand = async (uid, fnName, ...args) => {
   const instance = ViewletStates.getInstance(uid)
   if (!instance) {
-    Logger.warn(`cannot execute ${fnName} instance not found ${uid}`)
+    if (fnName !== DomEventListenerFunctions.HandleBlur) {
+      Logger.warn(`cannot execute ${fnName} instance not found ${uid}`)
+    }
     return
   }
   const fn = await getFn(instance.factory, fnName)

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -78,6 +78,22 @@ test('getTitle - provider has no getTitle function', () => {
   expect(Viewlet.getTitle(1)).toBeUndefined()
 })
 
+test('executeViewletCommand ignores a late blur after the viewlet was disposed', async () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  await Viewlet.executeViewletCommand(2, 'handleBlur')
+
+  expect(warn).not.toHaveBeenCalled()
+})
+
+test('executeViewletCommand warns when another command targets a missing viewlet', async () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  await Viewlet.executeViewletCommand(2, 'handleInput')
+
+  expect(warn).toHaveBeenCalledWith('cannot execute handleInput instance not found 2')
+})
+
 test('getTitle', async () => {
   const getTitle = jest.fn(async (_uid = 0) => 'Test Title')
   const state = { uid: 1 }


### PR DESCRIPTION
Suppress the expected late input blur event after a quick-pick widget has already been disposed, while preserving missing-instance warnings for all other commands. Adds focused renderer-worker regression coverage for both cases.