### PR TITLE
fix: dispose extensions before workspace change

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js
+++ b/packages/renderer-worker/src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js
@@ -1,6 +1,15 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
+import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as LaunchExtensionManagementWorker from '../LaunchExtensionManagementWorker/LaunchExtensionManagementWorker.js'
 
 const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchExtensionManagementWorker.launchExtensionManagementWorker)
 
 export { invoke, invokeAndTransfer, restart }
+
+const disposeAllRuntimes = () => {
+  return invoke('Extensions.disposeAllRuntimes')
+}
+
+export const hydrate = () => {
+  GlobalEventBus.addListener('workspace.beforeChange', disposeAllRuntimes)
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -5,6 +5,7 @@ import * as CleanAuthCallbackUrl from '../CleanAuthCallbackUrl/CleanAuthCallback
 import * as CleanUpWorkersAfterLoad from '../CleanUpWorkersAfterLoad/CleanUpWorkersAfterLoad.js'
 import * as DevelopFileWatcher from '../DevelopFileWatcher/DevelopFileWatcher.js'
 import * as ExecuteCurrentTest from '../ExecuteCurrentTest/ExecuteCurrentTest.js'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as FileSystemMap from '../FileSystemMap/FileSystemMap.js'
 import * as FileSystemState from '../FileSystemState/FileSystemState.js'
 import * as Focus from '../Focus/Focus.js'
@@ -129,6 +130,7 @@ export const startup = async (platform, assetDir) => {
   LifeCycle.mark(LifeCyclePhase.One)
 
   IpcState.setConfig(initData.Config?.shouldLaunchMultipleWorkers)
+  ExtensionManagementWorker.hydrate()
 
   const promptOptions = platform === PlatformType.Electron ? await PromptMode.getPromptOptions() : undefined
 

--- a/packages/renderer-worker/test/ExtensionManagementWorkerWorkspace.test.ts
+++ b/packages/renderer-worker/test/ExtensionManagementWorkerWorkspace.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn(async (_method: string) => {})
+
+jest.unstable_mockModule('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js', () => ({
+  getOrCreateWorker: jest.fn(() => ({
+    dispose: jest.fn(),
+    invoke,
+    invokeAndTransfer: jest.fn(),
+    restart: jest.fn(),
+  })),
+}))
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  getPathSeparator: jest.fn(async () => '/'),
+}))
+
+jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
+  set: jest.fn(async () => {}),
+}))
+
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+const Workspace = await import('../src/parts/Workspace/Workspace.js')
+
+beforeEach(() => {
+  invoke.mockClear()
+  GlobalEventBus.state.listenerMap = Object.create(null)
+  Workspace.state.pathSeparator = '/'
+  Workspace.state.workspacePath = '/old-workspace'
+  Workspace.state.workspaceUri = '/old-workspace'
+})
+
+test('disposes extensions before changing workspace', async () => {
+  ExtensionManagementWorker.hydrate()
+
+  await Workspace.setPath('/new-workspace')
+
+  expect(invoke).toHaveBeenCalledTimes(1)
+  expect(invoke).toHaveBeenCalledWith('Extensions.disposeAllRuntimes')
+})

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -8,6 +8,7 @@ export const Commands = {
   definition: LanguageServer.definition,
   diagnostic: LanguageServer.diagnostic,
   dispose: LanguageServer.dispose,
+  disposeAll: LanguageServer.disposeAll,
   format: LanguageServer.format,
   references: LanguageServer.references,
 }

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -218,6 +218,7 @@ export const getModuleId = (commandId: any): any => {
     case 'LanguageServer.definition':
     case 'LanguageServer.diagnostic':
     case 'LanguageServer.dispose':
+    case 'LanguageServer.disposeAll':
     case 'LanguageServer.format':
     case 'LanguageServer.references':
       return ModuleId.LanguageServer

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from '@jest/globals'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import * as LanguageServerIpc from '../src/parts/LanguageServer/LanguageServer.ipc.ts'
 import {
   codeAction,
   complete,
@@ -20,6 +21,10 @@ const pushDiagnosticsServerScript = fileURLToPath(new URL('./fixtures/languageSe
 
 afterEach(() => {
   disposeAll()
+})
+
+test('exposes bulk disposal over IPC', () => {
+  expect(LanguageServerIpc.Commands.disposeAll).toBe(disposeAll)
 })
 
 test('JavaScript language servers use Electron as Node', () => {

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -29,3 +29,7 @@ test('getModuleId - GetElectronFileResponse.resolveElectronFileUri', () => {
 test('getModuleId - IpcTrace.append', () => {
   expect(ModuleMap.getModuleId('IpcTrace.append')).toBe(ModuleId.IpcTrace)
 })
+
+test('getModuleId - LanguageServer.disposeAll', () => {
+  expect(ModuleMap.getModuleId('LanguageServer.disposeAll')).toBe(ModuleId.LanguageServer)
+})


### PR DESCRIPTION
## Summary

Dispose all extension runtimes and language servers before replacing the active workspace, allowing required extensions to reactivate cleanly for the new workspace.