### PR TITLE
fix: close color picker with escape

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -1,3 +1,4 @@
+import * as BrowserKey from '../BrowserKey/BrowserKey.js'
 import * as Command from '../Command/Command.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as WrapEditorCommands from '../WrapEditorCommands/WrapEditorCommands.js'
@@ -123,6 +124,17 @@ const renderPending = async (editor) => {
   }
 }
 
+const executeWidgetCommand = WrapEditorCommands.wrapEditorCommand('Editor.executeWidgetCommand')
+const closeColorPicker = WrapEditorCommands.wrapEditorCommand('Editor.closeColorPicker')
+
+const handleColorPickerSliderKeyDown = (editor, ...args) => {
+  const key = args[args.length - 1]
+  if (key === BrowserKey.Escape) {
+    return closeColorPicker(editor)
+  }
+  return executeWidgetCommand(editor, ...args)
+}
+
 export const getCommands = async () => {
   const commandIds = await EditorWorker.invoke('Editor.getCommandIds')
   Object.assign(Commands, WrapEditorCommands.wrapEditorCommands(commandIds), WrapEditorCommands.wrapEditorCommands(subWidgetCommandIds), {
@@ -131,6 +143,7 @@ export const getCommands = async () => {
     renderPending,
     showOverlayMessage,
     hotReload,
+    'ColorPicker.handleSliderKeyDown': handleColorPickerSliderKeyDown,
   })
   return Commands
 }

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -61,6 +61,70 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
   expect(commands.hotReload).toBeDefined()
 })
 
+test('color picker slider escape closes the picker', async () => {
+  const editor = {
+    commands: [],
+    uid: 42,
+  }
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.closeColorPicker':
+        return undefined
+      case 'Editor.diff2':
+        return [1]
+      case 'Editor.getCommandIds':
+        return []
+      case 'Editor.render2':
+        return [['Viewlet.focus', 42]]
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const commands = await ViewletEditorTextCommands.getCommands()
+  const result = await commands['ColorPicker.handleSliderKeyDown'](editor, 'ColorPicker', 'ColorPicker.handleSliderKeyDown', 42, 7, 'Escape')
+
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.closeColorPicker', 42)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(3, 'Editor.diff2', 42)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(4, 'Editor.render2', 42, [1])
+  expect(result.commands).toEqual([['Viewlet.focus', 42]])
+})
+
+test('color picker slider navigation keys continue to execute the widget command', async () => {
+  const editor = {
+    commands: [],
+    uid: 42,
+  }
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.diff2':
+        return [1]
+      case 'Editor.executeWidgetCommand':
+        return undefined
+      case 'Editor.getCommandIds':
+        return []
+      case 'Editor.render2':
+        return []
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const commands = await ViewletEditorTextCommands.getCommands()
+  await commands['ColorPicker.handleSliderKeyDown'](editor, 'ColorPicker', 'ColorPicker.handleSliderKeyDown', 42, 7, 'ArrowRight')
+
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(
+    2,
+    'Editor.executeWidgetCommand',
+    42,
+    'ColorPicker',
+    'ColorPicker.handleSliderKeyDown',
+    42,
+    7,
+    'ArrowRight',
+  )
+})
+
 test('loadContentLater requests diagnostics after the initial render', async () => {
   editorWorkerInvoke.mockImplementation((method) => {
     if (method === 'Editor.getCommandIds') {


### PR DESCRIPTION
Fixes the final installed-package regression found during color-picker acceptance: the slider keydown listener consumed Escape before the editor close keybinding could run.

Escape now routes to Editor.closeColorPicker while slider navigation keys continue through Editor.executeWidgetCommand.

Tests:
- focused ViewletEditorTextCommands suite: 8 passed
- renderer-worker full suite: 330 suites passed, 1,445 tests passed
- renderer-worker type-check
- Prettier check