### PR TITLE
fix: support language server document formatting

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -5,4 +5,5 @@ export const name = 'LanguageServer'
 export const Commands = {
   complete: LanguageServer.complete,
   diagnostic: LanguageServer.diagnostic,
+  format: LanguageServer.format,
 }

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -26,6 +26,14 @@ export interface DiagnosticOptions {
   readonly uri: string
 }
 
+export interface FormatOptions {
+  readonly argv: readonly string[]
+  readonly id: string
+  readonly rootUri?: string
+  readonly textDocument: TextDocument
+  readonly uri: string
+}
+
 interface ConnectionState {
   readonly argv: readonly string[]
   readonly connection: LanguageServerConnection
@@ -81,6 +89,16 @@ export const diagnostic = async ({ argv, id, rootUri, textDocument, uri }: Diagn
   const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${normalizedRootUri}`, uri, argv, normalizedRootUri)
   return connection.diagnostic(normalizedDocument)
+}
+
+export const format = async ({ argv, id, rootUri, textDocument, uri }: FormatOptions): Promise<readonly unknown[]> => {
+  const normalizedDocument = {
+    ...textDocument,
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
+  }
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, uri, argv, normalizedRootUri)
+  return connection.format(normalizedDocument)
 }
 
 export const disposeAll = (): void => {

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -32,6 +32,7 @@ interface PendingDiagnostics {
 interface InitializeResult {
   readonly capabilities?: {
     readonly diagnosticProvider?: unknown
+    readonly documentFormattingProvider?: unknown
   }
 }
 
@@ -131,6 +132,7 @@ export class LanguageServerConnection {
   private nextRequestId = 1
   private running = true
   private stderr = ''
+  private supportsDocumentFormatting = false
   private supportsPullDiagnostics = false
 
   constructor({ argv, rootUri, uri }: LanguageServerConnectionOptions) {
@@ -220,6 +222,24 @@ export class LanguageServerConnection {
     return diagnostics
   }
 
+  async format(textDocument: TextDocument): Promise<readonly unknown[]> {
+    await this.ready
+    if (!this.supportsDocumentFormatting) {
+      return []
+    }
+    this.syncDocument(textDocument)
+    const result = await this.sendRequest('textDocument/formatting', {
+      options: {
+        insertSpaces: true,
+        tabSize: 2,
+      },
+      textDocument: {
+        uri: textDocument.uri,
+      },
+    })
+    return Array.isArray(result) ? result : []
+  }
+
   private configureMarkdown(languageId: string): void {
     if (languageId !== 'markdown' || this.markdownConfigured) {
       return
@@ -307,6 +327,7 @@ export class LanguageServerConnection {
         },
       ],
     })) as InitializeResult
+    this.supportsDocumentFormatting = Boolean(result?.capabilities?.documentFormattingProvider)
     this.supportsPullDiagnostics = Boolean(result?.capabilities?.diagnosticProvider)
     this.sendNotification('initialized', {})
     await Promise.race([this.initializationProgressStarted.promise, wait(100)])

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -213,6 +213,7 @@ export const getModuleId = (commandId: any): any => {
       return ModuleId.IsAutoUpdateSupported
     case 'LanguageServer.complete':
     case 'LanguageServer.diagnostic':
+    case 'LanguageServer.format':
       return ModuleId.LanguageServer
     case 'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage':
       return ModuleId.ListProcessesWithMemoryUsage

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { complete, diagnostic, disposeAll } from '../src/parts/LanguageServer/LanguageServer.ts'
+import { complete, diagnostic, disposeAll, format } from '../src/parts/LanguageServer/LanguageServer.ts'
 import { getSpawnOptions } from '../src/parts/LanguageServerConnection/LanguageServerConnection.ts'
 
 const serverScript = fileURLToPath(new URL('./fixtures/languageServer.js', import.meta.url))
@@ -98,6 +98,44 @@ test('diagnostic starts a stdio language server and synchronizes documents', asy
       severity: 2,
     },
   ])
+})
+
+test('format starts a stdio language server and synchronizes documents', async () => {
+  const options = {
+    argv: [serverScript],
+    id: 'sample.fixture',
+    textDocument: {
+      languageId: 'elm',
+      text: 'main = 1',
+      uri: '/tmp/Main.elm',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+
+  await expect(format(options)).resolves.toEqual([
+    {
+      newText: 'formatted:main = 1',
+      range: {
+        end: { character: 8, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+    },
+  ])
+})
+
+test('format returns no edits when the language server does not support document formatting', async () => {
+  await expect(
+    format({
+      argv: [completionOnlyServerScript],
+      id: 'sample.completion-only-fixture',
+      textDocument: {
+        languageId: 'typescript',
+        text: 'const value=1',
+        uri: '/tmp/sample.ts',
+      },
+      uri: pathToFileURL(process.execPath).href,
+    }),
+  ).resolves.toEqual([])
 })
 
 test('diagnostic supports published diagnostics and uses the provided workspace root', async () => {

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -21,6 +21,7 @@ const handleMessage = (message) => {
             interFileDependencies: false,
             workspaceDiagnostics: false,
           },
+          documentFormattingProvider: true,
           textDocumentSync: 1,
         },
       },
@@ -64,6 +65,23 @@ const handleMessage = (message) => {
         ],
         kind: 'full',
       },
+    })
+    return
+  }
+  if (message.method === 'textDocument/formatting') {
+    const text = documents.get(message.params.textDocument.uri)
+    send({
+      id: message.id,
+      jsonrpc: '2.0',
+      result: [
+        {
+          newText: `formatted:${text}`,
+          range: {
+            end: { character: text.length, line: 0 },
+            start: { character: 0, line: 0 },
+          },
+        },
+      ],
     })
   }
 }


### PR DESCRIPTION
Add shared-process support for LSP document formatting requests, including capability detection and document synchronization.