### PR TITLE
fix: enable save in file menu

### DIFF
--- a/packages/renderer-worker/src/parts/MenuEntriesFile/MenuEntriesFile.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesFile/MenuEntriesFile.js
@@ -44,7 +44,7 @@ export const getMenuEntries = () => {
     {
       id: 'save',
       label: FileStrings.save(),
-      flags: MenuItemFlags.Disabled,
+      flags: MenuItemFlags.None,
       command: 'Main.save',
     },
     {

--- a/packages/renderer-worker/test/MenuEntriesFile.test.ts
+++ b/packages/renderer-worker/test/MenuEntriesFile.test.ts
@@ -25,7 +25,7 @@ test('getMenuEntries', () => {
   })
   expect(menuEntries).toContainEqual({
     command: 'Main.save',
-    flags: MenuItemFlags.Disabled,
+    flags: MenuItemFlags.None,
     id: 'save',
     label: 'Save',
   })


### PR DESCRIPTION
Enables the implemented Save command in the File menu so modified editors can be saved from the menu.