### PR TITLE
fix: skip root view title updates

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -309,7 +309,7 @@ const getRenderCommands = (module, oldState, newState, uid = newState.uid || mod
 
   if (module.renderTitle && !module.renderTitle.isEqual(oldState, newState)) {
     const title = module.renderTitle.apply(oldState, newState)
-    if (parentId) {
+    if (parentId > 0) {
       const parentInstance = ViewletStates.getInstance(parentId)
       if (parentInstance?.factory?.setTitle && parentInstance.state.childUid === uid) {
         const oldParentRenderedState = parentInstance.renderedState

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -519,6 +519,24 @@ test('extension view render sends a dynamic title to its parent', () => {
   expect(commands).toEqual([['Viewlet.send', 2, 'setTitle', 'Testing: Updated']])
 })
 
+test('extension view render does not send a dynamic title to the root parent sentinel', () => {
+  const oldState = {
+    commands: [],
+    dom: [],
+    kind: 'virtualDom',
+    patches: [],
+    title: 'Testing',
+  }
+  const newState = {
+    ...oldState,
+    title: 'Testing: Updated',
+  }
+
+  const commands = ViewletManager.render(ViewletExtensionViewRender, oldState, newState, 1, -1)
+
+  expect(commands).toEqual([])
+})
+
 test('extension view render keeps the parent actions state in sync', () => {
   const parentState = {
     actionsUid: 3,


### PR DESCRIPTION
Do not emit parent title commands for the root view sentinel (`parentUid = -1`).

Adds a focused ViewletManager regression test. The full renderer-worker suite passes (1,425 tests).