### PR TITLE
fix: expand quick pick input

### DIFF
--- a/static/css/parts/ViewletQuickPick.css
+++ b/static/css/parts/ViewletQuickPick.css
@@ -32,6 +32,11 @@
   contain: strict;
 }
 
+.QuickPickInputWrapper {
+  display: flex;
+  flex: 1;
+}
+
 .QuickPickItems {
   outline: 0;
   margin: 0;


### PR DESCRIPTION
Expand the Quick Pick input wrapper so the input fills the available header width instead of retaining its intrinsic width.