### PR TITLE
feature: show active problem counts

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -19,6 +19,7 @@ import * as PanelWorker from '../PanelWorker/PanelWorker.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
 import * as Product from '../Product/Product.js'
 import * as RenderMainAreaPending from '../RenderMainAreaPending/RenderMainAreaPending.ts'
 import { reorderCommands } from '../ReorderCommands/ReorderCommands.js'
@@ -2415,12 +2416,33 @@ export const handleWorkspaceRefresh = async (state: LayoutState, refresh: Worksp
   return result
 }
 
+export const refreshProblemsSummary = async (state: LayoutState): Promise<LayoutStateResult> => {
+  try {
+    const summary = await ProblemsWorker.invoke('Problems.getProblemsSummary')
+    return callGlobalEvent(state, 'handleProblemsSummaryChange', summary)
+  } catch {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
+}
+
+const callGlobalEventAndRefreshProblemsSummary = async (state: LayoutState, eventName: string, ...args): Promise<LayoutStateResult> => {
+  const eventResult = await callGlobalEvent(state, eventName, ...args)
+  const summaryResult = await refreshProblemsSummary(eventResult.newState)
+  return {
+    newState: summaryResult.newState,
+    commands: [...eventResult.commands, ...summaryResult.commands],
+  }
+}
+
 export const handleActiveEditorChange = async (state: LayoutState, activeUri: string) => {
-  return callGlobalEvent(state, 'handleActiveEditorChange', activeUri)
+  return callGlobalEventAndRefreshProblemsSummary(state, 'handleActiveEditorChange', activeUri)
 }
 
 export const handleDiagnosticsChange = async (state: LayoutState, uri: string) => {
-  return callGlobalEvent(state, 'handleDiagnosticsChange', uri)
+  return callGlobalEventAndRefreshProblemsSummary(state, 'handleDiagnosticsChange', uri)
 }
 
 export const handleSettingsChanged = async (state: LayoutState) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -45,6 +45,7 @@ export const CommandsWithSideEffects = {
   handleSashPointerUp: ViewletLayout.handleSashPointerUp,
   handleSettingsChanged: ViewletLayout.handleSettingsChanged,
   handleWorkspaceRefresh: ViewletLayout.handleWorkspaceRefresh,
+  refreshProblemsSummary: ViewletLayout.refreshProblemsSummary,
   refreshSourceControlBadgeCount: ViewletLayout.refreshSourceControlBadgeCount,
   renderMainAreaPending: ViewletLayout.renderMainAreaPending,
   setMountedViewlets: ViewletLayout.setMountedViewlets,

--- a/packages/renderer-worker/src/parts/ViewletPanel/ViewletPanel.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletPanel/ViewletPanel.ipc.ts
@@ -1,4 +1,9 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
+import * as Command from '../Command/Command.js'
+
+export const contentLoadedEffects = async (): Promise<void> => {
+  await Command.execute('Layout.refreshProblemsSummary')
+}
 
 export const {
   Commands,

--- a/packages/renderer-worker/src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js
@@ -1,4 +1,9 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
+import * as Command from '../Command/Command.js'
+
+export const contentLoadedEffects = async () => {
+  await Command.execute('Layout.refreshProblemsSummary')
+}
 
 export const {
   Commands,

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const hydratePreferences = jest.fn()
 const extensionManagementInvoke = jest.fn<(method: string, ...params: readonly unknown[]) => Promise<unknown>>(async () => undefined)
+const problemsInvoke = jest.fn<(method: string, ...params: readonly unknown[]) => Promise<unknown>>(async () => ({
+  errorCount: 0,
+  hasEditor: false,
+  problemCount: 0,
+  warningCount: 0,
+}))
 
 jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => {
   return {
@@ -14,6 +20,12 @@ jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => {
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => {
   return {
     invoke: extensionManagementInvoke,
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ProblemsWorker/ProblemsWorker.ts', () => {
+  return {
+    invoke: problemsInvoke,
   }
 })
 
@@ -177,6 +189,39 @@ test('handleActiveEditorChange ignores viewlets that are not loaded', async () =
   })
 })
 
+test('handleActiveEditorChange refreshes the problems summary for loaded viewlets', async () => {
+  const summary = {
+    errorCount: 2,
+    hasEditor: true,
+    problemCount: 5,
+    warningCount: 1,
+  }
+  problemsInvoke.mockResolvedValueOnce(summary)
+  const panelHandler = jest.fn((state: { uid: number }, receivedSummary) => ({
+    ...state,
+    summary: receivedSummary,
+  }))
+  const statusBarHandler = jest.fn((state: { uid: number }, receivedSummary) => ({
+    ...state,
+    summary: receivedSummary,
+  }))
+  ViewletStates.set('panel', createInstance(1, 'handleProblemsSummaryChange', panelHandler))
+  ViewletStates.set('status-bar', createInstance(2, 'handleProblemsSummaryChange', statusBarHandler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleActiveEditorChange(state, 'file:///test.ts')
+
+  expect(problemsInvoke).toHaveBeenCalledWith('Problems.getProblemsSummary')
+  expect(panelHandler).toHaveBeenCalledWith({ uid: 1 }, summary)
+  expect(statusBarHandler).toHaveBeenCalledWith({ uid: 2 }, summary)
+  expect(result).toEqual({
+    commands: [['render.1'], ['render.2']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
 test('handleDiagnosticsChange forwards the changed uri to loaded viewlets', async () => {
   const handler = jest.fn((state: { uid: number }, uri: string) => {
     return {
@@ -191,6 +236,26 @@ test('handleDiagnosticsChange forwards the changed uri to loaded viewlets', asyn
 
   expect(handler).toHaveBeenCalledWith({ uid: 1 }, 'file:///test.ts')
   expect(ViewletManager.render).toHaveBeenCalledTimes(1)
+  expect(result).toEqual({
+    commands: [['render.1']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
+test('handleDiagnosticsChange keeps the viewlet update when refreshing the problems summary fails', async () => {
+  problemsInvoke.mockRejectedValueOnce(new Error('Failed to query problems'))
+  const handler = jest.fn((state: { uid: number }, uri: string) => ({
+    ...state,
+    refreshedUri: uri,
+  }))
+  ViewletStates.set('problems', createInstance(1, 'handleDiagnosticsChange', handler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleDiagnosticsChange(state, 'file:///test.ts')
+
+  expect(handler).toHaveBeenCalledWith({ uid: 1 }, 'file:///test.ts')
   expect(result).toEqual({
     commands: [['render.1']],
     newState: {

--- a/packages/renderer-worker/test/ViewletProblemsSummaryEffects.test.ts
+++ b/packages/renderer-worker/test/ViewletProblemsSummaryEffects.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const execute = jest.fn<(command: string) => Promise<undefined>>(async () => undefined)
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({ execute }))
+
+const ViewletPanel = await import('../src/parts/ViewletPanel/ViewletPanel.ipc.ts')
+const ViewletStatusBar = await import('../src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('refreshes the problems summary when the panel loads', async () => {
+  await ViewletPanel.contentLoadedEffects()
+
+  expect(execute).toHaveBeenCalledWith('Layout.refreshProblemsSummary')
+})
+
+test('refreshes the problems summary when the status bar loads', async () => {
+  await ViewletStatusBar.contentLoadedEffects()
+
+  expect(execute).toHaveBeenCalledWith('Layout.refreshProblemsSummary')
+})


### PR DESCRIPTION
## Summary

- refresh a stateless problems summary whenever the active editor or diagnostics change
- fan the total problem count to the Problems panel badge and active-editor errors/warnings to the status bar
- hydrate counts whenever the panel or status bar loads, without creating a hidden Problems view
- preserve loaded-view updates when the Problems worker query is unavailable

## Tests

- npm test -- --runInBand (packages/renderer-worker): 1,368 passed
- npm run lint
- npm run type-check
- npm run build:static:ignore-icon-theme
- npm run build:server
- npm run test-static-export