### PR TITLE
feature: trace worker IPC to JSONL

### DIFF
--- a/packages/renderer-worker/src/parts/GetIpcTraceTransferrables/GetIpcTraceTransferrables.ts
+++ b/packages/renderer-worker/src/parts/GetIpcTraceTransferrables/GetIpcTraceTransferrables.ts
@@ -1,0 +1,28 @@
+import * as IsTransferrable from '../IsTransferrable/IsTransferrable.ts'
+
+const walkValue = (value: unknown, transferrables: Transferable[], seen: WeakSet<object>): void => {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+    return
+  }
+  if (seen.has(value)) {
+    return
+  }
+  seen.add(value)
+  if (value instanceof ArrayBuffer || IsTransferrable.isTransferrable(value)) {
+    transferrables.push(value as Transferable)
+    return
+  }
+  if (ArrayBuffer.isView(value)) {
+    walkValue(value.buffer, transferrables, seen)
+    return
+  }
+  for (const child of Array.isArray(value) ? value : Object.values(value)) {
+    walkValue(child, transferrables, seen)
+  }
+}
+
+export const getIpcTraceTransferrables = (value: unknown): Transferable[] => {
+  const transferrables: Transferable[] = []
+  walkValue(value, transferrables, new WeakSet())
+  return transferrables
+}

--- a/packages/renderer-worker/src/parts/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.js
+++ b/packages/renderer-worker/src/parts/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.js
@@ -2,17 +2,26 @@ import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as RendererProcessIpcParentType from '../RendererProcessIpcParentType/RendererProcessIpcParentType.js'
 import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as GetTransferrables from '../GetTransferrables/GetTransferrables.ts'
+import * as IpcTrace from '../IpcTrace/IpcTrace.js'
 
-export const create = async ({ url, name, port, id }) => {
+/** @param {any} options */
+export const create = async (options) => {
+  const { url, name, port, id, traceId = '' } = options
   // TODO no need to create port if worker
   // has been prelaunched in renderer process
   const { port1, port2 } = GetPortTuple.getPortTuple(port)
+  const workerPort = await IpcTrace.maybeCreateProxy({
+    id,
+    name,
+    port: port2,
+    traceId,
+  })
   await RendererProcess.invokeAndTransfer('IpcParent.create', {
     method: RendererProcessIpcParentType.ModuleWorkerWithMessagePort,
     url,
     name,
     raw: true,
-    port: port2,
+    port: workerPort,
     id,
   })
   return port1

--- a/packages/renderer-worker/src/parts/IpcTrace/IpcTrace.js
+++ b/packages/renderer-worker/src/parts/IpcTrace/IpcTrace.js
@@ -1,0 +1,189 @@
+import * as GetIpcTraceTransferrables from '../GetIpcTraceTransferrables/GetIpcTraceTransferrables.ts'
+import * as IpcTraceConfig from '../IpcTraceConfig/IpcTraceConfig.js'
+import * as Process from '../Process/Process.js'
+import * as SerializeIpcTraceMessage from '../SerializeIpcTraceMessage/SerializeIpcTraceMessage.js'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+const flushRecordCount = 100
+const flushDelay = 100
+
+/** @type {any} */
+export const state = {
+  batches: new Map(),
+  connectionId: 0,
+  disabled: false,
+  flushTimer: undefined,
+  getArgv: Process.getArgv,
+  getTransferrables: GetIpcTraceTransferrables.getIpcTraceTransferrables,
+  now: () => performance.now(),
+  optionsPromise: undefined,
+  pendingRecordCount: 0,
+  serialize: SerializeIpcTraceMessage.serializeIpcTraceMessage,
+  setTimeout: (callback, delay) => globalThis.setTimeout(callback, delay),
+  timeOrigin: () => performance.timeOrigin,
+  wallTime: () => new Date().toISOString(),
+  write: (workerId, records) => SharedProcess.invoke('IpcTrace.append', workerId, records),
+  writeChain: Promise.resolve(),
+  writeStderr: Process.writeStderr,
+}
+
+const reportError = (error) => {
+  if (state.disabled) {
+    return
+  }
+  state.disabled = true
+  if (state.flushTimer !== undefined) {
+    clearTimeout(state.flushTimer)
+    state.flushTimer = undefined
+  }
+  state.batches.clear()
+  state.pendingRecordCount = 0
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`IPC tracing disabled: ${message}`)
+  void Promise.resolve(state.writeStderr(`IPC tracing disabled: ${message}\n`)).catch(() => {})
+}
+
+const getOptions = async () => {
+  state.optionsPromise ||= Promise.resolve(state.getArgv())
+    .then((argv) => {
+      const options = IpcTraceConfig.parseTraceIpc(argv)
+      if (options.error) {
+        reportError(new Error(options.error))
+      }
+      return options
+    })
+    .catch((error) => {
+      reportError(error)
+      return { error: '', selectors: new Set() }
+    })
+  return state.optionsPromise
+}
+
+const getWorkerId = (traceId, name, runtimeId) => {
+  if (traceId) {
+    return traceId
+  }
+  const suffix = name ? `-${name}` : ''
+  return `runtime-${runtimeId}${suffix}`
+}
+
+const writeBatches = (batches) => {
+  state.writeChain = state.writeChain
+    .then(async () => {
+      for (const [workerId, records] of batches) {
+        await state.write(workerId, records)
+      }
+    })
+    .catch(reportError)
+}
+
+export const flush = async () => {
+  if (state.flushTimer !== undefined) {
+    clearTimeout(state.flushTimer)
+    state.flushTimer = undefined
+  }
+  if (state.pendingRecordCount === 0) {
+    await state.writeChain
+    return
+  }
+  const batches = state.batches
+  state.batches = new Map()
+  state.pendingRecordCount = 0
+  writeBatches(batches)
+  await state.writeChain
+}
+
+const queueRecord = (workerId, record) => {
+  if (state.disabled) {
+    return
+  }
+  let records = state.batches.get(workerId)
+  if (!records) {
+    records = []
+    state.batches.set(workerId, records)
+  }
+  records.push(record)
+  state.pendingRecordCount++
+  if (state.pendingRecordCount >= flushRecordCount) {
+    void flush()
+    return
+  }
+  state.flushTimer ||= state.setTimeout(() => {
+    state.flushTimer = undefined
+    void flush()
+  }, flushDelay)
+}
+
+const getData = (event) => {
+  if (typeof MessageEvent !== 'undefined' && event instanceof MessageEvent) {
+    return event.data
+  }
+  return event?.data ?? event
+}
+
+const createForwarder = (source, target, workerId, connectionId, direction, sequence) => {
+  source.onmessage = (event) => {
+    const message = getData(event)
+    const monotonicTime = state.now()
+    const startTime = monotonicTime
+    let serializedMessage
+    try {
+      serializedMessage = state.serialize(message)
+    } catch (error) {
+      serializedMessage = {
+        $type: 'SerializationError',
+        message: error instanceof Error ? error.message : String(error),
+      }
+    }
+    const serializationDuration = state.now() - startTime
+    const transferables = state.getTransferrables(message)
+    target.postMessage(message, transferables)
+    queueRecord(workerId, {
+      connectionId,
+      direction,
+      message: serializedMessage,
+      monotonicTime,
+      sequence: sequence.value++,
+      serializationDuration,
+      version: 1,
+      wallTime: state.wallTime(),
+      workerId,
+    })
+  }
+  source.start?.()
+}
+
+export const maybeCreateProxy = async ({ id, name = '', port, traceId = '' }) => {
+  if (!port || state.disabled) {
+    return port
+  }
+  const options = await getOptions()
+  if (state.disabled || !IpcTraceConfig.shouldTrace(options.selectors, traceId)) {
+    return port
+  }
+  const workerId = getWorkerId(traceId, name, id)
+  const connectionId = `${state.timeOrigin()}-${state.connectionId++}`
+  try {
+    const { port1: proxyPort, port2: workerPort } = new MessageChannel()
+    const sequence = { value: 1 }
+    createForwarder(port, proxyPort, workerId, connectionId, 'parent-to-worker', sequence)
+    createForwarder(proxyPort, port, workerId, connectionId, 'worker-to-parent', sequence)
+    return workerPort
+  } catch (error) {
+    reportError(error)
+    return port
+  }
+}
+
+export const reset = () => {
+  if (state.flushTimer !== undefined) {
+    clearTimeout(state.flushTimer)
+  }
+  state.batches = new Map()
+  state.connectionId = 0
+  state.disabled = false
+  state.flushTimer = undefined
+  state.optionsPromise = undefined
+  state.pendingRecordCount = 0
+  state.writeChain = Promise.resolve()
+}

--- a/packages/renderer-worker/src/parts/IpcTraceConfig/IpcTraceConfig.js
+++ b/packages/renderer-worker/src/parts/IpcTraceConfig/IpcTraceConfig.js
@@ -1,0 +1,38 @@
+const traceIpcFlag = '--trace-ipc'
+const traceIpcPrefix = `${traceIpcFlag}=`
+
+export const parseTraceIpc = (argv) => {
+  let value
+  for (let index = 1; index < argv.length; index++) {
+    const argument = argv[index]
+    if (argument === traceIpcFlag) {
+      const nextArgument = argv[index + 1]
+      value = typeof nextArgument === 'string' && !nextArgument.startsWith('--') ? nextArgument : ''
+      break
+    }
+    if (typeof argument === 'string' && argument.startsWith(traceIpcPrefix)) {
+      value = argument.slice(traceIpcPrefix.length)
+      break
+    }
+  }
+  if (value === undefined) {
+    return { error: '', selectors: new Set() }
+  }
+  const selectors = new Set(
+    value
+      .split(',')
+      .map((selector) => selector.trim())
+      .filter(Boolean),
+  )
+  if (selectors.size === 0) {
+    return {
+      error: '--trace-ipc requires a comma-separated worker id list or *',
+      selectors,
+    }
+  }
+  return { error: '', selectors }
+}
+
+export const shouldTrace = (selectors, traceId) => {
+  return selectors.has('*') || Boolean(traceId && selectors.has(traceId))
+}

--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
@@ -1,6 +1,7 @@
 import * as ContentSecurityPolicy from '../ContentSecurityPolicy/ContentSecurityPolicy.js'
 import * as GetExtensionWorkerMemoryUsage from '../GetExtensionWorkerMemoryUsage/GetExtensionWorkerMemoryUsage.js'
 import * as Id from '../Id/Id.js'
+import * as IpcTrace from '../IpcTrace/IpcTrace.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
@@ -18,10 +19,16 @@ export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, 
     const pathName = new URL(url, 'http://localhost').pathname
     await ContentSecurityPolicy.set(pathName, contentSecurityPolicy)
   }
+  const workerPort = await IpcTrace.maybeCreateProxy({
+    id,
+    name,
+    port,
+    traceId: extensionId,
+  })
   await RendererProcess.invokeAndTransfer('IpcParent.create', {
     method: RendererProcessIpcParentType.ModuleWorkerWithMessagePort,
     name,
-    port,
+    port: workerPort,
     raw: true,
     url,
     id,

--- a/packages/renderer-worker/src/parts/SerializeIpcTraceMessage/SerializeIpcTraceMessage.js
+++ b/packages/renderer-worker/src/parts/SerializeIpcTraceMessage/SerializeIpcTraceMessage.js
@@ -1,0 +1,76 @@
+const getConstructorName = (value) => {
+  return value?.constructor?.name || 'Object'
+}
+
+const serializeError = (error) => {
+  return {
+    $type: getConstructorName(error),
+    message: error.message,
+    name: error.name,
+    stack: error.stack,
+  }
+}
+
+const serializeValue = (value, seen, nextReference) => {
+  if (value === null || typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'bigint') {
+    return { $type: 'BigInt', value: String(value) }
+  }
+  if (typeof value === 'undefined') {
+    return { $type: 'Undefined' }
+  }
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return { $type: getConstructorName(value), value: String(value) }
+  }
+  if (value instanceof Error) {
+    return serializeError(value)
+  }
+  if (typeof MessagePort !== 'undefined' && value instanceof MessagePort) {
+    return { $type: 'MessagePort' }
+  }
+  if (value instanceof ArrayBuffer) {
+    return { $type: 'ArrayBuffer', byteLength: value.byteLength }
+  }
+  if (ArrayBuffer.isView(value)) {
+    const length = 'length' in value && typeof value.length === 'number' ? value.length : undefined
+    return {
+      $type: getConstructorName(value),
+      byteLength: value.byteLength,
+      length,
+    }
+  }
+  if (value instanceof Date) {
+    return { $type: 'Date', value: value.toISOString() }
+  }
+  const existingReference = seen.get(value)
+  if (existingReference !== undefined) {
+    return { $ref: existingReference }
+  }
+  const reference = nextReference.value++
+  seen.set(value, reference)
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeValue(item, seen, nextReference))
+  }
+  const result = {}
+  for (const key of Object.keys(value)) {
+    try {
+      result[key] = serializeValue(value[key], seen, nextReference)
+    } catch (error) {
+      result[key] = {
+        $type: 'SerializationError',
+        message: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+  const constructorName = getConstructorName(value)
+  if (constructorName !== 'Object') {
+    result.$type = constructorName
+  }
+  return result
+}
+
+export const serializeIpcTraceMessage = (value) => {
+  return serializeValue(value, new WeakMap(), { value: 1 })
+}

--- a/packages/renderer-worker/test/GetIpcTraceTransferrables.test.ts
+++ b/packages/renderer-worker/test/GetIpcTraceTransferrables.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@jest/globals'
+import * as GetIpcTraceTransferrables from '../src/parts/GetIpcTraceTransferrables/GetIpcTraceTransferrables.ts'
+
+test('finds array buffers through typed arrays without duplicating them', () => {
+  const buffer = new ArrayBuffer(8)
+  const value = {
+    buffer,
+    typedArray: new Uint8Array(buffer),
+  }
+  expect(GetIpcTraceTransferrables.getIpcTraceTransferrables(value)).toEqual([buffer])
+})
+
+test('supports cyclic messages', () => {
+  const value: any = { buffer: new ArrayBuffer(4) }
+  value.self = value
+  expect(GetIpcTraceTransferrables.getIpcTraceTransferrables(value)).toEqual([value.buffer])
+})

--- a/packages/renderer-worker/test/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.test.ts
+++ b/packages/renderer-worker/test/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.test.ts
@@ -25,6 +25,12 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
   }
 })
 
+jest.unstable_mockModule('../src/parts/IpcTrace/IpcTrace.js', () => {
+  return {
+    maybeCreateProxy: async ({ port }) => port,
+  }
+})
+
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug =
   await import('../src/parts/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.js')

--- a/packages/renderer-worker/test/IpcTrace.test.ts
+++ b/packages/renderer-worker/test/IpcTrace.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+class FakeMessagePort {
+  onmessage: ((event: { data: unknown }) => void) | undefined
+  other: FakeMessagePort | undefined
+  transfers: readonly (readonly unknown[])[] = []
+
+  postMessage(message: unknown, transferables: readonly unknown[] = []): void {
+    this.transfers = [...this.transfers, transferables]
+    this.other?.onmessage?.({ data: message })
+  }
+
+  start(): void {}
+}
+
+class FakeMessageChannel {
+  port1 = new FakeMessagePort()
+  port2 = new FakeMessagePort()
+
+  constructor() {
+    this.port1.other = this.port2
+    this.port2.other = this.port1
+  }
+}
+
+// @ts-ignore
+globalThis.MessageChannel = FakeMessageChannel
+
+const IpcTrace = await import('../src/parts/IpcTrace/IpcTrace.js')
+
+beforeEach(() => {
+  IpcTrace.reset()
+  IpcTrace.state.getArgv = jest.fn(async () => ['/usr/bin/lvce', '--trace-ipc=builtin.eslint'])
+  IpcTrace.state.getTransferrables = jest.fn(() => [])
+  IpcTrace.state.now = jest.fn(() => 12)
+  IpcTrace.state.serialize = jest.fn((value) => value)
+  IpcTrace.state.timeOrigin = jest.fn(() => 100)
+  IpcTrace.state.wallTime = jest.fn(() => '2026-08-15T21:55:00.000Z')
+  IpcTrace.state.write = jest.fn(async () => undefined)
+  IpcTrace.state.writeStderr = jest.fn(async () => undefined)
+})
+
+test('forwards selected worker messages in both directions and records them', async () => {
+  const parentChannel = new FakeMessageChannel()
+  const workerPort = (await IpcTrace.maybeCreateProxy({
+    id: 42,
+    name: 'ESLint Worker',
+    port: parentChannel.port2,
+    traceId: 'builtin.eslint',
+  })) as unknown as FakeMessagePort
+  const receivedByWorker: unknown[] = []
+  const receivedByParent: unknown[] = []
+  workerPort.onmessage = (event) => receivedByWorker.push(event.data)
+  parentChannel.port1.onmessage = (event) => receivedByParent.push(event.data)
+
+  parentChannel.port1.postMessage({ method: 'Lint.lint' })
+  workerPort.postMessage({ result: [] })
+  await IpcTrace.flush()
+
+  expect(receivedByWorker).toEqual([{ method: 'Lint.lint' }])
+  expect(receivedByParent).toEqual([{ result: [] }])
+  expect(IpcTrace.state.write).toHaveBeenCalledWith(
+    'builtin.eslint',
+    expect.arrayContaining([
+      expect.objectContaining({
+        direction: 'parent-to-worker',
+        sequence: 1,
+        workerId: 'builtin.eslint',
+      }),
+      expect.objectContaining({
+        direction: 'worker-to-parent',
+        sequence: 2,
+        workerId: 'builtin.eslint',
+      }),
+    ]),
+  )
+})
+
+test('keeps unselected workers on the direct port path', async () => {
+  const parentChannel = new FakeMessageChannel()
+  const port = await IpcTrace.maybeCreateProxy({
+    id: 42,
+    name: 'Other Worker',
+    port: parentChannel.port2,
+    traceId: 'builtin.other',
+  })
+  expect(port).toBe(parentChannel.port2)
+  expect(IpcTrace.state.write).not.toHaveBeenCalled()
+})
+
+test('disables tracing after a writer failure without breaking forwarding', async () => {
+  IpcTrace.state.write = jest.fn(async () => {
+    throw new Error('disk full')
+  })
+  const parentChannel = new FakeMessageChannel()
+  const workerPort = (await IpcTrace.maybeCreateProxy({
+    id: 42,
+    name: 'ESLint Worker',
+    port: parentChannel.port2,
+    traceId: 'builtin.eslint',
+  })) as unknown as FakeMessagePort
+  const received: unknown[] = []
+  workerPort.onmessage = (event) => received.push(event.data)
+
+  parentChannel.port1.postMessage({ method: 'Lint.lint' })
+  await IpcTrace.flush()
+  parentChannel.port1.postMessage({ method: 'Lint.lintAgain' })
+
+  expect(IpcTrace.state.disabled).toBe(true)
+  expect(received).toEqual([{ method: 'Lint.lint' }, { method: 'Lint.lintAgain' }])
+})

--- a/packages/renderer-worker/test/IpcTraceConfig.test.ts
+++ b/packages/renderer-worker/test/IpcTraceConfig.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals'
+import * as IpcTraceConfig from '../src/parts/IpcTraceConfig/IpcTraceConfig.js'
+
+test('parses comma-separated worker ids', () => {
+  const options = IpcTraceConfig.parseTraceIpc(['/usr/bin/lvce', '--trace-ipc=builtin.eslint, builtin.eslint.evaluation-worker'])
+  expect([...options.selectors]).toEqual(['builtin.eslint', 'builtin.eslint.evaluation-worker'])
+  expect(options.error).toBe('')
+})
+
+test('parses a separate wildcard value', () => {
+  const options = IpcTraceConfig.parseTraceIpc(['/usr/bin/lvce', '--trace-ipc', '*'])
+  expect(IpcTraceConfig.shouldTrace(options.selectors, '')).toBe(true)
+})
+
+test('rejects an empty value', () => {
+  const options = IpcTraceConfig.parseTraceIpc(['/usr/bin/lvce', '--trace-ipc='])
+  expect(options.error).toBe('--trace-ipc requires a comma-separated worker id list or *')
+})
+
+test('does not consume the next cli flag as a worker id', () => {
+  const options = IpcTraceConfig.parseTraceIpc(['/usr/bin/lvce', '--trace-ipc', '--verbose'])
+  expect(options.error).toBe('--trace-ipc requires a comma-separated worker id list or *')
+})
+
+test('matches exact stable ids', () => {
+  const options = IpcTraceConfig.parseTraceIpc(['/usr/bin/lvce', '--trace-ipc=builtin.eslint'])
+  expect(IpcTraceConfig.shouldTrace(options.selectors, 'builtin.eslint')).toBe(true)
+  expect(IpcTraceConfig.shouldTrace(options.selectors, 'builtin.eslint.evaluation-worker')).toBe(false)
+})

--- a/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
@@ -28,6 +28,12 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
   }
 })
 
+jest.unstable_mockModule('../src/parts/IpcTrace/IpcTrace.js', () => {
+  return {
+    maybeCreateProxy: async ({ port }) => port,
+  }
+})
+
 jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
   return {
     getPlatform: jest.fn(() => PlatformType.Web),

--- a/packages/renderer-worker/test/SerializeIpcTraceMessage.test.ts
+++ b/packages/renderer-worker/test/SerializeIpcTraceMessage.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@jest/globals'
+import * as SerializeIpcTraceMessage from '../src/parts/SerializeIpcTraceMessage/SerializeIpcTraceMessage.js'
+
+test('preserves JSON values and tags special values', () => {
+  const value = {
+    buffer: new ArrayBuffer(8),
+    error: new TypeError('bad input'),
+    number: 42n,
+    typedArray: new Uint8Array(4),
+  }
+  const serialized = SerializeIpcTraceMessage.serializeIpcTraceMessage(value)
+  expect(serialized).toMatchObject({
+    buffer: { $type: 'ArrayBuffer', byteLength: 8 },
+    error: { $type: 'TypeError', message: 'bad input', name: 'TypeError' },
+    number: { $type: 'BigInt', value: '42' },
+    typedArray: { $type: 'Uint8Array', byteLength: 4, length: 4 },
+  })
+})
+
+test('represents cycles with references', () => {
+  const value: any = { method: 'Lint.lint' }
+  value.self = value
+  expect(SerializeIpcTraceMessage.serializeIpcTraceMessage(value)).toEqual({
+    method: 'Lint.lint',
+    self: { $ref: 1 },
+  })
+})

--- a/packages/shared-process/src/parts/GetHelpString/GetHelpString.ts
+++ b/packages/shared-process/src/parts/GetHelpString/GetHelpString.ts
@@ -5,5 +5,9 @@ export const getHelpString = (): any => {
 
 Usage:
   ${Platform.applicationName} [path]
+
+Diagnostics:
+  --trace-ipc=<worker-ids>  Trace comma-separated worker IDs (or *) to JSONL.
+                            Traces can be large and contain source code.
 `
 }

--- a/packages/shared-process/src/parts/IpcTrace/IpcTrace.ipc.ts
+++ b/packages/shared-process/src/parts/IpcTrace/IpcTrace.ipc.ts
@@ -1,0 +1,7 @@
+import * as IpcTrace from './IpcTrace.ts'
+
+export const name = 'IpcTrace'
+
+export const Commands: Record<string, (...args: any[]) => any> = {
+  append: IpcTrace.append,
+}

--- a/packages/shared-process/src/parts/IpcTrace/IpcTrace.ts
+++ b/packages/shared-process/src/parts/IpcTrace/IpcTrace.ts
@@ -1,0 +1,59 @@
+import { appendFile, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
+
+export interface TraceRecord {
+  readonly [key: string]: unknown
+}
+
+interface Dependencies {
+  readonly appendFile: typeof appendFile
+  readonly cacheDirectory: string
+  readonly mkdir: typeof mkdir
+  readonly timeOrigin: number
+}
+
+export const state: Dependencies = {
+  appendFile,
+  cacheDirectory: PlatformPaths.cacheDir,
+  mkdir,
+  timeOrigin: performance.timeOrigin,
+}
+
+let writeChain: Promise<void> = Promise.resolve()
+const initializedDirectories = new Set<string>()
+const unsafeWorkerIdCharacterRegex = /[^a-z\d._-]/gi
+
+export const sanitizeWorkerId = (workerId: string): string => {
+  return workerId.replaceAll(unsafeWorkerIdCharacterRegex, '_') || 'unknown-worker'
+}
+
+export const getSessionName = (timeOrigin: number): string => {
+  return new Date(timeOrigin).toISOString().replaceAll(':', '-')
+}
+
+export const appendWithDependencies = async (workerId: string, records: readonly TraceRecord[], dependencies: Dependencies): Promise<void> => {
+  if (records.length === 0) {
+    return
+  }
+  const sessionName = getSessionName(dependencies.timeOrigin)
+  const traceDirectory = join(dependencies.cacheDirectory, 'ipcTraces', sessionName)
+  if (!initializedDirectories.has(traceDirectory)) {
+    await dependencies.mkdir(traceDirectory, { recursive: true })
+    initializedDirectories.add(traceDirectory)
+  }
+  const fileName = `${sanitizeWorkerId(workerId)}.jsonl`
+  const content = `${records.map((record) => JSON.stringify(record)).join('\n')}\n`
+  await dependencies.appendFile(join(traceDirectory, fileName), content)
+}
+
+export const append = (workerId: string, records: readonly TraceRecord[]): Promise<void> => {
+  const operation = writeChain.then(() => appendWithDependencies(workerId, records, state))
+  writeChain = operation.catch(() => {})
+  return operation
+}
+
+export const reset = (): void => {
+  initializedDirectories.clear()
+  writeChain = Promise.resolve()
+}

--- a/packages/shared-process/src/parts/Module/Module.ts
+++ b/packages/shared-process/src/parts/Module/Module.ts
@@ -112,6 +112,8 @@ export const load = (moduleId: any): any => {
       return import('../HandleWindowAllClosed/HandleWindowAllClosed.ipc.ts')
     case ModuleId.InstallExtension:
       return import('../InstallExtension/InstallExtension.ipc.ts')
+    case ModuleId.IpcTrace:
+      return import('../IpcTrace/IpcTrace.ipc.ts')
     case ModuleId.IsAutoUpdateSupported:
       return import('../IsAutoUpdateSupported/IsAutoUpdateSupported.ipc.ts')
     case ModuleId.LanguageServer:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.ts
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.ts
@@ -82,3 +82,4 @@ export const SendMessagePortToMainProcess = 88
 export const SecretStorage = 89
 export const ChromeCookieImport = 90
 export const FirefoxCookieImport = 91
+export const IpcTrace = 92

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -209,6 +209,8 @@ export const getModuleId = (commandId: any): any => {
       return ModuleId.HandleWindowAllClosed
     case 'InstallExtension.installExtension':
       return ModuleId.InstallExtension
+    case 'IpcTrace.append':
+      return ModuleId.IpcTrace
     case 'IsAutoUpdateSupported.isAutoUpdateSupported':
       return ModuleId.IsAutoUpdateSupported
     case 'LanguageServer.codeAction':

--- a/packages/shared-process/test/CliHelp.test.ts
+++ b/packages/shared-process/test/CliHelp.test.ts
@@ -26,5 +26,9 @@ test('handleCliArgs', async () => {
 
 Usage:
   lvce-oss [path]
+
+Diagnostics:
+  --trace-ipc=<worker-ids>  Trace comma-separated worker IDs (or *) to JSONL.
+                            Traces can be large and contain source code.
 `)
 })

--- a/packages/shared-process/test/IpcTrace.test.ts
+++ b/packages/shared-process/test/IpcTrace.test.ts
@@ -1,4 +1,5 @@
 import { expect, jest, test } from '@jest/globals'
+import { join } from 'node:path'
 import * as IpcTrace from '../src/parts/IpcTrace/IpcTrace.ts'
 
 test('appends JSONL records to the application trace directory', async () => {
@@ -10,9 +11,9 @@ test('appends JSONL records to the application trace directory', async () => {
     mkdir: mkdir as never,
     timeOrigin: 0,
   })
-  const directory = '/cache/lvce-oss/ipcTraces/1970-01-01T00-00-00.000Z'
+  const directory = join('/cache/lvce-oss', 'ipcTraces', '1970-01-01T00-00-00.000Z')
   expect(mkdir).toHaveBeenCalledWith(directory, { recursive: true })
-  expect(appendFile).toHaveBeenCalledWith(`${directory}/builtin.eslint_evaluation-worker.jsonl`, '{"sequence":1}\n{"sequence":2}\n')
+  expect(appendFile).toHaveBeenCalledWith(join(directory, 'builtin.eslint_evaluation-worker.jsonl'), '{"sequence":1}\n{"sequence":2}\n')
 })
 
 test('sanitizes unsafe worker ids', () => {

--- a/packages/shared-process/test/IpcTrace.test.ts
+++ b/packages/shared-process/test/IpcTrace.test.ts
@@ -1,0 +1,20 @@
+import { expect, jest, test } from '@jest/globals'
+import * as IpcTrace from '../src/parts/IpcTrace/IpcTrace.ts'
+
+test('appends JSONL records to the application trace directory', async () => {
+  const mkdir = jest.fn<(path: string, options: { recursive: boolean }) => Promise<void>>(async () => undefined)
+  const appendFile = jest.fn<(path: string, content: string) => Promise<void>>(async () => undefined)
+  await IpcTrace.appendWithDependencies('builtin.eslint/evaluation-worker', [{ sequence: 1 }, { sequence: 2 }], {
+    appendFile: appendFile as never,
+    cacheDirectory: '/cache/lvce-oss',
+    mkdir: mkdir as never,
+    timeOrigin: 0,
+  })
+  const directory = '/cache/lvce-oss/ipcTraces/1970-01-01T00-00-00.000Z'
+  expect(mkdir).toHaveBeenCalledWith(directory, { recursive: true })
+  expect(appendFile).toHaveBeenCalledWith(`${directory}/builtin.eslint_evaluation-worker.jsonl`, '{"sequence":1}\n{"sequence":2}\n')
+})
+
+test('sanitizes unsafe worker ids', () => {
+  expect(IpcTrace.sanitizeWorkerId('../../worker name')).toBe('.._.._worker_name')
+})

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -25,3 +25,7 @@ test('getModuleId - FirefoxCookieImport.importCookies', () => {
 test('getModuleId - GetElectronFileResponse.resolveElectronFileUri', () => {
   expect(ModuleMap.getModuleId('GetElectronFileResponse.resolveElectronFileUri')).toBe(ModuleId.GetElectronFileResponse)
 })
+
+test('getModuleId - IpcTrace.append', () => {
+  expect(ModuleMap.getModuleId('IpcTrace.append')).toBe(ModuleId.IpcTrace)
+})


### PR DESCRIPTION
Add opt-in --trace-ipc worker port proxies and batched JSONL traces under the application cache directory.