### PR TITLE
feature: add JSON validation table alignment e2e test

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/viewlet.extension-detail-json-validation-table-alignment/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/viewlet.extension-detail-json-validation-table-alignment/extension.json
@@ -1,0 +1,12 @@
+{
+  "id": "test.json-validation-table-alignment",
+  "name": "JSON Validation Table Alignment",
+  "description": "Checks JSON validation table alignment",
+  "version": "1.0.0",
+  "jsonValidation": [
+    {
+      "fileMatch": "*.test.json",
+      "schema": "test://schema.json"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/src/viewlet.extension-detail-json-validation-table-alignment.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.extension-detail-json-validation-table-alignment.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.extension-detail-json-validation-table-alignment'
+
+export const test: Test = async ({ expect, Extension, ExtensionDetail, Locator }) => {
+  const extensionUri = new URL('../fixtures/viewlet.extension-detail-json-validation-table-alignment', import.meta.url).toString()
+  await Extension.addWebExtension(extensionUri)
+  await ExtensionDetail.open('test.json-validation-table-alignment')
+  await ExtensionDetail.selectFeatures()
+  await ExtensionDetail.openJsonValidation()
+
+  const table = Locator('.FeatureContent .Table')
+  const headings = table.locator('thead th.TableHeading.TableCell')
+  const cells = table.locator('tbody td.TableCell')
+  await expect(headings).toHaveCount(2)
+  await expect(headings.nth(0)).toHaveText('File Match')
+  await expect(headings.nth(1)).toHaveText('Schema')
+  await expect(cells).toHaveCount(2)
+  await expect(headings.nth(0)).toHaveCSS('padding-left', '10px')
+  await expect(headings.nth(1)).toHaveCSS('padding-left', '10px')
+  await expect(cells.nth(0)).toHaveCSS('padding-left', '10px')
+  await expect(cells.nth(1)).toHaveCSS('padding-left', '10px')
+}


### PR DESCRIPTION
Adds browser e2e coverage for extension detail JSON Validation table alignment.

The test registers a fixture extension, opens Features > JSON Validation, and verifies that both headings and body cells share the same left padding.