### PR TITLE
fix: append direct render widgets before commit

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -441,14 +441,21 @@ export const openWidget = async (moduleId, ...args) => {
     commands.unshift(['Viewlet.dispose', moduleId])
   }
   const layout = ViewletStates.getState(ViewletModuleId.Layout)
-  const focusByNameIndex = commands.findIndex((command) => command[0] === 'Viewlet.focusElementByName')
+  const appendBeforeIndex = commands.findIndex((command) => {
+    return (
+      command[0] === 'Viewlet.commitPending' ||
+      command[0] === 'Viewlet.focusElementByName' ||
+      command[0] === 'Viewlet.focusSelector' ||
+      command[0] === 'Viewlet.focusSelectorAfterRender'
+    )
+  })
 
   if (isOwnedWidget) {
     commands.splice(0, commands.length, ...LayoutWidgets.declareWidget(args[0], childUid, commands))
   } else {
     const append = ['Viewlet.append', layout.uid, childUid]
-    if (focusByNameIndex !== -1) {
-      commands.splice(focusByNameIndex, 0, append)
+    if (appendBeforeIndex !== -1) {
+      commands.splice(appendBeforeIndex, 0, append)
     } else {
       commands.push(['Viewlet.append', layout.uid, childUid])
     }

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -434,6 +434,25 @@ test('openWidget - once', async () => {
   })
 })
 
+test('openWidget - appends a directly rendered widget before committing its renderer commands', async () => {
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([
+    ['Viewlet.createFunctionalRoot', 'QuickPick', 2, true],
+    ['Viewlet.commitPending', 2, 17],
+  ])
+  // @ts-ignore
+  RendererProcess.invoke.mockImplementation(async () => {})
+
+  await Viewlet.openWidget('QuickPick', ['everything'])
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.executeCommands', [
+    ['Viewlet.createFunctionalRoot', 'QuickPick', 2, true],
+    ['Viewlet.append', 1, 2],
+    ['Viewlet.commitPending', 2, 17],
+    ['Viewlet.focus', 2],
+  ])
+})
+
 test('openWidget - declares DefineKeyBinding as an owned widget', async () => {
   const layoutState = {
     ...ViewletStates.getState('Layout'),


### PR DESCRIPTION
## Details

Direct-rendered widget commands are queued in the renderer process and represented in the renderer-worker command list by `Viewlet.commitPending`. The widget root must be appended before that marker, just as it was previously appended before inline focus commands.

## Change

- append non-owned widgets before the first direct-render commit or focus command
- retain direct worker-to-renderer command dispatch
- cover the detached Quick Pick focus regression with a renderer-worker test

## Validation

- renderer-worker: 329 suites passed (22 skipped), 1,411 tests passed (231 skipped)
- renderer-worker type-check passed
- changed files pass Prettier and `git diff --check`
- package-wide XO and root lint currently report pre-existing repository-wide failures unrelated to this change