### PR TITLE
fix: convert opened folder paths to file uris

### DIFF
--- a/packages/renderer-worker/src/parts/OpenFolderElectron/OpenFolderElectron.js
+++ b/packages/renderer-worker/src/parts/OpenFolderElectron/OpenFolderElectron.js
@@ -1,5 +1,6 @@
 import * as Command from '../Command/Command.js'
 import * as ElectronDialog from '../ElectronDialog/ElectronDialog.js'
+import * as PathToFileUri from '../PathToFileUri/PathToFileUri.js'
 
 export const openFolder = async () => {
   const folders = await ElectronDialog.showOpenDialog(
@@ -10,5 +11,6 @@ export const openFolder = async () => {
     return
   }
   const path = folders[0]
-  await Command.execute(/* Workspace.setPath */ 'Workspace.setPath', /* path */ path)
+  const uri = PathToFileUri.pathToFileUri(path)
+  await Command.execute(/* Workspace.setUri */ 'Workspace.setUri', /* uri */ uri)
 }

--- a/packages/renderer-worker/src/parts/OpenFolderRemote/OpenFolderRemote.js
+++ b/packages/renderer-worker/src/parts/OpenFolderRemote/OpenFolderRemote.js
@@ -1,17 +1,12 @@
 import * as Command from '../Command/Command.js'
+import * as PathToFileUri from '../PathToFileUri/PathToFileUri.js'
 import * as Prompt from '../Prompt/Prompt.js'
-
-const toFileUri = (path) => {
-  const url = new URL('file:///')
-  url.pathname = path.replaceAll('\\', '/')
-  return url.toString()
-}
 
 export const openFolder = async () => {
   const path = await Prompt.prompt('Choose Path:', '/home')
   if (!path) {
     return
   }
-  const uri = toFileUri(path)
+  const uri = PathToFileUri.pathToFileUri(path)
   await Command.execute(/* Workspace.setUri */ 'Workspace.setUri', /* uri */ uri)
 }

--- a/packages/renderer-worker/src/parts/PathToFileUri/PathToFileUri.js
+++ b/packages/renderer-worker/src/parts/PathToFileUri/PathToFileUri.js
@@ -1,0 +1,5 @@
+export const pathToFileUri = (path) => {
+  const url = new URL('file:///')
+  url.pathname = path.replaceAll('\\', '/').replaceAll('%', '%25')
+  return url.toString()
+}

--- a/packages/renderer-worker/test/OpenFolder.test.ts
+++ b/packages/renderer-worker/test/OpenFolder.test.ts
@@ -32,6 +32,7 @@ test.skip('openFolder', async () => {
 })
 
 test('openFolder - electron', async () => {
+  const folderPath = '/home/simon/Downloads/aegypten/2025 Ägypten'
   jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
     return {
       platform: PlatformType.Electron,
@@ -49,7 +50,7 @@ test('openFolder - electron', async () => {
   jest.unstable_mockModule('../src/parts/ElectronDialog/ElectronDialog.js', () => {
     return {
       showOpenDialog: jest.fn(() => {
-        return ['/test/some-file']
+        return [folderPath]
       }),
       showMessageBox: jest.fn(() => {
         throw new Error('not implemented')
@@ -64,8 +65,10 @@ test('openFolder - electron', async () => {
   })
 
   const ElectronDialog = await import('../src/parts/ElectronDialog/ElectronDialog.js')
+  const Command = await import('../src/parts/Command/Command.js')
   const OpenFolder = await import('../src/parts/OpenFolder/OpenFolder.js')
   await OpenFolder.openFolder()
   expect(ElectronDialog.showOpenDialog).toHaveBeenCalledTimes(1)
   expect(ElectronDialog.showOpenDialog).toHaveBeenCalledWith('Open Folder', ['openDirectory', 'dontAddToRecent', 'showHiddenFiles'])
+  expect(Command.execute).toHaveBeenCalledWith('Workspace.setUri', 'file:///home/simon/Downloads/aegypten/2025%20%C3%84gypten')
 })

--- a/packages/renderer-worker/test/PathToFileUri.test.ts
+++ b/packages/renderer-worker/test/PathToFileUri.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import * as PathToFileUri from '../src/parts/PathToFileUri/PathToFileUri.js'
+
+test('converts a Linux path with spaces and umlauts', () => {
+  expect(PathToFileUri.pathToFileUri('/home/simon/Downloads/aegypten/2025 Ägypten')).toBe('file:///home/simon/Downloads/aegypten/2025%20%C3%84gypten')
+})
+
+test('converts Windows path separators', () => {
+  expect(PathToFileUri.pathToFileUri('C:\\Users\\test\\My Folder')).toBe('file:///C:/Users/test/My%20Folder')
+})
+
+test('encodes reserved path characters', () => {
+  expect(PathToFileUri.pathToFileUri('/tmp/100% #?.txt')).toBe('file:///tmp/100%25%20%23%3F.txt')
+})


### PR DESCRIPTION
Convert Electron open-folder paths to properly encoded file URIs before setting the workspace. This preserves spaces, umlauts, and reserved characters in recently opened entries.