### PR TITLE
Support language server code actions

### DIFF
--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -380,6 +380,13 @@ export class LanguageServerConnection {
     const result = (await this.sendRequest('initialize', {
       capabilities: {
         textDocument: {
+          codeAction: {
+            codeActionLiteralSupport: {
+              codeActionKind: {
+                valueSet: ['', 'quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite', 'source', 'source.organizeImports'],
+              },
+            },
+          },
           completion: {
             completionItem: {
               snippetSupport: true,

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -11,12 +11,13 @@ const send = (message) => {
 /** @param {any} message */
 const handleMessage = (message) => {
   if (message.method === 'initialize') {
+    const codeActionKinds = message.params.capabilities?.textDocument?.codeAction?.codeActionLiteralSupport?.codeActionKind?.valueSet
     send({
       id: message.id,
       jsonrpc: '2.0',
       result: {
         capabilities: {
-          codeActionProvider: true,
+          codeActionProvider: Array.isArray(codeActionKinds) && codeActionKinds.includes('quickfix'),
           completionProvider: {},
           definitionProvider: true,
           diagnosticProvider: {


### PR DESCRIPTION
Advertise standard code-action literal support to language servers so servers such as ELP can return quick fixes.