### PR TITLE
fix: use configured product name in dialogs

### DIFF
--- a/packages/renderer-worker/src/parts/ElectronDialog/ElectronDialog.js
+++ b/packages/renderer-worker/src/parts/ElectronDialog/ElectronDialog.js
@@ -26,7 +26,7 @@ export const showOpenDialog = (title, properties) => {
 export const showMessageBox = async (options) => {
   // TODO maybe request window id here instead of at caller
   Assert.object(options)
-  const productName = await Product.getProductNameLong()
+  const productName = options.productName ?? (await Product.getProductNameLong())
   const windowId = await GetWindowId.getWindowId()
   const finalOptions = {
     ...options,

--- a/packages/renderer-worker/test/ElectronDialog.test.ts
+++ b/packages/renderer-worker/test/ElectronDialog.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetWindowId/GetWindowId.js', () => ({
+  getWindowId: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({
+  getProductNameLong: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const ElectronDialog = await import('../src/parts/ElectronDialog/ElectronDialog.js')
+const GetWindowId = await import('../src/parts/GetWindowId/GetWindowId.js')
+const Product = await import('../src/parts/Product/Product.js')
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(GetWindowId.getWindowId).mockResolvedValue(42)
+  jest.mocked(Product.getProductNameLong).mockReturnValue('Lvce Editor - OSS')
+})
+
+test('showMessageBox - preserves configured product name', async () => {
+  await ElectronDialog.showMessageBox({
+    buttons: ['Ok'],
+    message: 'Lvce Editor',
+    productName: 'Lvce Editor',
+  })
+
+  expect(Product.getProductNameLong).not.toHaveBeenCalled()
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('ElectronDialog.showMessageBox', {
+    buttons: ['Ok'],
+    message: 'Lvce Editor',
+    productName: 'Lvce Editor',
+    windowId: 42,
+  })
+})
+
+test('showMessageBox - uses default product name', async () => {
+  await ElectronDialog.showMessageBox({
+    buttons: ['Ok'],
+    message: 'Message',
+  })
+
+  expect(Product.getProductNameLong).toHaveBeenCalledTimes(1)
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('ElectronDialog.showMessageBox', {
+    buttons: ['Ok'],
+    message: 'Message',
+    productName: 'Lvce Editor - OSS',
+    windowId: 42,
+  })
+})


### PR DESCRIPTION
Preserve an explicitly configured dialog product name so the production About dialog uses the bundled config.json branding. Keep the renderer product name as the fallback for dialogs without an explicit value.