### PR TITLE
fix: preserve non-file remote source uris

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemDisk.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemDisk.js
@@ -68,9 +68,6 @@ export const readDirWithFileTypes = (path) => {
 }
 
 export const getBlobUrl = (path) => {
-  if (!path.startsWith('/')) {
-    path = `/${path}`
-  }
   return GetRemoteSrc.getRemoteSrc(path)
 }
 

--- a/packages/renderer-worker/src/parts/GetRemoteSrc/GetRemoteSrc.js
+++ b/packages/renderer-worker/src/parts/GetRemoteSrc/GetRemoteSrc.js
@@ -1,4 +1,16 @@
 export const getRemoteSrc = (uri) => {
-  const src = `/remote${uri}`
-  return src
+  const isWindowsPath = /^[a-zA-Z]:[\\/]/.test(uri)
+  if (!isWindowsPath) {
+    try {
+      const url = new URL(uri)
+      if (url.protocol !== 'file:') {
+        return uri
+      }
+      uri = url.pathname
+    } catch {
+      // The URI is a file system path.
+    }
+  }
+  const normalizedUri = uri.replaceAll('\\', '/')
+  return normalizedUri.startsWith('/') ? `/remote${normalizedUri}` : `/remote/${normalizedUri}`
 }

--- a/packages/renderer-worker/test/FileSystemDisk.test.ts
+++ b/packages/renderer-worker/test/FileSystemDisk.test.ts
@@ -18,6 +18,14 @@ const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js'
 
 const FileSystemDisk = await import('../src/parts/FileSystem/FileSystemDisk.js')
 
+test('getBlobUrl preserves a memfs uri', () => {
+  expect(FileSystemDisk.getBlobUrl('memfs:///workspace/image.svg')).toBe('memfs:///workspace/image.svg')
+})
+
+test('getBlobUrl converts a file uri to a remote source', () => {
+  expect(FileSystemDisk.getBlobUrl('file:///tmp/image.svg')).toBe('/remote/tmp/image.svg')
+})
+
 test.skip('readFile', async () => {
   // @ts-ignore
   SharedProcess.invoke.mockImplementation((method, ...parameters) => {

--- a/packages/renderer-worker/test/GetRemoteSrc.test.ts
+++ b/packages/renderer-worker/test/GetRemoteSrc.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@jest/globals'
+import * as GetRemoteSrc from '../src/parts/GetRemoteSrc/GetRemoteSrc.js'
+
+test('preserves a memfs uri', () => {
+  expect(GetRemoteSrc.getRemoteSrc('memfs:///workspace/image.svg')).toBe('memfs:///workspace/image.svg')
+})
+
+test('preserves an https uri', () => {
+  expect(GetRemoteSrc.getRemoteSrc('https://example.com/image.svg')).toBe('https://example.com/image.svg')
+})
+
+test('converts a file uri to a remote source', () => {
+  expect(GetRemoteSrc.getRemoteSrc('file:///tmp/image.svg')).toBe('/remote/tmp/image.svg')
+})
+
+test('converts an absolute path to a remote source', () => {
+  expect(GetRemoteSrc.getRemoteSrc('/tmp/image.svg')).toBe('/remote/tmp/image.svg')
+})
+
+test('converts a relative path to a remote source', () => {
+  expect(GetRemoteSrc.getRemoteSrc('tmp/image.svg')).toBe('/remote/tmp/image.svg')
+})
+
+test('converts a windows path to a remote source', () => {
+  expect(GetRemoteSrc.getRemoteSrc('C:\\workspace\\image.svg')).toBe('/remote/C:/workspace/image.svg')
+})


### PR DESCRIPTION
Preserve valid non-file URIs when resolving renderer sources so memfs items are not sent to /remote. Continue mapping file URIs and filesystem paths to the /remote endpoint, with focused regression coverage.