### PR TITLE
fix: load TypeScript from HTML worker in Electron

### DIFF
--- a/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
+++ b/packages/build/src/parts/BundleElectronApp/BundleElectronApp.ts
@@ -21,6 +21,7 @@ import * as Logger from '../Logger/Logger.ts'
 import * as Path from '../Path/Path.ts'
 import * as Platform from '../Platform/Platform.ts'
 import * as PrepareElectronCss from '../PrepareElectronCss/PrepareElectronCss.ts'
+import * as PrepareElectronHtmlExtension from '../PrepareElectronHtmlExtension/PrepareElectronHtmlExtension.ts'
 import * as ReadFile from '../ReadFile/ReadFile.ts'
 import * as Remove from '../Remove/Remove.ts'
 import * as RemoveUnusedLocales from '../RemoveUnusedLocales/RemoveUnusedLocales.ts'
@@ -99,18 +100,14 @@ const copyExtensionHostHelperProcessSources = async ({ resourcesPath }) => {
 }
 
 const copyExtensions = async ({ resourcesPath, commitHash }) => {
+  const extensionsPath = `${resourcesPath}/app/static/${commitHash}/extensions`
   await Copy.copy({
     from: 'extensions',
-    to: `${resourcesPath}/app/static/${commitHash}/extensions`,
+    to: extensionsPath,
     dereference: true,
   })
 
-  await Remove.remove(`${resourcesPath}/app/static/${commitHash}/extensions/builtin.language-features-html/typescript`)
-  await Replace.replace({
-    path: `${resourcesPath}/app/static/${commitHash}/extensions/builtin.language-features-html/html-worker/src/parts/TypeScriptPath/TypeScriptPath.js`,
-    occurrence: '../../../../typescript/lib/typescript-esm.js',
-    replacement: '../../../../../builtin.language-features-typescript/typescript/lib/typescript-esm.js',
-  })
+  await PrepareElectronHtmlExtension.prepareElectronHtmlExtension({ extensionsPath })
   await CopyElectronFileIcons.copyElectronFileIcons({ resourcesPath, commitHash })
 }
 

--- a/packages/build/src/parts/PrepareElectronHtmlExtension/PrepareElectronHtmlExtension.ts
+++ b/packages/build/src/parts/PrepareElectronHtmlExtension/PrepareElectronHtmlExtension.ts
@@ -1,0 +1,20 @@
+import * as Remove from '../Remove/Remove.ts'
+import * as Replace from '../Replace/Replace.ts'
+
+const htmlExtensionId = 'builtin.language-features-html'
+const typeScriptExtensionId = 'builtin.language-features-typescript'
+
+export const prepareElectronHtmlExtension = async ({ extensionsPath }: { readonly extensionsPath: string }): Promise<void> => {
+  const htmlExtensionPath = `${extensionsPath}/${htmlExtensionId}`
+  await Remove.remove(`${htmlExtensionPath}/typescript`)
+  await Replace.replace({
+    path: `${htmlExtensionPath}/html-worker/src/parts/TypeScriptPath/TypeScriptPath.js`,
+    occurrence: '../../../../typescript/lib',
+    replacement: `../../../../../${typeScriptExtensionId}/typescript/lib`,
+  })
+  await Replace.replace({
+    path: `${htmlExtensionPath}/html-worker/dist/htmlWorkerMain.js`,
+    occurrence: '../../typescript/lib',
+    replacement: `../../../${typeScriptExtensionId}/typescript/lib`,
+  })
+}

--- a/packages/build/test/PrepareElectronHtmlExtension.test.ts
+++ b/packages/build/test/PrepareElectronHtmlExtension.test.ts
@@ -1,0 +1,40 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { prepareElectronHtmlExtension } from '../src/parts/PrepareElectronHtmlExtension/PrepareElectronHtmlExtension.ts'
+
+test('deduplicates TypeScript and rewrites both HTML worker entry points', async () => {
+  const extensionsPath = await mkdtemp(join(tmpdir(), 'lvce-electron-html-extension-'))
+  const htmlExtensionPath = join(extensionsPath, 'builtin.language-features-html')
+  const sourcePath = join(htmlExtensionPath, 'html-worker', 'src', 'parts', 'TypeScriptPath', 'TypeScriptPath.js')
+  const bundlePath = join(htmlExtensionPath, 'html-worker', 'dist', 'htmlWorkerMain.js')
+  const typeScriptPath = join(htmlExtensionPath, 'typescript', 'lib', 'typescript-esm.js')
+
+  try {
+    await mkdir(join(sourcePath, '..'), { recursive: true })
+    await mkdir(join(bundlePath, '..'), { recursive: true })
+    await mkdir(join(typeScriptPath, '..'), { recursive: true })
+    await writeFile(
+      sourcePath,
+      `new URL('../../../../typescript/lib/typescript-esm.js', import.meta.url)\nnew URL(\`../../../../typescript/lib/\${libFileName}\`, import.meta.url)`,
+    )
+    await writeFile(
+      bundlePath,
+      `new URL('../../typescript/lib/typescript-esm.js', import.meta.url)\nnew URL(\`../../typescript/lib/\${libFileName}\`, import.meta.url)`,
+    )
+    await writeFile(typeScriptPath, 'duplicate TypeScript')
+
+    await prepareElectronHtmlExtension({ extensionsPath })
+
+    await expect(access(join(htmlExtensionPath, 'typescript'))).rejects.toThrow()
+    expect(await readFile(sourcePath, 'utf8')).toBe(
+      `new URL('../../../../../builtin.language-features-typescript/typescript/lib/typescript-esm.js', import.meta.url)\nnew URL(\`../../../../../builtin.language-features-typescript/typescript/lib/\${libFileName}\`, import.meta.url)`,
+    )
+    expect(await readFile(bundlePath, 'utf8')).toBe(
+      `new URL('../../../builtin.language-features-typescript/typescript/lib/typescript-esm.js', import.meta.url)\nnew URL(\`../../../builtin.language-features-typescript/typescript/lib/\${libFileName}\`, import.meta.url)`,
+    )
+  } finally {
+    await rm(extensionsPath, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Fix Electron packaging by rewriting both source and bundled HTML worker TypeScript paths after deduplication.