### PR TITLE
fix: keep preview activity item active with sidebar

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -468,11 +468,40 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
   }
 }
 
+const renderActivityBarCommands = async (activityBarId: number) => {
+  const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', activityBarId)
+  return ActivityBarWorker.invoke('ActivityBar.render2', activityBarId, diffResult)
+}
+
 const renderSideBarActivityBarCommands = async (activityBarId: number, sideBarView: string, sideBarVisible: boolean) => {
   await ActivityBarWorker.invoke('ActivityBar.handleSideBarStateChange', activityBarId, sideBarView, sideBarVisible)
-  const diffResult = await ActivityBarWorker.invoke('ActivityBar.diff2', activityBarId)
-  const activityBarCommands = await ActivityBarWorker.invoke('ActivityBar.render2', activityBarId, diffResult)
-  return activityBarCommands
+  return renderActivityBarCommands(activityBarId)
+}
+
+const getActivePreviewViewId = (state: LayoutState) => {
+  if (!state.previewVisible || state.previewViewletId !== ViewletModuleId.ExtensionView) {
+    return ''
+  }
+  return state.previewUri
+}
+
+const renderPreviewActivityBarCommands = async (oldState: LayoutState, newState: LayoutState) => {
+  const { activityBarId } = newState
+  if (activityBarId === -1) {
+    return []
+  }
+  const oldViewId = getActivePreviewViewId(oldState)
+  const newViewId = getActivePreviewViewId(newState)
+  if (oldViewId === newViewId) {
+    return []
+  }
+  if (oldViewId) {
+    await ActivityBarWorker.invoke('ActivityBar.handleActiveViewStateChange', activityBarId, oldViewId, false)
+  }
+  if (newViewId) {
+    await ActivityBarWorker.invoke('ActivityBar.handleActiveViewStateChange', activityBarId, newViewId, true)
+  }
+  return renderActivityBarCommands(activityBarId)
 }
 
 const renderActivityBarAuthCommands = async (state: LayoutState) => {
@@ -984,7 +1013,12 @@ export const showPreview = async (state: LayoutState, uri: string = state.previe
 
   if (previewVisible && previewId !== -1) {
     if (state.previewViewletId !== previewViewletId || (previewViewletId === ViewletModuleId.ExtensionView && state.previewUri !== uri)) {
-      return replacePreview(state, uri, previewViewletId)
+      const result = await replacePreview(state, uri, previewViewletId)
+      const activityBarCommands = await renderPreviewActivityBarCommands(state, result.newState)
+      return {
+        newState: result.newState,
+        commands: [...result.commands, ...activityBarCommands],
+      }
     }
     if (previewViewletId === ViewletModuleId.Preview) {
       await Command.execute('Preview.setUri', uri)
@@ -1007,14 +1041,20 @@ export const showPreview = async (state: LayoutState, uri: string = state.previe
   ViewletStates.setState(uid, partialNewState)
   // @ts-ignore
   const result = await show(partialNewState, LayoutModules.Preview)
+  const activityBarCommands = await renderPreviewActivityBarCommands(state, result.newState)
   return {
-    ...result,
     newState: result.newState,
+    commands: [...result.commands, ...activityBarCommands],
   }
 }
 
-export const hidePreview = (state: LayoutState) => {
-  return hide(state, LayoutModules.Preview)
+export const hidePreview = async (state: LayoutState) => {
+  const result = await hide(state, LayoutModules.Preview)
+  const activityBarCommands = await renderPreviewActivityBarCommands(state, result.newState)
+  return {
+    newState: result.newState,
+    commands: [...result.commands, ...activityBarCommands],
+  }
 }
 
 export const togglePreview = (state: LayoutState, uri: string = state.previewUri) => {

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -133,6 +133,7 @@ const mockActivityBarRender = () => {
   // @ts-ignore
   ActivityBarWorker.invoke.mockImplementation(async (method, ...args) => {
     switch (method) {
+      case 'ActivityBar.handleActiveViewStateChange':
       case 'ActivityBar.handleSideBarStateChange':
         return undefined
       case 'ActivityBar.diff2':
@@ -704,9 +705,15 @@ test('toggleSideBarView opens a preview-preferred extension view alongside the s
     true,
     undefined,
   )
+  expect(activityBarInvokeMock.mock.calls).toEqual([
+    ['ActivityBar.handleActiveViewStateChange', 7, 'sample.views.preview', true],
+    ['ActivityBar.diff2', 7],
+    ['ActivityBar.render2', 7, 'diff-1'],
+  ])
 })
 
 test('toggleSideBarView hides the preview when its selected activity item is clicked again', async () => {
+  mockActivityBarRender()
   // @ts-ignore
   GetExtensionViews.getExtensionView.mockResolvedValue({
     id: 'sample.views.preview',
@@ -714,6 +721,7 @@ test('toggleSideBarView hides the preview when its selected activity item is cli
   })
   const state = {
     ...ViewletLayout.create(1),
+    activityBarId: 7,
     previewId: 11,
     previewUri: 'sample.views.preview',
     previewViewletId: 'ExtensionView',
@@ -728,6 +736,66 @@ test('toggleSideBarView hides the preview when its selected activity item is cli
   })
   expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(11, 'ExtensionView')
   expect(Viewlet.disposeFunctional).toHaveBeenCalledWith(11)
+  expect(activityBarInvokeMock.mock.calls).toEqual([
+    ['ActivityBar.handleActiveViewStateChange', 7, 'sample.views.preview', false],
+    ['ActivityBar.diff2', 7],
+    ['ActivityBar.render2', 7, 'diff-1'],
+  ])
+})
+
+test('showPreview updates both activity items when replacing a preview extension view', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'ExtensionView', 1, true]])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    previewId: 11,
+    previewUri: 'sample.views.first',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+  }
+
+  const result = await ViewletLayout.showPreview(state, 'sample.views.second', 'ExtensionView')
+
+  expect(result.newState).toMatchObject({
+    previewUri: 'sample.views.second',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+  })
+  expect(activityBarInvokeMock.mock.calls).toEqual([
+    ['ActivityBar.handleActiveViewStateChange', 7, 'sample.views.first', false],
+    ['ActivityBar.handleActiveViewStateChange', 7, 'sample.views.second', true],
+    ['ActivityBar.diff2', 7],
+    ['ActivityBar.render2', 7, 'diff-1'],
+  ])
+})
+
+test('showPreview deactivates a preview extension item when a file preview replaces it', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.createFunctionalRoot', 'Preview', 1, true]])
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    previewId: 11,
+    previewUri: 'sample.views.preview',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+  }
+
+  const result = await ViewletLayout.showPreview(state, 'file:///readme.md')
+
+  expect(result.newState).toMatchObject({
+    previewUri: 'file:///readme.md',
+    previewViewletId: 'Preview',
+    previewVisible: true,
+  })
+  expect(activityBarInvokeMock.mock.calls).toEqual([
+    ['ActivityBar.handleActiveViewStateChange', 7, 'sample.views.preview', false],
+    ['ActivityBar.diff2', 7],
+    ['ActivityBar.render2', 7, 'diff-1'],
+  ])
 })
 
 test.each([
@@ -772,6 +840,11 @@ test.each([
   })
   expect(SaveState.saveViewletStateWithStorageId).not.toHaveBeenCalled()
   expect(Viewlet.disposeFunctional).not.toHaveBeenCalledWith(11)
+  expect(activityBarInvokeMock.mock.calls).toEqual([
+    ['ActivityBar.handleSideBarStateChange', 7, sideBarView, true],
+    ['ActivityBar.diff2', 7],
+    ['ActivityBar.render2', 7, 'diff-1'],
+  ])
   if (!sideBarVisible) {
     expect(ViewletManager.load).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
Keep preview-preferred extension views active independently from the primary sidebar activity item. Synchronize preview open, close, and replacement transitions back to the activity bar, with regression coverage for opening and switching sidebar views while a preview view remains visible.