### PR TITLE
fix: size editor gutter for large line numbers

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.editor-large-line-numbers.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-large-line-numbers.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-large-line-numbers'
+
+export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/large.txt`
+  const content = Array.from({ length: 4472 }, (_, index) => `line ${index + 1}`).join('\n')
+  await FileSystem.writeFile(uri, content)
+  await Settings.update({
+    'editor.lineNumbers': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  await Editor.setDeltaY(80_000)
+
+  await expect(Locator('.Gutter')).toHaveCSS('width', /^(3[1-9]|[4-9]\d|\d{3,})(?:\.\d+)?px$/ as unknown as string)
+}

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -161,11 +161,13 @@
 }
 
 .Gutter {
-  contain: strict;
-  width: 30px;
+  contain: layout paint style;
+  flex-shrink: 0;
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-width: 30px;
+  width: max-content;
 }
 
 .Gutter:empty {
@@ -175,9 +177,16 @@
 .LineNumber,
 .DiffEditorLineNumber {
   color: var(--EditorLineNumberForeground, rgba(155, 162, 160, 0.3));
-  contain: strict;
   flex-shrink: 0;
   margin-right: 1px;
   height: var(--EditorLineHeight);
   text-align: right;
+}
+
+.LineNumber {
+  contain: content;
+}
+
+.DiffEditorLineNumber {
+  contain: strict;
 }


### PR DESCRIPTION
Let the editor gutter grow to its visible line-number width while keeping the existing 30px minimum. This prevents four-digit and larger line numbers from being clipped.