### PR TITLE
fix: load extension detail table styles

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -561,7 +561,7 @@
       "css": [
         "/css/parts/AdditionalDetails.css", "/css/parts/BrowserScrollBar.css", "/css/parts/Button.css", "/css/parts/Category.css",
         "/css/parts/Changelog.css", "/css/parts/FeatureContent.css", "/css/parts/Features.css", "/css/parts/Markdown.css",
-        "/css/parts/Message.css", "/css/parts/ScrollToTop.css", "/css/parts/ViewletExtensionDetail.css",
+        "/css/parts/Message.css", "/css/parts/ScrollToTop.css", "/css/parts/Table.css", "/css/parts/ViewletExtensionDetail.css",
         "/css/parts/ViewletExtensionDetailHeader.css", "/css/parts/ViewletExtensionDetailTabs.css"
       ],
       "state": { "idKey": "uid", "fields": ["uri", "x", "y", "width", "height"], "defaults": { "name": "" } },

--- a/packages/renderer-worker/test/ViewletExtensionDetailCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionDetailCss.test.ts
@@ -4,3 +4,7 @@ import { Css } from '../src/parts/ViewletExtensionDetail/ViewletExtensionDetail.
 test('loads changelog styles', () => {
   expect(Css).toContain('/css/parts/Changelog.css')
 })
+
+test('loads table styles', () => {
+  expect(Css).toContain('/css/parts/Table.css')
+})


### PR DESCRIPTION
Loads the shared table stylesheet for extension details so JSON Validation schema links use the active theme color and invalid schema references retain their error styling.