### PR TITLE
fix: serve index document from static server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build server
         run: npm run build:server
+      - name: Test built server
+        if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'x64'
+        run: npm run test:server
       - name: Test Static Export
         run: npm run test-static-export
       - name: Run extension host worker tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,9 @@ jobs:
           PATH_PREFIX: /lvce-editor
       - name: Build server
         run: npm run build:server
+      - name: Test built server
+        if: matrix.os == 'ubuntu-24.04'
+        run: npm run test:server
       - name: Test Static Export
         run: npm run test-static-export
       - name: Run extension host worker tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,9 @@ jobs:
       - run: npm run type-check
       - run: npm test
       - run: npm run build:server
+      - name: Test built server
+        if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'x64'
+        run: npm run test:server
       - name: Cache Electron Builder Dependencies (Windows)
         uses: actions/cache@v6
         id: electron-builder-cache-windows

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:static": "node packages/build/bin/build.ts --target=static",
     "build:static:ignore-icon-theme": "node packages/build/bin/build.ts --target=static --ignore-icon-theme",
     "build:server": "node packages/build/bin/build.ts --target=server",
+    "test:server": "node packages/build/src/parts/TestServer/TestServer.ts",
     "build:electron:deb": "node packages/build/bin/build.ts --target=electron-deb",
     "build:electron:deb:x64": "node packages/build/bin/build.ts --target=electron-deb --arch=x64",
     "build:electron:deb:arm64": "node packages/build/bin/build.ts --target=electron-deb --arch=arm64",

--- a/packages/build/src/parts/BuildServer/BuildServer.ts
+++ b/packages/build/src/parts/BuildServer/BuildServer.ts
@@ -20,6 +20,12 @@ const getObjectDependencies = (obj) => {
 }
 
 export const getServerIsStaticReplacement = (commitHash: string): string => `const isStatic = (url) => {
+  if (url === '/' || url.startsWith('/?')) {
+    return true
+  }
+  if (url === '/index.html' || url.startsWith('/index.html?')) {
+    return true
+  }
   if (url.startsWith('/${commitHash}')) {
     return true
   }

--- a/packages/build/src/parts/TestServer/TestServer.ts
+++ b/packages/build/src/parts/TestServer/TestServer.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as Copy from '../Copy/Copy.ts'
+import * as Path from '../Path/Path.ts'
+
+const wait = (milliseconds: number): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+const getFreePort = async (): Promise<number> => {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    server.close()
+    throw new Error('Failed to allocate a test server port')
+  }
+  const { port } = address
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+  return port
+}
+
+const waitForListening = async (child: ChildProcessWithoutNullStreams): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    let output = ''
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for built server startup\n${output}`))
+    }, 30_000)
+    const handleData = (chunk: Buffer): void => {
+      output += chunk.toString()
+      if (output.includes('listening on')) {
+        clearTimeout(timeout)
+        resolve()
+      }
+    }
+    child.stdout.on('data', handleData)
+    child.stderr.on('data', handleData)
+    child.once('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('exit', (code) => {
+      clearTimeout(timeout)
+      reject(new Error(`Built server exited before startup with code ${code}\n${output}`))
+    })
+  })
+}
+
+const stopServer = async (child: ChildProcessWithoutNullStreams): Promise<void> => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+  const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()))
+  child.kill()
+  await Promise.race([exited, wait(5_000)])
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL')
+  }
+}
+
+const main = async (): Promise<void> => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'lvce-built-server-'))
+  let child: ChildProcessWithoutNullStreams | undefined
+  try {
+    const packageRoot = join(temporaryDirectory, 'node_modules', '@lvce-editor')
+    await Copy.copy({
+      from: Path.absolute('packages/build/.tmp/server'),
+      to: packageRoot,
+    })
+
+    const serverRoot = join(packageRoot, 'server')
+    const staticServerRoot = join(packageRoot, 'static-server')
+    const config = JSON.parse(await readFile(join(staticServerRoot, 'config.json'), 'utf8'))
+    const expectedHeaders = config.headers[config.files['/']]
+    const expectedContent = await readFile(join(staticServerRoot, 'static', 'index.html'), 'utf8')
+    const port = await getFreePort()
+    const serverProcess = spawn(process.execPath, [join(serverRoot, 'bin', 'server.js'), temporaryDirectory], {
+      cwd: serverRoot,
+      env: {
+        ...process.env,
+        PORT: `${port}`,
+      },
+      stdio: 'pipe',
+    })
+    child = serverProcess
+    await waitForListening(serverProcess)
+
+    for (const path of ['/', '/?workspace=/test', '/index.html', '/index.html?workspace=/test']) {
+      const response = await fetch(`http://localhost:${port}${path}`)
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), expectedContent)
+      assert.equal(response.headers.get('content-security-policy'), expectedHeaders['Content-Security-Policy'])
+      assert.equal(response.headers.get('cross-origin-embedder-policy'), expectedHeaders['Cross-Origin-Embedder-Policy'])
+      assert.equal(response.headers.get('cross-origin-opener-policy'), expectedHeaders['Cross-Origin-Opener-Policy'])
+      assert.equal(response.headers.get('cross-origin-resource-policy'), expectedHeaders['Cross-Origin-Resource-Policy'])
+    }
+  } finally {
+    if (child) {
+      await stopServer(child)
+    }
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+await main()

--- a/packages/build/test/BuildServer.test.ts
+++ b/packages/build/test/BuildServer.test.ts
@@ -13,13 +13,16 @@ const readJson = async (path: string): Promise<any> => {
   return JSON.parse(await readFile(path, 'utf8'))
 }
 
-test('generated server sends the root document through the shared process', () => {
+test('generated server sends index documents through the static server', () => {
   const replacement = getServerIsStaticReplacement('abcdefg')
   const isStatic = runInNewContext(`${replacement}; isStatic`) as (url: string) => boolean
 
-  expect(isStatic('/')).toBe(false)
-  expect(isStatic('/?workspace=/test')).toBe(false)
+  expect(isStatic('/')).toBe(true)
+  expect(isStatic('/?workspace=/test')).toBe(true)
+  expect(isStatic('/index.html')).toBe(true)
+  expect(isStatic('/index.html?workspace=/test')).toBe(true)
   expect(isStatic('/abcdefg/packages/renderer-worker.js')).toBe(true)
+  expect(isStatic('/api/status')).toBe(false)
 })
 
 test('setVersionsAndDependencies includes process explorer as shared-process dependency', async () => {


### PR DESCRIPTION
Route release index-document requests through the static server so the generated CSP and cross-origin isolation headers are preserved. Development routing and dynamic application routes remain unchanged.

Add generated-router coverage and a built-server HTTP smoke test for the unchanged document body, CSP, COEP, COOP, and CORP headers.