### PR TITLE
feature: support unified remote workspace backend

### DIFF
--- a/packages/extension-host-helper-process/package.json
+++ b/packages/extension-host-helper-process/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "#test": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --detectOpenHandles --forceExit",
+    "test": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --detectOpenHandles --forceExit",
     "#test:watch": "node --unhandled-rejections=warn --experimental-vm-modules ../../node_modules/jest/bin/jest.js --watch"
   },
   "keywords": [],

--- a/packages/extension-host-helper-process/src/parts/LoadFile/LoadFile.js
+++ b/packages/extension-host-helper-process/src/parts/LoadFile/LoadFile.js
@@ -1,12 +1,33 @@
+import { resolve, sep } from 'node:path'
 import * as Command from '@lvce-editor/command'
 import * as Assert from '../Assert/Assert.js'
 import * as ImportScript from '../ImportScript/ImportScript.js'
 import { VError } from '../VError/VError.js'
 
+export const resolveRemoteExtensionPath = (value, extensionsPath = process.env.LVCE_REMOTE_EXTENSIONS_PATH) => {
+  if (!extensionsPath) {
+    return value
+  }
+  const normalized = value.replaceAll('\\', '/')
+  const marker = '/extensions/'
+  const markerIndex = normalized.lastIndexOf(marker)
+  if (markerIndex === -1) {
+    return value
+  }
+  const relativePath = normalized.slice(markerIndex + marker.length)
+  const root = resolve(extensionsPath)
+  const resolved = resolve(root, relativePath)
+  if (resolved !== root && !resolved.startsWith(`${root}${sep}`)) {
+    throw new Error('Remote extension path escapes the built-in extensions directory')
+  }
+  return resolved
+}
+
 export const loadFile = async (path) => {
   try {
     Assert.string(path)
-    const module = await ImportScript.importScript(path)
+    const resolvedPath = resolveRemoteExtensionPath(path)
+    const module = await ImportScript.importScript(resolvedPath)
     if (module && module.commandMap) {
       const commandMap = module.commandMap
       Command.register(commandMap)

--- a/packages/extension-host-helper-process/test/LoadFile.test.js
+++ b/packages/extension-host-helper-process/test/LoadFile.test.js
@@ -1,0 +1,17 @@
+import { expect, test } from '@jest/globals'
+import { resolve } from 'node:path'
+import { resolveRemoteExtensionPath } from '../src/parts/LoadFile/LoadFile.js'
+
+test('maps a built-in node extension into the remote server installation', () => {
+  expect(resolveRemoteExtensionPath('/usr/lib/lvce/extensions/builtin.git/node/src/gitClient.js', '/opt/lvce/extensions')).toBe(
+    resolve('/opt/lvce/extensions', 'builtin.git/node/src/gitClient.js'),
+  )
+})
+
+test('keeps non-extension paths unchanged', () => {
+  expect(resolveRemoteExtensionPath('/tmp/custom-extension/client.js', '/opt/lvce/extensions')).toBe('/tmp/custom-extension/client.js')
+})
+
+test('rejects a built-in extension path that escapes the remote extensions directory', () => {
+  expect(() => resolveRemoteExtensionPath('/usr/lib/lvce/extensions/../outside/client.js', '/opt/lvce/extensions')).toThrow(/escapes/)
+})

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -525,6 +525,7 @@ export const commandMap = {
   'Workspace.hydrate': lazy('Workspace.hydrate'),
   'Workspace.setPath': lazy('Workspace.setPath'),
   'Workspace.setUri': lazy('Workspace.setUri'),
+  'WebSocketCapability.create': lazy('WebSocketCapability.create'),
   'Layout.getAllQuickPickMenuEntries': lazy('Layout.getAllQuickPickMenuEntries'),
   'Layout.attachViewlet': lazy('Layout.attachViewlet'),
   'Layout.createPanelViewlet': lazy('Layout.createPanelViewlet'),

--- a/packages/renderer-worker/src/parts/IpcParentWithNodeAlternate/IpcParentWithNodeAlternate.js
+++ b/packages/renderer-worker/src/parts/IpcParentWithNodeAlternate/IpcParentWithNodeAlternate.js
@@ -3,8 +3,21 @@ import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SendMessagePortToElectron from '../SendMessagePortToElectron/SendMessagePortToElectron.js'
 import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 
 export const create = async (options) => {
+  const remoteUrl = WorkspaceBackend.getWebSocketUrl(options.type)
+  if (remoteUrl) {
+    const module = await import('../IpcParentWithWebSocket/IpcParentWithWebSocket.js')
+    const rawIpc = await module.create({ ...options, url: remoteUrl })
+    if (options.raw) {
+      return rawIpc
+    }
+    return {
+      rawIpc,
+      module,
+    }
+  }
   switch (Platform.getPlatform()) {
     case PlatformType.Web:
     case PlatformType.Remote:

--- a/packages/renderer-worker/src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.js
+++ b/packages/renderer-worker/src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.js
@@ -7,10 +7,13 @@ import * as ReconnectingWebSocket from '../ReconnectingWebSocket/ReconnectingWeb
 import * as WaitForWebSocketToBeOpen from '../WaitForWebSocketToBeOpen/WaitForWebSocketToBeOpen.js'
 import * as Location from '../Location/Location.js'
 
-export const create = async ({ type }) => {
+/**
+ * @param {{ readonly type: string, readonly url?: string }} options
+ */
+export const create = async ({ type, url = '' }) => {
   Assert.string(type)
   const host = Location.getHost()
-  const wsUrl = GetWebSocketUrl.getWebSocketUrl(type, host)
+  const wsUrl = url || GetWebSocketUrl.getWebSocketUrl(type, host)
   const webSocket = ReconnectingWebSocket.create(wsUrl)
   let firstWebSocketEvent = await WaitForWebSocketToBeOpen.waitForWebSocketToBeOpen(webSocket)
   if (firstWebSocketEvent.type === FirstWebSocketEventType.Close) {

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -225,6 +225,8 @@ export const load = (moduleId) => {
       return import('../MeasureTextHeight/MeasureTextHeight.ipc.js')
     case ModuleId.FileSystemMemory:
       return import('../FileSystem/FileSystemMemory.ipc.js')
+    case ModuleId.WebSocketCapability:
+      return import('../WebSocketCapability/WebSocketCapability.ipc.js')
     default:
       throw new Error(`module ${moduleId} not found`)
   }

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -114,3 +114,4 @@ export const ExtensionNodeRpc = 149
 export const License = 150
 export const SendMessagePortToMainProcess = 151
 export const FileSystemMemory = 152
+export const WebSocketCapability = 153

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -172,6 +172,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.Workbench
     case 'Workspace':
       return ModuleId.Workspace
+    case 'WebSocketCapability':
+      return ModuleId.WebSocketCapability
     case 'WindowTitle':
       return ModuleId.WindowTitle
     case 'PointerCapture':

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -27,6 +27,7 @@ import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker.js'
 import * as TextMeasurementWorker from '../TextMeasurementWorker/TextMeasurementWorker.js'
 import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 
 export const sendMessagePortToExtensionHostWorker = async (port, initialCommand, rpcId) => {
   Assert.object(port)
@@ -42,12 +43,18 @@ export const sendMessagePortToSharedProcess = async (port, initialCommand, rpcId
 
 export const sendMessagePortToProcessExplorer = async (port) => {
   Assert.object(port)
+  if (await WorkspaceBackend.connectMessagePort('process-explorer', port)) {
+    return
+  }
   await SharedProcess.invokeAndTransfer('HandleMessagePortForProcessExplorer.handleMessagePortForProcessExplorer', port)
 }
 
 export const sendMessagePortToTerminalProcess = async (port, initialCommand, rpcId) => {
   Assert.object(port)
   Assert.string(initialCommand)
+  if (await WorkspaceBackend.connectMessagePort('terminal-process', port)) {
+    return
+  }
   await SharedProcess.invokeAndTransfer(initialCommand, port, rpcId)
 }
 

--- a/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.ipc.js
+++ b/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.ipc.js
@@ -1,0 +1,7 @@
+import * as WebSocketCapability from './WebSocketCapability.js'
+
+export const name = 'WebSocketCapability'
+
+export const Commands = {
+  create: WebSocketCapability.create,
+}

--- a/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.js
+++ b/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.js
@@ -1,0 +1,11 @@
+import * as GetWebSocketUrl from '../GetWebSocketUrl/GetWebSocketUrl.js'
+import * as Location from '../Location/Location.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
+
+export const create = (type) => {
+  const remoteUrl = WorkspaceBackend.getWebSocketUrl(type)
+  return {
+    protocols: [],
+    url: remoteUrl || GetWebSocketUrl.getWebSocketUrl(type, Location.getHost()),
+  }
+}

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -9,6 +9,7 @@ import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
 import * as WindowTitle from '../WindowTitle/WindowTitle.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 import { state } from '../WorkspaceState/WorkspaceState.js'
 
 /**
@@ -27,12 +28,13 @@ export const setPath = async (path) => {
   // @ts-ignore
   state.workspaceUri = path
   state.pathSeparator = pathSeparator
+  WorkspaceBackend.reset()
   await onWorkspaceChange()
 }
 
-export const setUri = async (uri, providedPathSeparator) => {
+export const setUri = async (uri, providedPathSeparator, backend) => {
   const protocol = GetProtocol.getProtocol(uri)
-  const path = protocol === 'file' ? decodeURIComponent(uri.slice('file://'.length)) : uri
+  const path = backend?.workspacePath || (protocol === 'file' ? decodeURIComponent(uri.slice('file://'.length)) : uri)
   const pathSeparator = providedPathSeparator ?? (await FileSystem.getPathSeparator(uri))
   await updateWindowTitle(path, pathSeparator)
   if (path !== state.workspacePath) {
@@ -41,6 +43,11 @@ export const setUri = async (uri, providedPathSeparator) => {
   state.workspacePath = path
   state.workspaceUri = uri
   state.pathSeparator = pathSeparator
+  if (backend) {
+    WorkspaceBackend.set(uri, backend.url, backend.token)
+  } else {
+    WorkspaceBackend.reset()
+  }
   await onWorkspaceChange()
 }
 

--- a/packages/renderer-worker/src/parts/WorkspaceBackend/WorkspaceBackend.js
+++ b/packages/renderer-worker/src/parts/WorkspaceBackend/WorkspaceBackend.js
@@ -1,0 +1,58 @@
+import * as IpcParentWithWebSocket from '../IpcParentWithWebSocket/IpcParentWithWebSocket.js'
+import * as Json from '../Json/Json.js'
+import * as WorkspaceState from '../WorkspaceState/WorkspaceState.js'
+
+export const state = {
+  token: '',
+  url: '',
+  workspaceUri: '',
+}
+
+const isLoopbackUrl = (value) => {
+  const url = new URL(value)
+  return url.protocol === 'ws:' && (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]')
+}
+
+export const set = (workspaceUri, url, token) => {
+  if (typeof workspaceUri !== 'string' || typeof url !== 'string' || typeof token !== 'string') {
+    throw new TypeError('Invalid workspace backend')
+  }
+  if (!isLoopbackUrl(url)) {
+    throw new TypeError('Workspace backend must use a loopback WebSocket URL')
+  }
+  state.workspaceUri = workspaceUri
+  state.url = url
+  state.token = token
+}
+
+export const reset = () => {
+  state.workspaceUri = ''
+  state.url = ''
+  state.token = ''
+}
+
+export const getWebSocketUrl = (type) => {
+  if (!state.url || WorkspaceState.state.workspaceUri !== state.workspaceUri) {
+    return ''
+  }
+  const url = new URL(`/websocket/${encodeURIComponent(type)}`, state.url)
+  url.searchParams.set('token', state.token)
+  return url.toString()
+}
+
+export const connectMessagePort = async (type, port) => {
+  const url = getWebSocketUrl(type)
+  if (!url) {
+    return false
+  }
+  const webSocket = await IpcParentWithWebSocket.create({ type, url })
+  webSocket.onmessage = (event) => {
+    port.postMessage(Json.parse(event.data))
+  }
+  webSocket.onclose = () => port.close()
+  port.onmessage = (event) => {
+    webSocket.send(Json.stringifyCompact(event.data))
+  }
+  port.start?.()
+  return true
+}

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -29,10 +29,17 @@ jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManage
   }
 })
 
+jest.unstable_mockModule('../src/parts/WorkspaceBackend/WorkspaceBackend.js', () => {
+  return {
+    connectMessagePort: jest.fn(async () => false),
+  }
+})
+
 const DialogWorker = await import('../src/parts/DialogWorker/DialogWorker.js')
 const DragAndDropWorker = await import('../src/parts/DragAndDropWorker/DragAndDropWorker.js')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const WorkspaceBackend = await import('../src/parts/WorkspaceBackend/WorkspaceBackend.js')
 const SendMessagePortToExtensionHostWorker = await import('../src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js')
 
 test('sendMessagePortToProcessExplorer', async () => {
@@ -42,6 +49,20 @@ test('sendMessagePortToProcessExplorer', async () => {
 
   expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
   expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePortForProcessExplorer.handleMessagePortForProcessExplorer', port)
+})
+
+test('sendMessagePortToTerminalProcess uses the remote workspace backend', async () => {
+  const port = {}
+  jest.mocked(WorkspaceBackend.connectMessagePort).mockResolvedValueOnce(true)
+
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToTerminalProcess(
+    port,
+    'HandleMessagePortForTerminalProcess.handleMessagePortForTerminalProcess',
+    1,
+  )
+
+  expect(WorkspaceBackend.connectMessagePort).toHaveBeenCalledWith('terminal-process', port)
+  expect(SharedProcess.invokeAndTransfer).not.toHaveBeenCalled()
 })
 
 test('sendMessagePortToDialogWorker', async () => {

--- a/packages/renderer-worker/test/WorkspaceBackend.test.ts
+++ b/packages/renderer-worker/test/WorkspaceBackend.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+interface MockWebSocket {
+  onclose?: () => void
+  onmessage?: (event: { readonly data: string }) => void
+  readonly send: (value: string) => void
+}
+
+const create = jest.fn<() => Promise<MockWebSocket>>()
+const workspaceState = { workspaceUri: '' }
+
+jest.unstable_mockModule('../src/parts/WorkspaceState/WorkspaceState.js', () => ({ state: workspaceState }))
+jest.unstable_mockModule('../src/parts/IpcParentWithWebSocket/IpcParentWithWebSocket.js', () => ({ create }))
+
+const WorkspaceBackend = await import('../src/parts/WorkspaceBackend/WorkspaceBackend.js')
+
+beforeEach(() => {
+  WorkspaceBackend.reset()
+  workspaceState.workspaceUri = ''
+  create.mockReset()
+})
+
+test('returns an authenticated WebSocket URL for the matching workspace', () => {
+  workspaceState.workspaceUri = 'remote-ssh://host/work'
+  WorkspaceBackend.set('remote-ssh://host/work', 'ws://127.0.0.1:45123', 'secret')
+
+  expect(WorkspaceBackend.getWebSocketUrl('terminal-process')).toBe('ws://127.0.0.1:45123/websocket/terminal-process?token=secret')
+})
+
+test('does not affect a different workspace', () => {
+  workspaceState.workspaceUri = 'file:///tmp/work'
+  WorkspaceBackend.set('remote-ssh://host/work', 'ws://127.0.0.1:45123', 'secret')
+
+  expect(WorkspaceBackend.getWebSocketUrl('terminal-process')).toBe('')
+})
+
+test('rejects non-loopback endpoints', () => {
+  expect(() => WorkspaceBackend.set('remote-ssh://host/work', 'ws://example.com:45123', 'secret')).toThrow(/loopback/)
+})
+
+test('bridges a message port to the remote backend', async () => {
+  workspaceState.workspaceUri = 'remote-ssh://host/work'
+  WorkspaceBackend.set('remote-ssh://host/work', 'ws://127.0.0.1:45123', 'secret')
+  const webSocket: MockWebSocket = { send: jest.fn<(value: string) => void>() }
+  create.mockResolvedValue(webSocket)
+  const port = {
+    close: jest.fn(),
+    onmessage: undefined as undefined | ((event: { readonly data: unknown }) => void),
+    postMessage: jest.fn(),
+    start: jest.fn(),
+  }
+
+  await expect(WorkspaceBackend.connectMessagePort('terminal-process', port)).resolves.toBe(true)
+  port.onmessage?.({ data: ['request'] })
+  expect(webSocket.send).toHaveBeenCalledWith('["request"]')
+  webSocket.onmessage?.({ data: '["response"]' })
+  expect(port.postMessage).toHaveBeenCalledWith(['response'])
+})

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "bin": "bin/server.js",
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "test": "node --test \"test/**/*.test.js\""
+  },
   "keywords": [
     "Lvce Editor",
     "Server"

--- a/packages/server/src/remoteSshOptions.js
+++ b/packages/server/src/remoteSshOptions.js
@@ -1,0 +1,62 @@
+const defaultIdleTimeout = 3 * 60 * 60 * 1000
+
+const getArgument = (argv, name) => {
+  const prefix = `${name}=`
+  const argument = argv.find((value) => value.startsWith(prefix))
+  return argument ? argument.slice(prefix.length) : undefined
+}
+
+const parseInteger = (value, fallback, name) => {
+  if (value === undefined) {
+    return fallback
+  }
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isSafeInteger(parsed)) {
+    throw new TypeError(`${name} must be an integer`)
+  }
+  return parsed
+}
+
+export const getRemoteSshOptions = (argv, env = process.env) => {
+  const enabled = argv.includes('--as-remote-ssh-server')
+  if (!enabled) {
+    return {
+      enabled: false,
+      host: env.HOST || 'localhost',
+      idleTimeout: defaultIdleTimeout,
+      port: parseInteger(env.PORT, 3000, 'PORT'),
+      token: '',
+    }
+  }
+  const token = getArgument(argv, '--connection-token') || env.LVCE_REMOTE_SSH_CONNECTION_TOKEN || ''
+  if (!token) {
+    throw new TypeError('Remote SSH server requires --connection-token')
+  }
+  const port = parseInteger(getArgument(argv, '--port') || env.PORT, 0, '--port')
+  if (port < 0 || port > 65_535) {
+    throw new RangeError('--port must be between 0 and 65535')
+  }
+  const idleTimeout = parseInteger(getArgument(argv, '--idle-timeout') || env.LVCE_REMOTE_SSH_IDLE_TIMEOUT, defaultIdleTimeout, '--idle-timeout')
+  if (idleTimeout < 0) {
+    throw new RangeError('--idle-timeout must not be negative')
+  }
+  return {
+    enabled: true,
+    host: '127.0.0.1',
+    idleTimeout,
+    port,
+    token,
+  }
+}
+
+export const isAuthenticatedRemoteRequest = (request, options) => {
+  if (!options.enabled) {
+    return false
+  }
+  try {
+    const url = new URL(request.url || '/', 'http://127.0.0.1')
+    return url.searchParams.get('token') === options.token
+  } catch {
+    return false
+  }
+}

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -5,13 +5,12 @@ import { createServer } from 'node:http'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Worker } from 'node:worker_threads'
+import { getRemoteSshOptions, isAuthenticatedRemoteRequest } from './remoteSshOptions.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '../../../')
 
 const { argv, env } = process
-
-const PORT = env.PORT ? parseInt(env.PORT) : 3000
 
 let argv2 = argv[2]
 
@@ -30,6 +29,30 @@ if (!argv2) {
 }
 
 const isPublic = argv.includes('--public')
+const remoteSshOptions = getRemoteSshOptions(argvSliced, env)
+const PORT = remoteSshOptions.port
+let remoteClientCount = 0
+let remoteIdleTimer
+
+const scheduleRemoteIdleShutdown = () => {
+  if (!remoteSshOptions.enabled || remoteClientCount !== 0) {
+    return
+  }
+  clearTimeout(remoteIdleTimer)
+  remoteIdleTimer = setTimeout(() => {
+    server.close(() => process.exit(0))
+  }, remoteSshOptions.idleTimeout)
+  remoteIdleTimer.unref()
+}
+
+const trackRemoteClient = (socket) => {
+  clearTimeout(remoteIdleTimer)
+  remoteClientCount++
+  socket.once('close', () => {
+    remoteClientCount--
+    scheduleRemoteIdleShutdown()
+  })
+}
 
 /**
  * @enum {string}
@@ -89,6 +112,11 @@ const isStatic = (url) => {
 }
 
 const handleRequest = (req, res) => {
+  if (remoteSshOptions.enabled) {
+    res.statusCode = 404
+    res.end()
+    return
+  }
   if (isStatic(req.url)) {
     return handleResponseViaStaticServer(req, res, 'StaticServer.getResponse')
   }
@@ -243,6 +271,7 @@ const getHandleMessage = (request) => {
     httpVersionMajor: request.httpVersionMajor,
     httpVersionMinor: request.httpVersionMinor,
     query: request.query,
+    remoteAuthorityAuthenticated: remoteSshOptions.enabled,
   }
 }
 
@@ -357,6 +386,13 @@ const handleResponseViaStaticServer = async (request, res, method, ...params) =>
  * @param {import('net').Socket} socket
  */
 const handleUpgrade = (request, socket) => {
+  if (remoteSshOptions.enabled && !isAuthenticatedRemoteRequest(request, remoteSshOptions)) {
+    socket.end('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n')
+    return
+  }
+  if (remoteSshOptions.enabled) {
+    trackRemoteClient(socket)
+  }
   sendHandleSharedProcess(request, socket, 'HandleWebSocket.handleWebSocket')
 }
 
@@ -369,11 +405,16 @@ const handleServerError = (error) => {
   }
 }
 
+const server = createServer(handleRequest)
+
 const handleAppReady = () => {
+  scheduleRemoteIdleShutdown()
   if (process.send) {
     process.send('ready')
   } else {
-    console.info(`[server] listening on http://localhost:${PORT}`)
+    const address = server.address()
+    const port = typeof address === 'object' && address ? address.port : PORT
+    console.info(`[server] listening on http://${remoteSshOptions.host}:${port}`)
   }
 }
 
@@ -385,11 +426,10 @@ const handleUncaughtExceptionMonitor = (error, origin) => {
 const main = () => {
   process.on('message', handleMessageFromParent)
   process.on('uncaughtExceptionMonitor', handleUncaughtExceptionMonitor)
-  const server = createServer(handleRequest)
   server.on('listening', handleAppReady)
   server.on('upgrade', handleUpgrade)
   server.on('error', handleServerError)
-  const host = isPublic ? undefined : 'localhost'
+  const host = remoteSshOptions.enabled ? remoteSshOptions.host : isPublic ? undefined : remoteSshOptions.host
   server.listen(PORT, host)
 }
 

--- a/packages/server/test/remoteSshOptions.test.js
+++ b/packages/server/test/remoteSshOptions.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getRemoteSshOptions, isAuthenticatedRemoteRequest } from '../src/remoteSshOptions.js'
+
+test('uses the regular server defaults without the remote flag', () => {
+  assert.deepEqual(getRemoteSshOptions([], {}), {
+    enabled: false,
+    host: 'localhost',
+    idleTimeout: 10_800_000,
+    port: 3000,
+    token: '',
+  })
+})
+
+test('parses private remote SSH server options', () => {
+  assert.deepEqual(getRemoteSshOptions(['--as-remote-ssh-server', '--port=45123', '--connection-token=secret', '--idle-timeout=25'], {}), {
+    enabled: true,
+    host: '127.0.0.1',
+    idleTimeout: 25,
+    port: 45123,
+    token: 'secret',
+  })
+})
+
+test('requires an authentication token in remote mode', () => {
+  assert.throws(() => getRemoteSshOptions(['--as-remote-ssh-server'], {}), /requires --connection-token/)
+})
+
+test('accepts only the configured query token', () => {
+  const options = getRemoteSshOptions(['--as-remote-ssh-server', '--connection-token=secret'], {})
+  assert.equal(isAuthenticatedRemoteRequest({ url: '/websocket/terminal-process?token=secret' }, options), true)
+  assert.equal(isAuthenticatedRemoteRequest({ url: '/websocket/terminal-process?token=wrong' }, options), false)
+  assert.equal(isAuthenticatedRemoteRequest({ url: '/websocket/terminal-process' }, options), false)
+})

--- a/packages/server/test/remoteSshServer.integration.test.js
+++ b/packages/server/test/remoteSshServer.integration.test.js
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+const serverPath = path.join(import.meta.dirname, '..', 'src', 'server.js')
+
+const waitForListeningPort = (child) => {
+  return new Promise((resolve, reject) => {
+    let output = ''
+    const timeout = setTimeout(() => reject(new Error(`Timed out waiting for remote server\n${output}`)), 30_000)
+    const onData = (chunk) => {
+      output += chunk.toString('utf8')
+      const match = output.match(/listening on http:\/\/127\.0\.0\.1:(\d+)/)
+      if (match) {
+        clearTimeout(timeout)
+        child.stdout.off('data', onData)
+        resolve(Number.parseInt(match[1], 10))
+      }
+    }
+    child.stdout.on('data', onData)
+    child.stderr.on('data', (chunk) => {
+      output += chunk.toString('utf8')
+    })
+    child.once('error', reject)
+    child.once('exit', (code) => reject(new Error(`Remote server exited with code ${code}\n${output}`)))
+  })
+}
+
+const waitForOpen = (webSocket) => {
+  return new Promise((resolve, reject) => {
+    webSocket.onopen = resolve
+    webSocket.onerror = () => reject(new Error('WebSocket failed before opening'))
+  })
+}
+
+const waitForClose = (webSocket) => {
+  return new Promise((resolve) => {
+    webSocket.onclose = resolve
+    webSocket.onerror = () => {}
+  })
+}
+
+const createRpc = (webSocket) => {
+  let nextId = 1
+  const callbacks = new Map()
+  webSocket.onmessage = (event) => {
+    const response = JSON.parse(event.data)
+    const callback = callbacks.get(response.id)
+    if (callback) {
+      callbacks.delete(response.id)
+      callback(response)
+    }
+  }
+  return (method, ...params) => {
+    const id = nextId++
+    const promise = new Promise((resolve) => callbacks.set(id, resolve))
+    webSocket.send(JSON.stringify({ id, jsonrpc: '2.0', method, params }))
+    return promise.then((response) => {
+      if (response.error) {
+        const error = new Error(response.error.message)
+        error.code = response.error.data?.code
+        throw error
+      }
+      return response.result
+    })
+  }
+}
+
+const stopProcessGroup = (child) => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+  try {
+    process.kill(process.platform === 'win32' ? child.pid : -child.pid, 'SIGTERM')
+  } catch {
+    child.kill('SIGTERM')
+  }
+}
+
+test('remote mode authenticates and exposes existing workspace processes', { skip: typeof WebSocket === 'undefined' }, async (context) => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'lvce-remote-backend-'))
+  const token = 'integration-secret'
+  const child = spawn(process.execPath, [serverPath, '--as-remote-ssh-server', '--port=0', `--connection-token=${token}`, '--idle-timeout=30000'], {
+    detached: true,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  context.after(async () => {
+    stopProcessGroup(child)
+    await rm(directory, { force: true, recursive: true })
+  })
+  const port = await waitForListeningPort(child)
+
+  const unauthorized = new WebSocket(`ws://127.0.0.1:${port}/websocket/file-system-process?token=wrong`)
+  await waitForClose(unauthorized)
+
+  const webSocket = new WebSocket(`ws://127.0.0.1:${port}/websocket/file-system-process?token=${token}`)
+  await waitForOpen(webSocket)
+  context.after(() => webSocket.close())
+  const invoke = createRpc(webSocket)
+
+  const toUri = (value) => {
+    const url = new URL('file:///')
+    url.pathname = value
+    return url.href
+  }
+  assert.equal(await invoke('FileSystem.stat', toUri(directory)), 3)
+  const folder = path.join(directory, 'folder')
+  const file = path.join(folder, 'file.txt')
+  await invoke('FileSystem.mkdir', toUri(folder))
+  await invoke('FileSystem.writeFile', toUri(file), Buffer.from('hello').toString('base64'), 'base64')
+  assert.equal(Buffer.from(await invoke('FileSystem.readFile', toUri(file), 'base64'), 'base64').toString('utf8'), 'hello')
+  assert.deepEqual(await invoke('FileSystem.readDirWithFileTypes', toUri(directory)), [{ name: 'folder', type: 3 }])
+  assert.equal(await readFile(file, 'utf8'), 'hello')
+  await invoke('FileSystem.forceRemove', toUri(folder))
+  await assert.rejects(readFile(file, 'utf8'), { code: 'ENOENT' })
+
+  if (process.platform !== 'win32') {
+    const processWebSocket = new WebSocket(`ws://127.0.0.1:${port}/websocket/process-explorer?token=${token}`)
+    await waitForOpen(processWebSocket)
+    context.after(() => processWebSocket.close())
+    const invokeProcessExplorer = createRpc(processWebSocket)
+    const rootPid = await invokeProcessExplorer('ProcessId.getMainProcessId', { includeElectronData: false })
+    assert.equal(Number.isSafeInteger(rootPid), true)
+    const processes = await invokeProcessExplorer('ListProcessesWithMemoryUsage.listProcessesWithMemoryUsage', rootPid, false)
+    assert.equal(Array.isArray(processes), true)
+    assert.equal(processes.length > 0, true)
+  }
+})

--- a/packages/shared-process/package-lock.json
+++ b/packages/shared-process/package-lock.json
@@ -34,7 +34,7 @@
       },
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "^4.16.0",
-        "@lvce-editor/file-system-process": "^5.14.0",
+        "@lvce-editor/file-system-process": "^5.15.0",
         "@lvce-editor/file-watcher-process": "^4.13.0",
         "@lvce-editor/network-process": "^5.2.0",
         "@lvce-editor/preload": "^1.5.0",
@@ -857,9 +857,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.14.0.tgz",
-      "integrity": "sha512-zDkSEAUi5IsWqAqAwWtAN+AnuPr/6ZG0nrB5kLhT9i3P/TvODMB02DFVs3XgSQF+8i0QeAFkpfu78nhRb7RoNQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.15.0.tgz",
+      "integrity": "sha512-y03NsQiqnq9p5Frl7dNFDDp+tRbadGnngSTGlHT7AcFCbgOSo5YhwDKRkfqsXqEj+JxSJ40DtvSR8vZ7+2XzoQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/packages/shared-process/package.json
+++ b/packages/shared-process/package.json
@@ -36,7 +36,7 @@
   },
   "optionalDependencies": {
     "@lvce-editor/embeds-process": "^4.16.0",
-    "@lvce-editor/file-system-process": "^5.14.0",
+    "@lvce-editor/file-system-process": "^5.15.0",
     "@lvce-editor/file-watcher-process": "^4.13.0",
     "@lvce-editor/network-process": "^5.2.0",
     "@lvce-editor/preload": "^1.5.0",

--- a/packages/shared-process/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
+++ b/packages/shared-process/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
@@ -20,7 +20,7 @@ const getConnectSrc = (): any => {
   if (IsElectron.isElectron) {
     return []
   }
-  return [`connect-src 'self'`]
+  return [`connect-src 'self' ws://127.0.0.1:* ws://localhost:*`]
 }
 
 const getFrameAncestors = (): any => {

--- a/packages/shared-process/src/parts/GetTypeFromUrl/GetTypeFromUrl.ts
+++ b/packages/shared-process/src/parts/GetTypeFromUrl/GetTypeFromUrl.ts
@@ -5,17 +5,19 @@ export const getTypeFromUrl = (url: any): any => {
     throw new VError('invalid url')
   }
   const questionMarkIndex = url.indexOf('?')
-  if (questionMarkIndex === -1) {
-    const slashIndex = url.lastIndexOf('/')
-    const rest = url.slice(slashIndex + 1)
-    if (!rest) {
-      throw new Error('missing type parameter')
-    }
-    return rest
+  const path = questionMarkIndex === -1 ? url : url.slice(0, questionMarkIndex)
+  const slashIndex = path.lastIndexOf('/')
+  const pathType = path.slice(slashIndex + 1)
+  if (pathType) {
+    return pathType
   }
-  // deprecated
-  const rest = url.slice(questionMarkIndex)
-  const searchParams = new URLSearchParams(rest)
-  const type = searchParams.get('type')
-  return type
+  if (questionMarkIndex !== -1) {
+    // deprecated
+    const searchParams = new URLSearchParams(url.slice(questionMarkIndex))
+    const queryType = searchParams.get('type')
+    if (queryType) {
+      return queryType
+    }
+  }
+  throw new Error('missing type parameter')
 }

--- a/packages/shared-process/src/parts/IsAllowedWebSocketOrigin/IsAllowedWebSocketOrigin.ts
+++ b/packages/shared-process/src/parts/IsAllowedWebSocketOrigin/IsAllowedWebSocketOrigin.ts
@@ -26,6 +26,9 @@ const getAllowedHosts = (headers: any): any => {
 }
 
 export const isAllowedWebSocketOrigin = (request: any): any => {
+  if (request.remoteAuthorityAuthenticated === true) {
+    return true
+  }
   const { headers } = request
   const origin = normalizeHeaderValue(getHeaderValue(headers, 'origin'))
   if (!origin) {

--- a/packages/shared-process/test/GetTypeFromUrl.test.ts
+++ b/packages/shared-process/test/GetTypeFromUrl.test.ts
@@ -15,3 +15,8 @@ test('valid query parameters', () => {
   const url = '/?type=shared-process'
   expect(GetTypeFromUrl.getTypeFromUrl(url)).toBe('shared-process')
 })
+
+test('valid path with authentication query parameter', () => {
+  const url = '/websocket/file-system-process?token=secret'
+  expect(GetTypeFromUrl.getTypeFromUrl(url)).toBe('file-system-process')
+})

--- a/packages/shared-process/test/IsAllowedWebSocketOrigin.test.ts
+++ b/packages/shared-process/test/IsAllowedWebSocketOrigin.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from '@jest/globals'
 import * as IsAllowedWebSocketOrigin from '../src/parts/IsAllowedWebSocketOrigin/IsAllowedWebSocketOrigin.js'
 
+test('isAllowedWebSocketOrigin - authenticated remote authority', () => {
+  expect(IsAllowedWebSocketOrigin.isAllowedWebSocketOrigin({ remoteAuthorityAuthenticated: true })).toBe(true)
+})
+
 test('isAllowedWebSocketOrigin - same host', () => {
   expect(
     IsAllowedWebSocketOrigin.isAllowedWebSocketOrigin({

--- a/packages/static-server/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
+++ b/packages/static-server/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
@@ -22,7 +22,7 @@ const getConnectSrc = ({ isForElectronProduction }: ContentSecurityPolicyOptions
   if (isForElectronProduction) {
     return []
   }
-  return [`connect-src 'self'`]
+  return [`connect-src 'self' ws://127.0.0.1:* ws://localhost:*`]
 }
 
 const getFrameAncestors = () => {

--- a/packages/static-server/src/parts/ContentSecurityPolicyRendererWorker/ContentSecurityPolicyRendererWorker.ts
+++ b/packages/static-server/src/parts/ContentSecurityPolicyRendererWorker/ContentSecurityPolicyRendererWorker.ts
@@ -2,7 +2,7 @@ import * as GetContentSecurityPolicy from '../GetContentSecurityPolicy/GetConten
 
 export const value = GetContentSecurityPolicy.getContentSecurityPolicy([
   `default-src 'none'`,
-  `connect-src 'self'`,
+  `connect-src 'self' ws://127.0.0.1:* ws://localhost:*`,
   `script-src 'self'`,
   `font-src 'self'`,
 ])

--- a/packages/static-server/src/parts/Static/Static.ts
+++ b/packages/static-server/src/parts/Static/Static.ts
@@ -1,4 +1,4 @@
 import { join } from 'node:path'
 import { root } from '../Root/Root.ts'
 
-export const STATIC = join(root, 'static')
+export const STATIC = process.env.LVCE_STATIC_ROOT || join(root, 'static')


### PR DESCRIPTION
## Summary

- add a private `--as-remote-ssh-server` mode to the existing LVCE server
- authenticate loopback WebSocket endpoints and route remote terminal, search, process explorer, filesystem, Git, and other Node extension RPCs to the remote backend
- keep the remote workspace URI while exposing its absolute POSIX workspace path
- map bundled Node extension entrypoints to the remote built-in extension installation
- update file-system-process to v5.15.0 for protected permanent removal

## Tests

- server integration: authenticated filesystem operations and real process-explorer process listing
- renderer: 335 suites / 1,462 active tests
- shared process: 96 suites / 365 active tests
- static server: 6 suites / 18 tests
- extension host helper: 2 suites / 6 tests
- relevant package typechecks and repository lint