### PR TITLE
feature: connect views directly to renderer process

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js
@@ -1,8 +1,11 @@
 import * as AboutViewWorkerUrl from '../AboutViewWorkerUrl/AboutViewWorkerUrl.js'
 import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchAboutViewWorker = async () => {
   const name = 'About View Worker'
@@ -12,5 +15,10 @@ export const launchAboutViewWorker = async () => {
     url: getConfiguredWorkerUrl('develop.aboutViewWorkerPath', AboutViewWorkerUrl.aboutViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'About.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js
@@ -1,8 +1,11 @@
 import * as ExtensionDetailViewWorkerUrl from '../ExtensionDetailViewWorkerUrl/ExtensionDetailViewWorkerUrl.js'
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchExtensionDetailViewWorker = async () => {
   const name = 'Extension Detail View Worker'
@@ -15,5 +18,10 @@ export const launchExtensionDetailViewWorker = async () => {
     ),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'ExtensionDetail.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js
@@ -1,11 +1,13 @@
 import * as ExtensionSearchViewWorkerUrl from '../ExtensionSearchViewWorkerUrl/ExtensionSearchViewWorkerUrl.js'
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchExtensionSearchViewWorker = async () => {
   const name = Platform.getPlatform() === PlatformType.Electron ? 'Extension Search View Worker (Electron)' : 'Extension Search View Worker'
@@ -23,5 +25,10 @@ export const launchExtensionSearchViewWorker = async () => {
   } catch {
     // ignore
   }
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'SearchExtensions.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchOutputViewWorker/LaunchOutputViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchOutputViewWorker/LaunchOutputViewWorker.js
@@ -1,9 +1,11 @@
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as OutputViewWorkerUrl from '../OutputViewWorkerUrl/OutputViewWorkerUrl.js'
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchOutputViewWorker = async () => {
   const name = 'Output View Worker'
@@ -14,6 +16,10 @@ export const launchOutputViewWorker = async () => {
   })
   HandleIpc.handleIpc(ipc)
   await JsonRpc.invoke(ipc, 'Output.initialize')
-
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'Output.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts
@@ -1,9 +1,11 @@
 import * as ProblemsWorkerUrl from '../ProblemsWorkerUrl/ProblemsWorkerUrl.js'
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchProblemsWorker = async () => {
   const name = 'Problems Worker'
@@ -14,5 +16,10 @@ export const launchProblemsWorker = async () => {
   })
   HandleIpc.handleIpc(ipc)
   await JsonRpc.invoke(ipc, 'Problems.initialize')
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'Problems.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchQuickPickWorker/LaunchQuickPickWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchQuickPickWorker/LaunchQuickPickWorker.js
@@ -1,8 +1,11 @@
 import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import { quickPickWorkerUrl } from '../QuickPickWorkerUrl/QuickPickWorkerUrl.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchQuickPickWorker = async () => {
   const name = 'QuickPick Worker'
@@ -12,5 +15,10 @@ export const launchQuickPickWorker = async () => {
     url: getConfiguredWorkerUrl('develop.quickPickWorkerPath', quickPickWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'QuickPick.handleRendererProcessMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchSourceControlWorker/LaunchSourceControlWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchSourceControlWorker/LaunchSourceControlWorker.js
@@ -1,9 +1,11 @@
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as SourceControlWorkerUrl from '../SourceControlWorkerUrl/SourceControlWorkerUrl.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchSourceControlWorker = async () => {
   const name = 'Source Control Worker'
@@ -14,5 +16,10 @@ export const launchSourceControlWorker = async () => {
   })
   HandleIpc.handleIpc(ipc)
   await JsonRpc.invoke(ipc, 'Initialize.initialize')
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'SourceControl.handleRendererProcessMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js
@@ -1,10 +1,12 @@
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as ExtensionManagementRpcId from '../ExtensionManagementRpcId/ExtensionManagementRpcId.js'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as StatusBarWorkerUrl from '../StatusBarWorkerUrl/StatusBarWorkerUrl.js'
 
 export const launchStatusBarWorker = async () => {
@@ -19,6 +21,11 @@ export const launchStatusBarWorker = async () => {
   await Promise.all([
     ExtensionManagementWorker.invokeAndTransfer('Extensions.handleMessagePort', port1, ExtensionManagementRpcId.StatusBarWorker),
     JsonRpc.invokeAndTransfer(ipc, 'StatusBar.handleExtensionManagementMessagePort', port2),
+  ])
+  const { port1: rendererWorkerPort, port2: rendererProcessPort } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'StatusBar.handleMessagePort', rendererWorkerPort),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', rendererProcessPort),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js
@@ -1,8 +1,11 @@
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as TitleBarWorkerUrl from '../TitleBarWorkerUrl/TitleBarWorkerUrl.js'
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
 
 export const launchTitleBarWorker = async () => {
   const name = 'Title Bar Worker'
@@ -12,5 +15,10 @@ export const launchTitleBarWorker = async () => {
     url: GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.titleBarWorkerPath', TitleBarWorkerUrl.titleBarWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'TitleBar.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/ViewletAbout/ViewletAbout.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletAbout/ViewletAbout.ipc.ts
@@ -9,6 +9,7 @@ export const {
   dispose,
   getCommands,
   getKeyBindings,
+  hasDirectRender,
   hasFunctionalEvents,
   hasFunctionalRender,
   hasFunctionalResize,

--- a/packages/renderer-worker/src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ipc.ts
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, wrapExtensionDetailCommand,
 } = createWorkerViewlet({ workerId: 'extensionDetail' })

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, handleExtensionsChanged, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, handleExtensionsChanged, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'extensionSearch' })

--- a/packages/renderer-worker/src/parts/ViewletOutput/ViewletOutput.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletOutput/ViewletOutput.ipc.ts
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderDialog, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'output' })

--- a/packages/renderer-worker/src/parts/ViewletProblems/ViewletProblems.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletProblems/ViewletProblems.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getBadgeCount, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, resizeWithDependencies, saveState,
 } = createWorkerViewlet({ workerId: 'problemsViewWorker' })

--- a/packages/renderer-worker/src/parts/ViewletQuickPick/ViewletQuickPick.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletQuickPick/ViewletQuickPick.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
+  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
   name, render, renderActions, renderEventListeners, renderItems, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'quickPickWorker' })

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlRender.js
@@ -3,6 +3,8 @@ import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker
 
 export const hasFunctionalRender = true
 
+export const hasDirectRender = true
+
 export const hasFunctionalRootRender = true
 
 export const hasFunctionalEvents = true

--- a/packages/renderer-worker/src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js
@@ -14,6 +14,7 @@ export const {
   dispose,
   getCommands,
   getKeyBindings,
+  hasDirectRender,
   hasFunctionalEvents,
   hasFunctionalRender,
   hasFunctionalResize,

--- a/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBar.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBar.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, handleFocusChange, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getTitle, handleFocusChange, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'titleBar' })

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -25,7 +25,7 @@
         "getKeyBindings": { "name": "About.getKeyBindings", "parameters": [] },
         "renderEventListeners": { "name": "About.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "rootRender": true },
       "renderComparison": "always"
     }
   },
@@ -604,7 +604,7 @@
         "getTitle": { "name": "ExtensionDetail.renderTitle", "parameters": [{ "source": "state", "name": "uid" }] },
         "renderEventListeners": { "name": "ExtensionDetail.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "always"
     }
   },
@@ -665,7 +665,7 @@
       },
       "extraCommands": [{ "name": "handleExtensionsChanged", "method": "handleExtensionsChanged" }],
       "title": "Extensions: Installed",
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }
   },
   {
@@ -1041,7 +1041,7 @@
         "renderEventListeners": { "name": "Output.renderEventListeners", "parameters": [] }
       },
       "outputs": [{ "stateField": "actionsDom", "method": { "name": "Output.renderActions", "parameters": [{ "source": "state", "name": "uid" }] } }],
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "always"
     }
   },
@@ -1198,7 +1198,7 @@
       "outputs": [{ "stateField": "actionsDom", "method": { "name": "Problems.renderActions", "parameters": [{ "source": "state", "name": "uid" }] } }],
       "renderActionsComparison": "always",
       "renderComparison": "emptyCommands",
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }
   },
   {
@@ -1275,7 +1275,7 @@
         "renderEventListeners": { "name": "QuickPick.renderEventListeners", "parameters": [] }
       },
       "renderComparison": "always",
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }
   },
   {
@@ -1494,7 +1494,7 @@
         "getCommandIds": { "name": "StatusBar.getCommandIds", "parameters": [] },
         "renderEventListeners": { "name": "StatusBar.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "commands"
     }
   },
@@ -1587,7 +1587,7 @@
         "getMenuEntries": { "name": "TitleBar.getMenuEntries2", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
         "renderEventListeners": { "name": "TitleBar.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }
   },
   {

--- a/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
+++ b/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Worker launch tests use ESM module mocks for transport dependencies. */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const ipc = {
+  send(): void {},
+}
+
+jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => ({
+  getConfiguredWorkerUrl: jest.fn(() => 'file:///worker.js'),
+}))
+jest.unstable_mockModule('../src/parts/GetPortTuple/GetPortTuple.js', () => ({
+  getPortTuple: jest.fn(() => ({ port1: 'worker-port', port2: 'renderer-process-port' })),
+}))
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => ({
+  handleIpc: jest.fn(),
+}))
+jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => ({
+  create: jest.fn(async () => ipc),
+}))
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invoke: jest.fn(async () => undefined),
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
+const GetPortTuple = await import('../src/parts/GetPortTuple/GetPortTuple.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+const LaunchAboutViewWorker = await import('../src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js')
+const LaunchExtensionSearchViewWorker = await import('../src/parts/LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js')
+const LaunchOutputViewWorker = await import('../src/parts/LaunchOutputViewWorker/LaunchOutputViewWorker.js')
+const LaunchProblemsWorker = await import('../src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts')
+const LaunchQuickPickWorker = await import('../src/parts/LaunchQuickPickWorker/LaunchQuickPickWorker.js')
+const LaunchSourceControlWorker = await import('../src/parts/LaunchSourceControlWorker/LaunchSourceControlWorker.js')
+const LaunchStatusBarWorker = await import('../src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js')
+const LaunchTitleBarWorker = await import('../src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test.each([
+  ['about', LaunchAboutViewWorker.launchAboutViewWorker, 'About.handleMessagePort'],
+  ['extension search', LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort'],
+  ['output', LaunchOutputViewWorker.launchOutputViewWorker, 'Output.handleMessagePort'],
+  ['problems', LaunchProblemsWorker.launchProblemsWorker, 'Problems.handleMessagePort'],
+  ['quick pick', LaunchQuickPickWorker.launchQuickPickWorker, 'QuickPick.handleRendererProcessMessagePort'],
+  ['source control', LaunchSourceControlWorker.launchSourceControlWorker, 'SourceControl.handleRendererProcessMessagePort'],
+  ['status bar', LaunchStatusBarWorker.launchStatusBarWorker, 'StatusBar.handleMessagePort'],
+  ['title bar', LaunchTitleBarWorker.launchTitleBarWorker, 'TitleBar.handleMessagePort'],
+] as const)('%s worker connects directly to the renderer process', async (_name, launch, command) => {
+  await launch()
+
+  expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, command, 'worker-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
+})

--- a/packages/renderer-worker/test/LaunchExtensionDetailViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchExtensionDetailViewWorker.test.ts
@@ -16,6 +16,18 @@ jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetPortTuple/GetPortTuple.js', () => ({
+  getPortTuple: jest.fn(() => ({ port1: 'extension-detail-port', port2: 'renderer-process-port' })),
+}))
+
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
 jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
   return {
     create: jest.fn(() => {
@@ -27,10 +39,12 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
 const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
 const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchExtensionDetailViewWorker = await import('../src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 
 beforeEach(() => {
-  jest.resetAllMocks()
+  jest.clearAllMocks()
 })
 
 test('launches the extension detail view worker', async () => {
@@ -49,5 +63,7 @@ test('launches the extension detail view worker', async () => {
     url: 'file:///extension-detail-view-worker.js',
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'ExtensionDetail.handleMessagePort', 'extension-detail-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/ViewletDirectRender.test.ts
+++ b/packages/renderer-worker/test/ViewletDirectRender.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletAbout from '../src/parts/ViewletAbout/ViewletAbout.ipc.ts'
+import * as ViewletExtensionDetail from '../src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ipc.ts'
+import * as ViewletExtensions from '../src/parts/ViewletExtensions/ViewletExtensions.ipc.js'
+import * as ViewletOutput from '../src/parts/ViewletOutput/ViewletOutput.ipc.ts'
+import * as ViewletProblems from '../src/parts/ViewletProblems/ViewletProblems.ipc.js'
+import * as ViewletQuickPick from '../src/parts/ViewletQuickPick/ViewletQuickPick.ipc.js'
+import * as ViewletSourceControl from '../src/parts/ViewletSourceControl/ViewletSourceControl.ipc.js'
+import * as ViewletStatusBar from '../src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js'
+import * as ViewletTitleBar from '../src/parts/ViewletTitleBar/ViewletTitleBar.ipc.js'
+
+test.each([
+  ['about', ViewletAbout],
+  ['extension detail', ViewletExtensionDetail],
+  ['extensions', ViewletExtensions],
+  ['output', ViewletOutput],
+  ['problems', ViewletProblems],
+  ['quick pick', ViewletQuickPick],
+  ['source control', ViewletSourceControl],
+  ['status bar', ViewletStatusBar],
+  ['title bar', ViewletTitleBar],
+])('%s declares direct rendering support', (_name, viewlet) => {
+  expect(viewlet.hasDirectRender).toBe(true)
+})


### PR DESCRIPTION
Connect the remaining view workers directly to the renderer process and enable direct rendering for their viewlets. Add focused coverage for worker port transfer and direct-render capability declarations.