### PR TITLE
fix: prevent split editor line numbers from shrinking

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.main-split-down-line-numbers.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-split-down-line-numbers.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-split-down-line-numbers'
+
+export const test: Test = async ({ FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.txt`
+  const content = Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join('\n')
+  await FileSystem.writeFile(uri, content)
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  await Main.splitDown()
+  await Main.openUri(uri)
+
+  const editors = Locator('.Editor')
+  await expect(editors).toHaveCount(2)
+  await expect(editors.nth(0).locator('.LineNumber').first()).toHaveCSS('flex-shrink', '0')
+  await expect(editors.nth(1).locator('.LineNumber').first()).toHaveCSS('flex-shrink', '0')
+}

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -176,6 +176,7 @@
 .DiffEditorLineNumber {
   color: var(--EditorLineNumberForeground, rgba(155, 162, 160, 0.3));
   contain: strict;
+  flex-shrink: 0;
   margin-right: 1px;
   height: var(--EditorLineHeight);
   text-align: right;


### PR DESCRIPTION
## Summary

Prevent editor gutter line numbers from shrinking when the main area is split into top and bottom groups.

Add an end-to-end regression covering line-number sizing in both split editors.