### PR TITLE
fix: include built-in Erlang highlighting

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -132,6 +132,12 @@
     "created": "2022-06-16"
   },
   {
+    "name": "builtin.language-basics-erlang",
+    "repository": "github.com/lvce-editor/language-basics-erlang",
+    "version": "0.0.2",
+    "created": "2023-07-05"
+  },
+  {
     "name": "builtin.language-basics-elm",
     "repository": "github.com/lvce-editor/language-basics-elm",
     "version": "0.15.5",

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -14,6 +14,19 @@ test('marks bundled extensions as builtin', async () => {
   })
 })
 
+test('includes the built-in Erlang syntax highlighting extension', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+  const extension = extensions.find((item) => item.id === 'builtin.language-basics-erlang')
+
+  expect(extension).toMatchObject({
+    builtin: true,
+    path: '/test-prefix/test-commit/extensions/builtin.language-basics-erlang',
+  })
+})
+
 test('excludes extensions that are not web compatible', async () => {
   const extensions = await getAllExtensionsJson({
     commitHash: 'test-commit',


### PR DESCRIPTION
Bundle the released Erlang language-basics extension so .erl files receive language registration, bracket/comment configuration, and syntax highlighting in LVCE. Add a build inventory regression test that locks in the built-in extension.