### PR TITLE
fix: show color area selection

### DIFF
--- a/static/css/parts/ViewletColorPicker.css
+++ b/static/css/parts/ViewletColorPicker.css
@@ -1,4 +1,6 @@
 :root {
+  --ColorPickerColorAreaOffsetX: 0px;
+  --ColorPickerColorAreaOffsetY: 0px;
   --ColorPickerColor: black;
   --ColorPickerOffsetX: 0px;
 }
@@ -16,6 +18,7 @@
 .ColorPickerRectangle {
   contain: strict;
   flex: 1;
+  touch-action: none;
 }
 
 .ColorPickerBackgroundColor,
@@ -36,6 +39,20 @@
 
 .ColorPickerDark {
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgb(0, 0, 0));
+}
+
+.ColorPickerSelectionThumb {
+  position: absolute;
+  top: clamp(8px, var(--ColorPickerColorAreaOffsetY), calc(100% - 8px));
+  left: clamp(8px, var(--ColorPickerColorAreaOffsetX), calc(100% - 8px));
+  width: 14px;
+  height: 14px;
+  border: 2px solid white;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px black;
+  contain: strict;
+  pointer-events: none;
+  translate: -50% -50%;
 }
 
 .ColorPickerSlider {


### PR DESCRIPTION
## Summary

- add color-picker saturation/value selection marker styling
- keep the marker visible and contained at all four edges
- disable browser touch gestures while dragging in the color area

## Validation

- Prettier CSS check
- npm run build:static
- integrated Electron UI with the candidate color-picker worker: click, drag, out-of-bounds tracking, edge clamping, and renderer-error check

Companion styling for lvce-editor/color-picker-worker#173 and frozen color-picker dogfood finding 05.