### PR TITLE
fix: include media preview in server package

### DIFF
--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
@@ -460,9 +460,12 @@ const copyPlaygroundFiles = async ({ commitHash }) => {
   await generatePlaygroundFileMap({ commitHash })
 }
 
-const shouldBeCopied = (extensionName) => {
+export const shouldBeCopied = (extensionName) => {
   return (
-    extensionName === 'builtin.vscode-icons' || extensionName.startsWith('builtin.theme-') || extensionName.startsWith('builtin.language-basics-')
+    extensionName === 'builtin.media-preview' ||
+    extensionName === 'builtin.vscode-icons' ||
+    extensionName.startsWith('builtin.theme-') ||
+    extensionName.startsWith('builtin.language-basics-')
   )
 }
 

--- a/packages/build/test/BuildStaticServer.test.ts
+++ b/packages/build/test/BuildStaticServer.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import { shouldBeCopied } from '../src/parts/BuildStaticServer/BuildStaticServer.ts'
+
+test('includes media preview in server builds', () => {
+  expect(shouldBeCopied('builtin.media-preview')).toBe(true)
+})
+
+test('excludes unrelated extensions from server builds', () => {
+  expect(shouldBeCopied('builtin.video-preview')).toBe(false)
+})


### PR DESCRIPTION
Include the built-in media preview extension in server builds so image and media files can use the preview editor when LVCE is served remotely.