### PR TITLE
feature: add Zig syntax highlighting

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -306,6 +306,12 @@
     "created": "2022-09-25"
   },
   {
+    "name": "builtin.language-basics-zig",
+    "repository": "github.com/lvce-editor/language-basics-zig",
+    "version": "0.1.0",
+    "created": "2026-08-13"
+  },
+  {
     "name": "builtin.language-basics-scss",
     "repository": "github.com/lvce-editor/language-basics-scss",
     "version": "0.2.0",

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -27,6 +27,19 @@ test('includes the built-in Erlang syntax highlighting extension', async () => {
   })
 })
 
+test('includes the built-in Zig syntax highlighting extension', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+  const extension = extensions.find((item) => item.id === 'builtin.language-basics-zig')
+
+  expect(extension).toMatchObject({
+    builtin: true,
+    path: '/test-prefix/test-commit/extensions/builtin.language-basics-zig',
+  })
+})
+
 test('excludes extensions that are not web compatible', async () => {
   const extensions = await getAllExtensionsJson({
     commitHash: 'test-commit',


### PR DESCRIPTION
Adds the released Zig language basics extension to official LVCE builds, including a regression test that verifies it is bundled as a built-in extension.