### PR TITLE
feature: transfer test worker view ports directly

### DIFF
--- a/packages/renderer-worker/src/parts/AboutViewWorker/AboutViewWorker.js
+++ b/packages/renderer-worker/src/parts/AboutViewWorker/AboutViewWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchAboutViewWorker from '../LaunchAboutViewWorker/LaunchAboutViewWorker.js'
 
-const { invoke } = GetOrCreateWorker.getOrCreateWorker(LaunchAboutViewWorker.launchAboutViewWorker)
+const { invoke, invokeAndTransfer } = GetOrCreateWorker.getOrCreateWorker(LaunchAboutViewWorker.launchAboutViewWorker)
 
-export { invoke }
+export { invoke, invokeAndTransfer }

--- a/packages/renderer-worker/src/parts/ActivityBarWorker/ActivityBarWorker.js
+++ b/packages/renderer-worker/src/parts/ActivityBarWorker/ActivityBarWorker.js
@@ -1,10 +1,10 @@
 import * as GetOrCreateWorkerWithSleep from '../GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js'
 import * as LaunchActivityBarWorker from '../LaunchActivityBarWorker/LaunchActivityBarWorker.ts'
 
-const { invoke, restart, sleep } = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(
+const { invoke, invokeAndTransfer, restart, sleep } = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(
   LaunchActivityBarWorker.launchActivityBarWorker,
   'ActivityBar.sleep',
   'ActivityBar.wakeUp',
 )
 
-export { invoke, restart, sleep }
+export { invoke, invokeAndTransfer, restart, sleep }

--- a/packages/renderer-worker/src/parts/ExplorerViewWorker/ExplorerViewWorker.js
+++ b/packages/renderer-worker/src/parts/ExplorerViewWorker/ExplorerViewWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchExplorerWorker from '../LaunchExplorerWorker/LaunchExplorerWorker.ts'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchExplorerWorker.launchExplorerWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchExplorerWorker.launchExplorerWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js
+++ b/packages/renderer-worker/src/parts/GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js
@@ -47,6 +47,10 @@ export const getOrCreateWorkerWithSleep = (launchWorker, sleepCommand, wakeUpCom
     return run(() => worker.invoke(method, ...params))
   }
 
+  const invokeAndTransfer = (method, ...params) => {
+    return run(() => worker.invokeAndTransfer(method, ...params))
+  }
+
   const restart = (terminateCommand) => {
     return run(() => worker.restart(terminateCommand))
   }
@@ -69,6 +73,7 @@ export const getOrCreateWorkerWithSleep = (launchWorker, sleepCommand, wakeUpCom
 
   return {
     invoke,
+    invokeAndTransfer,
     restart,
     sleep,
   }

--- a/packages/renderer-worker/src/parts/LanguageModelsViewWorker/LanguageModelsViewWorker.js
+++ b/packages/renderer-worker/src/parts/LanguageModelsViewWorker/LanguageModelsViewWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import { launchLanguageModelsViewWorker } from '../LaunchLanguageModelsViewWorker/LaunchLanguageModelsViewWorker.js'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(launchLanguageModelsViewWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(launchLanguageModelsViewWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/MainAreaWorker/MainAreaWorker.js
+++ b/packages/renderer-worker/src/parts/MainAreaWorker/MainAreaWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import { launchMainAreaWorker } from '../LaunchMainAreaWorker/LaunchMainAreaWorker.ts'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(launchMainAreaWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(launchMainAreaWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/OutputViewWorker/OutputViewWorker.js
+++ b/packages/renderer-worker/src/parts/OutputViewWorker/OutputViewWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchOutputViewWorker from '../LaunchOutputViewWorker/LaunchOutputViewWorker.js'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchOutputViewWorker.launchOutputViewWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchOutputViewWorker.launchOutputViewWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/PanelWorker/PanelWorker.js
+++ b/packages/renderer-worker/src/parts/PanelWorker/PanelWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import { launchPanelWorker } from '../LaunchPanelWorker/LaunchPanelWorker.ts'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(launchPanelWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(launchPanelWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import { launchRunningExtensionsViewWorker } from '../LaunchRunningExtensionsViewWorker/LaunchRunningExtensionsViewWorker.ts'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(launchRunningExtensionsViewWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(launchRunningExtensionsViewWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.ipc.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.ipc.js
@@ -35,4 +35,5 @@ export const Commands = {
   sendMessagePortToTerminalProcess: SendMessagePortToExtensionHostWorker.sendMessagePortToTerminalProcess,
   sendMessagePortToTextMeasurementWorker: SendMessagePortToExtensionHostWorker.sendMessagePortToTextMeasurementWorker,
   sendMessagePortToTextSearchWorker: SendMessagePortToExtensionHostWorker.sendMessagePortToTextSearchWorker,
+  sendMessagePortToViewWorker: SendMessagePortToExtensionHostWorker.sendMessagePortToViewWorker,
 }

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -1,33 +1,78 @@
+import * as AboutViewWorker from '../AboutViewWorker/AboutViewWorker.js'
+import * as ActivityBarWorker from '../ActivityBarWorker/ActivityBarWorker.js'
 import * as Assert from '../Assert/Assert.ts'
 import * as AuthWorker from '../AuthWorker/AuthWorker.js'
 import * as ChatCoordinatorWorker from '../ChatCoordinatorWorker/ChatCoordinatorWorker.js'
+import * as ChatDebugViewWorker from '../ChatDebugViewWorker/ChatDebugViewWorker.js'
 import * as ChatMathWorker from '../ChatMathWorker/ChatMathWorker.js'
 import * as ChatMessageParsingWorker from '../ChatMessageParsingWorker/ChatMessageParsingWorker.js'
 import * as ChatNetworkWorker from '../ChatNetworkWorker/ChatNetworkWorker.js'
-import * as DiffWorker from '../DiffWorker/DiffWorker.js'
-import * as DragAndDropWorker from '../DragAndDropWorker/DragAndDropWorker.js'
-import * as DialogWorker from '../DialogWorker/DialogWorker.js'
 import * as ChatStorageWorker from '../ChatStorageWorker/ChatStorageWorker.js'
 import * as ChatToolWorker from '../ChatToolWorker/ChatToolWorker.js'
 import * as ChatViewModelWorker from '../ChatViewModelWorker/ChatViewModelWorker.js'
+import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import * as ClipBoardWorker from '../ClipBoardWorker/ClipBoardWorker.js'
+import * as DialogWorker from '../DialogWorker/DialogWorker.js'
+import * as DiffViewWorker from '../DiffViewWorker/DiffViewWorker.js'
+import * as DiffWorker from '../DiffWorker/DiffWorker.js'
+import * as DragAndDropWorker from '../DragAndDropWorker/DragAndDropWorker.js'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as ErrorWorker from '../ErrorWorker/ErrorWorker.ts'
+import * as ExplorerViewWorker from '../ExplorerViewWorker/ExplorerViewWorker.js'
+import * as ExtensionDetailViewWorker from '../ExtensionDetailViewWorker/ExtensionDetailViewWorker.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as ExtensionSearchViewWorker from '../ExtensionSearchViewWorker/ExtensionSearchViewWorker.js'
 import * as FileSearchWorker from '../FileSearchWorker/FileSearchWorker.js'
 import * as FileSystemWorker from '../FileSystemWorker/FileSystemWorker.js'
 import * as IconThemeWorker from '../IconThemeWorker/IconThemeWorker.js'
 import * as IframeWorker from '../IframeWorker/IframeWorker.js'
+import * as KeyBindingsViewWorker from '../KeyBindingsViewWorker/KeyBindingsViewWorker.js'
+import * as LanguageModelsViewWorker from '../LanguageModelsViewWorker/LanguageModelsViewWorker.js'
+import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
 import * as MarkdownWorker from '../MarkdownWorker/MarkdownWorker.js'
 import * as OpenerWorker from '../OpenerWorker/OpenerWorker.js'
+import * as OutputViewWorker from '../OutputViewWorker/OutputViewWorker.js'
+import * as PanelWorker from '../PanelWorker/PanelWorker.js'
 import * as PreviewSandBoxWorker from '../PreviewSandBoxWorker/PreviewSandBoxWorker.js'
+import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
+import * as ProcessExplorerWorker from '../ProcessExplorerWorker/ProcessExplorerWorker.js'
 import * as QuickPickWorker from '../QuickPickWorker/QuickPickWorker.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
+import * as SettingsViewWorker from '../SettingsViewWorker/SettingsViewWorker.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 import * as SourceControlWorker from '../SourceControlWorker/SourceControlWorker.js'
+import * as StatusBarWorker from '../StatusBarWorker/StatusBarWorker.js'
 import * as TextMeasurementWorker from '../TextMeasurementWorker/TextMeasurementWorker.js'
+import * as TextSearchViewWorker from '../TextSearchViewWorker/TextSearchViewWorker.js'
 import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
+import * as TitleBarWorker from '../TitleBarWorker/TitleBarWorker.js'
 import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
+
+const directViewWorkers = {
+  About: [AboutViewWorker, 'About.handleMessagePort'],
+  ActivityBar: [ActivityBarWorker, 'ActivityBar.handleMessagePort'],
+  Chat: [ChatViewWorker, 'Chat.handleMessagePort'],
+  ChatDebug: [ChatDebugViewWorker, 'ChatDebug.handleMessagePort'],
+  DiffView: [DiffViewWorker, 'DiffView.handleMessagePort'],
+  Explorer: [ExplorerViewWorker, 'Explorer.handleMessagePort'],
+  ExtensionDetail: [ExtensionDetailViewWorker, 'ExtensionDetail.handleMessagePort'],
+  KeyBindings: [KeyBindingsViewWorker, 'KeyBindings.handleMessagePort'],
+  LanguageModels: [LanguageModelsViewWorker, 'LanguageModels.handleMessagePort'],
+  MainArea: [MainAreaWorker, 'MainArea.handleMessagePort'],
+  Output: [OutputViewWorker, 'Output.handleMessagePort'],
+  Panel: [PanelWorker, 'Panel.handleMessagePort'],
+  Problems: [ProblemsWorker, 'Problems.handleMessagePort'],
+  ProcessExplorer: [ProcessExplorerWorker, 'ProcessExplorer.handleMessagePort'],
+  QuickPick: [QuickPickWorker, 'QuickPick.handleRendererProcessMessagePort'],
+  RunningExtensions: [RunningExtensionsViewWorker, 'RunningExtensions.handleMessagePort'],
+  SearchExtensions: [ExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort'],
+  Settings: [SettingsViewWorker, 'Settings.handleMessagePort'],
+  SourceControl: [SourceControlWorker, 'SourceControl.handleRendererProcessMessagePort'],
+  StatusBar: [StatusBarWorker, 'StatusBar.handleMessagePort'],
+  TextSearch: [TextSearchViewWorker, 'TextSearch.handleMessagePort'],
+  TitleBar: [TitleBarWorker, 'TitleBar.handleMessagePort'],
+}
 
 export const sendMessagePortToExtensionHostWorker = async (port, initialCommand, rpcId) => {
   Assert.object(port)
@@ -103,7 +148,18 @@ export const sendMessagePortToClipBoardWorker = async (port, initialCommand, rpc
 export const sendMessagePortToMainAreaWorker = async (port, initialCommand, rpcId) => {
   Assert.object(port)
   Assert.string(initialCommand)
-  await MarkdownWorker.invokeAndTransfer(initialCommand, port, rpcId)
+  await MainAreaWorker.invokeAndTransfer(initialCommand, port, rpcId)
+}
+
+export const sendMessagePortToViewWorker = async (port, rpcId) => {
+  Assert.object(port)
+  Assert.string(rpcId)
+  const target = directViewWorkers[rpcId]
+  if (!target) {
+    throw new Error(`direct view worker not found: ${rpcId}`)
+  }
+  const [worker, initialCommand] = target
+  await worker.invokeAndTransfer(initialCommand, port, false)
 }
 
 export const sendMessagePortToFileSystemWorker = async (port, initialCommand, rpcId) => {

--- a/packages/renderer-worker/src/parts/TextSearchViewWorker/TextSearchViewWorker.js
+++ b/packages/renderer-worker/src/parts/TextSearchViewWorker/TextSearchViewWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchTextSearchViewWorker from '../LaunchTextSearchViewWorker/LaunchTextSearchViewWorker.js'
 
-const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchTextSearchViewWorker.launchTextSearchViewWorker)
+const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(LaunchTextSearchViewWorker.launchTextSearchViewWorker)
 
-export { invoke, restart }
+export { invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/TitleBarWorker/TitleBarWorker.js
+++ b/packages/renderer-worker/src/parts/TitleBarWorker/TitleBarWorker.js
@@ -1,10 +1,10 @@
 import * as GetOrCreateWorkerWithSleep from '../GetOrCreateWorkerWithSleep/GetOrCreateWorkerWithSleep.js'
 import * as LaunchTitleBarWorker from '../LaunchTitleBarWorker/LaunchTitleBarWorker.js'
 
-const { invoke, restart, sleep } = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(
+const { invoke, invokeAndTransfer, restart, sleep } = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(
   LaunchTitleBarWorker.launchTitleBarWorker,
   'TitleBar.sleep',
   'TitleBar.wakeUp',
 )
 
-export { invoke, restart, sleep }
+export { invoke, invokeAndTransfer, restart, sleep }

--- a/packages/renderer-worker/test/GetOrCreateWorkerWithSleep.test.ts
+++ b/packages/renderer-worker/test/GetOrCreateWorkerWithSleep.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 const worker = {
   dispose: jest.fn<() => Promise<void>>(),
   invoke: jest.fn<(method: string, ...params: readonly unknown[]) => Promise<unknown>>(),
+  invokeAndTransfer: jest.fn<(method: string, ...params: readonly unknown[]) => Promise<unknown>>(),
   restart: jest.fn<(terminateCommand: string) => Promise<void>>(),
 }
 
@@ -25,6 +26,16 @@ test('invokes an awake worker without a wake-up command', async () => {
 
   expect(worker.invoke).toHaveBeenCalledTimes(1)
   expect(worker.invoke).toHaveBeenCalledWith('Worker.doSomething', 1)
+})
+
+test('transfers to an awake worker without a wake-up command', async () => {
+  worker.invokeAndTransfer.mockResolvedValue('result')
+  const wrappedWorker = GetOrCreateWorkerWithSleep.getOrCreateWorkerWithSleep(jest.fn(), 'Worker.sleep', 'Worker.wakeUp')
+
+  await expect(wrappedWorker.invokeAndTransfer('Worker.handleMessagePort', 1)).resolves.toBe('result')
+
+  expect(worker.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(worker.invokeAndTransfer).toHaveBeenCalledWith('Worker.handleMessagePort', 1)
 })
 
 test('sleeps and restores a worker before its next invocations', async () => {

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -29,6 +29,18 @@ jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManage
   }
 })
 
+jest.unstable_mockModule('../src/parts/ExplorerViewWorker/ExplorerViewWorker.js', () => {
+  return {
+    invokeAndTransfer: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/MainAreaWorker/MainAreaWorker.js', () => {
+  return {
+    invokeAndTransfer: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/WorkspaceBackend/WorkspaceBackend.js', () => {
   return {
     connectMessagePort: jest.fn(async () => false),
@@ -38,6 +50,8 @@ jest.unstable_mockModule('../src/parts/WorkspaceBackend/WorkspaceBackend.js', ()
 const DialogWorker = await import('../src/parts/DialogWorker/DialogWorker.js')
 const DragAndDropWorker = await import('../src/parts/DragAndDropWorker/DragAndDropWorker.js')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+const ExplorerViewWorker = await import('../src/parts/ExplorerViewWorker/ExplorerViewWorker.js')
+const MainAreaWorker = await import('../src/parts/MainAreaWorker/MainAreaWorker.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const WorkspaceBackend = await import('../src/parts/WorkspaceBackend/WorkspaceBackend.js')
 const SendMessagePortToExtensionHostWorker = await import('../src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js')
@@ -90,4 +104,26 @@ test('sendMessagePortToExtensionHostWorker forwards to extension management work
 
   expect(ExtensionManagementWorker.invokeAndTransfer).toHaveBeenCalledTimes(1)
   expect(ExtensionManagementWorker.invokeAndTransfer).toHaveBeenCalledWith('Extensions.handleMessagePort', port, 42)
+})
+
+test('sendMessagePortToMainAreaWorker forwards to main area worker', async () => {
+  const port = {}
+
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToMainAreaWorker(port, 'HandleMessagePort.handleMessagePort', 42)
+
+  expect(MainAreaWorker.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', port, 42)
+})
+
+test('sendMessagePortToViewWorker forwards to the selected direct view worker', async () => {
+  const port = {}
+
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToViewWorker(port, 'Explorer')
+
+  expect(ExplorerViewWorker.invokeAndTransfer).toHaveBeenCalledWith('Explorer.handleMessagePort', port, false)
+})
+
+test('sendMessagePortToViewWorker rejects unknown workers', async () => {
+  await expect(SendMessagePortToExtensionHostWorker.sendMessagePortToViewWorker({}, 'Unknown')).rejects.toThrow(
+    'direct view worker not found: Unknown',
+  )
 })


### PR DESCRIPTION
## Summary
- transfer Test Worker ports to direct-render view workers through a generic dispatcher
- support transferable calls for sleep-managed workers
- route Main Area ports to Main Area Worker

## Tests
- renderer-worker focused tests
- renderer-worker type-check