### PR TITLE
feature: stage voice as disabled builtin extension

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/DownloadBuiltinExtensions.ts
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/DownloadBuiltinExtensions.ts
@@ -11,6 +11,7 @@ import * as ExitCode from '../ExitCode/ExitCode.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Path from '../Path/Path.ts'
 import * as Process from '../Process/Process.ts'
+import { getEnabledBuiltinExtensions } from '../GetEnabledBuiltinExtensions/GetEnabledBuiltinExtensions.ts'
 import extensions from './builtinExtensions.json' with { type: 'json' }
 
 const downloadUrl = async (url, outFile) => {
@@ -122,7 +123,7 @@ const printError = (error) => {
 
 const main = async () => {
   try {
-    await downloadExtensions(extensions)
+    await downloadExtensions(getEnabledBuiltinExtensions(extensions))
   } catch (error) {
     printError(error)
     Process.exit(ExitCode.Error)

--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -24,6 +24,13 @@
     "created": "2026-07-14"
   },
   {
+    "name": "builtin.gpt-voice",
+    "repository": "github.com/lvce-editor/gpt-voice-extension",
+    "version": "2.2.1",
+    "created": "2026-08-06",
+    "enabled": false
+  },
+  {
     "name": "builtin.language-basics-bat",
     "repository": "github.com/lvce-editor/language-basics-bat",
     "version": "0.12.0",

--- a/packages/build/src/parts/GetBuiltinExtensionRepository/GetBuiltinExtensionRepository.ts
+++ b/packages/build/src/parts/GetBuiltinExtensionRepository/GetBuiltinExtensionRepository.ts
@@ -1,0 +1,8 @@
+const githubRepositoryPrefix = 'github.com/'
+
+export const getBuiltinExtensionRepository = (extension) => {
+  if (!extension.repository.startsWith(githubRepositoryPrefix)) {
+    throw new Error(`expected extension repository to start with ${githubRepositoryPrefix}`)
+  }
+  return extension.repository.slice(githubRepositoryPrefix.length)
+}

--- a/packages/build/src/parts/GetEnabledBuiltinExtensions/GetEnabledBuiltinExtensions.ts
+++ b/packages/build/src/parts/GetEnabledBuiltinExtensions/GetEnabledBuiltinExtensions.ts
@@ -1,0 +1,3 @@
+export const getEnabledBuiltinExtensions = (extensions) => {
+  return extensions.filter((extension) => extension.enabled !== false)
+}

--- a/packages/build/src/parts/UpdateBuiltinExtensions/UpdateBuiltinExtensions.ts
+++ b/packages/build/src/parts/UpdateBuiltinExtensions/UpdateBuiltinExtensions.ts
@@ -5,20 +5,10 @@ import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
 import builtinExtensions from '../DownloadBuiltinExtensions/builtinExtensions.json' with { type: 'json' }
 import * as ExitCode from '../ExitCode/ExitCode.ts'
+import { getBuiltinExtensionRepository } from '../GetBuiltinExtensionRepository/GetBuiltinExtensionRepository.ts'
 import * as Logger from '../Logger/Logger.ts'
 import * as Process from '../Process/Process.ts'
 import * as Root from '../Root/Root.ts'
-
-const getRepository = (name) => {
-  if (name.startsWith('builtin.')) {
-    return 'lvce-editor/' + name.slice('builtin.'.length)
-  }
-  throw new Error(`expected extension name to start with builtin.`)
-}
-
-const getName = (extension) => {
-  return extension.name
-}
 
 /**
  *
@@ -102,7 +92,7 @@ const getNewBuiltinExtensions = (builtinExtensions, versions) => {
 
 const updateBuiltinExtensions = async () => {
   const start = performance.now()
-  const repositories = builtinExtensions.map(getName).map(getRepository)
+  const repositories = builtinExtensions.map(getBuiltinExtensionRepository)
   const newVersions = await Promise.all(repositories.map(getLatestReleaseVersion))
   const newBuiltinExtensions = getNewBuiltinExtensions(builtinExtensions, newVersions)
   const end = performance.now()

--- a/packages/build/test/GetBuiltinExtensionRepository.test.ts
+++ b/packages/build/test/GetBuiltinExtensionRepository.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@jest/globals'
+import { getBuiltinExtensionRepository } from '../src/parts/GetBuiltinExtensionRepository/GetBuiltinExtensionRepository.ts'
+
+test('returns the repository owner and name', () => {
+  expect(
+    getBuiltinExtensionRepository({
+      name: 'builtin.gpt-voice',
+      repository: 'github.com/lvce-editor/gpt-voice-extension',
+    }),
+  ).toBe('lvce-editor/gpt-voice-extension')
+})
+
+test('throws when the repository is not hosted on GitHub', () => {
+  expect(() =>
+    getBuiltinExtensionRepository({
+      name: 'builtin.test',
+      repository: 'example.com/lvce-editor/test',
+    }),
+  ).toThrow('expected extension repository to start with github.com/')
+})

--- a/packages/build/test/GetEnabledBuiltinExtensions.test.ts
+++ b/packages/build/test/GetEnabledBuiltinExtensions.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@jest/globals'
+import { getEnabledBuiltinExtensions } from '../src/parts/GetEnabledBuiltinExtensions/GetEnabledBuiltinExtensions.ts'
+
+test('includes extensions when enabled is not specified', () => {
+  const extension = { name: 'builtin.test' }
+
+  expect(getEnabledBuiltinExtensions([extension])).toEqual([extension])
+})
+
+test('includes enabled extensions', () => {
+  const extension = { enabled: true, name: 'builtin.test' }
+
+  expect(getEnabledBuiltinExtensions([extension])).toEqual([extension])
+})
+
+test('excludes disabled extensions', () => {
+  const extension = { enabled: false, name: 'builtin.test' }
+
+  expect(getEnabledBuiltinExtensions([extension])).toEqual([])
+})


### PR DESCRIPTION
Register the voice extension release as a builtin candidate while keeping it excluded from downloads and packaged builds. Use each builtin entry’s declared repository when checking for updates so the voice extension can track its differently named repository.