### PR TITLE
fix: run JavaScript language servers with Electron Node

### DIFF
--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -57,13 +57,20 @@ export interface LanguageServerConnectionOptions {
   readonly uri: string
 }
 
-const getSpawnOptions = (uri: string, argv: readonly string[]): { readonly args: readonly string[]; readonly command: string } => {
+export const getSpawnOptions = (
+  uri: string,
+  argv: readonly string[],
+): { readonly args: readonly string[]; readonly command: string; readonly env?: NodeJS.ProcessEnv } => {
   const executablePath = fileURLToPath(uri)
   const extension = extname(executablePath).toLowerCase()
   if (extension === '.js' || extension === '.mjs' || extension === '.cjs') {
     return {
       args: [executablePath, ...argv],
       command: process.execPath,
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+      },
     }
   }
   return {
@@ -127,8 +134,9 @@ export class LanguageServerConnection {
 
   constructor({ argv, rootUri, uri }: LanguageServerConnectionOptions) {
     this.rootUri = rootUri
-    const { args, command } = getSpawnOptions(uri, argv)
+    const { args, command, env } = getSpawnOptions(uri, argv)
     this.child = spawn(command, [...args], {
+      env,
       stdio: ['pipe', 'pipe', 'pipe'],
     })
     this.child.stdout.on('data', (chunk: Buffer) => {

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -13,9 +13,10 @@ afterEach(() => {
 
 test('JavaScript language servers use Electron as Node', () => {
   const serverUri = pathToFileURL('/tmp/language-server.mjs').href
+  const serverPath = fileURLToPath(serverUri)
 
   expect(getSpawnOptions(serverUri, ['--stdio'])).toMatchObject({
-    args: ['/tmp/language-server.mjs', '--stdio'],
+    args: [serverPath, '--stdio'],
     command: process.execPath,
     env: {
       ELECTRON_RUN_AS_NODE: '1',
@@ -25,10 +26,11 @@ test('JavaScript language servers use Electron as Node', () => {
 
 test('native language servers inherit the current environment unchanged', () => {
   const serverUri = pathToFileURL('/tmp/language-server').href
+  const serverPath = fileURLToPath(serverUri)
 
   expect(getSpawnOptions(serverUri, ['--stdio'])).toEqual({
     args: ['--stdio'],
-    command: '/tmp/language-server',
+    command: serverPath,
   })
 })
 

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { complete, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
+import { getSpawnOptions } from '../src/parts/LanguageServerConnection/LanguageServerConnection.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
 const completionOnlyServerScript = fileURLToPath(new URL('./fixtures/languageServerCompletionOnly.js', import.meta.url))
@@ -8,6 +9,27 @@ const pushDiagnosticsServerScript = fileURLToPath(new URL('./fixtures/languageSe
 
 afterEach(() => {
   disposeAll()
+})
+
+test('JavaScript language servers use Electron as Node', () => {
+  const serverUri = pathToFileURL('/tmp/language-server.mjs').href
+
+  expect(getSpawnOptions(serverUri, ['--stdio'])).toMatchObject({
+    args: ['/tmp/language-server.mjs', '--stdio'],
+    command: process.execPath,
+    env: {
+      ELECTRON_RUN_AS_NODE: '1',
+    },
+  })
+})
+
+test('native language servers inherit the current environment unchanged', () => {
+  const serverUri = pathToFileURL('/tmp/language-server').href
+
+  expect(getSpawnOptions(serverUri, ['--stdio'])).toEqual({
+    args: ['--stdio'],
+    command: '/tmp/language-server',
+  })
 })
 
 test('complete starts a stdio language server and synchronizes documents', async () => {


### PR DESCRIPTION
Launch JavaScript language servers through the current Electron executable with ELECTRON_RUN_AS_NODE=1. Native language-server launch behavior remains unchanged.