### PR TITLE
fix: normalize published diagnostic uris

### DIFF
--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -6,6 +6,7 @@ import {
   executeMarkdownLanguageServerRequest,
   isMarkdownLanguageServerRequest,
 } from '../MarkdownLanguageServerRequest/MarkdownLanguageServerRequest.ts'
+import { normalizeLanguageServerDocumentUri } from '../NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
 
 interface JsonRpcMessage {
   readonly error?: {
@@ -411,12 +412,13 @@ export class LanguageServerConnection {
     if (typeof uri !== 'string' || !Array.isArray(diagnostics)) {
       return
     }
-    this.publishedDiagnostics.set(uri, diagnostics)
-    const waiters = this.diagnosticWaiters.get(uri)
+    const normalizedUri = normalizeLanguageServerDocumentUri(uri)
+    this.publishedDiagnostics.set(normalizedUri, diagnostics)
+    const waiters = this.diagnosticWaiters.get(normalizedUri)
     if (!waiters) {
       return
     }
-    this.diagnosticWaiters.delete(uri)
+    this.diagnosticWaiters.delete(normalizedUri)
     for (const waiter of waiters) {
       waiter.resolve(diagnostics)
     }

--- a/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
+++ b/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
@@ -15,9 +15,6 @@ const normalizeRemoteFileUrl = (uri: string): string | undefined => {
 }
 
 export const normalizeLanguageServerDocumentUri = (uri: string): string => {
-  if (uri.startsWith('/')) {
-    return pathToFileURL(uri).href
-  }
-  const normalizedUri = normalizeRemoteFileUrl(uri) || uri
+  const normalizedUri = uri.startsWith('/') ? pathToFileURL(uri).href : normalizeRemoteFileUrl(uri) || uri
   return normalizedUri.replace(windowsFileUriRegex, (_, driveLetter: string) => `file:///${driveLetter.toLowerCase()}%3A`)
 }

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -134,21 +134,42 @@ test('diagnostic supports published diagnostics and uses the provided workspace 
   ).resolves.toEqual([])
 })
 
-test(
-  'diagnostic resolves when a completion-only server does not publish diagnostics',
-  async () => {
-    const options = {
-      argv: [completionOnlyServerScript],
-      id: 'sample.completion-only-fixture',
-      textDocument: {
-        languageId: 'typescript',
-        text: 'const value = 1',
-        uri: '/tmp/sample.ts',
-      },
-      uri: pathToFileURL(process.execPath).href,
-    }
+test('diagnostic normalizes Windows URIs published by a language server', async () => {
+  const options = {
+    argv: [pushDiagnosticsServerScript, '--uppercase-windows-uri'],
+    id: 'sample.windows-push-diagnostics-fixture',
+    rootUri: 'file:///D:/workspace',
+    textDocument: {
+      languageId: 'erlang',
+      text: 'invalid',
+      uri: 'file:///D:/workspace/src/main.erl',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
 
-    await expect(diagnostic(options)).resolves.toEqual([])
-  },
-  2000,
-)
+  await expect(diagnostic(options)).resolves.toEqual([
+    {
+      message: 'fixtureDiagnostic:invalid:file:///d%3A/workspace',
+      range: {
+        end: { character: 3, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+      severity: 2,
+    },
+  ])
+})
+
+test('diagnostic resolves when a completion-only server does not publish diagnostics', async () => {
+  const options = {
+    argv: [completionOnlyServerScript],
+    id: 'sample.completion-only-fixture',
+    textDocument: {
+      languageId: 'typescript',
+      text: 'const value = 1',
+      uri: '/tmp/sample.ts',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+
+  await expect(diagnostic(options)).resolves.toEqual([])
+}, 2000)

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'node:url'
 import { normalizeLanguageServerDocumentUri } from '../src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
 
 test('normalizes an absolute path', () => {
-  expect(normalizeLanguageServerDocumentUri('/tmp/README.md')).toBe(pathToFileURL('/tmp/README.md').href)
+  expect(normalizeLanguageServerDocumentUri('/tmp/README.md')).toBe(normalizeLanguageServerDocumentUri(pathToFileURL('/tmp/README.md').href))
 })
 
 test('normalizes a Windows file URI', () => {

--- a/packages/shared-process/test/fixtures/languageServerPushDiagnostics.js
+++ b/packages/shared-process/test/fixtures/languageServerPushDiagnostics.js
@@ -10,6 +10,9 @@ const send = (message) => {
 
 /** @param {string} uri @param {string} text */
 const publishDiagnostics = (uri, text) => {
+  const publishedUri = process.argv.includes('--uppercase-windows-uri')
+    ? uri.replace(/^file:\/\/\/([a-z])%3A/i, (_, driveLetter) => `file:///${driveLetter.toUpperCase()}:`)
+    : uri
   const diagnostics =
     text === 'valid'
       ? []
@@ -28,7 +31,7 @@ const publishDiagnostics = (uri, text) => {
     method: 'textDocument/publishDiagnostics',
     params: {
       diagnostics,
-      uri,
+      uri: publishedUri,
     },
   })
 }


### PR DESCRIPTION
Normalize language-server `publishDiagnostics` URIs before matching them against document waiters and cached results.

Adds regression coverage for Windows drive-letter casing and colon encoding differences.