### PR TITLE
fix: restore preview width when reopening

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1149,14 +1149,21 @@ export const showPreview = async (
   uri: string = initialState.previewUri,
   previewViewletId: string = getPreviewViewletId(uri),
 ) => {
-  const state =
-    !initialState.previewVisible && initialState.secondaryPreviewVisible
+  const stateWithRestoredWidth =
+    !initialState.previewVisible && initialState.previewWidthBeforeClose > 0
       ? {
           ...initialState,
-          previewWidth: initialState.windowWidth / 3,
-          secondaryPreviewWidth: initialState.windowWidth / 3,
+          previewWidth: initialState.previewWidthBeforeClose,
         }
       : initialState
+  const state =
+    !stateWithRestoredWidth.previewVisible && stateWithRestoredWidth.secondaryPreviewVisible
+      ? {
+          ...stateWithRestoredWidth,
+          previewWidth: stateWithRestoredWidth.windowWidth / 3,
+          secondaryPreviewWidth: stateWithRestoredWidth.windowWidth / 3,
+        }
+      : stateWithRestoredWidth
   const { previewVisible, previewId, uid } = state
 
   if (previewVisible && previewId !== -1) {

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -654,3 +654,30 @@ test('hidePreview disables preview sash', async () => {
   expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(7, 'Preview')
   expect(Viewlet.disposeFunctional).toHaveBeenCalledWith(7)
 })
+
+test('showPreview restores the resized preview width after hiding', async () => {
+  const state = LayoutPoints.getPoints({
+    ...ViewletLayout.create(1),
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    previewId: 7,
+    previewMinWidth: 100,
+    previewUri: 'file:///test.html',
+    previewViewletId: 'Preview',
+    previewVisible: true,
+    previewWidth: 400,
+    statusBarHeight: 20,
+    titleBarHeight: 35,
+    windowHeight: 1080,
+    windowWidth: 1920,
+  })
+
+  const hidden = await ViewletLayout.hidePreview(state)
+  const reopened = await ViewletLayout.showPreview(hidden.newState, 'file:///test.html')
+
+  expect(reopened.newState).toMatchObject({
+    previewLeft: 1520,
+    previewVisible: true,
+    previewWidth: 400,
+  })
+})


### PR DESCRIPTION
## Summary

Restore the last resized preview width through the shared show-preview path, including the Preview toolbar close/reopen flow.