### PR TITLE
feature: connect remaining view workers directly to renderer process

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchChatDebugViewWorker/LaunchChatDebugViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchChatDebugViewWorker/LaunchChatDebugViewWorker.js
@@ -1,8 +1,11 @@
 import { chatDebugViewWorkerUrl } from '../ChatDebugViewWorkerUrl/ChatDebugViewWorkerUrl.js'
 import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchChatDebugViewWorker = async () => {
   const name = 'Chat Debug View Worker'
@@ -12,5 +15,10 @@ export const launchChatDebugViewWorker = async () => {
     url: getConfiguredWorkerUrl('develop.chatDebugViewWorkerPath', chatDebugViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'ChatDebug.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchChatViewWorker/LaunchChatViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchChatViewWorker/LaunchChatViewWorker.js
@@ -1,8 +1,11 @@
 import * as ChatViewWorkerUrl from '../ChatViewWorkerUrl/ChatViewWorkerUrl.js'
 import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchChatViewWorker = async () => {
   const name = 'Chat View Worker'
@@ -12,5 +15,10 @@ export const launchChatViewWorker = async () => {
     url: getConfiguredWorkerUrl('develop.chatViewWorkerPath', ChatViewWorkerUrl.chatViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'Chat.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchDiffViewWorker/LaunchDiffViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchDiffViewWorker/LaunchDiffViewWorker.js
@@ -1,9 +1,11 @@
 import * as DiffViewWorkerUrl from '../DiffViewWorkerUrl/DiffViewWorkerUrl.js'
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchDiffViewWorker = async () => {
   const name = 'Diff View Worker'
@@ -14,5 +16,10 @@ export const launchDiffViewWorker = async () => {
   })
   HandleIpc.handleIpc(ipc)
   await JsonRpc.invoke(ipc, 'DiffView.initialize')
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'DiffView.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchKeyBindingsViewWorker/LaunchKeyBindingsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchKeyBindingsViewWorker/LaunchKeyBindingsViewWorker.js
@@ -1,8 +1,11 @@
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as KeyBindingsViewWorkerUrl from '../KeyBindingsViewWorkerUrl/KeyBindingsViewWorkerUrl.js'
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchKeyBindingsViewWorker = async () => {
   const name = 'KeyBindings View Worker'
@@ -12,5 +15,10 @@ export const launchKeyBindingsViewWorker = async () => {
     url: GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.keyBindingsViewWorkerPath', KeyBindingsViewWorkerUrl.keyBindingsViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'KeyBindings.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchLanguageModelsViewWorker/LaunchLanguageModelsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchLanguageModelsViewWorker/LaunchLanguageModelsViewWorker.js
@@ -1,8 +1,11 @@
 import * as LanguageModelsViewWorkerUrl from '../LanguageModelsViewWorkerUrl/LanguageModelsViewWorkerUrl.js'
 import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchLanguageModelsViewWorker = async () => {
   const name = 'Language Models View Worker'
@@ -12,5 +15,10 @@ export const launchLanguageModelsViewWorker = async () => {
     url: getConfiguredWorkerUrl('develop.languageModelsViewPath', LanguageModelsViewWorkerUrl.languageModelsViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'LanguageModels.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchPanelWorker/LaunchPanelWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchPanelWorker/LaunchPanelWorker.ts
@@ -1,8 +1,11 @@
 import * as PanelWorkerUrl from '../PanelWorkerUrl/PanelWorkerUrl.js'
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchPanelWorker = async () => {
   const configuredWorkerUrl = GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.panelWorkerPath', PanelWorkerUrl.panelWorkerUrl)
@@ -12,5 +15,10 @@ export const launchPanelWorker = async () => {
     name: 'Panel Worker',
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'Panel.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchProcessExplorerWorker/LaunchProcessExplorerWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchProcessExplorerWorker/LaunchProcessExplorerWorker.js
@@ -1,8 +1,11 @@
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as ProcessExplorerWorkerUrl from '../ProcessExplorerWorkerUrl/ProcessExplorerWorkerUrl.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchProcessExplorerWorker = async () => {
   const name = 'Process Explorer Worker'
@@ -12,5 +15,10 @@ export const launchProcessExplorerWorker = async () => {
     url: GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.processExplorerWorkerPath', ProcessExplorerWorkerUrl.processExplorerWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'ProcessExplorer.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts
@@ -1,7 +1,10 @@
 import { getConfiguredWorkerUrl } from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import { runningExtensionsViewWorkerUrl } from '../RunningExtensionsViewWorkerUrl/RunningExtensionsViewWorkerUrl.ts'
 
 export const launchRunningExtensionsViewWorker = async () => {
@@ -11,5 +14,10 @@ export const launchRunningExtensionsViewWorker = async () => {
     url: getConfiguredWorkerUrl('develop.runningExtensionsViewPath', runningExtensionsViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'RunningExtensions.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchSettingsViewWorker/LaunchSettingsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchSettingsViewWorker/LaunchSettingsViewWorker.js
@@ -1,8 +1,10 @@
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as SettingsViewWorkerUrl from '../SettingsViewWorkerUrl/SettingsViewWorkerUrl.js'
 
 export const launchSettingsViewWorker = async () => {
@@ -14,5 +16,10 @@ export const launchSettingsViewWorker = async () => {
   })
   HandleIpc.handleIpc(ipc)
   await JsonRpc.invoke(ipc, 'Initialize.initialize')
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'Settings.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/ViewletChat/ViewletChat.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletChat/ViewletChat.ipc.ts
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'chatView' })

--- a/packages/renderer-worker/src/parts/ViewletChatDebug/ViewletChatDebug.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletChatDebug/ViewletChatDebug.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
+  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
   name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'chatDebug' })

--- a/packages/renderer-worker/src/parts/ViewletDiffEditor2/ViewletDiffEditor2.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletDiffEditor2/ViewletDiffEditor2.ipc.js
@@ -2,7 +2,7 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
+  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
   name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'diffView' })
 

--- a/packages/renderer-worker/src/parts/ViewletKeyBindings/ViewletKeyBindings.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletKeyBindings/ViewletKeyBindings.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'keyBindings' })

--- a/packages/renderer-worker/src/parts/ViewletLanguageModels/ViewletLanguageModels.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletLanguageModels/ViewletLanguageModels.ipc.ts
@@ -1,7 +1,7 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getTitle, hasFunctionalEvents,
+  Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getTitle, hasDirectRender, hasFunctionalEvents,
   hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus, name, render, renderDialog, renderEventListeners,
   renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'languageModels' })

--- a/packages/renderer-worker/src/parts/ViewletPanel/ViewletPanel.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletPanel/ViewletPanel.ipc.ts
@@ -14,6 +14,7 @@ export const {
   dispose,
   getCommands,
   getKeyBindings,
+  hasDirectRender,
   hasFunctionalEvents,
   hasFunctionalRender,
   hasFunctionalResize,

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
+  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
   name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'processExplorer' })

--- a/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts
@@ -1,7 +1,7 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getTitle, handleExtensionsChanged, hasFunctionalEvents,
+  Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getTitle, handleExtensionsChanged, hasDirectRender, hasFunctionalEvents,
   hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus, name, render, renderEventListeners,
   renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'runningExtensionsView' })

--- a/packages/renderer-worker/src/parts/ViewletSettings/ViewletSettings.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletSettings/ViewletSettings.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
   loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
 } = createWorkerViewlet({ workerId: 'settingsView' })

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -218,7 +218,7 @@
         "getMenuEntries": { "name": "ChatDebug.getMenuEntries", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
         "renderEventListeners": { "name": "ChatDebug.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }
   },
   {
@@ -354,7 +354,7 @@
         },
         "renderEventListeners": { "name": "Chat.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "always"
     }
   },
@@ -496,7 +496,7 @@
         "getMenuEntries": { "name": "DiffView.getMenuEntries", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
         "renderEventListeners": { "name": "DiffView.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "ignoreKeyBindingErrors": true,
       "ignoreEventListenerErrors": true
     }
@@ -843,7 +843,7 @@
         },
         "renderEventListeners": { "name": "KeyBindings.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "emptyCommands"
     }
   },
@@ -907,7 +907,7 @@
         },
         "renderEventListeners": { "name": "LanguageModels.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "rootRender": true },
       "renderComparison": "always"
     }
   },
@@ -1129,7 +1129,7 @@
         "getCommandIds": { "name": "Panel.getCommandIds", "parameters": [] },
         "renderEventListeners": { "name": "Panel.renderEventListeners", "parameters": [] }
       },
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "commands"
     }
   },
@@ -1261,7 +1261,7 @@
         "renderEventListeners": { "name": "ProcessExplorer.renderEventListeners", "parameters": [] }
       },
       "renderComparison": "emptyCommands",
-      "capabilities": { "events": true, "render": true, "rootRender": true }
+      "capabilities": { "directRender": true, "events": true, "render": true, "rootRender": true }
     }
   },
   {
@@ -1369,7 +1369,7 @@
         "renderEventListeners": { "name": "RunningExtensions.renderEventListeners", "parameters": [] }
       },
       "extraCommands": [{ "name": "handleExtensionsChanged", "method": "refresh" }],
-      "capabilities": { "events": true, "render": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "rootRender": true },
       "renderComparison": "emptyCommands"
     }
   },
@@ -1428,7 +1428,7 @@
         "renderEventListeners": { "name": "Settings.renderEventListeners", "parameters": [] }
       },
       "outputs": [{ "stateField": "actionsDom", "hotReload": false, "method": { "name": "Settings.renderActions", "parameters": [{ "source": "state", "name": "uid" }] } }],
-      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true },
+      "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "emptyCommands"
     }
   },

--- a/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
+++ b/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
@@ -32,11 +32,20 @@ const GetPortTuple = await import('../src/parts/GetPortTuple/GetPortTuple.js')
 const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchAboutViewWorker = await import('../src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js')
 const LaunchActivityBarWorker = await import('../src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts')
+const LaunchChatDebugViewWorker = await import('../src/parts/LaunchChatDebugViewWorker/LaunchChatDebugViewWorker.js')
+const LaunchChatViewWorker = await import('../src/parts/LaunchChatViewWorker/LaunchChatViewWorker.js')
+const LaunchDiffViewWorker = await import('../src/parts/LaunchDiffViewWorker/LaunchDiffViewWorker.js')
 const LaunchExtensionSearchViewWorker = await import('../src/parts/LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js')
+const LaunchKeyBindingsViewWorker = await import('../src/parts/LaunchKeyBindingsViewWorker/LaunchKeyBindingsViewWorker.js')
+const LaunchLanguageModelsViewWorker = await import('../src/parts/LaunchLanguageModelsViewWorker/LaunchLanguageModelsViewWorker.js')
 const LaunchMainAreaWorker = await import('../src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts')
 const LaunchOutputViewWorker = await import('../src/parts/LaunchOutputViewWorker/LaunchOutputViewWorker.js')
+const LaunchPanelWorker = await import('../src/parts/LaunchPanelWorker/LaunchPanelWorker.ts')
 const LaunchProblemsWorker = await import('../src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts')
+const LaunchProcessExplorerWorker = await import('../src/parts/LaunchProcessExplorerWorker/LaunchProcessExplorerWorker.js')
 const LaunchQuickPickWorker = await import('../src/parts/LaunchQuickPickWorker/LaunchQuickPickWorker.js')
+const LaunchRunningExtensionsViewWorker = await import('../src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts')
+const LaunchSettingsViewWorker = await import('../src/parts/LaunchSettingsViewWorker/LaunchSettingsViewWorker.js')
 const LaunchSourceControlWorker = await import('../src/parts/LaunchSourceControlWorker/LaunchSourceControlWorker.js')
 const LaunchStatusBarWorker = await import('../src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js')
 const LaunchTextSearchViewWorker = await import('../src/parts/LaunchTextSearchViewWorker/LaunchTextSearchViewWorker.js')
@@ -50,12 +59,21 @@ beforeEach(() => {
 test.each([
   ['about', LaunchAboutViewWorker.launchAboutViewWorker, 'About.handleMessagePort'],
   ['activity bar', LaunchActivityBarWorker.launchActivityBarWorker, 'ActivityBar.handleMessagePort'],
+  ['chat', LaunchChatViewWorker.launchChatViewWorker, 'Chat.handleMessagePort'],
+  ['chat debug', LaunchChatDebugViewWorker.launchChatDebugViewWorker, 'ChatDebug.handleMessagePort'],
+  ['diff', LaunchDiffViewWorker.launchDiffViewWorker, 'DiffView.handleMessagePort'],
   ['extension search', LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort'],
+  ['keybindings', LaunchKeyBindingsViewWorker.launchKeyBindingsViewWorker, 'KeyBindings.handleMessagePort'],
+  ['language models', LaunchLanguageModelsViewWorker.launchLanguageModelsViewWorker, 'LanguageModels.handleMessagePort'],
   ['main area', LaunchMainAreaWorker.launchMainAreaWorker, 'MainArea.handleMessagePort'],
   ['output', LaunchOutputViewWorker.launchOutputViewWorker, 'Output.handleMessagePort'],
+  ['panel', LaunchPanelWorker.launchPanelWorker, 'Panel.handleMessagePort'],
   ['problems', LaunchProblemsWorker.launchProblemsWorker, 'Problems.handleMessagePort'],
+  ['process explorer', LaunchProcessExplorerWorker.launchProcessExplorerWorker, 'ProcessExplorer.handleMessagePort'],
   ['quick pick', LaunchQuickPickWorker.launchQuickPickWorker, 'QuickPick.handleRendererProcessMessagePort'],
   ['source control', LaunchSourceControlWorker.launchSourceControlWorker, 'SourceControl.handleRendererProcessMessagePort'],
+  ['running extensions', LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker, 'RunningExtensions.handleMessagePort'],
+  ['settings', LaunchSettingsViewWorker.launchSettingsViewWorker, 'Settings.handleMessagePort'],
   ['status bar', LaunchStatusBarWorker.launchStatusBarWorker, 'StatusBar.handleMessagePort'],
   ['text search', LaunchTextSearchViewWorker.launchTextSearchViewWorker, 'TextSearch.handleMessagePort'],
   ['title bar', LaunchTitleBarWorker.launchTitleBarWorker, 'TitleBar.handleMessagePort'],

--- a/packages/renderer-worker/test/LaunchProcessExplorerWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchProcessExplorerWorker.test.ts
@@ -13,6 +13,10 @@ jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorke
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetPortTuple/GetPortTuple.js', () => ({
+  getPortTuple: jest.fn(() => ({ port1: 'worker-port', port2: 'renderer-process-port' })),
+}))
+
 jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => {
   return {
     handleIpc: jest.fn(() => {
@@ -29,10 +33,21 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
 const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
+const GetPortTuple = await import('../src/parts/GetPortTuple/GetPortTuple.js')
 const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchProcessExplorerWorker = await import('../src/parts/LaunchProcessExplorerWorker/LaunchProcessExplorerWorker.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 
 test('launchProcessExplorerWorker', async () => {
   const ipc = {
@@ -41,9 +56,15 @@ test('launchProcessExplorerWorker', async () => {
   // @ts-ignore
   GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///process-explorer-worker.js')
   // @ts-ignore
+  GetPortTuple.getPortTuple.mockReturnValue({ port1: 'worker-port', port2: 'renderer-process-port' })
+  // @ts-ignore
   IpcParent.create.mockResolvedValue(ipc)
   // @ts-ignore
   HandleIpc.handleIpc.mockReturnValue(undefined)
+  // @ts-ignore
+  JsonRpc.invokeAndTransfer.mockResolvedValue(undefined)
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockResolvedValue(undefined)
 
   const result = await LaunchProcessExplorerWorker.launchProcessExplorerWorker()
 
@@ -60,5 +81,8 @@ test('launchProcessExplorerWorker', async () => {
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledTimes(1)
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'ProcessExplorer.handleMessagePort', 'worker-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/LaunchRunningExtensionsViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchRunningExtensionsViewWorker.test.ts
@@ -13,6 +13,10 @@ jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorke
   }
 })
 
+jest.unstable_mockModule('../src/parts/GetPortTuple/GetPortTuple.js', () => ({
+  getPortTuple: jest.fn(() => ({ port1: 'worker-port', port2: 'renderer-process-port' })),
+}))
+
 jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => {
   return {
     handleIpc: jest.fn(() => {
@@ -29,10 +33,21 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
 const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
+const GetPortTuple = await import('../src/parts/GetPortTuple/GetPortTuple.js')
 const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchRunningExtensionsViewWorker = await import('../src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 
 test('launchRunningExtensionsViewWorker', async () => {
   const ipc = {
@@ -41,9 +56,15 @@ test('launchRunningExtensionsViewWorker', async () => {
   // @ts-ignore
   GetConfiguredWorkerUrl.getConfiguredWorkerUrl.mockReturnValue('file:///running-extensions-view-worker.js')
   // @ts-ignore
+  GetPortTuple.getPortTuple.mockReturnValue({ port1: 'worker-port', port2: 'renderer-process-port' })
+  // @ts-ignore
   IpcParent.create.mockResolvedValue(ipc)
   // @ts-ignore
   HandleIpc.handleIpc.mockReturnValue(undefined)
+  // @ts-ignore
+  JsonRpc.invokeAndTransfer.mockResolvedValue(undefined)
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockResolvedValue(undefined)
 
   const result = await LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker()
 
@@ -60,5 +81,8 @@ test('launchRunningExtensionsViewWorker', async () => {
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledTimes(1)
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'RunningExtensions.handleMessagePort', 'worker-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/ViewletDirectRender.test.ts
+++ b/packages/renderer-worker/test/ViewletDirectRender.test.ts
@@ -1,27 +1,45 @@
 import { expect, test } from '@jest/globals'
 import * as ViewletAbout from '../src/parts/ViewletAbout/ViewletAbout.ipc.ts'
 import * as ViewletActivityBar from '../src/parts/ViewletActivityBar/ViewletActivityBar.ipc.ts'
+import * as ViewletChat from '../src/parts/ViewletChat/ViewletChat.ipc.ts'
+import * as ViewletChatDebug from '../src/parts/ViewletChatDebug/ViewletChatDebug.ipc.js'
+import * as ViewletDiffEditor2 from '../src/parts/ViewletDiffEditor2/ViewletDiffEditor2.ipc.js'
 import * as ViewletExtensionDetail from '../src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ipc.ts'
 import * as ViewletExtensions from '../src/parts/ViewletExtensions/ViewletExtensions.ipc.js'
+import * as ViewletKeyBindings from '../src/parts/ViewletKeyBindings/ViewletKeyBindings.ipc.js'
+import * as ViewletLanguageModels from '../src/parts/ViewletLanguageModels/ViewletLanguageModels.ipc.ts'
 import * as ViewletOutput from '../src/parts/ViewletOutput/ViewletOutput.ipc.ts'
+import * as ViewletPanel from '../src/parts/ViewletPanel/ViewletPanel.ipc.ts'
 import * as ViewletProblems from '../src/parts/ViewletProblems/ViewletProblems.ipc.js'
+import * as ViewletProcessExplorer from '../src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js'
 import * as ViewletQuickPick from '../src/parts/ViewletQuickPick/ViewletQuickPick.ipc.js'
 import * as ViewletSourceControl from '../src/parts/ViewletSourceControl/ViewletSourceControl.ipc.js'
 import * as ViewletStatusBar from '../src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js'
 import * as ViewletMain from '../src/parts/ViewletMain/ViewletMain.ipc.js'
 import * as ViewletSearch from '../src/parts/ViewletSearch/ViewletSearch.ipc.ts'
+import * as ViewletRunningExtensions from '../src/parts/ViewletRunningExtensions/ViewletRunningExtensions.ipc.ts'
+import * as ViewletSettings from '../src/parts/ViewletSettings/ViewletSettings.ipc.js'
 import * as ViewletTitleBar from '../src/parts/ViewletTitleBar/ViewletTitleBar.ipc.js'
 
 test.each([
   ['about', ViewletAbout],
   ['activity bar', ViewletActivityBar],
+  ['chat', ViewletChat],
+  ['chat debug', ViewletChatDebug],
+  ['diff', ViewletDiffEditor2],
   ['extension detail', ViewletExtensionDetail],
   ['extensions', ViewletExtensions],
+  ['keybindings', ViewletKeyBindings],
+  ['language models', ViewletLanguageModels],
   ['output', ViewletOutput],
+  ['panel', ViewletPanel],
   ['problems', ViewletProblems],
+  ['process explorer', ViewletProcessExplorer],
   ['main area', ViewletMain],
   ['quick pick', ViewletQuickPick],
   ['source control', ViewletSourceControl],
+  ['running extensions', ViewletRunningExtensions],
+  ['settings', ViewletSettings],
   ['status bar', ViewletStatusBar],
   ['text search', ViewletSearch],
   ['title bar', ViewletTitleBar],


### PR DESCRIPTION
Connects Panel, Settings, Keybindings, Chat, Chat Debug, Diff, Language Models, Process Explorer, and Running Extensions directly to the renderer process. Adds launcher and direct-render capability regression coverage.