### PR TITLE
feature: update panel-worker to version 2.10.1

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -50,7 +50,7 @@
         "@lvce-editor/menu-worker": "^4.13.0",
         "@lvce-editor/opener-worker": "^1.17.0",
         "@lvce-editor/output-view": "^2.18.1",
-        "@lvce-editor/panel-worker": "^2.10.0",
+        "@lvce-editor/panel-worker": "^2.10.1",
         "@lvce-editor/preview-sandbox-worker": "^4.10.0",
         "@lvce-editor/preview-worker": "^6.12.0",
         "@lvce-editor/problems-view": "^1.31.3",
@@ -1124,9 +1124,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/panel-worker": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/panel-worker/-/panel-worker-2.10.0.tgz",
-      "integrity": "sha512-43zOS2WHfRxAnK6pEU3++vRNckxH5JQjoNIWcts8RtluZGQ1YEX8OX73gHkLbokwLTEOFPV0U98pE1yQ8WGnow==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/panel-worker/-/panel-worker-2.10.1.tgz",
+      "integrity": "sha512-xRh2Mssk+roVCN+iYHoxQY8mVIaSrwMMNIUnrcWn/3UEYXkIHXVU3XaO94ie9s6m0APf5Hh/5ADHRPtxpaeCMw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/preview-sandbox-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -82,7 +82,7 @@
     "@lvce-editor/menu-worker": "^4.13.0",
     "@lvce-editor/opener-worker": "^1.17.0",
     "@lvce-editor/output-view": "^2.18.1",
-    "@lvce-editor/panel-worker": "^2.10.0",
+    "@lvce-editor/panel-worker": "^2.10.1",
     "@lvce-editor/preview-sandbox-worker": "^4.10.0",
     "@lvce-editor/preview-worker": "^6.12.0",
     "@lvce-editor/problems-view": "^1.31.3",


### PR DESCRIPTION
## Summary

- update @lvce-editor/panel-worker from 2.10.0 to 2.10.1
- include Problems badge-count changes in the panel incremental diff
- complement the problems-view 1.31.3 update merged in #13900

## Tests

- renderer-worker type-check
- renderer-worker: 336 suites and 1,470 tests passed (22 suites / 231 tests skipped)
- panel-worker upstream: 72 unit tests passed
- panel-worker rendered E2E: 50 passed, 10 skipped, including Problems badge 3 -> 2 -> removed at 0
- git diff --check