### PR TITLE
feature: measure isolated extension worker memory

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -233,6 +233,7 @@ export const commandMap = {
   'KeyBindings.setIdentifiers': lazy('KeyBindings.setIdentifiers'),
   'KeyBindingsInitial.getKeyBindings': lazy('KeyBindingsInitial.getKeyBindings'),
   'Languages.getLanguageConfiguration': lazy('Languages.getLanguageConfiguration'),
+  'LaunchIsolatedExtensionHostWorker.getMemoryUsage': lazy('LaunchIsolatedExtensionHostWorker.getMemoryUsage'),
   'LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker': lazy('LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker'),
   'Listener.3444': lazy('Listener.3444'),
   'LocalStorage.clear': lazy('LocalStorage.clear'),

--- a/packages/renderer-worker/src/parts/GetExtensionWorkerMemoryUsage/GetExtensionWorkerMemoryUsage.js
+++ b/packages/renderer-worker/src/parts/GetExtensionWorkerMemoryUsage/GetExtensionWorkerMemoryUsage.js
@@ -1,0 +1,34 @@
+const dedicatedWorkerScope = 'DedicatedWorkerGlobalScope'
+
+const getPathName = (url) => {
+  if (typeof url !== 'string' || !url) {
+    return ''
+  }
+  try {
+    return new URL(url, 'http://localhost').pathname
+  } catch {
+    return ''
+  }
+}
+
+const isMatchingAttribution = (attribution, workerPathName) => {
+  return attribution?.scope === dedicatedWorkerScope && getPathName(attribution.url) === workerPathName
+}
+
+const isMatchingEntry = (entry, workerPathName) => {
+  return Array.isArray(entry?.attribution) && entry.attribution.some((attribution) => isMatchingAttribution(attribution, workerPathName))
+}
+
+export const getExtensionWorkerMemoryUsage = (measurement, workerUrl) => {
+  const workerPathName = getPathName(workerUrl)
+  if (!workerPathName || !Array.isArray(measurement?.breakdown)) {
+    return 0
+  }
+  let memoryUsage = 0
+  for (const entry of measurement.breakdown) {
+    if (Number.isFinite(entry?.bytes) && entry.bytes > 0 && isMatchingEntry(entry, workerPathName)) {
+      memoryUsage += entry.bytes
+    }
+  }
+  return memoryUsage
+}

--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.ipc.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.ipc.js
@@ -4,5 +4,6 @@ export const name = 'LaunchIsolatedExtensionHostWorker'
 
 export const Commands = {
   disposeIsolatedExtensionHostWorker: LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker,
+  getMemoryUsage: LaunchIsolatedExtensionHostWorker.getMemoryUsage,
   launchIsolatedExtensionHostWorker: LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker,
 }

--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
@@ -1,4 +1,5 @@
 import * as ContentSecurityPolicy from '../ContentSecurityPolicy/ContentSecurityPolicy.js'
+import * as GetExtensionWorkerMemoryUsage from '../GetExtensionWorkerMemoryUsage/GetExtensionWorkerMemoryUsage.js'
 import * as Id from '../Id/Id.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
@@ -6,6 +7,7 @@ import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as RendererProcessIpcParentType from '../RendererProcessIpcParentType/RendererProcessIpcParentType.js'
 
 const workerIds = Object.create(null)
+const workerUrls = Object.create(null)
 
 export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, workerName = '', contentSecurityPolicy = '') => {
   const suffix = extensionId ? `: ${extensionId}` : ''
@@ -25,6 +27,16 @@ export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, 
     id,
   })
   workerIds[extensionId] = id
+  workerUrls[extensionId] = url
+}
+
+export const getMemoryUsage = async (extensionId) => {
+  const workerUrl = workerUrls[extensionId]
+  if (typeof workerUrl !== 'string') {
+    return 0
+  }
+  const measurement = await RendererProcess.invoke('Performance.measureUserAgentSpecificMemory')
+  return GetExtensionWorkerMemoryUsage.getExtensionWorkerMemoryUsage(measurement, workerUrl)
 }
 
 export const disposeIsolatedExtensionHostWorker = async (extensionId) => {
@@ -33,11 +45,13 @@ export const disposeIsolatedExtensionHostWorker = async (extensionId) => {
     return
   }
   delete workerIds[extensionId]
+  delete workerUrls[extensionId]
   await RendererProcess.invoke('IpcParent.dispose', id)
 }
 
 export const clear = () => {
   for (const extensionId of Object.keys(workerIds)) {
     delete workerIds[extensionId]
+    delete workerUrls[extensionId]
   }
 }

--- a/packages/renderer-worker/test/GetExtensionWorkerMemoryUsage.test.ts
+++ b/packages/renderer-worker/test/GetExtensionWorkerMemoryUsage.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@jest/globals'
+import { getExtensionWorkerMemoryUsage } from '../src/parts/GetExtensionWorkerMemoryUsage/GetExtensionWorkerMemoryUsage.js'
+
+test('returns zero when memory measurement is unavailable', () => {
+  expect(getExtensionWorkerMemoryUsage(undefined, '/extensions/sample/main.js')).toBe(0)
+})
+
+test('returns zero when the worker url is unavailable', () => {
+  expect(getExtensionWorkerMemoryUsage({ breakdown: [] }, undefined)).toBe(0)
+})
+
+test('sums memory attributed to the matching dedicated worker', () => {
+  const measurement = {
+    breakdown: [
+      {
+        attribution: [{ scope: 'Window', url: 'https://example.test/' }],
+        bytes: 100,
+      },
+      {
+        attribution: [{ scope: 'DedicatedWorkerGlobalScope', url: 'https://example.test/extensions/sample/main.js' }],
+        bytes: 200,
+      },
+      {
+        attribution: [{ scope: 'DedicatedWorkerGlobalScope', url: 'https://example.test/extensions/sample/main.js' }],
+        bytes: 300,
+      },
+      {
+        attribution: [{ scope: 'DedicatedWorkerGlobalScope', url: 'https://example.test/extensions/other/main.js' }],
+        bytes: 400,
+      },
+    ],
+  }
+
+  expect(getExtensionWorkerMemoryUsage(measurement, '/extensions/sample/main.js')).toBe(500)
+})
+
+test('ignores invalid and unattributed breakdown entries', () => {
+  const measurement = {
+    breakdown: [
+      { attribution: [], bytes: 100 },
+      { attribution: [{ scope: 'DedicatedWorkerGlobalScope', url: '/extensions/sample/main.js' }], bytes: -1 },
+      { attribution: [{ scope: 'DedicatedWorkerGlobalScope', url: '/extensions/sample/main.js' }], bytes: Number.NaN },
+      { bytes: 200 },
+    ],
+  }
+
+  expect(getExtensionWorkerMemoryUsage(measurement, '/extensions/sample/main.js')).toBe(0)
+})

--- a/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
@@ -111,6 +111,39 @@ test('launchIsolatedExtensionHostWorker - applies the extension content security
   expect(ContentSecurityPolicy.set.mock.invocationCallOrder[0]).toBeLessThan(RendererProcess.invokeAndTransfer.mock.invocationCallOrder[0])
 })
 
+test('getMemoryUsage returns memory attributed to the extension worker', async () => {
+  const port = {}
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockResolvedValue(undefined)
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue({
+    breakdown: [
+      {
+        attribution: [
+          {
+            scope: 'DedicatedWorkerGlobalScope',
+            url: 'https://example.test/test/extension-host-worker/packages/e2e/fixtures/sample/main.js',
+          },
+        ],
+        bytes: 2048,
+      },
+    ],
+  })
+  await LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker(
+    port,
+    'sample.extension',
+    '/test/extension-host-worker/packages/e2e/fixtures/sample/main.js',
+  )
+
+  await expect(LaunchIsolatedExtensionHostWorker.getMemoryUsage('sample.extension')).resolves.toBe(2048)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Performance.measureUserAgentSpecificMemory')
+})
+
+test('getMemoryUsage returns zero when the extension worker is not running', async () => {
+  await expect(LaunchIsolatedExtensionHostWorker.getMemoryUsage('sample.extension')).resolves.toBe(0)
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
 test('disposeIsolatedExtensionHostWorker terminates the renderer process worker', async () => {
   const port = {}
   // @ts-ignore


### PR DESCRIPTION
Adds a renderer bridge that measures memory attributed to an isolated extension’s dedicated worker, using the existing user-agent-specific memory breakdown.