### PR TITLE
fix: propagate preview resize bounds

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1165,6 +1165,7 @@
         "hotReloadLoadContent": { "name": "Preview.loadContent", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "savedState" }] },
         "diff": { "name": "Preview.diff2", "parameters": [{ "source": "state", "name": "uid" }] },
         "render": { "name": "Preview.render2", "parameters": [{ "source": "state", "name": "uid" }, { "source": "result", "name": "diff" }] },
+        "resize": { "name": "Preview.resize", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "dimensions" }] },
         "saveState": { "name": "Preview.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "terminate": { "name": "Preview.terminate", "parameters": [] },
         "getCommandIds": { "name": "Preview.getCommandIds", "parameters": [] },

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -148,6 +148,27 @@ test('returns preview runtime diagnostics without treating them as viewlet state
   expect(invoke).toHaveBeenCalledWith('Preview.getRuntimeDiagnostics', 12)
 })
 
+test('forwards preview bounds changes to the preview worker', async () => {
+  const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
+    if (method === 'Preview.diff2' || method === 'Preview.render2') {
+      return []
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('preview'),
+    config: getWorkerViewletConfig('preview'),
+    worker: { invoke, restart: jest.fn() },
+  })
+  const state = viewlet.create(12, 'file:///workspace/index.html', 926, 29, 926, 906)
+  const dimensions = { height: 906, width: 400, x: 1452, y: 29 }
+
+  const result = await viewlet.resize!(state, dimensions)
+
+  expect(invoke).toHaveBeenCalledWith('Preview.resize', 12, dimensions)
+  expect(result).toMatchObject(dimensions)
+})
+
 test('preserves command short-circuit and phase-specific diff parameters', async () => {
   const config: any = createConfig({ commandSkipRenderWhenDiffEmpty: true })
   config.methods.commandDiff = {


### PR DESCRIPTION
## Summary
- register the preview worker resize lifecycle
- forward preview sash bounds to the mounted preview document
- add contract coverage for the exact 926px to 400px resize

## Tests
- 106 renderer layout/lifecycle tests
- renderer-worker TypeScript check
- git diff --check

Final follow-up from installed v0.102.4 acceptance for #13884 and #13889.