### PR TITLE
fix: fill preview areas beside panel

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -378,6 +378,18 @@ const getPreviewUri = (state: LayoutState, module: LayoutModules.LayoutModule): 
   return module === LayoutModules.SecondaryPreview ? state.secondaryPreviewUri : state.previewUri
 }
 
+const getPreviewBoundsCommand = (uid: number, state: LayoutState, module: LayoutModules.LayoutModule): any[] => {
+  const { kTop, kLeft, kWidth, kHeight } = module
+  return ['Viewlet.setBounds', uid, state[kLeft], state[kTop], state[kWidth], state[kHeight]]
+}
+
+const addPreviewBoundsCommand = (commands: any[], uid: number, state: LayoutState, module: LayoutModules.LayoutModule): void => {
+  if (!isPreviewModule(module) || commands.some((command) => command[0] === 'Viewlet.setBounds' && command[1] === uid)) {
+    return
+  }
+  commands.push(getPreviewBoundsCommand(uid, state, module))
+}
+
 export const loadContent = (state: LayoutState, savedState: any): LayoutState => {
   const { Layout } = savedState
   const { bounds } = Layout
@@ -535,6 +547,7 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
   }
   const restoreState: any = shouldRestore ? undefined : { restore: false }
   const commands = await ViewletManager.load(viewlet, false, shouldRestore, restoreState)
+  addPreviewBoundsCommand(commands, childUid, intermediateState, module)
   if (commands) {
     // commands.push(['Viewlet.append', uid, childUid])
   }
@@ -1116,6 +1129,7 @@ const replacePreview = async (state: LayoutState, uri: string, previewViewletId:
   }
   const loadCommands = await ViewletManager.load(viewlet, false, true, undefined)
   commands.push(...loadCommands)
+  addPreviewBoundsCommand(commands, childUid, state, LayoutModules.Preview)
   const latestState = ViewletStates.getState(state.uid)
   return {
     newState: {
@@ -1228,6 +1242,7 @@ const replaceSecondaryPreview = async (state: LayoutState, uri: string): Promise
   }
   const loadCommands = await ViewletManager.load(viewlet, false, true, undefined)
   commands.push(...loadCommands)
+  addPreviewBoundsCommand(commands, childUid, state, LayoutModules.SecondaryPreview)
   return {
     newState: {
       ...newState,
@@ -1537,6 +1552,9 @@ const loadIfVisible = async (
         height: latestState[kHeight],
       })
       commands.push(...resizeCommands)
+    }
+    if (visible) {
+      addPreviewBoundsCommand(commands, childUid, latestState, module)
     }
     const orderedCommands = reorderCommands(commands)
     return {
@@ -1914,6 +1932,7 @@ const getResizeCommands = async (oldState: LayoutState, newState: LayoutState) =
       if (resizeCommands.length === 1 && resizeCommands[0][0] === 'Viewlet.setBounds' && resizeCommands[0][1] === newState.mainId) {
         return []
       }
+      addPreviewBoundsCommand(resizeCommands, instanceUid, newState, module)
       return [...resizeCommands]
     }),
   )
@@ -1983,6 +2002,7 @@ const showAsync = async (uid, points, module, viewletUid) => {
       true,
     )
     if (commands) {
+      addPreviewBoundsCommand(commands, viewletUid, points, module)
       commands.push(['Viewlet.append', uid, viewletUid])
     }
     await RendererProcess.invoke('Viewlet.sendMultiple', commands)

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -352,6 +352,10 @@ test.each([
 test('showSecondaryPreview keeps an open primary preview mounted', async () => {
   const state = LayoutPoints.getPoints({
     ...ViewletLayout.create(1),
+    panelHeight: 200,
+    panelMaxHeight: 600,
+    panelMinHeight: 150,
+    panelVisible: true,
     previewId: 7,
     previewMinWidth: 100,
     previewUri: 'simple-browser://',
@@ -361,7 +365,9 @@ test('showSecondaryPreview keeps an open primary preview mounted', async () => {
     secondaryPreviewMinWidth: 100,
     secondaryPreviewWidth: 400,
     statusBarHeight: 20,
+    statusBarVisible: true,
     titleBarHeight: 35,
+    titleBarVisible: true,
     windowHeight: 800,
     windowWidth: 1200,
   })
@@ -388,11 +394,24 @@ test('showSecondaryPreview keeps an open primary preview mounted', async () => {
     true,
     undefined,
   )
+  expect(result.newState.secondaryPreviewHeight).toBe(result.newState.windowHeight - result.newState.secondaryPreviewTop)
+  expect(result.commands).toContainEqual([
+    'Viewlet.setBounds',
+    expect.any(Number),
+    result.newState.secondaryPreviewLeft,
+    result.newState.secondaryPreviewTop,
+    result.newState.secondaryPreviewWidth,
+    result.newState.secondaryPreviewHeight,
+  ])
 })
 
 test('showPreview keeps code visible when voice chat is already open', async () => {
   const state = LayoutPoints.getPoints({
     ...ViewletLayout.create(1),
+    panelHeight: 200,
+    panelMaxHeight: 600,
+    panelMinHeight: 150,
+    panelVisible: true,
     previewMinWidth: 100,
     secondaryPreviewId: 8,
     secondaryPreviewMinWidth: 100,
@@ -401,7 +420,9 @@ test('showPreview keeps code visible when voice chat is already open', async () 
     secondaryPreviewVisible: true,
     secondaryPreviewWidth: 600,
     statusBarHeight: 20,
+    statusBarVisible: true,
     titleBarHeight: 35,
+    titleBarVisible: true,
     windowHeight: 800,
     windowWidth: 1200,
   })
@@ -419,6 +440,15 @@ test('showPreview keeps code visible when voice chat is already open', async () 
     secondaryPreviewWidth: 400,
   })
   expect(Viewlet.disposeFunctional).not.toHaveBeenCalledWith(8)
+  expect(result.newState.previewHeight).toBe(result.newState.windowHeight - result.newState.previewTop)
+  expect(result.commands).toContainEqual([
+    'Viewlet.setBounds',
+    expect.any(Number),
+    result.newState.previewLeft,
+    result.newState.previewTop,
+    result.newState.previewWidth,
+    result.newState.previewHeight,
+  ])
 })
 
 test('hideSecondaryPreview leaves the primary preview mounted', async () => {


### PR DESCRIPTION
Ensure primary and secondary preview roots receive their full calculated bounds so they extend beside the panel and status area without leaving an empty strip.