### PR TITLE
fix: match preview selectors case insensitively

### DIFF
--- a/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
+++ b/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
@@ -108,7 +108,8 @@ export const findExtensionView = (views: readonly ExtensionView[], idOrUri: stri
   if (exactMatch) {
     return exactMatch
   }
-  return views.find((view) => view.type === 'preview' && view.selector?.some((selector) => idOrUri.endsWith(selector)))
+  const normalizedUri = idOrUri.toLowerCase()
+  return views.find((view) => view.type === 'preview' && view.selector?.some((selector) => normalizedUri.endsWith(selector.toLowerCase())))
 }
 
 export const getExtensionView = async (idOrUri: string): Promise<ExtensionView | undefined> => {

--- a/packages/renderer-worker/test/GetExtensionViews.test.ts
+++ b/packages/renderer-worker/test/GetExtensionViews.test.ts
@@ -17,6 +17,14 @@ const views = [
     selector: ['.test'],
     title: 'Testing',
   },
+  {
+    extensionId: 'builtin.video-preview',
+    icon: '',
+    id: 'builtin.video-preview',
+    selector: ['.mp4'],
+    title: 'Video Preview',
+    type: 'preview',
+  },
 ]
 
 test('findExtensionView finds a view by id', () => {
@@ -25,6 +33,10 @@ test('findExtensionView finds a view by id', () => {
 
 test('findExtensionView finds preview views by document selector', () => {
   expect(findExtensionView(views, 'file:///workspace/image.png')?.id).toBe('builtin.media-preview')
+})
+
+test('findExtensionView matches document selectors case-insensitively', () => {
+  expect(findExtensionView(views, 'file:///workspace/H264-UPPER.MP4')?.id).toBe('builtin.video-preview')
 })
 
 test('findExtensionView does not use sidebar view selectors for documents', () => {


### PR DESCRIPTION
## Summary

- match preview document selectors case-insensitively
- keep explicit extension-view ID matching exact
- cover the original uppercase MP4 association regression

## Why

The built-in Video Preview selector is `.mp4`, but document association used a case-sensitive suffix comparison. A byte-identical `H264-UPPER.MP4` therefore opened as binary text instead of video.

## Verification

- 1,321 renderer-worker tests passed (231 skipped)
- renderer-worker type check
- repository lint and unused-code checks
- Prettier and git diff checks
- Electron Debian x64 build
- real Electron replay of `H264-UPPER.MP4` now renders the video frame and native controls