### PR TITLE
feature: reload editors after extension file changes

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -456,6 +456,7 @@ export const commandMap = {
   'Viewlet.getDragData': lazy('Viewlet.getDragData'),
   'Viewlet.getTitle': lazy('Viewlet.getTitle'),
   'Viewlet.openWidget': lazy('Viewlet.openWidget'),
+  'Viewlet.reload': lazy('Viewlet.reload'),
   'Viewlet.send': lazy('Viewlet.send'),
   'ViewletDebugConsole.clear': lazy('ViewletDebugConsole.clear'),
   'ViewletDebugConsole.evaluate': lazy('ViewletDebugConsole.evaluate'),

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
@@ -1,9 +1,14 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Command from '../Command/Command.js'
 import * as ExtensionHostCommandType from '../ExtensionHostCommandType/ExtensionHostCommandType.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as FileSystemProtocol from '../FileSystemProtocol/FileSystemProtocol.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as ExtensionHostShared from './ExtensionHostShared.js'
+
+const notifyWorkspaceChanged = async (changes) => {
+  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', changes), Command.execute('Layout.refreshSourceControlBadgeCount')])
+}
 
 const getProviderProtocolPathAndUri = (uri) => {
   const protocol = GetProtocol.getProtocol(uri)
@@ -47,15 +52,19 @@ export const readFile = (uri) => {
   })
 }
 
-export const remove = (uri) => {
+export const remove = async (uri) => {
   const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
-  return executeProvider({
+  const result = await executeProvider({
     isolatedMethod: 'Extensions.executeFileSystemProviderRemove',
     isolatedParams: [providerUri],
     legacyMethod: ExtensionHostCommandType.FileSystemRemove,
     legacyParams: [path],
     protocol,
   })
+  await notifyWorkspaceChanged({
+    deleted: [uri],
+  })
+  return result
 }
 
 /**
@@ -63,16 +72,20 @@ export const remove = (uri) => {
  * @param {string} oldUri
  * @param {string} newUri
  */
-export const rename = (oldUri, newUri) => {
+export const rename = async (oldUri, newUri) => {
   const { protocol, path: oldPath, uri: providerOldUri } = getProviderProtocolPathAndUri(oldUri)
   const { path: newPath, uri: providerNewUri } = getProviderProtocolPathAndUri(newUri)
-  return executeProvider({
+  const result = await executeProvider({
     isolatedMethod: 'Extensions.executeFileSystemProviderRename',
     isolatedParams: [providerOldUri, providerNewUri],
     legacyMethod: ExtensionHostCommandType.FileSystemRename,
     legacyParams: [oldPath, newPath],
     protocol,
   })
+  await notifyWorkspaceChanged({
+    renamed: [[oldUri, newUri]],
+  })
+  return result
 }
 
 export const mkdir = (uri) => {
@@ -86,15 +99,19 @@ export const mkdir = (uri) => {
   })
 }
 
-export const createFile = (uri) => {
+export const createFile = async (uri) => {
   const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
-  return executeProvider({
+  const result = await executeProvider({
     isolatedMethod: 'Extensions.executeFileSystemProviderWriteFile',
     isolatedParams: [providerUri, ''],
     legacyMethod: ExtensionHostCommandType.FileSystemWriteFile,
     legacyParams: [path, ''],
     protocol,
   })
+  await notifyWorkspaceChanged({
+    changed: [uri],
+  })
+  return result
 }
 
 export const createFolder = (uri) => {
@@ -108,15 +125,19 @@ export const createFolder = (uri) => {
   })
 }
 
-export const writeFile = (uri, content) => {
+export const writeFile = async (uri, content) => {
   const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
-  return executeProvider({
+  const result = await executeProvider({
     isolatedMethod: 'Extensions.executeFileSystemProviderWriteFile',
     isolatedParams: [providerUri, content],
     legacyMethod: ExtensionHostCommandType.FileSystemWriteFile,
     legacyParams: [path, content],
     protocol,
   })
+  await notifyWorkspaceChanged({
+    changed: [uri],
+  })
+  return result
 }
 
 export const readDirWithFileTypes = (uri) => {

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
@@ -12,6 +12,7 @@ export const Commands = {
   getDragData: Viewlet.getDragData,
   getTitle: Viewlet.getTitle,
   openWidget: Viewlet.openWidget,
+  reload: Viewlet.reload,
   send: Viewlet.send,
   dispose: Viewlet.dispose,
   resize: Viewlet.resize,

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -104,6 +104,47 @@ export const refresh = async (id) => {
   await refreshInstance(instance, id)
 }
 
+export const reload = async (id) => {
+  const instance = ViewletStates.getInstance(id)
+  if (!instance || instance.status === 'reloading' || instance.status === 'disposed' || typeof instance.factory.loadContent !== 'function') {
+    return
+  }
+  instance.status = 'reloading'
+  try {
+    const oldState = instance.state
+    const savedState = instance.factory.saveState ? await instance.factory.saveState(oldState) : undefined
+    if (instance.factory.dispose) {
+      await instance.factory.dispose(oldState)
+    }
+    const newState = await instance.factory.loadContent(oldState, savedState)
+    Assert.object(newState)
+    if (ViewletStates.getInstance(id) !== instance) {
+      return
+    }
+    const commands = [...ViewletManager.render(instance.factory, instance.renderedState, newState)]
+    if (instance.factory.contentLoaded) {
+      const contentLoadedCommands = await instance.factory.contentLoaded(newState)
+      Assert.array(contentLoadedCommands)
+      commands.push(...contentLoadedCommands)
+    }
+    ViewletStates.setRenderedState(id, newState)
+    UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
+    if (commands.length > 0) {
+      await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+    }
+    instance.loadContentLaterStarted = false
+    instance.loadContentLaterPromise = undefined
+    ViewletManager.runLoadContentLater(id)
+    if (instance.factory.contentLoadedEffects) {
+      await instance.factory.contentLoadedEffects(newState)
+    }
+    instance.status = 'loaded'
+  } catch (error) {
+    instance.status = 'error'
+    throw error
+  }
+}
+
 /**
  * @deprecated
  */

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -8,3 +8,7 @@ test('registers the go-to-line quick pick command', () => {
 test('registers the viewlet focus-selector bridge command', () => {
   expect(commandMap['Viewlet.focusSelector']).toBeDefined()
 })
+
+test('registers the viewlet reload command', () => {
+  expect(commandMap['Viewlet.reload']).toBeDefined()
+})

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as DirentType from '../src/parts/DirentType/DirentType.js'
 
 const invoke = jest.fn<(...args: readonly any[]) => Promise<any>>()
+const execute = jest.fn<(...args: readonly any[]) => Promise<any>>()
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -10,6 +11,10 @@ beforeEach(() => {
 
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
   invoke,
+}))
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute,
 }))
 
 jest.unstable_mockModule('../src/parts/ExtensionHost/ExtensionHostShared.js', () => {
@@ -65,6 +70,10 @@ test('remove', async () => {
     noProviderFoundMessage: 'no file system provider found',
     params: ['memfs', '/test.txt'],
   })
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    deleted: ['memfs:///test.txt'],
+  })
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
 
 test('remove - error', async () => {
@@ -86,6 +95,10 @@ test('rename', async () => {
     noProviderFoundMessage: 'no file system provider found',
     params: ['memfs', '/test.txt', '/test2.txt'],
   })
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    renamed: [['memfs:///test.txt', 'memfs:///test2.txt']],
+  })
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
 
 test('rename - wrapped extension host uri', async () => {
@@ -144,6 +157,22 @@ test('writeFile', async () => {
     noProviderFoundMessage: 'no file system provider found',
     params: ['memfs', '/test-folder', 'test'],
   })
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    changed: ['memfs:///test-folder'],
+  })
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
+})
+
+test('createFile notifies workspace views with the changed uri', async () => {
+  // @ts-ignore
+  ExtensionHostShared.executeProvider.mockImplementation(() => {})
+
+  await ExtensionHostFileSystem.createFile('memfs:///new-file.txt')
+
+  expect(execute).toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', {
+    changed: ['memfs:///new-file.txt'],
+  })
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
 
 test('writeFile - wrapped extension host uri', async () => {
@@ -165,6 +194,7 @@ test('writeFile - error', async () => {
     throw new TypeError('x is not a function')
   })
   await expect(ExtensionHostFileSystem.writeFile('memfs:///test-folder', 'test')).rejects.toThrow(new TypeError('x is not a function'))
+  expect(execute).not.toHaveBeenCalled()
 })
 
 test('readDirWithFileTypes', async () => {

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -27,6 +27,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
       throw new Error('not implemented')
     }),
     render: jest.fn(() => []),
+    runLoadContentLater: jest.fn(),
   }
 })
 jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
@@ -132,6 +133,72 @@ test('focusSelector forwards focus to the renderer process', async () => {
   await Viewlet.focusSelector(7, '[name="editor"]')
 
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.focusSelector', 7, '[name="editor"]')
+})
+
+test('reload restores a viewlet from its current saved state and rerenders it', async () => {
+  const oldState = { content: 'old', uid: 2 } as const
+  const newState = { content: 'new', uid: 2 } as const
+  const savedState = { selection: 3 } as const
+  const saveState = jest.fn(async (_state: typeof oldState) => savedState)
+  const dispose = jest.fn(async (_state: typeof oldState) => {})
+  const loadContent = jest.fn(async (_state: typeof oldState, _savedState: typeof savedState) => newState)
+  const contentLoaded = jest.fn(async (_state: typeof newState) => [['Viewlet.afterLoad', 2]])
+  const contentLoadedEffects = jest.fn(async (_state: typeof newState) => {})
+  ViewletStates.set(2, {
+    factory: { contentLoaded, contentLoadedEffects, dispose, loadContent, saveState },
+    moduleId: 'Editor',
+    renderedState: oldState,
+    state: oldState,
+  })
+  jest.mocked(ViewletManager.render).mockReturnValue([['Viewlet.setDom2', 2, []]])
+  jest.mocked(RendererProcess.invoke).mockResolvedValue(undefined)
+
+  await Viewlet.reload(2)
+
+  expect(saveState).toHaveBeenCalledWith(oldState)
+  expect(dispose).toHaveBeenCalledWith(oldState)
+  expect(loadContent).toHaveBeenCalledWith(oldState, savedState)
+  expect(ViewletManager.render).toHaveBeenCalledWith(expect.anything(), oldState, newState)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.setDom2', 2, []],
+    ['Viewlet.afterLoad', 2],
+  ])
+  expect(ViewletManager.runLoadContentLater).toHaveBeenCalledWith(2)
+  expect(contentLoadedEffects).toHaveBeenCalledWith(newState)
+  expect(ViewletStates.getState(2)).toBe(newState)
+  expect(ViewletStates.getInstance(2).status).toBe('loaded')
+})
+
+test('reload ignores a viewlet that is already reloading', async () => {
+  const loadContent = jest.fn()
+  ViewletStates.set(2, {
+    factory: { loadContent },
+    moduleId: 'Editor',
+    renderedState: { uid: 2 },
+    state: { uid: 2 },
+    status: 'reloading',
+  })
+
+  await Viewlet.reload(2)
+
+  expect(loadContent).not.toHaveBeenCalled()
+})
+
+test('reload records a failed load and propagates the error', async () => {
+  const error = new Error('Failed to reload')
+  ViewletStates.set(2, {
+    factory: {
+      loadContent: jest.fn(async () => {
+        throw error
+      }),
+    },
+    moduleId: 'Editor',
+    renderedState: { uid: 2 },
+    state: { uid: 2 },
+  })
+
+  await expect(Viewlet.reload(2)).rejects.toThrow(error)
+  expect(ViewletStates.getInstance(2).status).toBe('error')
 })
 
 test('disposeFunctional disposes owned runtime viewlets', () => {


### PR DESCRIPTION
Extension filesystem mutations now publish structured workspace refreshes after successful writes, creates, renames, and deletes.

The main area matches changed URIs against all open editor inputs, while the renderer provides a generic viewlet reload path that preserves supported editor state. This refreshes text editors, either side of diff editors, image/media/video previews, and contributed webviews without reopening their tabs.

Tests cover filesystem notifications, command registration, reload lifecycle/error handling, and matching across editor input types.