### PR TITLE
feature: coordinate direct view worker events

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -454,6 +454,7 @@ export const commandMap = {
   'Viewlet.closeWidget': lazy('Viewlet.closeWidget'),
   'Viewlet.dispose': lazy('Viewlet.dispose'),
   'Viewlet.executeViewletCommand': lazy('Viewlet.executeViewletCommand'),
+  'Viewlet.requestRender': lazy('Viewlet.requestRender'),
   'Viewlet.focus': lazy('Viewlet.focus'),
   'Viewlet.focusSelector': lazy('Viewlet.focusSelector'),
   'Viewlet.resize': lazy('Viewlet.resize'),

--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -138,6 +138,12 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   const Events = {}
   const { idKey } = state
 
+  if (capabilities.directRender) {
+    Object.defineProperty(Commands, '__directEventRpcId', {
+      value: config.commandPrefix,
+    })
+  }
+
   const create = (id, uri, x, y, width, height, args, parentUid) => {
     const initialState = getStateField(config, id, uri, x, y, width, height, args, parentUid, context)
     return adapter.transformState(initialState)
@@ -198,6 +204,10 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
       ...currentState,
       commands: invocation.results.commands,
     })
+  }
+
+  Commands.__renderPending = (currentState) => {
+    return runCommandRenderPipeline(currentState, [])
   }
 
   const wrapCommand = (command) => {

--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -206,9 +206,11 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     })
   }
 
-  Commands.__renderPending = (currentState) => {
-    return runCommandRenderPipeline(currentState, [])
-  }
+  Object.defineProperty(Commands, '__renderPending', {
+    value(currentState) {
+      return runCommandRenderPipeline(currentState, [])
+    },
+  })
 
   const wrapCommand = (command) => {
     return async (currentState, ...args) => {

--- a/packages/renderer-worker/src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js
@@ -18,7 +18,7 @@ export const launchAboutViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'About.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'About'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts
@@ -21,7 +21,7 @@ export const launchActivityBarWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'ActivityBar.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'ActivityBar'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchChatDebugViewWorker/LaunchChatDebugViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchChatDebugViewWorker/LaunchChatDebugViewWorker.js
@@ -18,7 +18,7 @@ export const launchChatDebugViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'ChatDebug.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'ChatDebug'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchChatViewWorker/LaunchChatViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchChatViewWorker/LaunchChatViewWorker.js
@@ -18,7 +18,7 @@ export const launchChatViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Chat.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'Chat'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchDiffViewWorker/LaunchDiffViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchDiffViewWorker/LaunchDiffViewWorker.js
@@ -19,7 +19,7 @@ export const launchDiffViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'DiffView.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'DiffView'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchExplorerWorker/LaunchExplorerWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchExplorerWorker/LaunchExplorerWorker.ts
@@ -19,7 +19,7 @@ export const launchExplorerWorker = async (): Promise<any> => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Explorer.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'Explorer'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchExtensionDetailViewWorker/LaunchExtensionDetailViewWorker.js
@@ -21,7 +21,7 @@ export const launchExtensionDetailViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'ExtensionDetail.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'ExtensionDetail'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchExtensionSearchViewWorker/LaunchExtensionSearchViewWorker.js
@@ -28,7 +28,7 @@ export const launchExtensionSearchViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'SearchExtensions.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'SearchExtensions'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchKeyBindingsViewWorker/LaunchKeyBindingsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchKeyBindingsViewWorker/LaunchKeyBindingsViewWorker.js
@@ -18,7 +18,7 @@ export const launchKeyBindingsViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'KeyBindings.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'KeyBindings'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchLanguageModelsViewWorker/LaunchLanguageModelsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchLanguageModelsViewWorker/LaunchLanguageModelsViewWorker.js
@@ -18,7 +18,7 @@ export const launchLanguageModelsViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'LanguageModels.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'LanguageModels'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts
@@ -18,7 +18,7 @@ export const launchMainAreaWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'MainArea.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'MainArea'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchNotificationCenterViewWorker/LaunchNotificationCenterViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchNotificationCenterViewWorker/LaunchNotificationCenterViewWorker.js
@@ -26,7 +26,7 @@ export const launchNotificationCenterViewWorker = async () => {
   const { port1: rendererWorkerPort, port2: rendererProcessPort } = new MessageChannel()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'NotificationCenter.handleMessagePort', rendererWorkerPort),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', rendererProcessPort),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', rendererProcessPort, 'NotificationCenter'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchOutputViewWorker/LaunchOutputViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchOutputViewWorker/LaunchOutputViewWorker.js
@@ -19,7 +19,7 @@ export const launchOutputViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Output.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'Output'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchPanelWorker/LaunchPanelWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchPanelWorker/LaunchPanelWorker.ts
@@ -18,7 +18,7 @@ export const launchPanelWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Panel.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'Panel'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts
@@ -19,7 +19,7 @@ export const launchProblemsWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Problems.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'Problems'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchProcessExplorerWorker/LaunchProcessExplorerWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchProcessExplorerWorker/LaunchProcessExplorerWorker.js
@@ -18,7 +18,7 @@ export const launchProcessExplorerWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'ProcessExplorer.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'ProcessExplorer'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchQuickPickWorker/LaunchQuickPickWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchQuickPickWorker/LaunchQuickPickWorker.js
@@ -18,7 +18,7 @@ export const launchQuickPickWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'QuickPick.handleRendererProcessMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'QuickPick'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts
@@ -17,7 +17,7 @@ export const launchRunningExtensionsViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'RunningExtensions.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'RunningExtensions'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchSettingsViewWorker/LaunchSettingsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchSettingsViewWorker/LaunchSettingsViewWorker.js
@@ -19,7 +19,7 @@ export const launchSettingsViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Settings.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'Settings'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchSourceControlWorker/LaunchSourceControlWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchSourceControlWorker/LaunchSourceControlWorker.js
@@ -19,7 +19,7 @@ export const launchSourceControlWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'SourceControl.handleRendererProcessMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'SourceControl'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js
@@ -25,7 +25,7 @@ export const launchStatusBarWorker = async () => {
   const { port1: rendererWorkerPort, port2: rendererProcessPort } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'StatusBar.handleMessagePort', rendererWorkerPort),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', rendererProcessPort),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', rendererProcessPort, 'StatusBar'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchTextSearchViewWorker/LaunchTextSearchViewWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchTextSearchViewWorker/LaunchTextSearchViewWorker.js
@@ -19,7 +19,7 @@ export const launchTextSearchViewWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'TextSearch.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'TextSearch'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchTitleBarWorker/LaunchTitleBarWorker.js
@@ -18,7 +18,7 @@ export const launchTitleBarWorker = async () => {
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'TitleBar.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'TitleBar'),
   ])
   return ipc
 }

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.ipc.js
@@ -11,6 +11,7 @@ export const Commands = {
   getAllStates: Viewlet.getAllStates,
   getDragData: Viewlet.getDragData,
   getTitle: Viewlet.getTitle,
+  requestRender: Viewlet.requestRender,
   openWidget: Viewlet.openWidget,
   reload: Viewlet.reload,
   send: Viewlet.send,

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -594,6 +594,10 @@ export const executeViewletCommand = async (uid, fnName, ...args) => {
   await RendererProcess.invoke(/* Viewlet.sendMultiple */ 'Viewlet.sendMultiple', /* commands */ commands)
 }
 
+export const requestRender = (uid) => {
+  return executeViewletCommand(uid, '__renderPending')
+}
+
 // @ts-ignore
 export const disposeWidgetWithValue = async (id, value) => {
   try {

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -726,7 +726,11 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       await Command.execute('Layout.handleBadgeCountChange')
     }
     if (module.hasFunctionalRootRender) {
-      commands.push([kCreateFunctionalRoot, viewlet.id, viewletUid, module.hasFunctionalEvents])
+      if (module.hasDirectRender) {
+        commands.push([kCreateFunctionalRoot, viewlet.id, viewletUid, module.hasFunctionalEvents, module.Commands.__directEventRpcId])
+      } else {
+        commands.push([kCreateFunctionalRoot, viewlet.id, viewletUid, module.hasFunctionalEvents])
+      }
     } else {
       commands.push([kCreate, viewlet.id, viewletUid])
     }

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
@@ -4,6 +4,10 @@ import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker
 
 export const Commands = {}
 
+Object.defineProperty(Commands, '__directEventRpcId', {
+  value: 'SourceControl',
+})
+
 export const getCommands = async () => {
   const commands = await SourceControlWorker.invoke('SourceControl.getCommandIds')
   for (const command of commands) {

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -146,6 +146,7 @@ test('renders pending worker state without replaying a command', async () => {
 
   const result = await viewlet.Commands.__renderPending(state)
 
+  expect(Object.keys(viewlet.Commands)).not.toContain('__renderPending')
   expect(invoke.mock.calls).toEqual([
     ['Example.diff3', 9],
     ['Example.render3', 9, ['diff']],

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -94,6 +94,16 @@ test('exposes the configured workspace change behavior', () => {
   expect(viewlet.workspaceChangeEventPrepend).toBe(true)
 })
 
+test('exposes the direct event rpc id on direct-render viewlets', () => {
+  const viewlet = createWorkerViewletWithDependencies({
+    config: createConfig({ capabilities: { directRender: true, events: true, render: true, resize: true, rootRender: true } }),
+    worker: { invoke: jest.fn(), restart: jest.fn() },
+  })
+
+  expect(viewlet.Commands.__directEventRpcId).toBe('Example')
+  expect(Object.keys(viewlet.Commands)).not.toContain('__directEventRpcId')
+})
+
 test('configures immediate workspace feedback for the title bar and main area', () => {
   expect(getWorkerViewletConfig('titleBar').workspaceChangeEvent).toBe('workspace.titleChange')
   expect(getWorkerViewletConfig('mainArea').workspaceChangeEventPrepend).toBe(true)
@@ -119,6 +129,28 @@ test('creates command wrappers through the same lifecycle seam', async () => {
 
   expect(invoke).toHaveBeenNthCalledWith(2, 'Example.select', 9, 'item-1')
   expect(result.commands).toEqual([['setText', 'selected']])
+})
+
+test('renders pending worker state without replaying a command', async () => {
+  const invoke = jest.fn(async (method: string) => {
+    if (method === 'Example.diff3') {
+      return ['diff']
+    }
+    if (method === 'Example.render3') {
+      return [['setText', 'updated']]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({ config: createConfig(), context: { platform: 1 }, worker: { invoke, restart: jest.fn() } })
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+
+  const result = await viewlet.Commands.__renderPending(state)
+
+  expect(invoke.mock.calls).toEqual([
+    ['Example.diff3', 9],
+    ['Example.render3', 9, ['diff']],
+  ])
+  expect(result.commands).toEqual([['setText', 'updated']])
 })
 
 test('returns preview runtime diagnostics without treating them as viewlet state', async () => {

--- a/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
+++ b/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
@@ -57,30 +57,30 @@ beforeEach(() => {
 })
 
 test.each([
-  ['about', LaunchAboutViewWorker.launchAboutViewWorker, 'About.handleMessagePort'],
-  ['activity bar', LaunchActivityBarWorker.launchActivityBarWorker, 'ActivityBar.handleMessagePort'],
-  ['chat', LaunchChatViewWorker.launchChatViewWorker, 'Chat.handleMessagePort'],
-  ['chat debug', LaunchChatDebugViewWorker.launchChatDebugViewWorker, 'ChatDebug.handleMessagePort'],
-  ['diff', LaunchDiffViewWorker.launchDiffViewWorker, 'DiffView.handleMessagePort'],
-  ['extension search', LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort'],
-  ['keybindings', LaunchKeyBindingsViewWorker.launchKeyBindingsViewWorker, 'KeyBindings.handleMessagePort'],
-  ['language models', LaunchLanguageModelsViewWorker.launchLanguageModelsViewWorker, 'LanguageModels.handleMessagePort'],
-  ['main area', LaunchMainAreaWorker.launchMainAreaWorker, 'MainArea.handleMessagePort'],
-  ['output', LaunchOutputViewWorker.launchOutputViewWorker, 'Output.handleMessagePort'],
-  ['panel', LaunchPanelWorker.launchPanelWorker, 'Panel.handleMessagePort'],
-  ['problems', LaunchProblemsWorker.launchProblemsWorker, 'Problems.handleMessagePort'],
-  ['process explorer', LaunchProcessExplorerWorker.launchProcessExplorerWorker, 'ProcessExplorer.handleMessagePort'],
-  ['quick pick', LaunchQuickPickWorker.launchQuickPickWorker, 'QuickPick.handleRendererProcessMessagePort'],
-  ['source control', LaunchSourceControlWorker.launchSourceControlWorker, 'SourceControl.handleRendererProcessMessagePort'],
-  ['running extensions', LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker, 'RunningExtensions.handleMessagePort'],
-  ['settings', LaunchSettingsViewWorker.launchSettingsViewWorker, 'Settings.handleMessagePort'],
-  ['status bar', LaunchStatusBarWorker.launchStatusBarWorker, 'StatusBar.handleMessagePort'],
-  ['text search', LaunchTextSearchViewWorker.launchTextSearchViewWorker, 'TextSearch.handleMessagePort'],
-  ['title bar', LaunchTitleBarWorker.launchTitleBarWorker, 'TitleBar.handleMessagePort'],
-] as const)('%s worker connects directly to the renderer process', async (_name, launch, command) => {
+  ['about', LaunchAboutViewWorker.launchAboutViewWorker, 'About.handleMessagePort', 'About'],
+  ['activity bar', LaunchActivityBarWorker.launchActivityBarWorker, 'ActivityBar.handleMessagePort', 'ActivityBar'],
+  ['chat', LaunchChatViewWorker.launchChatViewWorker, 'Chat.handleMessagePort', 'Chat'],
+  ['chat debug', LaunchChatDebugViewWorker.launchChatDebugViewWorker, 'ChatDebug.handleMessagePort', 'ChatDebug'],
+  ['diff', LaunchDiffViewWorker.launchDiffViewWorker, 'DiffView.handleMessagePort', 'DiffView'],
+  ['extension search', LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort', 'SearchExtensions'],
+  ['keybindings', LaunchKeyBindingsViewWorker.launchKeyBindingsViewWorker, 'KeyBindings.handleMessagePort', 'KeyBindings'],
+  ['language models', LaunchLanguageModelsViewWorker.launchLanguageModelsViewWorker, 'LanguageModels.handleMessagePort', 'LanguageModels'],
+  ['main area', LaunchMainAreaWorker.launchMainAreaWorker, 'MainArea.handleMessagePort', 'MainArea'],
+  ['output', LaunchOutputViewWorker.launchOutputViewWorker, 'Output.handleMessagePort', 'Output'],
+  ['panel', LaunchPanelWorker.launchPanelWorker, 'Panel.handleMessagePort', 'Panel'],
+  ['problems', LaunchProblemsWorker.launchProblemsWorker, 'Problems.handleMessagePort', 'Problems'],
+  ['process explorer', LaunchProcessExplorerWorker.launchProcessExplorerWorker, 'ProcessExplorer.handleMessagePort', 'ProcessExplorer'],
+  ['quick pick', LaunchQuickPickWorker.launchQuickPickWorker, 'QuickPick.handleRendererProcessMessagePort', 'QuickPick'],
+  ['source control', LaunchSourceControlWorker.launchSourceControlWorker, 'SourceControl.handleRendererProcessMessagePort', 'SourceControl'],
+  ['running extensions', LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker, 'RunningExtensions.handleMessagePort', 'RunningExtensions'],
+  ['settings', LaunchSettingsViewWorker.launchSettingsViewWorker, 'Settings.handleMessagePort', 'Settings'],
+  ['status bar', LaunchStatusBarWorker.launchStatusBarWorker, 'StatusBar.handleMessagePort', 'StatusBar'],
+  ['text search', LaunchTextSearchViewWorker.launchTextSearchViewWorker, 'TextSearch.handleMessagePort', 'TextSearch'],
+  ['title bar', LaunchTitleBarWorker.launchTitleBarWorker, 'TitleBar.handleMessagePort', 'TitleBar'],
+] as const)('%s worker connects directly to the renderer process', async (_name, launch, command, rpcId) => {
   await launch()
 
   expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, command, 'worker-port')
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', rpcId)
 })

--- a/packages/renderer-worker/test/LaunchExplorerWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchExplorerWorker.test.ts
@@ -39,5 +39,5 @@ test('launchExplorerWorker connects the explorer worker directly to the renderer
   expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'Explorer.initialize')
   expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'Explorer.handleMessagePort', 'explorer-port')
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', 'Explorer')
 })

--- a/packages/renderer-worker/test/LaunchExtensionDetailViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchExtensionDetailViewWorker.test.ts
@@ -64,6 +64,6 @@ test('launches the extension detail view worker', async () => {
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'ExtensionDetail.handleMessagePort', 'extension-detail-port')
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', 'ExtensionDetail')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/LaunchProcessExplorerWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchProcessExplorerWorker.test.ts
@@ -83,6 +83,6 @@ test('launchProcessExplorerWorker', async () => {
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
   expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'ProcessExplorer.handleMessagePort', 'worker-port')
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', 'ProcessExplorer')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/LaunchRunningExtensionsViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchRunningExtensionsViewWorker.test.ts
@@ -83,6 +83,6 @@ test('launchRunningExtensionsViewWorker', async () => {
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
   expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'RunningExtensions.handleMessagePort', 'worker-port')
-  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', 'RunningExtensions')
   expect(result).toBe(ipc)
 })

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -95,6 +95,32 @@ test('executeViewletCommand warns when another command targets a missing viewlet
   expect(warn).toHaveBeenCalledWith('cannot execute handleInput instance not found 2')
 })
 
+test('requestRender renders pending worker state without executing the event again', async () => {
+  const renderPending = jest.fn(async (state: { commands: unknown[]; uid: number }) => ({
+    ...state,
+    commands: [['Viewlet.setText', 'updated']],
+  }))
+  const state = { commands: [], uid: 2 }
+  ViewletStates.set(2, {
+    state,
+    renderedState: state,
+    moduleId: 'Test',
+    factory: {
+      Commands: {
+        __renderPending: renderPending,
+      },
+      name: 'Test',
+    },
+  })
+  jest.mocked(ViewletManager.render).mockReturnValue([['Viewlet.setText', 'updated']])
+  jest.mocked(RendererProcess.invoke).mockResolvedValue(undefined)
+
+  await Viewlet.requestRender(2)
+
+  expect(renderPending).toHaveBeenCalledWith(state)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.setText', 'updated']])
+})
+
 test('getTitle', async () => {
   const getTitle = jest.fn(async (_uid = 0) => 'Test Title')
   const state = { uid: 1 }

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -201,6 +201,40 @@ test('load omits empty event listener registration for a new root', async () => 
   expect(commands).toEqual([['Viewlet.createFunctionalRoot', 'EmptyListenerTest', 9, true]])
 })
 
+test('load associates a direct-render root with its worker rpc', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const Commands = {}
+  Object.defineProperty(Commands, '__directEventRpcId', {
+    value: 'TestWorker',
+  })
+  const mockModule = {
+    Commands,
+    create: jest.fn(() => ({ uid: 9 })),
+    hasDirectRender: true,
+    hasFunctionalEvents: true,
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state) => state),
+    render: [],
+    renderEventListeners: jest.fn(() => []),
+  }
+  const viewlet = {
+    disposed: false,
+    getModule: async () => mockModule,
+    id: 'DirectEventTest',
+    shouldRenderEvents: false,
+    show: false,
+    type: 0,
+    uid: 9,
+    uri: '',
+  }
+
+  const commands = await ViewletManager.load(viewlet)
+
+  expect(commands).toEqual([['Viewlet.createFunctionalRoot', 'DirectEventTest', 9, true, 'TestWorker']])
+})
+
 test('load does not invoke the renderer for empty event listeners on a new root', async () => {
   // @ts-ignore
   RendererProcess.invoke.mockResolvedValue(undefined)


### PR DESCRIPTION
## Summary

- give every existing direct renderer-process worker port a stable RPC identity
- associate direct-render functional roots with that worker identity
- add a worker-requested rerender path that asks only for pending diff/render output
- keep Preview and Iframe Inspector on the renderer-worker event path

## Tests

- renderer-worker focused suite: 8 suites, 89 tests passed
- renderer-worker type-check passed
- repository lint currently reports the existing broad XO baseline (103,831 errors, including unchanged filename and semicolon rules)