### PR TITLE
fix: allow enabling default-disabled builtins

### DIFF
--- a/packages/shared-process/src/parts/ExtensionManagement/ExtensionManagement.ts
+++ b/packages/shared-process/src/parts/ExtensionManagement/ExtensionManagement.ts
@@ -13,12 +13,13 @@ import { VError } from '../VError/VError.ts'
 export const enable = async (id: any): Promise<any> => {
   try {
     const disabledExtensionsJsonPath = PlatformPaths.getDisabledExtensionsJsonPath()
-    const oldDisabledExtensionIds = await getDisabledExtensionIds()
-    if (!oldDisabledExtensionIds.includes(id)) {
+    const { disabledExtensionIds, enabledExtensionIds } = await getExtensionEnablement()
+    if (!disabledExtensionIds.includes(id) && enabledExtensionIds.includes(id)) {
       return
     }
-    const newDisabledExtensionIds = oldDisabledExtensionIds.filter((extensionId: any) => extensionId !== id)
-    const content = getNewDisabledExtensionContent(newDisabledExtensionIds)
+    const newDisabledExtensionIds = disabledExtensionIds.filter((extensionId: any) => extensionId !== id)
+    const newEnabledExtensionIds = enabledExtensionIds.includes(id) ? enabledExtensionIds : [...enabledExtensionIds, id]
+    const content = getNewExtensionEnablementContent(newDisabledExtensionIds, newEnabledExtensionIds)
     await mkdir(dirname(disabledExtensionsJsonPath), { recursive: true })
     await writeFile(disabledExtensionsJsonPath, content)
   } catch (error) {
@@ -26,11 +27,12 @@ export const enable = async (id: any): Promise<any> => {
   }
 }
 
-const getNewDisabledExtensionContent = (disabledExtensions: any): any => {
+const getNewExtensionEnablementContent = (disabledExtensions: any, enabledExtensions: any): any => {
   const content =
     JSON.stringify(
       {
         disabledExtensions,
+        enabledExtensions,
       },
       null,
       2,
@@ -41,12 +43,13 @@ const getNewDisabledExtensionContent = (disabledExtensions: any): any => {
 export const disable = async (id: any): Promise<any> => {
   try {
     const disabledExtensionsJsonPath = PlatformPaths.getDisabledExtensionsJsonPath()
-    const oldDisabledExtensionIds = await getDisabledExtensionIds()
-    if (oldDisabledExtensionIds.includes(id)) {
+    const { disabledExtensionIds, enabledExtensionIds } = await getExtensionEnablement()
+    if (disabledExtensionIds.includes(id) && !enabledExtensionIds.includes(id)) {
       return
     }
-    const newDisabledExtensionIds = [...oldDisabledExtensionIds, id]
-    const content = getNewDisabledExtensionContent(newDisabledExtensionIds)
+    const newDisabledExtensionIds = disabledExtensionIds.includes(id) ? disabledExtensionIds : [...disabledExtensionIds, id]
+    const newEnabledExtensionIds = enabledExtensionIds.filter((extensionId: any) => extensionId !== id)
+    const content = getNewExtensionEnablementContent(newDisabledExtensionIds, newEnabledExtensionIds)
     await mkdir(dirname(disabledExtensionsJsonPath), { recursive: true })
     await writeFile(disabledExtensionsJsonPath, content)
   } catch (error) {
@@ -54,21 +57,39 @@ export const disable = async (id: any): Promise<any> => {
   }
 }
 
-export const getDisabledExtensionIds = async (): Promise<any> => {
+const getStringArray = (value: any): any => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value.filter((extensionId: any) => typeof extensionId === 'string')
+}
+
+export const getExtensionEnablement = async (): Promise<any> => {
   try {
     const disabledExtensionsJsonPath = PlatformPaths.getDisabledExtensionsJsonPath()
     if (!existsSync(disabledExtensionsJsonPath)) {
-      return []
+      return {
+        disabledExtensionIds: [],
+        enabledExtensionIds: [],
+      }
     }
     const content = await readFile(disabledExtensionsJsonPath, 'utf8')
     const parsed = JSON.parse(content)
-    if (!parsed || !parsed.disabledExtensions || !Array.isArray(parsed.disabledExtensions)) {
-      return []
+    return {
+      disabledExtensionIds: getStringArray(parsed?.disabledExtensions),
+      enabledExtensionIds: getStringArray(parsed?.enabledExtensions),
     }
-    return parsed.disabledExtensions.filter((extensionId: any) => typeof extensionId === 'string')
   } catch {
-    return []
+    return {
+      disabledExtensionIds: [],
+      enabledExtensionIds: [],
+    }
   }
+}
+
+export const getDisabledExtensionIds = async (): Promise<any> => {
+  const { disabledExtensionIds } = await getExtensionEnablement()
+  return disabledExtensionIds
 }
 
 export const getBuiltinExtensions = (): any => {

--- a/packages/shared-process/src/parts/ExtensionManifests/ExtensionManifests.ts
+++ b/packages/shared-process/src/parts/ExtensionManifests/ExtensionManifests.ts
@@ -1,5 +1,5 @@
 import * as DeduplicateExtensions from '../DeduplicateExtensions/DeduplicateExtensions.ts'
-import { getDisabledExtensionIds } from '../ExtensionManagement/ExtensionManagement.ts'
+import { getExtensionEnablement } from '../ExtensionManagement/ExtensionManagement.ts'
 import * as ExtensionManifestInputType from '../ExtensionManifestInputType/ExtensionManifestInputType.ts'
 import * as ExtensionManifestsGetFromFolder from './ExtensionManifestsFromFolder.ts'
 import * as ExtensionManifestsGetFromLinkedExtension from './ExtensionManifestsFromLinkedExtension.ts'
@@ -30,11 +30,11 @@ const isBuiltin = (extension: any): any => {
   return extension && extension.id && extension.id.startsWith('builtin.')
 }
 
-const addExtensionDisabledStatus = (uniqueExtensions: any, disabledExtensionIds: any): any => {
+const addExtensionDisabledStatus = (uniqueExtensions: any, disabledExtensionIds: any, enabledExtensionIds: any): any => {
   return uniqueExtensions.map((extension: any) => {
     return {
       ...extension,
-      disabled: extension.disabled === true || disabledExtensionIds.includes(extension.id),
+      disabled: disabledExtensionIds.includes(extension.id) || (extension.disabled === true && !enabledExtensionIds.includes(extension.id)),
       isBuiltin: isBuiltin(extension),
     }
   })
@@ -42,9 +42,9 @@ const addExtensionDisabledStatus = (uniqueExtensions: any, disabledExtensionIds:
 
 export const getAll = async (inputs: any, builtinExtensionsPath: any = undefined): Promise<any> => {
   const manifests = await Promise.all(inputs.map(get))
-  const disabledIds = await getDisabledExtensionIds()
+  const { disabledExtensionIds, enabledExtensionIds } = await getExtensionEnablement()
   const flatManifests = manifests.flat(1)
   const uniqueExtensions = DeduplicateExtensions.deduplicateExtensions(flatManifests, builtinExtensionsPath)
-  const filteredExtensions = addExtensionDisabledStatus(uniqueExtensions, disabledIds)
+  const filteredExtensions = addExtensionDisabledStatus(uniqueExtensions, disabledExtensionIds, enabledExtensionIds)
   return filteredExtensions
 }

--- a/packages/shared-process/test/ExtensionManagement.test.ts
+++ b/packages/shared-process/test/ExtensionManagement.test.ts
@@ -318,6 +318,39 @@ test('getExtensions - linked extension overrides builtin extension', async () =>
   })
 })
 
+test('getExtensions - explicit enable overrides a builtin disabled by default', async () => {
+  const installedExtensionsPath = await getTmpDir()
+  const builtinExtensionsPath = await getTmpDir()
+  const linkedExtensionsPath = await getTmpDir()
+  const disabledExtensionsPath = await getTmpDir()
+  const disabledExtensionsJsonPath = join(disabledExtensionsPath, 'disabled-extensions.json')
+  const extensionId = 'builtin.gpt-voice'
+  await mkdir(join(builtinExtensionsPath, extensionId))
+  await writeFile(join(builtinExtensionsPath, extensionId, 'extension.json'), JSON.stringify({ disabled: true, id: extensionId }))
+  await writeFile(disabledExtensionsJsonPath, JSON.stringify({ disabledExtensions: [], enabledExtensions: [extensionId] }))
+  // @ts-ignore
+  PlatformPaths.getExtensionsPath.mockImplementation(() => installedExtensionsPath)
+  // @ts-ignore
+  PlatformPaths.getBuiltinExtensionsPath.mockImplementation(() => builtinExtensionsPath)
+  // @ts-ignore
+  PlatformPaths.getDisabledExtensionsPath.mockImplementation(() => disabledExtensionsPath)
+  // @ts-ignore
+  PlatformPaths.getDisabledExtensionsJsonPath.mockImplementation(() => disabledExtensionsJsonPath)
+  // @ts-ignore
+  PlatformPaths.getOnlyExtensionPath.mockImplementation(() => undefined)
+  // @ts-ignore
+  PlatformPaths.getLinkedExtensionsPath.mockImplementation(() => linkedExtensionsPath)
+
+  const extensions = await ExtensionManagement.getExtensions()
+
+  expect(extensions).toHaveLength(1)
+  expect(extensions[0]).toMatchObject({
+    disabled: false,
+    id: extensionId,
+    isBuiltin: true,
+  })
+})
+
 test('disable', async () => {
   const tmpDir1 = await getTmpDir()
   const tmpDir2 = await getTmpDir()
@@ -330,10 +363,12 @@ test('disable', async () => {
   PlatformPaths.getDisabledExtensionsPath.mockImplementation(() => tmpDir2)
   // @ts-ignore
   PlatformPaths.getDisabledExtensionsJsonPath.mockImplementation(() => join(tmpDir3, 'disabled-extensions.json'))
+  await writeFile(join(tmpDir3, 'disabled-extensions.json'), JSON.stringify({ disabledExtensions: [], enabledExtensions: ['test-extension'] }))
   await ExtensionManagement.disable('test-extension')
   const content = await readFile(join(tmpDir3, 'disabled-extensions.json'), 'utf8')
   const parsed = JSON.parse(content)
   expect(parsed.disabledExtensions).toEqual(['test-extension'])
+  expect(parsed.enabledExtensions).toEqual([])
 })
 
 test('enable', async () => {
@@ -346,6 +381,7 @@ test('enable', async () => {
   const content = await readFile(disabledExtensionsJsonPath, 'utf8')
   const parsed = JSON.parse(content)
   expect(parsed.disabledExtensions).toEqual(['test-extension-2'])
+  expect(parsed.enabledExtensions).toEqual(['test-extension-1'])
 })
 
 test('enable - extension not in disabled list', async () => {
@@ -358,6 +394,7 @@ test('enable - extension not in disabled list', async () => {
   const content = await readFile(disabledExtensionsJsonPath, 'utf8')
   const parsed = JSON.parse(content)
   expect(parsed.disabledExtensions).toEqual(['test-extension-1'])
+  expect(parsed.enabledExtensions).toEqual(['test-extension-2'])
 })
 
 test.skip('disable should fail if enabled extension path does not exist', async () => {


### PR DESCRIPTION
Summary:
- persist explicit enable overrides alongside disabled extension IDs
- let user enablement override a builtin default while explicit disable still wins
- cover the gpt-voice default-disabled enable flow with a regression test