### PR TITLE
fix: restore fetch file systems on web

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemFetch.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemFetch.js
@@ -1,3 +1,5 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as DirentType from '../DirentType/DirentType.js'
 import * as FileSystemWorker from '../FileSystemWorker/FileSystemWorker.js'
 import * as PathSeparatorType from '../PathSeparatorType/PathSeparatorType.js'
 
@@ -20,6 +22,14 @@ const normalizeUri = (uri) => {
   return uri
 }
 
+const fetchAsset = async (uri) => {
+  const response = await fetch(`${AssetDir.assetDir}${uri}`)
+  if (!response.ok) {
+    throw new Error(response.statusText)
+  }
+  return response
+}
+
 export const readFile = async (uri) => {
   uri = normalizeUri(uri)
   if (uri.startsWith('localhost:') || uri.startsWith(location.host)) {
@@ -28,7 +38,8 @@ export const readFile = async (uri) => {
   if (uri.startsWith('http://') || uri.startsWith('https://')) {
     return FileSystemWorker.invoke('FileSystemFetch.readFile', uri)
   }
-  return FileSystemWorker.invoke('FileSystem.readFile', uri)
+  const response = await fetchAsset(uri)
+  return response.text()
 }
 
 export const exists = async (uri) => {
@@ -48,7 +59,8 @@ export const readJson = async (uri) => {
   if (uri.startsWith('http://') || uri.startsWith('https://')) {
     return FileSystemWorker.invoke('FileSystem.readJson', uri)
   }
-  return FileSystemWorker.invoke('FileSystem.readJson', uri)
+  const response = await fetchAsset(uri)
+  return response.json()
 }
 
 export const writeFile = (uri, content) => {
@@ -76,7 +88,32 @@ export const remove = (uri) => {
 
 export const readDirWithFileTypes = async (uri) => {
   uri = normalizeUri(uri)
-  return FileSystemWorker.invoke('FileSystem.readDirWithFileTypes', uri)
+  const directoryPrefix = uri.endsWith(PathSeparatorType.Slash) ? uri : `${uri}${PathSeparatorType.Slash}`
+  const response = await fetchAsset('/config/fileMap.json')
+  const fileList = await response.json()
+  const dirents = []
+  for (const fileUri of fileList) {
+    if (!fileUri.startsWith(directoryPrefix)) {
+      continue
+    }
+    const rest = fileUri.slice(directoryPrefix.length)
+    if (rest.includes(PathSeparatorType.Slash)) {
+      const name = rest.slice(0, rest.indexOf(PathSeparatorType.Slash))
+      if (dirents.some((dirent) => dirent.name === name)) {
+        continue
+      }
+      dirents.push({
+        name,
+        type: DirentType.Directory,
+      })
+    } else {
+      dirents.push({
+        name: rest,
+        type: DirentType.File,
+      })
+    }
+  }
+  return dirents
 }
 
 export const chmod = (path, permissions) => {
@@ -86,5 +123,12 @@ export const chmod = (path, permissions) => {
 
 export const getBlob = async (uri, type) => {
   uri = normalizeUri(uri)
-  return FileSystemWorker.invoke('FileSystem.readFileAsBlob', uri, type)
+  if (uri.startsWith('localhost:') || uri.startsWith(location.host)) {
+    return FileSystemWorker.invoke('FileSystem.readFileAsBlob', `${location.protocol}//${uri}`, type)
+  }
+  if (uri.startsWith('http://') || uri.startsWith('https://')) {
+    return FileSystemWorker.invoke('FileSystem.readFileAsBlob', uri, type)
+  }
+  const response = await fetchAsset(uri)
+  return response.blob()
 }

--- a/packages/renderer-worker/test/FileSystemFetch.test.ts
+++ b/packages/renderer-worker/test/FileSystemFetch.test.ts
@@ -1,6 +1,73 @@
-import { expect, test } from '@jest/globals'
-import * as FileSystemFetch from '../src/parts/FileSystem/FileSystemFetch.js'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as DirentType from '../src/parts/DirentType/DirentType.js'
+
+const mockFileSystemWorkerInvoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+
+jest.unstable_mockModule('../src/parts/FileSystemWorker/FileSystemWorker.js', () => ({
+  invoke: mockFileSystemWorkerInvoke,
+}))
+
+const FileSystemFetch = await import('../src/parts/FileSystem/FileSystemFetch.js')
+
+const createJsonResponse = (value: unknown): Response => {
+  return new Response(JSON.stringify(value), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockFileSystemWorkerInvoke.mockRejectedValue(new Error('Disk file system is not available in web'))
+  Object.defineProperty(globalThis, 'location', {
+    configurable: true,
+    value: {
+      host: 'example.com',
+      protocol: 'https:',
+    },
+  })
+})
 
 test('isReadonly', () => {
   expect(FileSystemFetch.isReadonly()).toBe(true)
+})
+
+test('readDirWithFileTypes reads the static file map', async () => {
+  const fetch = jest.fn<typeof globalThis.fetch>()
+  fetch.mockResolvedValue(createJsonResponse(['/playground/main.zig', '/playground/nested/example.zig', '/playground-other/ignored.zig']))
+  globalThis.fetch = fetch
+
+  await expect(FileSystemFetch.readDirWithFileTypes('fetch:///playground')).resolves.toEqual([
+    {
+      name: 'main.zig',
+      type: DirentType.File,
+    },
+    {
+      name: 'nested',
+      type: DirentType.Directory,
+    },
+  ])
+  expect(fetch).toHaveBeenCalledWith('/config/fileMap.json')
+  expect(mockFileSystemWorkerInvoke).not.toHaveBeenCalled()
+})
+
+test('readFile reads a static asset', async () => {
+  const fetch = jest.fn<typeof globalThis.fetch>()
+  fetch.mockResolvedValue(new Response('const main = () => {}'))
+  globalThis.fetch = fetch
+
+  await expect(FileSystemFetch.readFile('fetch:///playground/main.zig')).resolves.toBe('const main = () => {}')
+  expect(fetch).toHaveBeenCalledWith('/playground/main.zig')
+  expect(mockFileSystemWorkerInvoke).not.toHaveBeenCalled()
+})
+
+test('readJson reads a static asset', async () => {
+  const fetch = jest.fn<typeof globalThis.fetch>()
+  fetch.mockResolvedValue(createJsonResponse({ name: 'zig' }))
+  globalThis.fetch = fetch
+
+  await expect(FileSystemFetch.readJson('fetch:///playground/config.json')).resolves.toEqual({ name: 'zig' })
+  expect(fetch).toHaveBeenCalledWith('/playground/config.json')
+  expect(mockFileSystemWorkerInvoke).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Restore renderer-local static asset and file-map reads for fetch:// workspaces after removal of the legacy extension host. This keeps web Fetch roots read-only while preventing them from falling through to the unavailable disk file system.