### PR TITLE
fix: support language server code actions

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -3,6 +3,7 @@ import * as LanguageServer from './LanguageServer.ts'
 export const name = 'LanguageServer'
 
 export const Commands = {
+  codeAction: LanguageServer.codeAction,
   complete: LanguageServer.complete,
   definition: LanguageServer.definition,
   diagnostic: LanguageServer.diagnostic,

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -19,6 +19,8 @@ export interface CompleteOptions {
   readonly uri: string
 }
 
+export type CodeActionOptions = CompleteOptions
+
 export interface DiagnosticOptions {
   readonly argv: readonly string[]
   readonly extensionId: string
@@ -86,6 +88,16 @@ export const complete = async ({ argv, extensionId, id, offset, rootUri, textDoc
   const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${normalizedRootUri}`, extensionId, uri, argv, normalizedRootUri)
   return connection.complete(normalizedDocument, offset)
+}
+
+export const codeAction = async ({ argv, extensionId, id, offset, rootUri, textDocument, uri }: CodeActionOptions): Promise<readonly unknown[]> => {
+  const normalizedDocument = {
+    ...textDocument,
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
+  }
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, extensionId, uri, argv, normalizedRootUri)
+  return connection.codeAction(normalizedDocument, offset)
 }
 
 export const diagnostic = async ({ argv, extensionId, id, rootUri, textDocument, uri }: DiagnosticOptions): Promise<readonly unknown[]> => {

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -31,6 +31,7 @@ interface PendingDiagnostics {
 
 interface InitializeResult {
   readonly capabilities?: {
+    readonly codeActionProvider?: unknown
     readonly diagnosticProvider?: unknown
     readonly documentFormattingProvider?: unknown
   }
@@ -91,6 +92,40 @@ const getPosition = (text: string, offset: number): { readonly character: number
   }
 }
 
+interface Position {
+  readonly character: number
+  readonly line: number
+}
+
+interface Range {
+  readonly end: Position
+  readonly start: Position
+}
+
+const comparePositions = (first: Position, second: Position): number => {
+  return first.line - second.line || first.character - second.character
+}
+
+const isPosition = (value: unknown): value is Position => {
+  return (
+    Boolean(value) && typeof value === 'object' && typeof (value as Position).character === 'number' && typeof (value as Position).line === 'number'
+  )
+}
+
+const containsPosition = (value: unknown, position: Position): boolean => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const range = (value as { readonly range?: Range }).range
+  return Boolean(
+    range &&
+    isPosition(range.start) &&
+    isPosition(range.end) &&
+    comparePositions(range.start, position) <= 0 &&
+    comparePositions(position, range.end) <= 0,
+  )
+}
+
 const getWorkspaceName = (rootUri: string): string => {
   try {
     return basename(fileURLToPath(rootUri)) || 'workspace'
@@ -132,6 +167,7 @@ export class LanguageServerConnection {
   private nextRequestId = 1
   private running = true
   private stderr = ''
+  private supportsCodeActions = false
   private supportsDocumentFormatting = false
   private supportsPullDiagnostics = false
 
@@ -170,6 +206,28 @@ export class LanguageServerConnection {
     this.running = false
     this.child.kill()
     this.rejectPendingRequests(new Error('Language server was disposed'))
+  }
+
+  async codeAction(textDocument: TextDocument, offset: number): Promise<readonly unknown[]> {
+    await this.ready
+    if (!this.supportsCodeActions) {
+      return []
+    }
+    const diagnostics = await this.diagnostic(textDocument)
+    const position = getPosition(textDocument.text, offset)
+    const result = await this.sendRequest('textDocument/codeAction', {
+      context: {
+        diagnostics: diagnostics.filter((diagnostic) => containsPosition(diagnostic, position)),
+      },
+      range: {
+        end: position,
+        start: position,
+      },
+      textDocument: {
+        uri: textDocument.uri,
+      },
+    })
+    return Array.isArray(result) ? result : []
   }
 
   async complete(textDocument: TextDocument, offset: number): Promise<readonly unknown[]> {
@@ -339,6 +397,7 @@ export class LanguageServerConnection {
         },
       ],
     })) as InitializeResult
+    this.supportsCodeActions = Boolean(result?.capabilities?.codeActionProvider)
     this.supportsDocumentFormatting = Boolean(result?.capabilities?.documentFormattingProvider)
     this.supportsPullDiagnostics = Boolean(result?.capabilities?.diagnosticProvider)
     this.sendNotification('initialized', {})

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -211,6 +211,7 @@ export const getModuleId = (commandId: any): any => {
       return ModuleId.InstallExtension
     case 'IsAutoUpdateSupported.isAutoUpdateSupported':
       return ModuleId.IsAutoUpdateSupported
+    case 'LanguageServer.codeAction':
     case 'LanguageServer.complete':
     case 'LanguageServer.definition':
     case 'LanguageServer.diagnostic':

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { complete, definition, diagnostic, dispose, disposeAll, format, type CompleteOptions } from '../src/parts/LanguageServer/LanguageServer.ts'
+import {
+  codeAction,
+  complete,
+  definition,
+  diagnostic,
+  dispose,
+  disposeAll,
+  format,
+  type CompleteOptions,
+} from '../src/parts/LanguageServer/LanguageServer.ts'
 import { getSpawnOptions } from '../src/parts/LanguageServerConnection/LanguageServerConnection.ts'
 import { normalizeLanguageServerDocumentUri } from '../src/parts/NormalizeLanguageServerDocumentUri/NormalizeLanguageServerDocumentUri.ts'
 
@@ -77,6 +86,59 @@ test('complete starts a JavaScript language server', async () => {
   }
 
   await expect(complete(options)).resolves.toEqual([{ insertText: 'fixtureCompletion', kind: 6, label: 'fixtureCompletion:con' }])
+})
+
+test('codeAction sends relevant diagnostics and synchronizes documents', async () => {
+  const options = {
+    argv: [serverScript],
+    extensionId: 'sample.extension',
+    id: 'sample.code-action-fixture',
+    offset: 2,
+    textDocument: {
+      languageId: 'elm',
+      text: 'unused',
+      uri: '/tmp/Main.elm',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+  const normalizedDocumentUri = normalizeLanguageServerDocumentUri(options.textDocument.uri)
+
+  await expect(codeAction(options)).resolves.toEqual([
+    {
+      edit: {
+        changes: {
+          [normalizedDocumentUri]: [
+            {
+              newText: 'fixed',
+              range: {
+                end: { character: 2, line: 0 },
+                start: { character: 2, line: 0 },
+              },
+            },
+          ],
+        },
+      },
+      kind: 'quickfix',
+      title: 'fixtureCodeAction:unused:1',
+    },
+  ])
+})
+
+test('codeAction returns no actions when the language server does not support them', async () => {
+  await expect(
+    codeAction({
+      argv: [completionOnlyServerScript],
+      extensionId: 'sample.extension',
+      id: 'sample.completion-only-code-action-fixture',
+      offset: 2,
+      textDocument: {
+        languageId: 'typescript',
+        text: 'const value = 1',
+        uri: '/tmp/sample.ts',
+      },
+      uri: pathToFileURL(process.execPath).href,
+    }),
+  ).resolves.toEqual([])
 })
 
 test('definition starts a stdio language server and synchronizes documents', async () => {

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -16,6 +16,7 @@ const handleMessage = (message) => {
       jsonrpc: '2.0',
       result: {
         capabilities: {
+          codeActionProvider: true,
           completionProvider: {},
           definitionProvider: true,
           diagnosticProvider: {
@@ -46,6 +47,33 @@ const handleMessage = (message) => {
       result: {
         items: [{ insertText: 'fixtureCompletion', kind: 6, label: `fixtureCompletion:${text}${processIdSuffix}` }],
       },
+    })
+    return
+  }
+  if (message.method === 'textDocument/codeAction') {
+    const text = documents.get(message.params.textDocument.uri)
+    send({
+      id: message.id,
+      jsonrpc: '2.0',
+      result: [
+        {
+          edit: {
+            changes: {
+              [message.params.textDocument.uri]: [
+                {
+                  newText: 'fixed',
+                  range: {
+                    end: message.params.range.end,
+                    start: message.params.range.start,
+                  },
+                },
+              ],
+            },
+          },
+          kind: 'quickfix',
+          title: `fixtureCodeAction:${text}:${message.params.context.diagnostics.length}`,
+        },
+      ],
     })
     return
   }


### PR DESCRIPTION
Adds textDocument/codeAction support to the shared language-server client so native language servers can return quick fixes with diagnostics at the cursor.