### PR TITLE
fix: read server argv from shared process

### DIFF
--- a/packages/renderer-worker/src/parts/Process/Process.js
+++ b/packages/renderer-worker/src/parts/Process/Process.js
@@ -1,3 +1,5 @@
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 
 export const version = '0.0.0-dev'
@@ -48,8 +50,15 @@ export const getArch = () => {
   return SharedProcess.invoke('Process.getArch')
 }
 
+export const getArgvCommand = (platform) => {
+  if (platform !== PlatformType.Electron) {
+    return 'Process.getArgv'
+  }
+  return 'ElectronProcess.getArgv'
+}
+
 export const getArgv = () => {
-  return SharedProcess.invoke('ElectronProcess.getArgv')
+  return SharedProcess.invoke(getArgvCommand(Platform.getPlatform()))
 }
 
 export const writeStderr = (value) => {

--- a/packages/renderer-worker/test/Process.test.ts
+++ b/packages/renderer-worker/test/Process.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+import * as Process from '../src/parts/Process/Process.js'
+
+test('getArgv reads argv from the shared process on a remote server', () => {
+  expect(Process.getArgvCommand(PlatformType.Remote)).toBe('Process.getArgv')
+})
+
+test('getArgv reads argv from the Electron main process in Electron', () => {
+  expect(Process.getArgvCommand(PlatformType.Electron)).toBe('ElectronProcess.getArgv')
+})

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -67,3 +67,16 @@ test('setUri uses a provided provider path separator', async () => {
   expect(Workspace.state.pathSeparator).toBe('\\')
   expect(getPathSeparator).not.toHaveBeenCalled()
 })
+
+test('setUri uses the remote backend workspace path', async () => {
+  await Workspace.setUri('remote-ssh://host/work', '/', {
+    token: 'secret',
+    url: 'ws://127.0.0.1:45123',
+    workspacePath: '/work',
+  })
+
+  expect(Workspace.getWorkspacePath()).toBe('/work')
+  expect(Workspace.getWorkspaceUri()).toBe('remote-ssh://host/work')
+  expect(Workspace.state.pathSeparator).toBe('/')
+  expect(getPathSeparator).not.toHaveBeenCalled()
+})

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -273,6 +273,7 @@ export const getModuleId = (commandId: any): any => {
     case 'Preferences.getAll':
       return ModuleId.Preferences
     case 'Process.getArch':
+    case 'Process.getArgv':
     case 'Process.getNodeVersion':
     case 'Process.getPid':
     case 'Process.getV8Version':

--- a/packages/shared-process/src/parts/Process/Process.ipc.ts
+++ b/packages/shared-process/src/parts/Process/Process.ipc.ts
@@ -4,6 +4,7 @@ export const Commands = {
   'Process.crash': Process.crash,
   'Process.crashAsync': Process.crashAsync,
   'Process.getArch': Process.getArch,
+  'Process.getArgv': Process.getArgv,
   'Process.getNodeVersion': Process.getNodeVersion,
   'Process.getPid': Process.getPid,
   'Process.getV8Version': Process.getV8Version,

--- a/packages/shared-process/src/parts/Process/Process.ts
+++ b/packages/shared-process/src/parts/Process/Process.ts
@@ -70,3 +70,7 @@ export const getNodeVersion = (): any => {
 export const getArch = (): any => {
   return process.arch
 }
+
+export const getArgv = (): readonly string[] => {
+  return process.argv
+}

--- a/packages/shared-process/test/Process.test.ts
+++ b/packages/shared-process/test/Process.test.ts
@@ -15,6 +15,10 @@ test('crashAsync', () => {
   expect(Process.crashAsync).rejects.toThrow()
 })
 
+test('getArgv', () => {
+  expect(Process.getArgv()).toEqual(process.argv)
+})
+
 test('kill - ESRCH', () => {
   const pid = 123
   const signal = Signal.SIGINT


### PR DESCRIPTION
## Summary
- route argv requests through the shared process on Web and Remote servers
- preserve Electron main-process argv behavior
- cover remote workspace backend paths used by terminals

## Root cause
Prompt-mode initialization asked the server-side shared process for Electron argv. With no Electron parent IPC, that JSON-RPC request never completed and test/server pages stayed blank.

## Tests
- shared-process: 96 suites, 368 tests passed
- renderer-worker: 337 suites, 1,472 tests passed
- focused argv/workspace tests and both package type checks passed
- changed files pass ESLint, Prettier, and diff checks
- browser WebSocket repro now receives the argv response and renders the workbench