### PR TITLE
fix: support jpg and webp mime types

### DIFF
--- a/packages/shared-process/src/parts/GetMimeType/GetMimeType.ts
+++ b/packages/shared-process/src/parts/GetMimeType/GetMimeType.ts
@@ -6,6 +6,8 @@ export const getMimeType = (fileExtension: any): any => {
       return MimeType.TextCss
     case '.html':
       return MimeType.TextHtml
+    case '.jpg':
+      return MimeType.ImageJpg
     case '.js':
     case '.mjs':
     case '.ts':
@@ -17,8 +19,6 @@ export const getMimeType = (fileExtension: any): any => {
       return MimeType.Markdown
     case '.mp3':
       return MimeType.AudioMpeg
-    case '.jpg':
-      return MimeType.ImageJpg
     case '.png':
       return MimeType.ImagePng
     case '.svg':

--- a/packages/shared-process/src/parts/GetMimeType/GetMimeType.ts
+++ b/packages/shared-process/src/parts/GetMimeType/GetMimeType.ts
@@ -17,6 +17,8 @@ export const getMimeType = (fileExtension: any): any => {
       return MimeType.Markdown
     case '.mp3':
       return MimeType.AudioMpeg
+    case '.jpg':
+      return MimeType.ImageJpg
     case '.png':
       return MimeType.ImagePng
     case '.svg':
@@ -25,6 +27,8 @@ export const getMimeType = (fileExtension: any): any => {
       return MimeType.FontTtf
     case '.webm':
       return MimeType.VideoWebm
+    case '.webp':
+      return MimeType.ImageWebp
     default:
       console.warn(`[shared-process] unsupported file extension: ${fileExtension}`)
       return ''

--- a/packages/shared-process/test/GetMimeType.test.ts
+++ b/packages/shared-process/test/GetMimeType.test.ts
@@ -17,6 +17,14 @@ test('png', () => {
   expect(GetMimeType.getMimeType('.png')).toBe('image/png')
 })
 
+test('jpg', () => {
+  expect(GetMimeType.getMimeType('.jpg')).toBe('image/jpg')
+})
+
+test('webp', () => {
+  expect(GetMimeType.getMimeType('.webp')).toBe('image/webp')
+})
+
 test('json', () => {
   expect(GetMimeType.getMimeType('.json')).toBe('application/json')
 })


### PR DESCRIPTION
Support .jpg and .webp file extensions in the shared process MIME type lookup and cover both mappings with regression tests.