### PR TITLE
feature: update editor-worker to version 19.30.10

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -28,7 +28,7 @@
         "@lvce-editor/diff-view": "^3.33.0",
         "@lvce-editor/diff-worker": "^3.4.0",
         "@lvce-editor/drag-and-drop-worker": "^0.4.0",
-        "@lvce-editor/editor-worker": "^19.30.9",
+        "@lvce-editor/editor-worker": "^19.30.10",
         "@lvce-editor/embeds-worker": "^4.10.0",
         "@lvce-editor/error-worker": "^3.9.0",
         "@lvce-editor/explorer-view": "^7.23.1",
@@ -989,9 +989,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/editor-worker": {
-      "version": "19.30.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/editor-worker/-/editor-worker-19.30.9.tgz",
-      "integrity": "sha512-1W2VI/FgGaF6QNBDFbc75mLJhZgprUsU3lio47JCc5e/Au7gYgTn5lY3oxw+SGP+jm6sJAz8VL1B82FIahu/Yw==",
+      "version": "19.30.10",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/editor-worker/-/editor-worker-19.30.10.tgz",
+      "integrity": "sha512-TtfmjiYsfuL5qcDyNqFXoHYz8KVGcGyLy0Pa9DkGDNnYWtDHjiBVW/+Rft2PON9BhuJdJ+84mbQig7fHwACdRQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -60,7 +60,7 @@
     "@lvce-editor/diff-view": "^3.33.0",
     "@lvce-editor/diff-worker": "^3.4.0",
     "@lvce-editor/drag-and-drop-worker": "^0.4.0",
-    "@lvce-editor/editor-worker": "^19.30.9",
+    "@lvce-editor/editor-worker": "^19.30.10",
     "@lvce-editor/embeds-worker": "^4.10.0",
     "@lvce-editor/error-worker": "^3.9.0",
     "@lvce-editor/explorer-view": "^7.23.1",


### PR DESCRIPTION
## Summary

- update `@lvce-editor/editor-worker` from 19.30.9 to 19.30.10
- include the Find widget save/reopen and Replace All undo fixes

## Validation

- verified the installed bundle contains the no-refresh editor save invocation
- verified the installed bundle reverses inverse undo batches
- renderer-worker focused filesystem tests passed (4 tests)
- renderer-worker type-check passed
- static build passed

Producer: [editor-worker v19.30.10](https://github.com/lvce-editor/editor-worker/releases/tag/v19.30.10)
