### PR TITLE
fix: avoid removed video preview module

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -7,9 +7,6 @@ import * as GetWebViews from '../GetWebViews/GetWebViews.ts'
 
 const mapExtToEditorType = {
   '.mp3': ViewletModuleId.Audio,
-  '.mp4': ViewletModuleId.Video,
-  '.mkv': ViewletModuleId.Video,
-  '.webm': ViewletModuleId.Video,
   '.ogg': ViewletModuleId.Audio,
   '.opus': ViewletModuleId.Audio,
 }

--- a/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
@@ -110,8 +110,6 @@ export const TitleBarMenuBar = 'TitleBarMenuBar'
 
 export const TodoList = 'TodoList'
 
-export const Video = 'Video'
-
 export const About = 'About'
 
 export const EditorSourceActions = 'EditorSourceActions'

--- a/packages/renderer-worker/test/ViewletMap.test.ts
+++ b/packages/renderer-worker/test/ViewletMap.test.ts
@@ -12,16 +12,16 @@ test('audio - ogg', async () => {
   expect(await ViewletMap.getModuleId('/test/file.ogg')).toBe(ViewletModuleId.Audio)
 })
 
-test('video - mp4', async () => {
-  expect(await ViewletMap.getModuleId('/test/file.mp4')).toBe(ViewletModuleId.Video)
+test('video - mp4 without a preview provider', async () => {
+  expect(await ViewletMap.getModuleId('/test/file.mp4')).toBe(ViewletModuleId.EditorText)
 })
 
-test('video - webm', async () => {
-  expect(await ViewletMap.getModuleId('/test/file.webm')).toBe(ViewletModuleId.Video)
+test('video - webm without a preview provider', async () => {
+  expect(await ViewletMap.getModuleId('/test/file.webm')).toBe(ViewletModuleId.EditorText)
 })
 
-test('video - mkv', async () => {
-  expect(await ViewletMap.getModuleId('/test/file.mkv')).toBe(ViewletModuleId.Video)
+test('video - mkv without a preview provider', async () => {
+  expect(await ViewletMap.getModuleId('/test/file.mkv')).toBe(ViewletModuleId.EditorText)
 })
 
 test('audio - opus', async () => {

--- a/packages/renderer-worker/test/ViewletMapExtensionViews.test.ts
+++ b/packages/renderer-worker/test/ViewletMapExtensionViews.test.ts
@@ -2,6 +2,7 @@ import { expect, jest, test } from '@jest/globals'
 
 const state = {
   views: [] as any[],
+  webViews: [] as any[],
 }
 
 jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => ({
@@ -15,7 +16,7 @@ jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', 
 }))
 
 jest.unstable_mockModule('../src/parts/GetWebViews/GetWebViews.ts', () => ({
-  getWebViews: jest.fn(async () => []),
+  getWebViews: jest.fn(async () => state.webViews),
 }))
 
 const ViewletMap = await import('../src/parts/ViewletMap/ViewletMap.js')
@@ -54,4 +55,28 @@ test('an explicit extension view opener uses the extension view renderer', async
   ]
 
   await expect(ViewletMap.getModuleId('/workspace/file.unknown', 'builtin.media-preview')).resolves.toBe(ViewletModuleId.ExtensionView)
+})
+
+test('video documents use a matching preview extension view', async () => {
+  state.views = [
+    {
+      id: 'builtin.video-preview',
+      selector: ['.mp4', '.avi', '.webm'],
+      type: 'preview',
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/video.mp4')).resolves.toBe(ViewletModuleId.ExtensionView)
+})
+
+test('video documents use a matching legacy webview provider', async () => {
+  state.views = []
+  state.webViews = [
+    {
+      id: 'builtin.video-preview',
+      selector: ['.mp4', '.avi', '.webm'],
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/video.mp4')).resolves.toBe(ViewletModuleId.WebView)
 })


### PR DESCRIPTION
Remove the stale fallback to the deleted Video viewlet so video files use registered preview providers and safely fall back when no provider is available. Add coverage for modern extension previews, legacy webview previews, and missing providers.