### PR TITLE
fix: stop forwarding stale action updates

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1047,7 +1047,7 @@ export const setActionsDom = (
   if (state.previewId !== childUid) {
     return {
       commands: [],
-      handled: false,
+      handled: true,
       renderParent: false,
       statePatch: {},
     }

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -565,6 +565,36 @@ test('extension view render keeps the parent actions state in sync', () => {
   expect(ViewletStates.getInstance(2).renderedState).toEqual(parentRenderedState)
 })
 
+test('repeated stale extension action renders do not send unsupported commands to the renderer process', () => {
+  const parentState = {
+    ...ViewletLayout.create(3),
+    previewId: 8,
+  }
+  ViewletStates.set(3, {
+    factory: ViewletLayout,
+    renderedState: parentState,
+    state: parentState,
+  })
+
+  const commands = Array.from({ length: 100 }, (_, index) => {
+    const oldState = {
+      actionsDom: [`old-actions-${index}`],
+      commands: [],
+      dom: [],
+      kind: 'virtualDom',
+      patches: [],
+      title: 'Testing',
+    }
+    const newState = {
+      ...oldState,
+      actionsDom: [`new-actions-${index}`],
+    }
+    return ViewletManager.render(ViewletExtensionViewRender, oldState, newState, 7, 3)
+  }).flat()
+
+  expect(commands).toEqual([])
+})
+
 test('extension view render creates preview actions and adds them to the layout', () => {
   const parentState = {
     ...ViewletLayout.create(2),


### PR DESCRIPTION
Stops stale extension action renders from falling through to unsupported renderer-process setActionsDom calls, preventing the resulting high-frequency console warning flood. Adds regression coverage for repeated updates.