### PR TITLE
fix: use standard Windows language server file uris

### DIFF
--- a/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
+++ b/packages/shared-process/src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts
@@ -16,5 +16,5 @@ const normalizeRemoteFileUrl = (uri: string): string | undefined => {
 
 export const normalizeLanguageServerDocumentUri = (uri: string): string => {
   const normalizedUri = uri.startsWith('/') ? pathToFileURL(uri).href : normalizeRemoteFileUrl(uri) || uri
-  return normalizedUri.replace(windowsFileUriRegex, (_, driveLetter: string) => `file:///${driveLetter.toLowerCase()}%3A`)
+  return normalizedUri.replace(windowsFileUriRegex, (_, driveLetter: string) => `file:///${driveLetter.toLowerCase()}:`)
 }

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -149,7 +149,7 @@ test('diagnostic normalizes Windows URIs published by a language server', async 
 
   await expect(diagnostic(options)).resolves.toEqual([
     {
-      message: 'fixtureDiagnostic:invalid:file:///d%3A/workspace',
+      message: 'fixtureDiagnostic:invalid:file:///d:/workspace',
       range: {
         end: { character: 3, line: 0 },
         start: { character: 0, line: 0 },

--- a/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
+++ b/packages/shared-process/test/NormalizeLanguageServerDocumentUri.test.ts
@@ -7,11 +7,11 @@ test('normalizes an absolute path', () => {
 })
 
 test('normalizes a Windows file URI', () => {
-  expect(normalizeLanguageServerDocumentUri('file:///D:/workspace/README.md')).toBe('file:///d%3A/workspace/README.md')
+  expect(normalizeLanguageServerDocumentUri('file:///D:/workspace/README.md')).toBe('file:///d:/workspace/README.md')
 })
 
 test('normalizes an encoded Windows file URI', () => {
-  expect(normalizeLanguageServerDocumentUri('file:///D%3A/workspace/README.md')).toBe('file:///d%3A/workspace/README.md')
+  expect(normalizeLanguageServerDocumentUri('file:///D%3A/workspace/README.md')).toBe('file:///d:/workspace/README.md')
 })
 
 test('preserves a normalized file URI', () => {
@@ -20,7 +20,7 @@ test('preserves a normalized file URI', () => {
 
 test('normalizes a remote file URL', () => {
   expect(normalizeLanguageServerDocumentUri('http://localhost:41283/remote/C:/My%20Project/src/Main.elm')).toBe(
-    'file:///c%3A/My%20Project/src/Main.elm',
+    'file:///c:/My%20Project/src/Main.elm',
   )
 })
 

--- a/packages/shared-process/test/fixtures/languageServerPushDiagnostics.js
+++ b/packages/shared-process/test/fixtures/languageServerPushDiagnostics.js
@@ -11,7 +11,7 @@ const send = (message) => {
 /** @param {string} uri @param {string} text */
 const publishDiagnostics = (uri, text) => {
   const publishedUri = process.argv.includes('--uppercase-windows-uri')
-    ? uri.replace(/^file:\/\/\/([a-z])%3A/i, (_, driveLetter) => `file:///${driveLetter.toUpperCase()}:`)
+    ? uri.replace(/^file:\/\/\/([a-z])(?::|%3A)/i, (_, driveLetter) => `file:///${driveLetter.toUpperCase()}:`)
     : uri
   const diagnostics =
     text === 'valid'


### PR DESCRIPTION
Use the standard unescaped drive colon in Windows file URIs sent to native language servers while retaining lowercase drive normalization.

This lets servers such as ELP resolve the workspace and publish diagnostics, while preserving normalized matching for returned URIs.