### PR TITLE
fix: preserve preview width when reopening

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -78,6 +78,7 @@ export interface LayoutState {
   readonly previewViewletId: string
   readonly previewVisible: boolean
   readonly previewWidth: number
+  readonly previewWidthBeforeClose: number
   readonly restore: boolean
   readonly sashId: any
   readonly sideBarHeight: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -166,6 +166,7 @@ export const create = (id: number): LayoutState => {
     previewLeft: 0,
     previewTop: 0,
     previewWidth: 0,
+    previewWidthBeforeClose: 0,
     secondaryPreviewHeight: 0,
     secondaryPreviewLeft: 0,
     secondaryPreviewTop: 0,
@@ -848,7 +849,7 @@ export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<L
     }
     const previewState = {
       ...state,
-      previewWidth: state.secondaryPreviewVisible ? state.windowWidth / 3 : state.windowWidth / 2,
+      previewWidth: state.previewWidthBeforeClose || (state.secondaryPreviewVisible ? state.windowWidth / 3 : state.windowWidth / 2),
     }
     const previewResult = await showPreview(previewState, sideBarView, ViewletModuleId.ExtensionView)
     const focusCommands = await Viewlet.getFocusCommands(sideBarView)
@@ -1197,9 +1198,13 @@ export const showPreview = async (
 
 export const hidePreview = async (state: LayoutState) => {
   const result = await hide(state, LayoutModules.Preview)
-  const activityBarCommands = await renderPreviewActivityBarCommands(state, result.newState)
+  const newState = {
+    ...result.newState,
+    previewWidthBeforeClose: state.previewWidth,
+  }
+  const activityBarCommands = await renderPreviewActivityBarCommands(state, newState)
   return {
-    newState: result.newState,
+    newState,
     commands: [...result.commands, ...activityBarCommands],
   }
 }

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -934,6 +934,46 @@ test('toggleSideBarView hides the preview when its selected activity item is cli
   ])
 })
 
+test('toggleSideBarView preserves resized preview width after hiding and reopening', async () => {
+  mockActivityBarRender()
+  // @ts-ignore
+  GetExtensionViews.getExtensionView.mockResolvedValue({
+    id: 'sample.views.preview',
+    preferredLocation: 'preview',
+  })
+  // @ts-ignore
+  ViewletManager.load.mockResolvedValue([])
+  const state = LayoutPoints.getPoints({
+    ...ViewletLayout.create(1),
+    activityBarId: 7,
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    previewId: 11,
+    previewMinWidth: 100,
+    previewUri: 'sample.views.preview',
+    previewViewletId: 'ExtensionView',
+    previewVisible: true,
+    previewWidth: 400,
+    sideBarMaxWidth: 1200,
+    sideBarMinWidth: 170,
+    sideBarVisible: true,
+    sideBarWidth: 240,
+    statusBarHeight: 20,
+    windowHeight: 800,
+    windowWidth: 1200,
+  })
+
+  const hidden = await ViewletLayout.toggleSideBarView(state, 'sample.views.preview')
+  const reopened = await ViewletLayout.toggleSideBarView(hidden.newState, 'sample.views.preview')
+
+  expect(reopened.newState).toMatchObject({
+    previewLeft: 800,
+    previewUri: 'sample.views.preview',
+    previewVisible: true,
+    previewWidth: 400,
+  })
+})
+
 test('showPreview updates both activity items when replacing a preview extension view', async () => {
   mockActivityBarRender()
   // @ts-ignore


### PR DESCRIPTION
## Summary
- remember the resized preview width when the preview closes
- reuse that width on reopen while keeping the existing first-open default
- cover the complete hide/reopen transition with a regression test

## Tests
- 92 renderer layout tests
- renderer-worker TypeScript check
- git diff --check

Follow-up to #13884 from official v0.102.2 installed-UI acceptance.