### PR TITLE
feature: expose active editor selections

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -210,6 +210,8 @@ export const commandMap = {
   'GetActiveEditor.getActiveEditorId': lazy('GetActiveEditor.getActiveEditorId'),
   'GetActiveEditor.getDiagnostics': lazy('GetActiveEditor.getDiagnostics'),
   'GetActiveEditor.getOpenEditorUris': lazy('GetActiveEditor.getOpenEditorUris'),
+  'GetActiveEditor.getSelections': lazy('GetActiveEditor.getSelections'),
+  'GetActiveEditor.setSelections': lazy('GetActiveEditor.setSelections'),
   'GetActiveEditor.updateAllDiagnostics': lazy('GetActiveEditor.updateAllDiagnostics'),
   'GetActiveEditor.updateDiagnostics': lazy('GetActiveEditor.updateDiagnostics'),
   'GetEditorSourceActions.getEditorSourceActions': lazy('GetEditorSourceActions.getEditorSourceActions'),

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
@@ -6,6 +6,8 @@ export const Commands = {
   getActiveEditorId: GetActiveEditor.getActiveEditorId,
   getDiagnostics: GetActiveEditor.getDiagnostics,
   getOpenEditorUris: GetActiveEditor.getOpenEditorUris,
+  getSelections: GetActiveEditor.getSelections,
+  setSelections: GetActiveEditor.setSelections,
   updateAllDiagnostics: GetActiveEditor.updateAllDiagnostics,
   updateDiagnostics: GetActiveEditor.updateDiagnostics,
 }

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -28,6 +28,19 @@ export const getDiagnostics = async () => {
   return getDiagnosticsWithInvoke(EditorWorker.invoke)
 }
 
+export const getSelectionsWithInvoke = async (invoke) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
+  if (!instance) {
+    return []
+  }
+  const selections = await invoke('Editor.getSelections2', instance.state.id)
+  return Array.from(selections)
+}
+
+export const getSelections = async () => {
+  return getSelectionsWithInvoke(EditorWorker.invoke)
+}
+
 export const getOpenEditorUrisWithInvoke = async (invoke) => {
   const instance = ViewletStates.getInstance(ViewletModuleId.Main)
   if (!instance) {
@@ -51,6 +64,18 @@ export const updateDiagnosticsWithCommand = async (executeCommand) => {
 
 export const updateDiagnostics = async () => {
   await updateDiagnosticsWithCommand(Command.execute)
+}
+
+export const setSelectionsWithCommand = async (executeCommand, selections) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
+  if (!instance) {
+    return
+  }
+  await executeCommand('Viewlet.executeViewletCommand', instance.state.id, 'setSelections', new Uint32Array(selections))
+}
+
+export const setSelections = async (selections) => {
+  await setSelectionsWithCommand(Command.execute, selections)
 }
 
 export const updateAllDiagnosticsWithCommand = async (invoke) => {

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -55,6 +55,50 @@ test('getDiagnostics returns an empty array when there is no active editor', asy
   expect(invoke).not.toHaveBeenCalled()
 })
 
+test('getSelections returns selections for the active editor', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.js',
+    },
+  })
+  const invoke = jest.fn(async () => new Uint32Array([1, 2, 3, 4]))
+
+  await expect(GetActiveEditor.getSelectionsWithInvoke(invoke)).resolves.toEqual([1, 2, 3, 4])
+  expect(invoke).toHaveBeenCalledWith('Editor.getSelections2', 42)
+})
+
+test('getSelections returns an empty array when there is no active editor', async () => {
+  const invoke = jest.fn()
+
+  await expect(GetActiveEditor.getSelectionsWithInvoke(invoke)).resolves.toEqual([])
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('setSelections updates selections for the active editor', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.js',
+    },
+  })
+
+  await GetActiveEditor.setSelectionsWithCommand(executeCommand, [1, 2, 3, 4])
+
+  expect(executeCommand).toHaveBeenCalledWith('Viewlet.executeViewletCommand', 42, 'setSelections', new Uint32Array([1, 2, 3, 4]))
+})
+
+test('setSelections does nothing when there is no active editor', async () => {
+  await expect(GetActiveEditor.setSelectionsWithCommand(executeCommand, [1, 2, 3, 4])).resolves.toBeUndefined()
+  expect(executeCommand).not.toHaveBeenCalled()
+})
+
 test('updateAllDiagnostics refreshes diagnostics for every open editor', async () => {
   await GetActiveEditor.updateAllDiagnosticsWithCommand(executeCommand)
 


### PR DESCRIPTION
Expose renderer commands to read and update selections in the active editor, including revealing newly selected ranges.