### PR TITLE
fix: include auth process in electron app

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -47,7 +47,7 @@
         "test/**/*.test.ts"
       ],
       "project": ["bin/**/*.ts", "src/**/*.ts", "test/**/*.ts"],
-      "ignoreDependencies": ["@lvce-editor/static-server"]
+      "ignoreDependencies": ["@lvce-editor/auth-process", "@lvce-editor/static-server"]
     },
     "packages/static-server": {
       "entry": [

--- a/packages/shared-process/package-lock.json
+++ b/packages/shared-process/package-lock.json
@@ -33,6 +33,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
+        "@lvce-editor/auth-process": "^1.16.0",
         "@lvce-editor/embeds-process": "^4.16.0",
         "@lvce-editor/file-system-process": "^5.15.1",
         "@lvce-editor/file-watcher-process": "^4.13.0",
@@ -830,6 +831,19 @@
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
       "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "license": "MIT"
+    },
+    "node_modules/@lvce-editor/auth-process": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.16.0.tgz",
+      "integrity": "sha512-l2EJbJmCxjh0a+LZ6YmiC2bTH2wkSB3YIOQRPZk83PZq+CwEn/P1o0TWGBtOAUEphFuy5ousfIA6IaEIauEwrw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "auth-process": "bin/oauthProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",

--- a/packages/shared-process/package.json
+++ b/packages/shared-process/package.json
@@ -35,6 +35,7 @@
     "xdg-basedir": "^5.1.0"
   },
   "optionalDependencies": {
+    "@lvce-editor/auth-process": "^1.16.0",
     "@lvce-editor/embeds-process": "^4.16.0",
     "@lvce-editor/file-system-process": "^5.15.1",
     "@lvce-editor/file-watcher-process": "^4.13.0",


### PR DESCRIPTION
Restores the auth process as a packaged shared-process dependency so Electron login can launch it, and protects the runtime-only dependency from static cleanup.