### PR TITLE
fix: route color picker keyboard input

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -8,6 +8,7 @@ const subWidgetCommandIds = [
   'ColorPicker.handleColorAreaPointerMove',
   'ColorPicker.handleColorAreaPointerUp',
   'ColorPicker.handleContextMenu',
+  'ColorPicker.handleSliderKeyDown',
   'ColorPicker.handleSliderPointerDown',
   'ColorPicker.handleSliderPointerMove',
   'ColorPicker.handleSliderPointerUp',

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -50,6 +50,7 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
   expect(commands['ColorPicker.handleColorAreaPointerMove']).toBeDefined()
   expect(commands['ColorPicker.handleColorAreaPointerUp']).toBeDefined()
   expect(commands['ColorPicker.handleContextMenu']).toBeDefined()
+  expect(commands['ColorPicker.handleSliderKeyDown']).toBeDefined()
   expect(commands['ColorPicker.handleSliderPointerDown']).toBeDefined()
   expect(commands['ColorPicker.handleSliderPointerMove']).toBeDefined()
   expect(commands['ColorPicker.handleSliderPointerUp']).toBeDefined()


### PR DESCRIPTION
## Summary
- expose the color picker slider keydown command through the editor renderer command bridge
- cover command registration in the renderer test

## Tests
- renderer-worker focused Jest test
- npm run type-check
- npm run build:static
- Electron acceptance with the local color-picker worker