### PR TITLE
fix: include Gleam syntax highlighting

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -138,6 +138,12 @@
     "created": "2023-07-05"
   },
   {
+    "name": "builtin.language-basics-gleam",
+    "repository": "github.com/lvce-editor/language-basics-gleam",
+    "version": "1.12.1",
+    "created": "2025-06-23"
+  },
+  {
     "name": "builtin.language-basics-elm",
     "repository": "github.com/lvce-editor/language-basics-elm",
     "version": "0.15.6",

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -27,6 +27,19 @@ test('includes the built-in Erlang syntax highlighting extension', async () => {
   })
 })
 
+test('includes the built-in Gleam syntax highlighting extension', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+  const extension = extensions.find((item) => item.id === 'builtin.language-basics-gleam')
+
+  expect(extension).toMatchObject({
+    builtin: true,
+    path: '/test-prefix/test-commit/extensions/builtin.language-basics-gleam',
+  })
+})
+
 test('includes the built-in Zig syntax highlighting extension', async () => {
   const extensions = await getAllExtensionsJson({
     commitHash: 'test-commit',


### PR DESCRIPTION
Bundle the Gleam language basics extension so .gleam files receive syntax highlighting out of the box. Pin the corrected v1.12.1 release and cover its presence in the generated built-in extension manifest.