### PR TITLE
feature: support language server references

### DIFF
--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -9,4 +9,5 @@ export const Commands = {
   diagnostic: LanguageServer.diagnostic,
   dispose: LanguageServer.dispose,
   format: LanguageServer.format,
+  references: LanguageServer.references,
 }

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -32,6 +32,8 @@ export interface DiagnosticOptions {
 
 export type DefinitionOptions = CompleteOptions
 
+export type ReferencesOptions = CompleteOptions
+
 export interface FormatOptions {
   readonly argv: readonly string[]
   readonly extensionId: string
@@ -128,6 +130,16 @@ export const format = async ({ argv, extensionId, id, rootUri, textDocument, uri
   const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${normalizedRootUri}`, extensionId, uri, argv, normalizedRootUri)
   return connection.format(normalizedDocument)
+}
+
+export const references = async ({ argv, extensionId, id, offset, rootUri, textDocument, uri }: ReferencesOptions): Promise<readonly unknown[]> => {
+  const normalizedDocument = {
+    ...textDocument,
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
+  }
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, extensionId, uri, argv, normalizedRootUri)
+  return connection.references(normalizedDocument, offset)
 }
 
 export const dispose = (extensionId: string): void => {

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -34,6 +34,7 @@ interface InitializeResult {
     readonly codeActionProvider?: unknown
     readonly diagnosticProvider?: unknown
     readonly documentFormattingProvider?: unknown
+    readonly referencesProvider?: unknown
   }
 }
 
@@ -170,6 +171,7 @@ export class LanguageServerConnection {
   private supportsCodeActions = false
   private supportsDocumentFormatting = false
   private supportsPullDiagnostics = false
+  private supportsReferences = false
 
   constructor({ argv, rootUri, uri }: LanguageServerConnectionOptions) {
     this.rootUri = rootUri
@@ -310,6 +312,24 @@ export class LanguageServerConnection {
     return Array.isArray(result) ? result : []
   }
 
+  async references(textDocument: TextDocument, offset: number): Promise<readonly unknown[]> {
+    await this.ready
+    if (!this.supportsReferences) {
+      return []
+    }
+    this.syncDocument(textDocument)
+    const result = await this.sendRequest('textDocument/references', {
+      context: {
+        includeDeclaration: true,
+      },
+      position: getPosition(textDocument.text, offset),
+      textDocument: {
+        uri: textDocument.uri,
+      },
+    })
+    return Array.isArray(result) ? result : []
+  }
+
   private configureMarkdown(languageId: string): void {
     if (languageId !== 'markdown' || this.markdownConfigured) {
       return
@@ -372,6 +392,9 @@ export class LanguageServerConnection {
           publishDiagnostics: {
             relatedInformation: true,
           },
+          references: {
+            dynamicRegistration: false,
+          },
           synchronization: {
             didSave: true,
             dynamicRegistration: false,
@@ -400,6 +423,7 @@ export class LanguageServerConnection {
     this.supportsCodeActions = Boolean(result?.capabilities?.codeActionProvider)
     this.supportsDocumentFormatting = Boolean(result?.capabilities?.documentFormattingProvider)
     this.supportsPullDiagnostics = Boolean(result?.capabilities?.diagnosticProvider)
+    this.supportsReferences = Boolean(result?.capabilities?.referencesProvider)
     this.sendNotification('initialized', {})
     await Promise.race([this.initializationProgressStarted.promise, wait(100)])
     if (this.initializationProgressWasStarted) {

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -217,6 +217,7 @@ export const getModuleId = (commandId: any): any => {
     case 'LanguageServer.diagnostic':
     case 'LanguageServer.dispose':
     case 'LanguageServer.format':
+    case 'LanguageServer.references':
       return ModuleId.LanguageServer
     case 'ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage':
       return ModuleId.ListProcessesWithMemoryUsage

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -8,6 +8,7 @@ import {
   dispose,
   disposeAll,
   format,
+  references,
   type CompleteOptions,
 } from '../src/parts/LanguageServer/LanguageServer.ts'
 import { getSpawnOptions } from '../src/parts/LanguageServerConnection/LanguageServerConnection.ts'
@@ -166,6 +167,33 @@ test('definition starts a stdio language server and synchronizes documents', asy
   })
 })
 
+test('references starts a stdio language server and includes declarations', async () => {
+  const options = {
+    argv: [serverScript],
+    extensionId: 'sample.extension',
+    id: 'sample.references-fixture',
+    offset: 15,
+    rootUri: 'file:///tmp',
+    textDocument: {
+      languageId: 'zig',
+      text: 'const value = 1;\n_ = value;',
+      uri: '/tmp/main.zig',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+  const normalizedDocumentUri = normalizeLanguageServerDocumentUri(options.textDocument.uri)
+
+  await expect(references(options)).resolves.toEqual([
+    {
+      range: {
+        end: { character: 5, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+      uri: `${normalizedDocumentUri}?references=const%20value%20%3D%201%3B%0A_%20%3D%20value%3B&includeDeclaration=true`,
+    },
+  ])
+})
+
 test('diagnostic starts a stdio language server and synchronizes documents', async () => {
   const options = {
     argv: [serverScript],
@@ -224,6 +252,23 @@ test('format returns no edits when the language server does not support document
       textDocument: {
         languageId: 'typescript',
         text: 'const value=1',
+        uri: '/tmp/sample.ts',
+      },
+      uri: pathToFileURL(process.execPath).href,
+    }),
+  ).resolves.toEqual([])
+})
+
+test('references returns no locations when the language server does not support them', async () => {
+  await expect(
+    references({
+      argv: [completionOnlyServerScript],
+      extensionId: 'sample.extension',
+      id: 'sample.completion-only-references-fixture',
+      offset: 2,
+      textDocument: {
+        languageId: 'typescript',
+        text: 'const value = 1',
         uri: '/tmp/sample.ts',
       },
       uri: pathToFileURL(process.execPath).href,

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -24,6 +24,7 @@ const handleMessage = (message) => {
             workspaceDiagnostics: false,
           },
           documentFormattingProvider: true,
+          referencesProvider: true,
           textDocumentSync: 1,
         },
       },
@@ -89,6 +90,23 @@ const handleMessage = (message) => {
         },
         uri: `${message.params.textDocument.uri}?definition=${encodeURIComponent(text)}`,
       },
+    })
+    return
+  }
+  if (message.method === 'textDocument/references') {
+    const text = documents.get(message.params.textDocument.uri)
+    send({
+      id: message.id,
+      jsonrpc: '2.0',
+      result: [
+        {
+          range: {
+            end: { character: 5, line: 0 },
+            start: { character: 0, line: 0 },
+          },
+          uri: `${message.params.textDocument.uri}?references=${encodeURIComponent(text)}&includeDeclaration=${message.params.context.includeDeclaration}`,
+        },
+      ],
     })
     return
   }


### PR DESCRIPTION
Add textDocument/references support to the shared language-server client, including declaration results, capability checks, URI normalization, and protocol coverage.