### PR TITLE
fix: open terminals from shortcut

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1002,8 +1002,23 @@ export const hidePanel = (state: LayoutState) => {
   return hide(state, LayoutModules.Panel)
 }
 
-export const togglePanel = (state, moduleId = ViewletModuleId.None) => {
-  return toggle(state, LayoutModules.Panel, moduleId)
+const getCurrentPanelView = async (state: LayoutState): Promise<string> => {
+  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId)
+  if (!instance) {
+    return state.panelView
+  }
+  return PanelWorker.invoke('Panel.getCurrentViewletId', instance.state.uid)
+}
+
+export const togglePanel = async (state: LayoutState, moduleId = ViewletModuleId.None): Promise<LayoutStateResult> => {
+  if (!state.panelVisible) {
+    return showPanel(state, moduleId || state.panelView)
+  }
+  const currentPanelView = await getCurrentPanelView(state)
+  if (!moduleId || currentPanelView === moduleId) {
+    return hidePanel(state)
+  }
+  return showPanel(state, moduleId)
 }
 
 const mainMinHeight = 100

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -31,7 +31,7 @@ export const getKeyBindings = () => {
     {
       key: KeyModifier.CtrlCmd | KeyCode.Backquote,
       command: 'Layout.togglePanel',
-      args: ['Terminal'],
+      args: ['Terminals'],
     },
     {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyM,

--- a/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 import * as KeyCode from '../src/parts/KeyCode/KeyCode.js'
+import * as KeyModifier from '../src/parts/KeyModifier/KeyModifier.js'
 import * as ViewletLayoutKeyBindings from '../src/parts/ViewletLayout/ViewletLayoutKeyBindings.js'
 import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.js'
 
@@ -17,6 +18,20 @@ test('getKeyBindings - rename widget', () => {
         command: 'EditorRename.close',
         key: KeyCode.Escape,
         when: WhenExpression.FocusEditorRename,
+      },
+    ]),
+  )
+})
+
+test('getKeyBindings - toggle terminal panel', () => {
+  const keyBindings = ViewletLayoutKeyBindings.getKeyBindings()
+
+  expect(keyBindings).toEqual(
+    expect.arrayContaining([
+      {
+        args: ['Terminals'],
+        command: 'Layout.togglePanel',
+        key: KeyModifier.CtrlCmd | KeyCode.Backquote,
       },
     ]),
   )

--- a/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPanelMaximize.test.ts
@@ -3,12 +3,15 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 const panelWorkerInvocations: any[] = []
 let panelWorkerDiffResult: any[] = []
 let panelWorkerRenderCommands: any[] = []
+let currentPanelView = ''
 
 jest.unstable_mockModule('../src/parts/PanelWorker/PanelWorker.js', () => {
   return {
     invoke: async (method, ...args) => {
       panelWorkerInvocations.push([method, ...args])
       switch (method) {
+        case 'Panel.getCurrentViewletId':
+          return currentPanelView
         case 'Panel.handlePanelLayoutChanged':
         case 'Panel.toggleView':
           return undefined
@@ -33,6 +36,7 @@ beforeEach(() => {
   panelWorkerInvocations.length = 0
   panelWorkerDiffResult = []
   panelWorkerRenderCommands = []
+  currentPanelView = ''
 })
 
 const createPanelInstance = (uid = 77) => {
@@ -206,6 +210,45 @@ test('showPanel selects requested panel view when panel is visible', async () =>
     ['Panel.diff2', 77],
     ['Panel.render2', 77, [11]],
   ])
+})
+
+test('togglePanel selects the requested view when a different panel view is visible', async () => {
+  createPanelInstance()
+  currentPanelView = 'Problems'
+  panelWorkerDiffResult = [11]
+  panelWorkerRenderCommands = [['Viewlet.setPatches', 77, []]]
+  const state = {
+    ...ViewletLayout.create(1),
+    panelVisible: true,
+    panelView: 'Terminals',
+  }
+
+  const result = await ViewletLayout.togglePanel(state, 'Terminals')
+
+  expect(result.newState.panelVisible).toBe(true)
+  expect(result.newState.panelView).toBe('Terminals')
+  expect(result.commands).toEqual([['Viewlet.setPatches', 77, []]])
+  expect(panelWorkerInvocations).toEqual([
+    ['Panel.getCurrentViewletId', 77],
+    ['Panel.toggleView', 77, 'Terminals', ''],
+    ['Panel.diff2', 77],
+    ['Panel.render2', 77, [11]],
+  ])
+})
+
+test('togglePanel hides the panel when the requested view is already visible', async () => {
+  createPanelInstance()
+  currentPanelView = 'Terminals'
+  const state = {
+    ...ViewletLayout.create(1),
+    panelVisible: true,
+    panelView: 'Terminals',
+  }
+
+  const result = await ViewletLayout.togglePanel(state, 'Terminals')
+
+  expect(result.newState.panelVisible).toBe(false)
+  expect(panelWorkerInvocations).toEqual([['Panel.getCurrentViewletId', 77]])
 })
 
 test('maximizePanel notifies panel worker when panel instance exists', async () => {


### PR DESCRIPTION
## Summary

- make Ctrl+Backquote open the Terminals view and close it only when Terminals is already active
- query the panel worker's actual active view so stale layout state cannot hide the wrong panel
- cover the exact keybinding and visible-panel transitions

## Verification

- 20 focused renderer-worker tests
- renderer-worker type-check
- static build