### PR TITLE
feature: add active terminal text command

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -432,6 +432,7 @@ export const commandMap = {
   'Terminals.handleClickTab': lazy('Terminals.handleClickTab'),
   'Terminals.handleMouseDown': lazy('Terminals.handleMouseDown'),
   'Terminals.killTerminal': lazy('Terminals.killTerminal'),
+  'Terminals.sendText': lazy('Terminals.sendText'),
   'Terminals.splitTerminal': lazy('Terminals.splitTerminal'),
   'Test.execute': lazy('Test.execute'),
   'Test.executeAll': lazy('Test.executeAll'),

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -235,6 +235,16 @@ export const handleClickTab = (state, index) => {
   return focusIndex(state, Number(index))
 }
 
+export const sendText = async (state, text) => {
+  Assert.string(text)
+  const { childUid } = state
+  if (childUid === -1) {
+    throw new Error('No active terminal')
+  }
+  await Viewlet.executeViewletCommand(childUid, 'handleInput', text)
+  return state
+}
+
 export const handleClickAction = (state, indexOrCommand, command = indexOrCommand) => {
   Assert.string(command)
   switch (command) {

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminalsCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminalsCommands.js
@@ -6,5 +6,6 @@ export const Commands = {
   handleClickTab: ViewletTerminals.handleClickTab,
   handleMouseDown: ViewletTerminals.handleMouseDown,
   killTerminal: ViewletTerminals.killTerminal,
+  sendText: ViewletTerminals.sendText,
   splitTerminal: ViewletTerminals.splitTerminal,
 }

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -12,3 +12,7 @@ test('registers the viewlet focus-selector bridge command', () => {
 test('registers the viewlet reload command', () => {
   expect(commandMap['Viewlet.reload']).toBeDefined()
 })
+
+test('registers the terminal send text command', () => {
+  expect(commandMap['Terminals.sendText']).toBeDefined()
+})

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 const commandExecute = jest.fn()
 const rendererProcessInvoke = jest.fn()
 const viewletDisposeFunctional = jest.fn((uid) => [['Viewlet.dispose', uid]])
+const viewletExecuteViewletCommand = jest.fn()
 const viewletResize = jest.fn(async (uid, dimensions) => [['Viewlet.setBounds', uid, dimensions]])
 let nextId = 42
 let terminalTabsPreference: boolean | undefined
@@ -47,6 +48,7 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
 jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
   return {
     disposeFunctional: viewletDisposeFunctional,
+    executeViewletCommand: viewletExecuteViewletCommand,
     resize: viewletResize,
   }
 })
@@ -264,6 +266,21 @@ test('handleMouseDown focuses an already active terminal', () => {
     focusVersion: 1,
   })
   expect(ViewletTerminalsRender.renderFocus.apply(state, newState)).toEqual([['Viewlet.focus', 41]])
+})
+
+test('sendText writes text to the active terminal', async () => {
+  const state = createLoadedState()
+
+  await expect(ViewletTerminals.sendText(state, 'echo hello world\r')).resolves.toBe(state)
+
+  expect(viewletExecuteViewletCommand).toHaveBeenCalledWith(41, 'handleInput', 'echo hello world\r')
+})
+
+test('sendText rejects when there is no active terminal', async () => {
+  const state = ViewletTerminals.create(1, '', 10, 20, 800, 400)
+
+  await expect(ViewletTerminals.sendText(state, 'echo hello world\r')).rejects.toThrow('No active terminal')
+  expect(viewletExecuteViewletCommand).not.toHaveBeenCalled()
 })
 
 test('killTerminal disposes the active split and expands the remaining split', async () => {


### PR DESCRIPTION
Adds an editor command that writes text to the active integrated terminal, enabling extensions to run user-visible terminal commands. Includes focused renderer-worker coverage.