### PR TITLE
feature: expose active editor diagnostics

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -208,6 +208,7 @@ export const commandMap = {
   'Focus.setAdditionalFocus': lazy('Focus.setAdditionalFocus'),
   'Focus.setFocus': lazy('Focus.setFocus'),
   'GetActiveEditor.getActiveEditorId': lazy('GetActiveEditor.getActiveEditorId'),
+  'GetActiveEditor.getDiagnostics': lazy('GetActiveEditor.getDiagnostics'),
   'GetActiveEditor.getOpenEditorUris': lazy('GetActiveEditor.getOpenEditorUris'),
   'GetActiveEditor.updateAllDiagnostics': lazy('GetActiveEditor.updateAllDiagnostics'),
   'GetActiveEditor.updateDiagnostics': lazy('GetActiveEditor.updateDiagnostics'),

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
@@ -4,6 +4,7 @@ export const name = 'GetActiveEditor'
 
 export const Commands = {
   getActiveEditorId: GetActiveEditor.getActiveEditorId,
+  getDiagnostics: GetActiveEditor.getDiagnostics,
   getOpenEditorUris: GetActiveEditor.getOpenEditorUris,
   updateAllDiagnostics: GetActiveEditor.updateAllDiagnostics,
   updateDiagnostics: GetActiveEditor.updateDiagnostics,

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -16,6 +16,18 @@ export const getActiveEditorId = () => {
   return instance.state.id
 }
 
+export const getDiagnosticsWithInvoke = async (invoke) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
+  if (!instance) {
+    return []
+  }
+  return invoke('Editor.getDiagnostics', instance.state.id)
+}
+
+export const getDiagnostics = async () => {
+  return getDiagnosticsWithInvoke(EditorWorker.invoke)
+}
+
 export const getOpenEditorUrisWithInvoke = async (invoke) => {
   const instance = ViewletStates.getInstance(ViewletModuleId.Main)
   if (!instance) {

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -31,6 +31,30 @@ test('updateDiagnostics refreshes diagnostics for the active editor', async () =
   expect(executeCommand).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'updateDiagnostics')
 })
 
+test('getDiagnostics returns diagnostics for the active editor', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.js',
+    },
+  })
+  const diagnostics = [{ message: 'Unexpected semicolon', rowIndex: 0 }]
+  const invoke = jest.fn(async () => diagnostics)
+
+  await expect(GetActiveEditor.getDiagnosticsWithInvoke(invoke)).resolves.toEqual(diagnostics)
+  expect(invoke).toHaveBeenCalledWith('Editor.getDiagnostics', 42)
+})
+
+test('getDiagnostics returns an empty array when there is no active editor', async () => {
+  const invoke = jest.fn()
+
+  await expect(GetActiveEditor.getDiagnosticsWithInvoke(invoke)).resolves.toEqual([])
+  expect(invoke).not.toHaveBeenCalled()
+})
+
 test('updateAllDiagnostics refreshes diagnostics for every open editor', async () => {
   await GetActiveEditor.updateAllDiagnosticsWithCommand(executeCommand)
 


### PR DESCRIPTION
Expose the active editor's diagnostics through a renderer command so isolated extensions can inspect current lint and language-service alerts.