### PR TITLE
fix: route remote workspace services through server

### DIFF
--- a/packages/extension-host-helper-process/src/parts/HandleWebSocket/HandleWebSocket.js
+++ b/packages/extension-host-helper-process/src/parts/HandleWebSocket/HandleWebSocket.js
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.js'
+import * as CommandMapRef from '../CommandMapRef/CommandMapRef.js'
 import * as IpcChild from '../IpcChild/IpcChild.js'
 import * as IpcChildType from '../IpcChildType/IpcChildType.js'
 import * as HandleIpcClosed from '../HandleIpcClosed/HandleIpcClosed.js'
@@ -9,6 +10,7 @@ export const handleWebSocket = async (handle, request) => {
   Assert.object(request)
   handle.on('close', HandleIpcClosed.handleIpcClosed)
   await IpcChild.listen({
+    commandMap: CommandMapRef.commandMapRef,
     method: IpcChildType.WebSocket,
     request,
     handle,

--- a/packages/extension-host-helper-process/src/parts/LoadFile/LoadFile.js
+++ b/packages/extension-host-helper-process/src/parts/LoadFile/LoadFile.js
@@ -1,6 +1,7 @@
 import { resolve, sep } from 'node:path'
 import * as Command from '@lvce-editor/command'
 import * as Assert from '../Assert/Assert.js'
+import * as CommandMapRef from '../CommandMapRef/CommandMapRef.js'
 import * as ImportScript from '../ImportScript/ImportScript.js'
 import { VError } from '../VError/VError.js'
 
@@ -31,6 +32,7 @@ export const loadFile = async (path) => {
     if (module && module.commandMap) {
       const commandMap = module.commandMap
       Command.register(commandMap)
+      Object.assign(CommandMapRef.commandMapRef, commandMap)
     } else if (module && module.execute) {
       throw new Error(`execute function is not supported anymore. Use commandMap instead`)
     } else {

--- a/packages/extension-host-helper-process/test/HandleWebSocket.test.js
+++ b/packages/extension-host-helper-process/test/HandleWebSocket.test.js
@@ -1,0 +1,27 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/IpcChild/IpcChild.js', () => ({
+  listen: jest.fn(),
+}))
+
+const CommandMapRef = await import('../src/parts/CommandMapRef/CommandMapRef.js')
+const HandleWebSocket = await import('../src/parts/HandleWebSocket/HandleWebSocket.js')
+const IpcChild = await import('../src/parts/IpcChild/IpcChild.js')
+
+test('passes dynamically loaded commands to the websocket rpc', async () => {
+  const closeListener = jest.fn()
+  const handle = {
+    on: jest.fn(),
+  }
+  const request = {}
+  CommandMapRef.commandMapRef['Exec.exec'] = closeListener
+
+  await HandleWebSocket.handleWebSocket(handle, request)
+
+  expect(IpcChild.listen).toHaveBeenCalledWith({
+    commandMap: CommandMapRef.commandMapRef,
+    method: 6,
+    request,
+    handle,
+  })
+})

--- a/packages/extension-host-helper-process/test/LoadFile.test.js
+++ b/packages/extension-host-helper-process/test/LoadFile.test.js
@@ -1,6 +1,20 @@
-import { expect, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import { resolve } from 'node:path'
-import { resolveRemoteExtensionPath } from '../src/parts/LoadFile/LoadFile.js'
+
+jest.unstable_mockModule('../src/parts/ImportScript/ImportScript.js', () => ({
+  importScript: jest.fn(),
+}))
+
+const CommandMapRef = await import('../src/parts/CommandMapRef/CommandMapRef.js')
+const ImportScript = await import('../src/parts/ImportScript/ImportScript.js')
+const { loadFile, resolveRemoteExtensionPath } = await import('../src/parts/LoadFile/LoadFile.js')
+
+beforeEach(() => {
+  for (const key of Object.keys(CommandMapRef.commandMapRef)) {
+    delete CommandMapRef.commandMapRef[key]
+  }
+  jest.clearAllMocks()
+})
 
 test('maps a built-in node extension into the remote server installation', () => {
   expect(resolveRemoteExtensionPath('/usr/lib/lvce/extensions/builtin.git/node/src/gitClient.js', '/opt/lvce/extensions')).toBe(
@@ -14,4 +28,17 @@ test('keeps non-extension paths unchanged', () => {
 
 test('rejects a built-in extension path that escapes the remote extensions directory', () => {
   expect(() => resolveRemoteExtensionPath('/usr/lib/lvce/extensions/../outside/client.js', '/opt/lvce/extensions')).toThrow(/escapes/)
+})
+
+test('adds loaded commands to the active helper process command map', async () => {
+  const execute = jest.fn()
+  jest.mocked(ImportScript.importScript).mockResolvedValue({
+    commandMap: {
+      'Exec.exec': execute,
+    },
+  })
+
+  await loadFile('/test/gitClient.js')
+
+  expect(CommandMapRef.commandMapRef['Exec.exec']).toBe(execute)
 })

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -70,7 +70,7 @@
         "@lvce-editor/terminal-worker": "^2.9.0",
         "@lvce-editor/test-worker": "^17.12.1",
         "@lvce-editor/text-measurement-worker": "^1.23.0",
-        "@lvce-editor/text-search-view": "^1.9.0",
+        "@lvce-editor/text-search-view": "^1.9.1",
         "@lvce-editor/text-search-worker": "^7.15.0",
         "@lvce-editor/title-bar-worker": "^4.18.0",
         "@lvce-editor/update-worker": "^2.14.0"
@@ -1247,9 +1247,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-view": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/text-search-view/-/text-search-view-1.9.0.tgz",
-      "integrity": "sha512-1SUK5KsMcMCITs+ToN6QaRIaYPY6gcwThjrofa3PjClBra43s4p6T/vjWASvjpW2pQe8LsEqjpfRD7thsESPYA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/text-search-view/-/text-search-view-1.9.1.tgz",
+      "integrity": "sha512-Oy/CnNRrAUDgin1bO++3mToGg5Zy9qsRShaCoRzkHil2at4FQrGQ6cIYnH6EivHxqw8mHO+QyVJOAOhZzFoOgg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-search-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -102,7 +102,7 @@
     "@lvce-editor/terminal-worker": "^2.9.0",
     "@lvce-editor/test-worker": "^17.12.1",
     "@lvce-editor/text-measurement-worker": "^1.23.0",
-    "@lvce-editor/text-search-view": "^1.9.0",
+    "@lvce-editor/text-search-view": "^1.9.1",
     "@lvce-editor/text-search-worker": "^7.15.0",
     "@lvce-editor/title-bar-worker": "^4.18.0",
     "@lvce-editor/update-worker": "^2.14.0"

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -160,6 +160,7 @@ export const commandMap = {
   'ExtensionMeta.addNodeExtension': lazy('ExtensionMeta.addNodeExtension'),
   'ExtensionMeta.addWebExtension': lazy('ExtensionMeta.addWebExtension'),
   'ExtensionNodeRpc.create': lazy('ExtensionNodeRpc.create'),
+  'ExtensionNodeRpc.createConnection': lazy('ExtensionNodeRpc.createConnection'),
   'ExtensionNodeRpc.dispose': lazy('ExtensionNodeRpc.dispose'),
   'ExtensionNodeRpc.invoke': lazy('ExtensionNodeRpc.invoke'),
   'Extensions.openCachedExtensionsFolder': lazy('Extensions.openCachedExtensionsFolder'),

--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -6,12 +6,18 @@ import * as WorkerViewletAdapterMap from '../WorkerViewletAdapterMap/WorkerViewl
 import * as WorkerViewletConfig from '../WorkerViewletConfig/WorkerViewletConfig.js'
 import * as Workspace from '../Workspace/Workspace.js'
 
-const createContext = () => ({
+const createContext = (getPlatform) => ({
   assetDir: AssetDir.assetDir,
   isTest: Workspace.isTest?.() ?? false,
-  platform: Platform.getPlatform(),
-  workspacePath: Workspace.state.workspacePath,
-  workspaceUri: Workspace.getWorkspaceUri?.(),
+  get platform() {
+    return getPlatform()
+  },
+  get workspacePath() {
+    return Workspace.state.workspacePath
+  },
+  get workspaceUri() {
+    return Workspace.getWorkspaceUri?.()
+  },
 })
 
 const getValue = (values, name, description) => {
@@ -400,14 +406,19 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   )
 }
 
-export const createWorkerViewletWithDependencies = ({ adapter = WorkerViewletAdapterMap.getWorkerViewletAdapter(''), config, context = {}, worker }) => {
+export const createWorkerViewletWithDependencies = ({
+  adapter = WorkerViewletAdapterMap.getWorkerViewletAdapter(''),
+  config,
+  context = {},
+  worker,
+}) => {
   WorkerViewletConfig.validateWorkerViewletConfig('test', config)
   return createWorkerViewletInternal({ adapter, config, context, worker })
 }
 
-export const createWorkerViewlet = ({ workerId }) => {
+export const createWorkerViewlet = ({ workerId, getPlatform = Platform.getPlatform }) => {
   const config = WorkerViewletConfig.getWorkerViewletConfig(workerId)
-  const context = createContext()
+  const context = createContext(getPlatform)
   const worker = WorkerInvokerMap.getWorkerInvoker(workerId)
   const adapter = WorkerViewletAdapterMap.getWorkerViewletAdapter(workerId)
   return createWorkerViewletInternal({ adapter, config, context, worker })

--- a/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.ipc.js
+++ b/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.ipc.js
@@ -4,6 +4,7 @@ export const name = 'ExtensionNodeRpc'
 
 export const Commands = {
   create: ExtensionNodeRpc.create,
+  createConnection: ExtensionNodeRpc.createConnection,
   dispose: ExtensionNodeRpc.dispose,
   invoke: ExtensionNodeRpc.invoke,
 }

--- a/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js
+++ b/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js
@@ -3,8 +3,23 @@ import * as Id from '../Id/Id.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 
 const rpcs = Object.create(null)
+
+export const createConnection = async (extensionId, rpcId) => {
+  const value = WorkspaceBackend.getWebSocketUrl('extension-host-helper-process')
+  if (!value) {
+    throw new Error('ExtensionNodeRpc.createConnection command not found without a remote workspace backend')
+  }
+  const url = new URL(value)
+  url.searchParams.set('extensionId', extensionId)
+  url.searchParams.set('rpcId', rpcId)
+  return {
+    protocols: [],
+    url: url.toString(),
+  }
+}
 
 const getRpc = (id) => {
   const rpc = rpcs[id]

--- a/packages/renderer-worker/src/parts/GetOrCreateWorker/GetOrCreateWorker.js
+++ b/packages/renderer-worker/src/parts/GetOrCreateWorker/GetOrCreateWorker.js
@@ -22,6 +22,9 @@ export const getOrCreateWorker = (fn) => {
     async dispose() {
       const promise = workers.get(fn)
       workers.delete(fn)
+      if (!promise) {
+        return
+      }
       const ipc = await promise
       ipc.dispose()
     },

--- a/packages/renderer-worker/src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js
+++ b/packages/renderer-worker/src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js
@@ -1,8 +1,9 @@
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 
 export const loadProcessExplorerViewletModule = (platform = Platform.getPlatform()) => {
-  if (platform === PlatformType.Web) {
+  if (platform === PlatformType.Web && !WorkspaceBackend.isActive()) {
     return import('../ViewletProcessExplorerUnsupported/ViewletProcessExplorerUnsupported.ipc.js')
   }
   return import('../ViewletProcessExplorer/ViewletProcessExplorer.ipc.js')

--- a/packages/renderer-worker/src/parts/TextSearchWorker/TextSearchWorker.js
+++ b/packages/renderer-worker/src/parts/TextSearchWorker/TextSearchWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchTextSearchWorker from '../LaunchTextSearchWorker/LaunchTextSearchWorker.js'
 
-const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchTextSearchWorker.launchTextSearchWorker)
+const { dispose, invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchTextSearchWorker.launchTextSearchWorker)
 
-export { invoke, invokeAndTransfer, restart }
+export { dispose, invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js
@@ -1,7 +1,36 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
+
+const getPlatform = () => (WorkspaceBackend.isActive() ? PlatformType.Remote : Platform.getPlatform())
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent, menus,
-  name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
-} = createWorkerViewlet({ workerId: 'processExplorer' })
+  Commands,
+  Css,
+  Events,
+  Variables,
+  create,
+  dispose,
+  getCommands,
+  getKeyBindings,
+  getMenus,
+  getQuickPickMenuEntries,
+  getStorageKey,
+  getTitle,
+  hasDirectRender,
+  hasFunctionalEvents,
+  hasFunctionalRender,
+  hasFunctionalResize,
+  hasFunctionalRootRender,
+  hotReload,
+  loadContent,
+  menus,
+  name,
+  render,
+  renderActions,
+  renderEventListeners,
+  renderTitle,
+  resize,
+  saveState,
+} = createWorkerViewlet({ workerId: 'processExplorer', getPlatform })

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1234,7 +1234,7 @@
   {
     "id": "processExplorer",
     "fileName": "process-explorer-worker/index.js",
-    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self'"],
+    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self' ws://127.0.0.1:* ws://localhost:*"],
     "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/process-explorer-worker/index.js",
     "productionPath": "/packages/process-explorer-worker/index.js",
     "settingName": "develop.processExplorerWorkerPath",
@@ -1540,7 +1540,7 @@
   {
     "id": "terminalWorker",
     "fileName": "terminalWorkerMain.js",
-    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self'", "script-src 'self'"],
+    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self' ws://127.0.0.1:* ws://localhost:*", "script-src 'self'"],
     "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/terminal-worker/dist/terminalWorkerMain.js",
     "productionPath": "/packages/terminal-worker/dist/terminalWorkerMain.js",
     "settingName": "develop.terminalWorkerPath",
@@ -1571,7 +1571,7 @@
     "productionPath": "/packages/text-search-worker/dist/textSearchWorkerMain.js",
     "settingName": "develop.textSearchWorkerPath",
     "hotReloadCommand": "Search.hotReload",
-    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self'", "sandbox allow-same-origin"]
+    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self' ws://127.0.0.1:* ws://localhost:*", "sandbox allow-same-origin"]
   },
   {
     "id": "titleBar",

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -8,6 +8,7 @@ import * as Location from '../Location/Location.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
+import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
 import * as WindowTitle from '../WindowTitle/WindowTitle.js'
 import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 import { state } from '../WorkspaceState/WorkspaceState.js'
@@ -29,6 +30,7 @@ export const setPath = async (path) => {
   state.workspaceUri = path
   state.pathSeparator = pathSeparator
   WorkspaceBackend.reset()
+  await TextSearchWorker.dispose()
   await onWorkspaceChange()
 }
 
@@ -48,6 +50,7 @@ export const setUri = async (uri, providedPathSeparator, backend) => {
   } else {
     WorkspaceBackend.reset()
   }
+  await TextSearchWorker.dispose()
   await onWorkspaceChange()
 }
 

--- a/packages/renderer-worker/src/parts/WorkspaceBackend/WorkspaceBackend.js
+++ b/packages/renderer-worker/src/parts/WorkspaceBackend/WorkspaceBackend.js
@@ -40,6 +40,8 @@ export const getWebSocketUrl = (type) => {
   return url.toString()
 }
 
+export const isActive = () => Boolean(state.url && WorkspaceState.state.workspaceUri === state.workspaceUri)
+
 export const connectMessagePort = async (type, port) => {
   const url = getWebSocketUrl(type)
   if (!url) {

--- a/packages/renderer-worker/test/ExtensionNodeRpc.test.ts
+++ b/packages/renderer-worker/test/ExtensionNodeRpc.test.ts
@@ -21,11 +21,35 @@ jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
   invoke: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/WorkspaceBackend/WorkspaceBackend.js', () => ({
+  getWebSocketUrl: jest.fn(),
+}))
+
 const ExtensionNodeRpc = await import('../src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js')
 const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const Id = await import('../src/parts/Id/Id.js')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
 const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+const WorkspaceBackend = await import('../src/parts/WorkspaceBackend/WorkspaceBackend.js')
+
+test('createConnection returns an authenticated remote helper URL', async () => {
+  // @ts-ignore
+  WorkspaceBackend.getWebSocketUrl.mockReturnValue('ws://127.0.0.1:3000/websocket/extension-host-helper-process?token=test-token')
+
+  await expect(ExtensionNodeRpc.createConnection('builtin.git', 'git-client')).resolves.toEqual({
+    protocols: [],
+    url: 'ws://127.0.0.1:3000/websocket/extension-host-helper-process?token=test-token&extensionId=builtin.git&rpcId=git-client',
+  })
+})
+
+test('createConnection rejects when no remote workspace backend is active', async () => {
+  // @ts-ignore
+  WorkspaceBackend.getWebSocketUrl.mockReturnValue('')
+
+  await expect(ExtensionNodeRpc.createConnection('builtin.git', 'git-client')).rejects.toThrow(
+    'ExtensionNodeRpc.createConnection command not found without a remote workspace backend',
+  )
+})
 
 test('create, invoke, and dispose', async () => {
   const rpc = {

--- a/packages/renderer-worker/test/GetOrCreateWorker.test.ts
+++ b/packages/renderer-worker/test/GetOrCreateWorker.test.ts
@@ -1,0 +1,11 @@
+import { expect, jest, test } from '@jest/globals'
+import * as GetOrCreateWorker from '../src/parts/GetOrCreateWorker/GetOrCreateWorker.js'
+
+test('dispose does not launch an unused worker', async () => {
+  const launch = jest.fn()
+  const worker = GetOrCreateWorker.getOrCreateWorker(launch)
+
+  await worker.dispose()
+
+  expect(launch).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
+++ b/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
@@ -1,6 +1,16 @@
-import { expect, test } from '@jest/globals'
-import * as LoadProcessExplorerViewletModule from '../src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js'
-import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/WorkspaceBackend/WorkspaceBackend.js', () => ({
+  isActive: jest.fn(() => false),
+}))
+
+const LoadProcessExplorerViewletModule = await import('../src/parts/LoadProcessExplorerViewletModule/LoadProcessExplorerViewletModule.js')
+const PlatformType = await import('../src/parts/PlatformType/PlatformType.js')
+const WorkspaceBackend = await import('../src/parts/WorkspaceBackend/WorkspaceBackend.js')
+
+beforeEach(() => {
+  jest.mocked(WorkspaceBackend.isActive).mockReturnValue(false)
+})
 
 test('loads unsupported viewlet on web', async () => {
   const module = await LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule(PlatformType.Web)
@@ -12,6 +22,17 @@ test('loads unsupported viewlet on web', async () => {
   })
   expect(module.getCommands()).toEqual({})
   expect(module.getKeyBindings()).toEqual([])
+})
+
+test('loads worker-backed viewlet on web with an active remote workspace backend', async () => {
+  jest.mocked(WorkspaceBackend.isActive).mockReturnValue(true)
+
+  const module = await LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule(PlatformType.Web)
+
+  const state = module.create(7, 'process-explorer://', 1, 2, 3, 4)
+  expect(state.platform).toBe(PlatformType.Remote)
+  expect(typeof module.getCommands).toBe('function')
+  expect(typeof module.getKeyBindings).toBe('function')
 })
 
 test.each([PlatformType.Electron, PlatformType.Remote])('loads worker-backed viewlet on platform %s', async (platform) => {

--- a/packages/renderer-worker/test/ViewletSearch.test.ts
+++ b/packages/renderer-worker/test/ViewletSearch.test.ts
@@ -26,9 +26,35 @@ jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
 
 const TextSearchViewWorker = await import('../src/parts/TextSearchViewWorker/TextSearchViewWorker.js')
 const ViewletSearch = await import('../src/parts/ViewletSearch/ViewletSearch.ipc.ts')
+const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
   jest.clearAllMocks()
+  Workspace.state.workspacePath = '/test-workspace'
+})
+
+test('loadContent uses the current workspace path', async () => {
+  const state = ViewletSearch.create(1, 'Search', 10, 20, 800, 600)
+  Workspace.state.workspacePath = '/new-workspace'
+
+  await ViewletSearch.loadContent(state, {})
+
+  expect(TextSearchViewWorker.invoke).toHaveBeenNthCalledWith(
+    1,
+    'TextSearch.create',
+    1,
+    10,
+    20,
+    800,
+    600,
+    '/new-workspace',
+    '/test-assets',
+    22,
+    '',
+    '',
+    2,
+    false,
+  )
 })
 
 test('create identifies sidebar search', () => {

--- a/packages/renderer-worker/test/WorkspaceBackend.test.ts
+++ b/packages/renderer-worker/test/WorkspaceBackend.test.ts
@@ -25,6 +25,7 @@ test('returns an authenticated WebSocket URL for the matching workspace', () => 
   WorkspaceBackend.set('remote-ssh://host/work', 'ws://127.0.0.1:45123', 'secret')
 
   expect(WorkspaceBackend.getWebSocketUrl('terminal-process')).toBe('ws://127.0.0.1:45123/websocket/terminal-process?token=secret')
+  expect(WorkspaceBackend.isActive()).toBe(true)
 })
 
 test('does not affect a different workspace', () => {
@@ -32,6 +33,7 @@ test('does not affect a different workspace', () => {
   WorkspaceBackend.set('remote-ssh://host/work', 'ws://127.0.0.1:45123', 'secret')
 
   expect(WorkspaceBackend.getWebSocketUrl('terminal-process')).toBe('')
+  expect(WorkspaceBackend.isActive()).toBe(false)
 })
 
 test('rejects non-loopback endpoints', () => {

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const getPathSeparator = jest.fn<(uri: string) => Promise<string>>(async () => '/')
 const setWindowTitle = jest.fn<(title: string) => Promise<void>>(async () => {})
+const disposeTextSearchWorker = jest.fn<() => Promise<void>>(async () => {})
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   getPathSeparator,
@@ -15,12 +16,17 @@ jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({
   getProductNameLong: () => 'Lvce Editor',
 }))
 
+jest.unstable_mockModule('../src/parts/TextSearchWorker/TextSearchWorker.js', () => ({
+  dispose: disposeTextSearchWorker,
+}))
+
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
   getPathSeparator.mockClear()
   setWindowTitle.mockClear()
+  disposeTextSearchWorker.mockClear()
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = ''
@@ -31,6 +37,7 @@ test('setPath uses the product name for an empty workspace', async () => {
   await Workspace.setPath('')
 
   expect(setWindowTitle).toHaveBeenCalledWith('Lvce Editor')
+  expect(disposeTextSearchWorker).toHaveBeenCalledTimes(1)
 })
 
 test('setPath uses the folder name for a workspace', async () => {
@@ -66,6 +73,7 @@ test('setUri uses a provided provider path separator', async () => {
   expect(Workspace.getWorkspaceUri()).toBe('remote-ssh:///test-folder')
   expect(Workspace.state.pathSeparator).toBe('\\')
   expect(getPathSeparator).not.toHaveBeenCalled()
+  expect(disposeTextSearchWorker).toHaveBeenCalledTimes(1)
 })
 
 test('setUri uses the remote backend workspace path', async () => {

--- a/packages/shared-process/src/parts/HandleWebSocketForExtensionHostHelperProcess/HandleWebSocketForExtensionHostHelperProcess.ts
+++ b/packages/shared-process/src/parts/HandleWebSocketForExtensionHostHelperProcess/HandleWebSocketForExtensionHostHelperProcess.ts
@@ -1,6 +1,31 @@
+import * as ExtensionHostHelperProcessIpc from '../ExtensionHostHelperProcessIpc/ExtensionHostHelperProcessIpc.ts'
 import * as HandleIncomingIpc from '../HandleIncomingIpc/HandleIncomingIpc.ts'
+import * as HandleIpc from '../HandleIpc/HandleIpc.ts'
 import * as IpcId from '../IpcId/IpcId.ts'
+import * as IpcParentType from '../IpcParentType/IpcParentType.ts'
+import * as JsonRpc from '../JsonRpc/JsonRpc.ts'
+import * as ResolveExtensionNodeRpcPath from '../ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.ts'
 
-export const handleWebSocket = (message: any, handle: any): any => {
-  return HandleIncomingIpc.handleIncomingIpc(IpcId.ExtensionHostHelperProcess, handle, message)
+export const handleWebSocket = async (message: any, handle: any): Promise<any> => {
+  const url = new URL(message.url, 'http://localhost')
+  const extensionId = url.searchParams.get('extensionId')
+  const rpcId = url.searchParams.get('rpcId')
+  if (!extensionId && !rpcId) {
+    return HandleIncomingIpc.handleIncomingIpc(IpcId.ExtensionHostHelperProcess, handle, message)
+  }
+  if (!extensionId || !rpcId) {
+    throw new Error('Remote extension node rpc request is incomplete')
+  }
+  const modulePath = await ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath(extensionId, rpcId)
+  const ipc = await ExtensionHostHelperProcessIpc.create({
+    method: IpcParentType.NodeForkedProcess,
+  })
+  HandleIpc.handleIpc(ipc)
+  try {
+    await JsonRpc.invoke(ipc, 'LoadFile.loadFile', modulePath)
+    await JsonRpc.invokeAndTransfer(ipc, 'HandleWebSocket.handleWebSocket', handle, message)
+  } catch (error) {
+    ipc.dispose()
+    throw error
+  }
 }

--- a/packages/shared-process/src/parts/ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.ts
+++ b/packages/shared-process/src/parts/ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.ts
@@ -1,0 +1,40 @@
+import { readFile, realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+const idRegex = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+const schemeRegex = /^[A-Za-z][A-Za-z\d+.-]*:/
+
+const isInside = (parent: string, child: string): boolean => child === parent || child.startsWith(`${parent}${path.sep}`)
+
+const validateId = (value: string, name: string): void => {
+  if (!idRegex.test(value)) {
+    throw new Error(`Invalid extension node rpc ${name}`)
+  }
+}
+
+export const resolveExtensionNodeRpcPath = async (extensionId: string, rpcId: string): Promise<string> => {
+  validateId(extensionId, 'extension id')
+  validateId(rpcId, 'rpc id')
+  const configuredRoot = process.env.LVCE_REMOTE_EXTENSIONS_PATH
+  if (!configuredRoot) {
+    throw new Error('Remote extensions path is unavailable')
+  }
+  const extensionsRoot = await realpath(configuredRoot)
+  const extensionRoot = await realpath(path.join(extensionsRoot, extensionId))
+  if (!isInside(extensionsRoot, extensionRoot)) {
+    throw new Error('Extension path escapes the remote extensions root')
+  }
+  const manifest = JSON.parse(await readFile(path.join(extensionRoot, 'extension.json'), 'utf8'))
+  const rpc = manifest.rpc?.find((candidate: any) => candidate?.id === rpcId)
+  if (!rpc || rpc.type !== 'node' || typeof rpc.url !== 'string') {
+    throw new Error(`Node rpc ${rpcId} is not declared by extension ${extensionId}`)
+  }
+  if (!rpc.url || path.isAbsolute(rpc.url) || schemeRegex.test(rpc.url)) {
+    throw new Error(`Node rpc ${rpcId} must use a relative url`)
+  }
+  const modulePath = await realpath(path.resolve(extensionRoot, rpc.url))
+  if (!isInside(extensionRoot, modulePath)) {
+    throw new Error('Extension node rpc path escapes the extension root')
+  }
+  return modulePath
+}

--- a/packages/shared-process/test/HandleWebSocketForExtensionHostHelperProcess.test.ts
+++ b/packages/shared-process/test/HandleWebSocketForExtensionHostHelperProcess.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as IpcParentType from '../src/parts/IpcParentType/IpcParentType.ts'
+
+const dispose = jest.fn()
+const ipc = { dispose }
+
+jest.unstable_mockModule('../src/parts/ExtensionHostHelperProcessIpc/ExtensionHostHelperProcessIpc.js', () => ({
+  create: jest.fn(async () => ipc),
+}))
+
+jest.unstable_mockModule('../src/parts/HandleIncomingIpc/HandleIncomingIpc.js', () => ({
+  handleIncomingIpc: jest.fn(async () => 'generic'),
+}))
+
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => ({
+  handleIpc: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invoke: jest.fn(async () => undefined),
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
+jest.unstable_mockModule('../src/parts/ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.js', () => ({
+  resolveExtensionNodeRpcPath: jest.fn(async () => '/remote/extensions/builtin.git/node/src/gitClient.js'),
+}))
+
+const ExtensionHostHelperProcessIpc = await import('../src/parts/ExtensionHostHelperProcessIpc/ExtensionHostHelperProcessIpc.js')
+const HandleIncomingIpc = await import('../src/parts/HandleIncomingIpc/HandleIncomingIpc.js')
+const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
+const HandleWebSocket = await import('../src/parts/HandleWebSocketForExtensionHostHelperProcess/HandleWebSocketForExtensionHostHelperProcess.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+const ResolveExtensionNodeRpcPath = await import('../src/parts/ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('uses the generic helper process for an unscoped websocket', async () => {
+  const message = { url: '/websocket/extension-host-helper-process' }
+  const handle = {}
+
+  await expect(HandleWebSocket.handleWebSocket(message, handle)).resolves.toBe('generic')
+
+  expect(HandleIncomingIpc.handleIncomingIpc).toHaveBeenCalledWith(3, handle, message)
+  expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath).not.toHaveBeenCalled()
+})
+
+test('preloads a declared remote extension node rpc', async () => {
+  const message = {
+    url: '/websocket/extension-host-helper-process?extensionId=builtin.git&rpcId=git-client',
+  }
+  const handle = {}
+
+  await HandleWebSocket.handleWebSocket(message, handle)
+
+  expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath).toHaveBeenCalledWith('builtin.git', 'git-client')
+  expect(ExtensionHostHelperProcessIpc.create).toHaveBeenCalledWith({ method: IpcParentType.NodeForkedProcess })
+  expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'LoadFile.loadFile', '/remote/extensions/builtin.git/node/src/gitClient.js')
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'HandleWebSocket.handleWebSocket', handle, message)
+})
+
+test('rejects an incomplete remote extension node rpc request', async () => {
+  await expect(HandleWebSocket.handleWebSocket({ url: '/websocket/extension-host-helper-process?extensionId=builtin.git' }, {})).rejects.toThrow(
+    'Remote extension node rpc request is incomplete',
+  )
+})
+
+test('disposes the helper process when preloading fails', async () => {
+  // @ts-ignore
+  JsonRpc.invoke.mockRejectedValueOnce(new Error('load failed'))
+
+  await expect(
+    HandleWebSocket.handleWebSocket({ url: '/websocket/extension-host-helper-process?extensionId=builtin.git&rpcId=git-client' }, {}),
+  ).rejects.toThrow('load failed')
+
+  expect(dispose).toHaveBeenCalledTimes(1)
+})

--- a/packages/shared-process/test/ResolveExtensionNodeRpcPath.test.ts
+++ b/packages/shared-process/test/ResolveExtensionNodeRpcPath.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from '@jest/globals'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import * as ResolveExtensionNodeRpcPath from '../src/parts/ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.ts'
@@ -31,7 +31,7 @@ test('resolves a declared node rpc inside the remote extension root', async () =
   const root = await createFixture()
 
   await expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath('builtin.git', 'git-client')).resolves.toBe(
-    path.join(root, 'builtin.git', 'node', 'src', 'gitClient.js'),
+    await realpath(path.join(root, 'builtin.git', 'node', 'src', 'gitClient.js')),
   )
 })
 

--- a/packages/shared-process/test/ResolveExtensionNodeRpcPath.test.ts
+++ b/packages/shared-process/test/ResolveExtensionNodeRpcPath.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, test } from '@jest/globals'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import * as ResolveExtensionNodeRpcPath from '../src/parts/ResolveExtensionNodeRpcPath/ResolveExtensionNodeRpcPath.ts'
+
+const roots: string[] = []
+const originalRemoteExtensionsPath = process.env.LVCE_REMOTE_EXTENSIONS_PATH
+
+const createFixture = async (rpcUrl = 'node/src/gitClient.js'): Promise<string> => {
+  const root = await mkdtemp(path.join(tmpdir(), 'lvce-remote-extensions-'))
+  roots.push(root)
+  const extensionRoot = path.join(root, 'builtin.git')
+  await mkdir(path.join(extensionRoot, 'node', 'src'), { recursive: true })
+  await writeFile(path.join(extensionRoot, 'node', 'src', 'gitClient.js'), 'export {}')
+  await writeFile(path.join(extensionRoot, 'extension.json'), JSON.stringify({ rpc: [{ id: 'git-client', type: 'node', url: rpcUrl }] }))
+  process.env.LVCE_REMOTE_EXTENSIONS_PATH = root
+  return root
+}
+
+afterEach(async () => {
+  if (originalRemoteExtensionsPath === undefined) {
+    delete process.env.LVCE_REMOTE_EXTENSIONS_PATH
+  } else {
+    process.env.LVCE_REMOTE_EXTENSIONS_PATH = originalRemoteExtensionsPath
+  }
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })))
+})
+
+test('resolves a declared node rpc inside the remote extension root', async () => {
+  const root = await createFixture()
+
+  await expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath('builtin.git', 'git-client')).resolves.toBe(
+    path.join(root, 'builtin.git', 'node', 'src', 'gitClient.js'),
+  )
+})
+
+test('rejects undeclared and invalid rpc identifiers', async () => {
+  await createFixture()
+
+  await expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath('builtin.git', 'missing')).rejects.toThrow('Node rpc missing is not declared')
+  await expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath('../builtin.git', 'git-client')).rejects.toThrow(
+    'Invalid extension node rpc extension id',
+  )
+})
+
+test('rejects a declared rpc path outside the extension root', async () => {
+  const root = await createFixture('../outside.js')
+  await writeFile(path.join(root, 'outside.js'), 'export {}')
+
+  await expect(ResolveExtensionNodeRpcPath.resolveExtensionNodeRpcPath('builtin.git', 'git-client')).rejects.toThrow(
+    'Extension node rpc path escapes the extension root',
+  )
+})

--- a/packages/static-server/test/GetHeadersTerminalWorker.test.ts
+++ b/packages/static-server/test/GetHeadersTerminalWorker.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import * as GetHeaders from '../src/parts/GetHeaders/GetHeaders.ts'
+
+test('terminal worker allows authenticated loopback websocket connections', () => {
+  const headers = GetHeaders.getHeaders({
+    absolutePath: '/test/terminalWorkerMain.js',
+    etag: 'test-etag',
+    isImmutable: false,
+    isForElectronProduction: false,
+    applicationName: 'lvce',
+  })
+
+  expect(headers['Content-Security-Policy']).toContain(`connect-src 'self' ws://127.0.0.1:* ws://localhost:*`)
+})
+
+test('text search worker allows authenticated loopback websocket connections', () => {
+  const headers = GetHeaders.getHeaders({
+    absolutePath: '/test/textSearchWorkerMain.js',
+    etag: 'test-etag',
+    isImmutable: false,
+    isForElectronProduction: false,
+    applicationName: 'lvce',
+  })
+
+  expect(headers['Content-Security-Policy']).toContain(`connect-src 'self' ws://127.0.0.1:* ws://localhost:*`)
+})
+
+test('process explorer worker allows authenticated loopback websocket connections', () => {
+  const headers = GetHeaders.getHeaders({
+    absolutePath: '/test/process-explorer-worker/index.js',
+    etag: 'test-etag',
+    isImmutable: false,
+    isForElectronProduction: false,
+    applicationName: 'lvce',
+  })
+
+  expect(headers['Content-Security-Policy']).toContain(`connect-src 'self' ws://127.0.0.1:* ws://localhost:*`)
+})


### PR DESCRIPTION
## Summary

- route terminal, text search, process explorer, and extension node RPC connections through the authenticated remote workspace backend
- securely preload declared remote extension node modules for Git functionality
- refresh workspace-sensitive worker state and allow loopback WebSocket connections in worker CSPs
- update text-search-view so search follows remote workspace changes

## Validation

- renderer-worker: 338 suites / 1,478 tests passed
- shared-process: 98 suites / 375 tests passed
- extension-host-helper-process: 3 suites / 8 tests passed
- static-server: 7 suites / 21 tests passed
- renderer/shared/static type checks passed
- repository lint passed
- static build passed
- real sshd E2E verified Explorer, edit/save, terminal, ripgrep search, Git, Process Explorer, and warm expansion latency