### PR TITLE
feature: hide title bar in full screen

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -551,6 +551,7 @@ export const commandMap = {
   'Layout.handleDiagnosticsChange': lazy('Layout.handleDiagnosticsChange'),
   'Layout.handleExtensionsChanged': lazy('Layout.handleExtensionsChanged'),
   'Layout.handleFocus': lazy('Layout.handleFocus'),
+  'Layout.handleFullScreenChange': lazy('Layout.handleFullScreenChange'),
   'Layout.handleResize': lazy('Layout.handleResize'),
   'Layout.handleSashDoubleClick': lazy('Layout.handleSashDoubleClick'),
   'Layout.handleSashPointerDown': lazy('Layout.handleSashPointerDown'),

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -39,6 +39,7 @@ export interface LayoutState {
   readonly contentAreaId: number
   readonly contentAreaVisible: boolean
   readonly explicitBounds: boolean
+  readonly fullScreen: boolean
   readonly initial: boolean
   readonly mainHeight: number
   readonly mainId: number
@@ -130,6 +131,7 @@ export interface LayoutState {
   readonly titleBarLeft: number
   readonly titleBarNative: boolean
   readonly titleBarTop: number
+  readonly titleBarVisibleBeforeFullScreen: boolean
   readonly titleBarVisible: boolean
   readonly titleBarWidth: number
   readonly uid: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -117,6 +117,7 @@ export const create = (id: number): LayoutState => {
     mainId: -1,
     contentAreaId: -1,
     explicitBounds: false,
+    fullScreen: false,
     statusBarId: -1,
     titleBarId: -1,
     workbenchId: -1,
@@ -186,6 +187,7 @@ export const create = (id: number): LayoutState => {
     titleBarHeight: 0,
     titleBarLeft: 0,
     titleBarTop: 0,
+    titleBarVisibleBeforeFullScreen: false,
     titleBarWidth: 0,
     panelMaxHeight: 0,
     panelMaximized: false,
@@ -1308,6 +1310,12 @@ export const toggleSecondaryPreview = (state: LayoutState, uri: string = state.s
 }
 
 export const showTitleBar = (state: LayoutState) => {
+  if (state.fullScreen) {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
   // @ts-ignore
   return show(state, LayoutModules.TitleBar)
 }
@@ -1317,8 +1325,50 @@ export const hideTitleBar = (state: LayoutState) => {
 }
 
 export const toggleTitleBar = (state: LayoutState) => {
+  if (state.fullScreen) {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
   // @ts-ignore
   return toggle(state, LayoutModules.TitleBar)
+}
+
+export const handleFullScreenChange = async (state: LayoutState, fullScreen: boolean): Promise<LayoutStateResult> => {
+  if (state.fullScreen === fullScreen) {
+    return {
+      newState: state,
+      commands: [],
+    }
+  }
+  if (fullScreen) {
+    const titleBarVisibleBeforeFullScreen = !state.titleBarNative && state.titleBarVisible
+    const newState = {
+      ...state,
+      fullScreen: true,
+      titleBarVisibleBeforeFullScreen,
+    }
+    if (!titleBarVisibleBeforeFullScreen) {
+      return {
+        newState,
+        commands: [],
+      }
+    }
+    return hideTitleBar(newState)
+  }
+  const newState = {
+    ...state,
+    fullScreen: false,
+    titleBarVisibleBeforeFullScreen: false,
+  }
+  if (!state.titleBarVisibleBeforeFullScreen) {
+    return {
+      newState,
+      commands: [],
+    }
+  }
+  return showTitleBar(newState)
 }
 
 export const setActionsDom = (state: LayoutState, actionsDom: readonly unknown[], childUid: number, eventListeners?: readonly unknown[]) => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -33,6 +33,7 @@ export const CommandsWithSideEffects = {
   handleContextMenu: ViewletLayout.handleContextMenu,
   handleDiagnosticsChange: ViewletLayout.handleDiagnosticsChange,
   handleFocus: ViewletLayout.handleFocus,
+  handleFullScreenChange: ViewletLayout.handleFullScreenChange,
   handleResize: ViewletLayout.handleResize,
   handleSashDoubleClick: ViewletLayout.handleSashDoubleClick,
   handleSashPointerDown: ViewletLayout.handleSashPointerDown,

--- a/packages/renderer-worker/test/ViewletLayoutFullScreen.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutFullScreen.test.ts
@@ -1,0 +1,102 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => ({
+  saveViewletState: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
+  disposeFunctional: jest.fn(() => []),
+}))
+
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => ({
+  load: jest.fn(async () => []),
+}))
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+
+test('create initializes full screen state', () => {
+  const state = ViewletLayout.create(1)
+
+  expect(state.fullScreen).toBe(false)
+  expect(state.titleBarVisibleBeforeFullScreen).toBe(false)
+})
+
+test('entering full screen hides a visible custom title bar', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    titleBarHeight: 35,
+    titleBarVisible: true,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const result = await ViewletLayout.handleFullScreenChange(state, true)
+
+  expect(result.newState).toMatchObject({
+    fullScreen: true,
+    titleBarVisible: false,
+    titleBarVisibleBeforeFullScreen: true,
+  })
+})
+
+test('leaving full screen keeps a manually hidden title bar hidden', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    fullScreen: true,
+    titleBarVisible: false,
+    titleBarVisibleBeforeFullScreen: false,
+  }
+
+  const result = await ViewletLayout.handleFullScreenChange(state, false)
+
+  expect(result.newState).toMatchObject({
+    fullScreen: false,
+    titleBarVisible: false,
+    titleBarVisibleBeforeFullScreen: false,
+  })
+})
+
+test('leaving full screen restores a title bar hidden by full screen', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    fullScreen: true,
+    titleBarHeight: 35,
+    titleBarVisible: false,
+    titleBarVisibleBeforeFullScreen: true,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const result = await ViewletLayout.handleFullScreenChange(state, false)
+
+  expect(result.newState).toMatchObject({
+    fullScreen: false,
+    titleBarVisible: true,
+    titleBarVisibleBeforeFullScreen: false,
+  })
+})
+
+test('duplicate full screen events preserve the title bar snapshot', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    fullScreen: true,
+    titleBarVisible: false,
+    titleBarVisibleBeforeFullScreen: true,
+  }
+
+  const result = await ViewletLayout.handleFullScreenChange(state, true)
+
+  expect(result.newState).toBe(state)
+})
+
+test('showing or toggling the title bar is ignored in full screen', async () => {
+  const state = {
+    ...ViewletLayout.create(1),
+    fullScreen: true,
+    titleBarVisible: false,
+    titleBarVisibleBeforeFullScreen: true,
+  }
+
+  expect(await ViewletLayout.showTitleBar(state)).toEqual({ newState: state, commands: [] })
+  expect(await ViewletLayout.toggleTitleBar(state)).toEqual({ newState: state, commands: [] })
+})


### PR DESCRIPTION
Hide the custom title bar in full-screen mode and restore it on exit only when it was visible before entering.