### PR TITLE
Hide scrollbar for diagnostic-only hovers

### DIFF
--- a/static/css/parts/ViewletEditorHover.css
+++ b/static/css/parts/ViewletEditorHover.css
@@ -21,6 +21,10 @@
   pointer-events: all;
 }
 
+.EditorHoverDiagnosticOnly {
+  overflow-y: hidden;
+}
+
 /* TODO use javascript scrollbar */
 .EditorHover::-webkit-scrollbar {
   height: 14px;


### PR DESCRIPTION
Hide vertical overflow for diagnostic-only editor hovers so a one-line ESLint message no longer displays a micro scrollbar. Other hovers retain scrolling.