### PR TITLE
fix: register panel maximize layout commands

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -587,6 +587,7 @@ export const commandMap = {
   'Layout.loadStatusBarIfVisible': lazy('Layout.loadStatusBarIfVisible'),
   'Layout.loadTitleBarIfVisible': lazy('Layout.loadTitleBarIfVisible'),
   'Layout.leaveSideBarFocusMode': lazy('Layout.leaveSideBarFocusMode'),
+  'Layout.maximizePanel': lazy('Layout.maximizePanel'),
   'Layout.moveSideBarLeft': lazy('Layout.moveSideBarLeft'),
   'Layout.moveSideBarRight': lazy('Layout.moveSideBarRight'),
   'Layout.openChat': lazy('Layout.openChat'),
@@ -622,4 +623,5 @@ export const commandMap = {
   'Layout.toggleSideBarPosition': lazy('Layout.toggleSideBarPosition'),
   'Layout.toggleStatusBar': lazy('Layout.toggleStatusBar'),
   'Layout.toggleTitleBar': lazy('Layout.toggleTitleBar'),
+  'Layout.unmaximizePanel': lazy('Layout.unmaximizePanel'),
 }

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -16,3 +16,8 @@ test('registers the viewlet reload command', () => {
 test('registers the terminal send text command', () => {
   expect(commandMap['Terminals.sendText']).toBeDefined()
 })
+
+test('registers the panel maximize commands', () => {
+  expect(commandMap['Layout.maximizePanel']).toBeDefined()
+  expect(commandMap['Layout.unmaximizePanel']).toBeDefined()
+})


### PR DESCRIPTION
## Summary
- register Layout.maximizePanel and Layout.unmaximizePanel in the renderer-worker RPC command map
- add regression coverage for both direct layout commands

## Root cause
Panel direct events were forwarded successfully through renderer-process, but renderer-worker could not dispatch the two unregistered commands. Layout.hidePanel was already registered, which is why Close worked while Maximize and Unmaximize did not.

## Validation
- renderer-worker: 339 suites passed, 1,488 tests passed, 231 skipped
- focused command-map and panel-layout tests: 21 passed
- root type-check: 6 projects passed
- root lint passed
- static build passed
- packaged Electron candidate: Maximize changed Panel from 150px to 600px and button to Unmaximize; Unmaximize restored 150px; Close removed Panel