### PR TITLE
fix: route remote terminal process through workspace backend

### DIFF
--- a/packages/renderer-worker/src/parts/SendMessagePortToElectron/SendMessagePortToElectron.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToElectron/SendMessagePortToElectron.js
@@ -1,8 +1,14 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
+
+const terminalProcessInitialCommand = 'HandleMessagePortForTerminalProcess.handleMessagePortForTerminalProcess'
 
 export const sendMessagePortToElectron = async (port, initialCommand, ipcId) => {
   Assert.object(port)
   Assert.string(initialCommand)
+  if (initialCommand === terminalProcessInitialCommand && (await WorkspaceBackend.connectMessagePort('terminal-process', port))) {
+    return
+  }
   await SharedProcess.invokeAndTransfer(initialCommand, port, ipcId)
 }

--- a/packages/renderer-worker/test/SendMessagePortToElectron.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToElectron.test.ts
@@ -1,0 +1,49 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Worker port tests use ESM module mocks for worker dependencies. */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invokeAndTransfer: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/WorkspaceBackend/WorkspaceBackend.js', () => ({
+  connectMessagePort: jest.fn(async () => false),
+}))
+
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const WorkspaceBackend = await import('../src/parts/WorkspaceBackend/WorkspaceBackend.js')
+const SendMessagePortToElectron = await import('../src/parts/SendMessagePortToElectron/SendMessagePortToElectron.js')
+
+const terminalCommand = 'HandleMessagePortForTerminalProcess.handleMessagePortForTerminalProcess'
+
+test('routes a terminal port to the active remote workspace backend', async () => {
+  const port = {}
+  jest.mocked(WorkspaceBackend.connectMessagePort).mockResolvedValueOnce(true)
+
+  await SendMessagePortToElectron.sendMessagePortToElectron(port, terminalCommand, 42)
+
+  expect(WorkspaceBackend.connectMessagePort).toHaveBeenCalledWith('terminal-process', port)
+  expect(SharedProcess.invokeAndTransfer).not.toHaveBeenCalled()
+})
+
+test('falls back to the local shared process without a remote backend', async () => {
+  const port = {}
+
+  await SendMessagePortToElectron.sendMessagePortToElectron(port, terminalCommand, 42)
+
+  expect(WorkspaceBackend.connectMessagePort).toHaveBeenCalledWith('terminal-process', port)
+  expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledWith(terminalCommand, port, 42)
+})
+
+test('keeps non-terminal Electron ports local', async () => {
+  const port = {}
+  const command = 'HandleMessagePort.handleMessagePort'
+
+  await SendMessagePortToElectron.sendMessagePortToElectron(port, command, 42)
+
+  expect(WorkspaceBackend.connectMessagePort).not.toHaveBeenCalled()
+  expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledWith(command, port, 42)
+})


### PR DESCRIPTION
## Summary

- route Electron terminal message ports through the active remote workspace backend
- preserve the local shared-process fallback for local workspaces and non-terminal ports
- cover remote routing, local fallback, and unrelated Electron ports

## Verification

- renderer-worker focused tests: 12 passed
- renderer-worker full suite: 339 suites / 1,487 tests passed
- renderer-worker type-check and lint
- local x64 Debian build
- real Electron UI against a real sshd: terminal process is a child of the remote daemon pty-host, uses the remote workspace cwd, and executes a sentinel without inheriting the local PROMPT_COMMAND