### PR TITLE
fix: avoid editor reload after saving

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -47,13 +47,15 @@ export const mkdir = async (uri) => {
   await fileSystem.mkdir(uri)
 }
 
-export const writeFile = async (uri, content, encoding = EncodingType.Utf8) => {
+export const writeFile = async (uri, content, encoding = EncodingType.Utf8, notify = true) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.writeFile(uri, content, encoding)
-  await notifyWorkspaceChanged({
-    changed: [uri],
-  })
+  if (notify) {
+    await notifyWorkspaceChanged({
+      changed: [uri],
+    })
+  }
 }
 
 export const writeBlob = async (uri, blob) => {

--- a/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
+++ b/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
@@ -57,3 +57,10 @@ test('writeFile notifies workspace views with the changed uri', async () => {
   })
   expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
+
+test('writeFile can skip reloading workspace views', async () => {
+  await FileSystem.writeFile('test://some-file.txt', 'updated', 'utf8', false)
+
+  expect(writeFile).toHaveBeenCalledWith('test://some-file.txt', 'updated', 'utf8')
+  expect(execute).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- let filesystem writes opt out of broadcasting a workspace refresh
- keep the existing default behavior for external workspace consumers
- cover both notifying and non-notifying write paths

## Tests
- renderer-worker test suite (329 passed)
- renderer-worker type-check
- focused formatting check
- assembled Electron: Find -> close -> save -> Find remains functional with no reference-node error