### PR TITLE
fix: render panel actions after root creation

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -7,6 +7,7 @@ import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import * as Command from '../Command/Command.js'
 import * as Commit from '../Commit/Commit.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as GetActionsVirtualDom from '../GetActionsVirtualDom/GetActionsVirtualDom.js'
 import * as GetAutoUpdateType from '../GetAutoUpdateType/GetAutoUpdateType.js'
 import * as GetDefaultTitleBarHeight from '../GetDefaultTitleBarHeight/GetDefaultTitleBarHeight.js'
 import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
@@ -1440,8 +1441,12 @@ export const createPanelViewlet = async (
     focus,
     true,
   )
-  const actionsDomIndex = commands.findIndex((command) => command[0] === 'Viewlet.send' && command[2] === 'setActionsDom')
-  const actionsDom = actionsDomIndex === -1 ? [] : commands[actionsDomIndex][3]
+  const actionsDomIndex = commands.findIndex(
+    (command) => (command[0] === 'Viewlet.send' && command[2] === 'setActionsDom') || (command[0] === 'Viewlet.setDom2' && command[1] === actionsUid),
+  )
+  const actionsDomCommand = commands[actionsDomIndex]
+  const actionsDom = actionsDomIndex === -1 ? [] : actionsDomCommand[0] === 'Viewlet.setDom2' ? actionsDomCommand[2] : actionsDomCommand[3]
+  const renderedActionsDom = actionsDom.length === 0 ? GetActionsVirtualDom.getActionsVirtualDom([]) : actionsDom
   if (actionsDomIndex !== -1) {
     commands.splice(actionsDomIndex, 1)
   }
@@ -1451,7 +1456,7 @@ export const createPanelViewlet = async (
   if (events.length > 0) {
     commands.push(['Viewlet.registerEventListeners', actionsUid, events])
   }
-  commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, editorUid])
+  commands.push(['Viewlet.setDom2', actionsUid, renderedActionsDom], ['Viewlet.setUid', actionsUid, editorUid])
   return {
     newState: state,
     commands,

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -486,6 +486,77 @@ test('createPanelViewlet omits empty event listener registration for its new act
   ])
 })
 
+test('createPanelViewlet renders initial actions after creating their root', async () => {
+  const state = ViewletLayout.create(1)
+  const actionsDom = [{ type: 'Button', childCount: 0 }]
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([
+    ['Viewlet.create', 'Terminals', 11],
+    ['Viewlet.setDom2', 33, actionsDom],
+  ])
+
+  const result = await ViewletLayout.createPanelViewlet(
+    state,
+    'Terminals',
+    11,
+    22,
+    33,
+    {
+      x: 0,
+      y: 35,
+      width: 400,
+      height: 200,
+    },
+    '',
+  )
+
+  expect(result.commands).toEqual([
+    ['Viewlet.create', 'Terminals', 11],
+    ['Viewlet.createFunctionalRoot', 'Terminals', 33, true],
+    ['Viewlet.setDom2', 33, actionsDom],
+    ['Viewlet.setUid', 33, 11],
+  ])
+})
+
+test('createPanelViewlet renders an empty actions root when the panel view has no actions', async () => {
+  const state = ViewletLayout.create(1)
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([['Viewlet.create', 'Problems', 11]])
+
+  const result = await ViewletLayout.createPanelViewlet(
+    state,
+    'Problems',
+    11,
+    22,
+    33,
+    {
+      x: 0,
+      y: 35,
+      width: 400,
+      height: 200,
+    },
+    '',
+  )
+
+  expect(result.commands).toEqual([
+    ['Viewlet.create', 'Problems', 11],
+    ['Viewlet.createFunctionalRoot', 'Problems', 33, true],
+    [
+      'Viewlet.setDom2',
+      33,
+      [
+        {
+          childCount: 0,
+          className: 'Actions',
+          role: 'toolbar',
+          type: 4,
+        },
+      ],
+    ],
+    ['Viewlet.setUid', 33, 11],
+  ])
+})
+
 test('createPanelViewlet forwards focus to the loaded panel view', async () => {
   const state = ViewletLayout.create(1)
   // @ts-ignore


### PR DESCRIPTION
Fix panel view creation so contributed actions render only after their functional root exists. Views without contributed actions now receive a valid empty toolbar root, preventing the renderer crash when opening the panel or terminal.