### PR TITLE
Improve output link color

### DIFF
--- a/static/css/parts/ViewletOutput.css
+++ b/static/css/parts/ViewletOutput.css
@@ -27,6 +27,14 @@
   overflow: auto;
 }
 
+.OutputContent a {
+  color: var(--vscode-textLink-foreground, dodgerblue);
+}
+
+.OutputContent a:hover {
+  color: var(--vscode-textLink-activeForeground, #4daafc);
+}
+
 .Output .Line {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Use the editor link theme color for output channel links, with a Dodger Blue fallback for themes that do not define it.