### PR TITLE
feature: support language server definitions

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -4,5 +4,6 @@ export const name = 'LanguageServer'
 
 export const Commands = {
   complete: LanguageServer.complete,
+  definition: LanguageServer.definition,
   diagnostic: LanguageServer.diagnostic,
 }

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -26,6 +26,8 @@ export interface DiagnosticOptions {
   readonly uri: string
 }
 
+export type DefinitionOptions = CompleteOptions
+
 interface ConnectionState {
   readonly argv: readonly string[]
   readonly connection: LanguageServerConnection
@@ -81,6 +83,16 @@ export const diagnostic = async ({ argv, id, rootUri, textDocument, uri }: Diagn
   const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${normalizedRootUri}`, uri, argv, normalizedRootUri)
   return connection.diagnostic(normalizedDocument)
+}
+
+export const definition = async ({ argv, id, offset, rootUri, textDocument, uri }: DefinitionOptions): Promise<unknown> => {
+  const normalizedDocument = {
+    ...textDocument,
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
+  }
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, uri, argv, normalizedRootUri)
+  return connection.definition(normalizedDocument, offset)
 }
 
 export const disposeAll = (): void => {

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -220,6 +220,18 @@ export class LanguageServerConnection {
     return diagnostics
   }
 
+  async definition(textDocument: TextDocument, offset: number): Promise<unknown> {
+    await this.ready
+    this.configureMarkdown(textDocument.languageId)
+    this.syncDocument(textDocument)
+    return this.sendRequest('textDocument/definition', {
+      position: getPosition(textDocument.text, offset),
+      textDocument: {
+        uri: textDocument.uri,
+      },
+    })
+  }
+
   private configureMarkdown(languageId: string): void {
     if (languageId !== 'markdown' || this.markdownConfigured) {
       return

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -212,6 +212,7 @@ export const getModuleId = (commandId: any): any => {
     case 'IsAutoUpdateSupported.isAutoUpdateSupported':
       return ModuleId.IsAutoUpdateSupported
     case 'LanguageServer.complete':
+    case 'LanguageServer.definition':
     case 'LanguageServer.diagnostic':
       return ModuleId.LanguageServer
     case 'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage':

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { complete, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
+import { complete, definition, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
 import { getSpawnOptions } from '../src/parts/LanguageServerConnection/LanguageServerConnection.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
@@ -74,6 +74,29 @@ test('complete starts a JavaScript language server', async () => {
   }
 
   await expect(complete(options)).resolves.toEqual([{ insertText: 'fixtureCompletion', kind: 6, label: 'fixtureCompletion:con' }])
+})
+
+test('definition starts a stdio language server and synchronizes documents', async () => {
+  const options = {
+    argv: [serverScript],
+    id: 'sample.definition-fixture',
+    offset: 15,
+    rootUri: 'file:///tmp',
+    textDocument: {
+      languageId: 'elm',
+      text: 'value = 1\nmain = value',
+      uri: '/tmp/Main.elm',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+
+  await expect(definition(options)).resolves.toEqual({
+    range: {
+      end: { character: 7, line: 1 },
+      start: { character: 0, line: 1 },
+    },
+    uri: 'file:///tmp/Main.elm?definition=value%20%3D%201%0Amain%20%3D%20value',
+  })
 })
 
 test('diagnostic starts a stdio language server and synchronizes documents', async () => {

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { complete, definition, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
 import { getSpawnOptions } from '../src/parts/LanguageServerConnection/LanguageServerConnection.ts'
+import { normalizeLanguageServerDocumentUri } from '../src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
 const completionOnlyServerScript = fileURLToPath(new URL('./fixtures/languageServerCompletionOnly.js', import.meta.url))
@@ -89,13 +90,14 @@ test('definition starts a stdio language server and synchronizes documents', asy
     },
     uri: pathToFileURL(process.execPath).href,
   }
+  const normalizedDocumentUri = normalizeLanguageServerDocumentUri(options.textDocument.uri)
 
   await expect(definition(options)).resolves.toEqual({
     range: {
       end: { character: 7, line: 1 },
       start: { character: 0, line: 1 },
     },
-    uri: 'file:///tmp/Main.elm?definition=value%20%3D%201%0Amain%20%3D%20value',
+    uri: `${normalizedDocumentUri}?definition=value%20%3D%201%0Amain%20%3D%20value`,
   })
 })
 

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -17,6 +17,7 @@ const handleMessage = (message) => {
       result: {
         capabilities: {
           completionProvider: {},
+          definitionProvider: true,
           diagnosticProvider: {
             interFileDependencies: false,
             workspaceDiagnostics: false,
@@ -42,6 +43,21 @@ const handleMessage = (message) => {
       jsonrpc: '2.0',
       result: {
         items: [{ insertText: 'fixtureCompletion', kind: 6, label: `fixtureCompletion:${text}` }],
+      },
+    })
+    return
+  }
+  if (message.method === 'textDocument/definition') {
+    const text = documents.get(message.params.textDocument.uri)
+    send({
+      id: message.id,
+      jsonrpc: '2.0',
+      result: {
+        range: {
+          end: { character: 7, line: 1 },
+          start: { character: 0, line: 1 },
+        },
+        uri: `${message.params.textDocument.uri}?definition=${encodeURIComponent(text)}`,
       },
     })
     return


### PR DESCRIPTION
Adds shared-process support for LSP textDocument/definition requests so language-server-backed extensions can provide definition locations.