### PR TITLE
fix: keep preferred preview open with sidebar

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -683,35 +683,28 @@ export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<L
     if (state.previewVisible && state.previewUri === sideBarView) {
       return hidePreview(state)
     }
-    const sideBarResult = state.sideBarVisible ? await hideSideBar(state) : { newState: state, commands: [] }
     const previewState = getPoints(
       {
-        ...sideBarResult.newState,
-        previewWidth: sideBarResult.newState.windowWidth / 2,
+        ...state,
+        previewWidth: state.windowWidth / 2,
       },
-      sideBarResult.newState.sideBarLocation,
+      state.sideBarLocation,
     )
     const previewResult = await showPreview(previewState, sideBarView, ViewletModuleId.ExtensionView)
     const focusCommands = await Viewlet.getFocusCommands(sideBarView)
     return {
       newState: previewResult.newState,
-      commands: [...sideBarResult.commands, ...previewResult.commands, ...focusCommands],
+      commands: [...previewResult.commands, ...focusCommands],
     }
   }
-  const previewResult = await hidePreferredLocationPreview(state)
-  const activeState = previewResult.newState
-  if (activeState.sideBarVisible && activeState.sideBarView === sideBarView) {
-    const result = await hideSideBar(activeState)
-    return {
-      newState: result.newState,
-      commands: [...previewResult.commands, ...result.commands],
-    }
+  if (state.sideBarVisible && state.sideBarView === sideBarView) {
+    return hideSideBar(state)
   }
-  const result = await showSideBar(activeState, sideBarView)
+  const result = await showSideBar(state, sideBarView)
   const focusCommands = await Viewlet.getFocusCommands(sideBarView)
   return {
     newState: result.newState,
-    commands: [...previewResult.commands, ...result.commands, ...focusCommands],
+    commands: [...result.commands, ...focusCommands],
   }
 }
 
@@ -919,23 +912,6 @@ const getPreferredViewLocation = async (viewId: string): Promise<'preview' | 'si
   }
   const view = await GetExtensionViews.getExtensionView(viewId)
   return view?.preferredLocation === 'preview' ? 'preview' : 'sideBar'
-}
-
-const hidePreferredLocationPreview = async (state: LayoutState): Promise<LayoutStateResult> => {
-  if (!state.previewVisible || state.previewViewletId !== ViewletModuleId.ExtensionView) {
-    return {
-      newState: state,
-      commands: [],
-    }
-  }
-  const preferredLocation = await getPreferredViewLocation(state.previewUri)
-  if (preferredLocation !== 'preview') {
-    return {
-      newState: state,
-      commands: [],
-    }
-  }
-  return hidePreview(state)
 }
 
 export const showStatusBar = (state: LayoutState) => {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -652,7 +652,7 @@ test('openChat leaves an already open chat unfocused by default', async () => {
   expect(result).toEqual({ newState: state, commands: [] })
 })
 
-test('toggleSideBarView opens a preview-preferred extension view in the preview area', async () => {
+test('toggleSideBarView opens a preview-preferred extension view alongside the sidebar', async () => {
   mockActivityBarRender()
   // @ts-ignore
   GetExtensionViews.getExtensionView.mockResolvedValue({
@@ -667,6 +667,8 @@ test('toggleSideBarView opens a preview-preferred extension view in the preview 
     activityBarVisible: true,
     activityBarWidth: 48,
     sideBarId: 12,
+    sideBarMaxWidth: 1200,
+    sideBarMinWidth: 170,
     sideBarSashVisible: true,
     sideBarView: 'Explorer',
     sideBarVisible: true,
@@ -682,14 +684,14 @@ test('toggleSideBarView opens a preview-preferred extension view in the preview 
   const result = await ViewletLayout.toggleSideBarView(state, 'sample.views.preview')
 
   expect(result.newState).toMatchObject({
-    mainWidth: 552,
+    mainWidth: 312,
     previewLeft: 600,
     previewUri: 'sample.views.preview',
     previewViewletId: 'ExtensionView',
     previewVisible: true,
     previewWidth: 600,
-    sideBarSashVisible: false,
-    sideBarVisible: false,
+    sideBarSashVisible: true,
+    sideBarVisible: true,
   })
   expect(ViewletManager.load).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -728,7 +730,10 @@ test('toggleSideBarView hides the preview when its selected activity item is cli
   expect(Viewlet.disposeFunctional).toHaveBeenCalledWith(11)
 })
 
-test('toggleSideBarView closes a preview-preferred extension view before opening a sidebar view', async () => {
+test.each([
+  ['opening Explorer', false, 'Explorer'],
+  ['switching from Explorer to Search', true, 'Search'],
+])('toggleSideBarView keeps a preview-preferred extension view open while %s', async (_label, sideBarVisible, sideBarView) => {
   mockActivityBarRender()
   // @ts-ignore
   GetExtensionViews.getExtensionView.mockImplementation(async (id) => {
@@ -751,29 +756,32 @@ test('toggleSideBarView closes a preview-preferred extension view before opening
     previewViewletId: 'ExtensionView',
     previewVisible: true,
     sideBarView: 'Explorer',
-    sideBarVisible: false,
+    sideBarVisible,
     statusBarHeight: 20,
     titleBarHeight: 0,
     windowHeight: 800,
     windowWidth: 1200,
   }
 
-  const result = await ViewletLayout.toggleSideBarView(state, 'Explorer')
+  const result = await ViewletLayout.toggleSideBarView(state, sideBarView)
 
   expect(result.newState).toMatchObject({
-    previewVisible: false,
-    sideBarView: 'Explorer',
+    previewVisible: true,
+    sideBarView,
     sideBarVisible: true,
   })
-  expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(11, 'ExtensionView')
-  expect(ViewletManager.load).toHaveBeenCalledWith(
-    expect.objectContaining({
-      id: 'SideBar',
-    }),
-    false,
-    true,
-    undefined,
-  )
+  expect(SaveState.saveViewletStateWithStorageId).not.toHaveBeenCalled()
+  expect(Viewlet.disposeFunctional).not.toHaveBeenCalledWith(11)
+  if (!sideBarVisible) {
+    expect(ViewletManager.load).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'SideBar',
+      }),
+      false,
+      true,
+      undefined,
+    )
+  }
 })
 
 test('layout allows the side bar to grow when the preview uses half the window', () => {


### PR DESCRIPTION
Keeps preview-preferred extension views open alongside ordinary sidebar views. Opening Gpt Voice no longer hides Explorer, and switching between Explorer and Search no longer closes the voice preview.