### PR TITLE
fix: show workspace switch feedback immediately

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -133,7 +133,7 @@ const createRenderTitle = (title) => {
 }
 
 const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
-  const { capabilities = {}, css = [], methods, name, state, variables = [] } = config
+  const { capabilities = {}, css = [], methods, name, state, variables = [], workspaceChangeEvent, workspaceChangeEventPrepend } = config
   const Commands = {}
   const Events = {}
   const idKey = state.idKey
@@ -374,6 +374,8 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     renderTitle,
     resize,
     saveState,
+    workspaceChangeEvent,
+    workspaceChangeEventPrepend,
   }
   workerViewlet.renderContent = workerViewlet.render[0]
   workerViewlet.renderDialog = workerViewlet.render[0]

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -464,7 +464,7 @@ const maybeRegisterEvents = (module) => {
       instance.renderedState = newState
       await RendererProcess.invoke(/* Viewlet.sendMultiple */ kSendMultiple, /* commands */ commands)
     }
-    GlobalEventBus.addListener('workspace.change', handleUpdate)
+    GlobalEventBus.addListener(module.workspaceChangeEvent || 'workspace.change', handleUpdate, { prepend: module.workspaceChangeEventPrepend })
   }
 
   // deprecated, use commands instead

--- a/packages/renderer-worker/src/parts/WorkerViewletConfig/WorkerViewletConfig.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletConfig/WorkerViewletConfig.js
@@ -45,6 +45,12 @@ export const validateWorkerViewletConfig = (workerId, viewlet) => {
       throw new TypeError(`invalid ${workerId} viewlet ${option}`)
     }
   }
+  if (viewlet.workspaceChangeEvent !== undefined && typeof viewlet.workspaceChangeEvent !== 'string') {
+    throw new TypeError(`invalid ${workerId} viewlet workspaceChangeEvent`)
+  }
+  if (viewlet.workspaceChangeEventPrepend !== undefined && typeof viewlet.workspaceChangeEventPrepend !== 'boolean') {
+    throw new TypeError(`invalid ${workerId} viewlet workspaceChangeEventPrepend`)
+  }
   for (const lifecycleName of requiredMethods) {
     validateMethod(workerId, lifecycleName, viewlet.methods?.[lifecycleName])
   }

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -892,6 +892,7 @@
     "contentSecurityPolicy": ["default-src 'none'"],
     "viewlet": {
       "name": "Main",
+      "workspaceChangeEventPrepend": true,
       "css": [
         "/css/parts/EditorTabs.css",
         "/css/parts/FileIcon.css",
@@ -1552,6 +1553,7 @@
     "contentSecurityPolicy": ["default-src 'none'"],
     "viewlet": {
       "name": "TitleBar",
+      "workspaceChangeEvent": "workspace.titleChange",
       "css": [
         "/css/parts/ViewletTitleBar.css", "/css/parts/ViewletTitleBarMenuBar.css", "/css/parts/TitleBarEntry.css",
         "/css/parts/ViewletTitleBarCommandCenter.css", "/css/parts/ViewletTitleBarTitle.css", "/css/parts/ViewletTitleBarButtons.css",

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -18,6 +18,7 @@ export const setPath = async (path) => {
   Assert.string(path)
   // TODO not in electron
   const pathSeparator = await FileSystem.getPathSeparator(path)
+  await updateWindowTitle(path, pathSeparator)
   if (path !== state.workspacePath) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }
@@ -33,6 +34,7 @@ export const setUri = async (uri, providedPathSeparator) => {
   const protocol = GetProtocol.getProtocol(uri)
   const path = protocol === 'file' ? decodeURIComponent(uri.slice('file://'.length)) : uri
   const pathSeparator = providedPathSeparator ?? (await FileSystem.getPathSeparator(uri))
+  await updateWindowTitle(path, pathSeparator)
   if (path !== state.workspacePath) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }
@@ -56,12 +58,17 @@ export const close = () => {
 
 export { isTest } from '../IsTest/IsTest.js'
 
-const getTitle = (workspacePath) => {
+const getTitle = (workspacePath, pathSeparator) => {
   if (!workspacePath) {
     return Product.getProductNameLong()
   }
-  const pathSeparator = state.pathSeparator
   return workspacePath.slice(workspacePath.lastIndexOf(pathSeparator) + 1)
+}
+
+const updateWindowTitle = async (workspacePath, pathSeparator) => {
+  const title = getTitle(workspacePath, pathSeparator)
+  await WindowTitle.set(title)
+  await GlobalEventBus.emitEvent('workspace.titleChange', workspacePath)
 }
 
 const getPathName = (workspacePath) => {
@@ -75,8 +82,6 @@ const getPathName = (workspacePath) => {
 }
 
 const onWorkspaceChange = async () => {
-  const title = getTitle(state.workspacePath)
-  await WindowTitle.set(title)
   if (Platform.getPlatform() === PlatformType.Web || Platform.getPlatform() === PlatformType.Remote) {
     const pathName = getPathName(state.workspacePath)
     await Location.setPathName(pathName)
@@ -113,6 +118,7 @@ export const hydrate = async ({ href }) => {
   if (state.workspaceUri && state.workspaceUri.startsWith('/')) {
     state.workspaceUri = `file://${state.workspaceUri}`
   }
+  await updateWindowTitle(state.workspacePath, state.pathSeparator)
   await onWorkspaceChange()
 }
 

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -84,6 +84,21 @@ test('passes test mode to the explorer worker', async () => {
   expect(invoke.mock.calls[0]).toEqual(['Explorer.create', 7, 'test://explorer', 1, 2, 300, 200, null, 5, 2, 'test://assets', true])
 })
 
+test('exposes the configured workspace change behavior', () => {
+  const viewlet = createWorkerViewletWithDependencies({
+    config: createConfig({ workspaceChangeEvent: 'workspace.titleChange', workspaceChangeEventPrepend: true }),
+    worker: { invoke: jest.fn(), restart: jest.fn() },
+  })
+
+  expect(viewlet.workspaceChangeEvent).toBe('workspace.titleChange')
+  expect(viewlet.workspaceChangeEventPrepend).toBe(true)
+})
+
+test('configures immediate workspace feedback for the title bar and main area', () => {
+  expect(getWorkerViewletConfig('titleBar').workspaceChangeEvent).toBe('workspace.titleChange')
+  expect(getWorkerViewletConfig('mainArea').workspaceChangeEventPrepend).toBe(true)
+})
+
 test('creates command wrappers through the same lifecycle seam', async () => {
   const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
     if (method === 'Example.getCommandIds') {

--- a/packages/renderer-worker/test/WorkspaceBeforeChange.test.ts
+++ b/packages/renderer-worker/test/WorkspaceBeforeChange.test.ts
@@ -1,17 +1,22 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const calls: any[] = []
+
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   getPathSeparator: jest.fn(async () => '/'),
 }))
 
 jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
-  set: jest.fn(async () => {}),
+  set: jest.fn(async (title) => {
+    calls.push(['title', title])
+  }),
 }))
 
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
+  calls.length = 0
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = '/old-workspace'
@@ -19,7 +24,9 @@ beforeEach(() => {
 })
 
 test('saves the outgoing workspace before changing to the next workspace', async () => {
-  const calls: any[] = []
+  GlobalEventBus.addListener('workspace.titleChange', (newPath) => {
+    calls.push(['title-change', newPath, Workspace.getWorkspacePath()])
+  })
   GlobalEventBus.addListener('workspace.beforeChange', (oldPath, newPath) => {
     calls.push(['before', oldPath, newPath, Workspace.getWorkspacePath()])
   })
@@ -30,6 +37,8 @@ test('saves the outgoing workspace before changing to the next workspace', async
   await Workspace.setPath('/new-workspace')
 
   expect(calls).toEqual([
+    ['title', 'new-workspace'],
+    ['title-change', '/new-workspace', '/old-workspace'],
     ['before', '/old-workspace', '/new-workspace', '/old-workspace'],
     ['after', '/new-workspace', '/new-workspace'],
   ])


### PR DESCRIPTION
Update the native and custom title bars before saving the outgoing workspace, and prioritize restored editor content ahead of other serial workspace refreshes.