### PR TITLE
fix: contain preview area layout

### DIFF
--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -233,6 +233,22 @@ const getSecondaryPreviewCloseButtonDom = () => {
   ]
 }
 
+const getPreviewAreaDom = (previewId: number, previewActionsUid: number | undefined, secondary: boolean) => {
+  const actionsDom = typeof previewActionsUid === 'number' && previewActionsUid !== -1 ? [getPreviewActionsDom(previewActionsUid)] : []
+  const previewDom = secondary ? getSecondaryPreviewDom(previewId) : getPreviewDom(previewId)
+  const closeButtonDom = secondary ? getSecondaryPreviewCloseButtonDom() : getPreviewCloseButtonDom()
+  return [
+    {
+      childCount: 2 + actionsDom.length,
+      className: secondary ? 'PreviewArea SecondaryPreviewArea' : 'PreviewArea',
+      type: VirtualDomElements.Div,
+    },
+    previewDom,
+    ...actionsDom,
+    ...closeButtonDom,
+  ]
+}
+
 const getContentAreaVirtualDomLeft = (state: LayoutState) => {
   const {
     activityBarVisible,
@@ -285,12 +301,9 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
   }
 
   if (previewVisible) {
-    children.push(getPreviewDom(previewId))
-    if (typeof previewActionsUid === 'number' && previewActionsUid !== -1) {
-      children.push(getPreviewActionsDom(previewActionsUid))
-    }
-    children.push(...getPreviewCloseButtonDom())
-    delta--
+    const previewAreaDom = getPreviewAreaDom(previewId, previewActionsUid, false)
+    children.push(...previewAreaDom)
+    delta -= previewAreaDom.length - 1
   }
 
   if (secondaryPreviewSashVisible) {
@@ -298,12 +311,9 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
   }
 
   if (secondaryPreviewVisible) {
-    children.push(getSecondaryPreviewDom(secondaryPreviewId))
-    if (typeof secondaryPreviewActionsUid === 'number' && secondaryPreviewActionsUid !== -1) {
-      children.push(getPreviewActionsDom(secondaryPreviewActionsUid))
-    }
-    children.push(...getSecondaryPreviewCloseButtonDom())
-    delta--
+    const previewAreaDom = getPreviewAreaDom(secondaryPreviewId, secondaryPreviewActionsUid, true)
+    children.push(...previewAreaDom)
+    delta -= previewAreaDom.length - 1
   }
 
   return [
@@ -360,23 +370,17 @@ const getContentAreaVirtualDomRight = (state: LayoutState) => {
     children.push(getSashPreviewDom())
   }
   if (previewVisible) {
-    children.push(getPreviewDom(previewId))
-    if (typeof previewActionsUid === 'number' && previewActionsUid !== -1) {
-      children.push(getPreviewActionsDom(previewActionsUid))
-    }
-    children.push(...getPreviewCloseButtonDom())
-    delta--
+    const previewAreaDom = getPreviewAreaDom(previewId, previewActionsUid, false)
+    children.push(...previewAreaDom)
+    delta -= previewAreaDom.length - 1
   }
   if (secondaryPreviewSashVisible) {
     children.push(getSashSecondaryPreviewDom())
   }
   if (secondaryPreviewVisible) {
-    children.push(getSecondaryPreviewDom(secondaryPreviewId))
-    if (typeof secondaryPreviewActionsUid === 'number' && secondaryPreviewActionsUid !== -1) {
-      children.push(getPreviewActionsDom(secondaryPreviewActionsUid))
-    }
-    children.push(...getSecondaryPreviewCloseButtonDom())
-    delta--
+    const previewAreaDom = getPreviewAreaDom(secondaryPreviewId, secondaryPreviewActionsUid, true)
+    children.push(...previewAreaDom)
+    delta -= previewAreaDom.length - 1
   }
 
   return [

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -383,8 +383,8 @@ const getPreviewUri = (state: LayoutState, module: LayoutModules.LayoutModule): 
 }
 
 const getPreviewBoundsCommand = (uid: number, state: LayoutState, module: LayoutModules.LayoutModule): any[] => {
-  const { kTop, kLeft, kWidth, kHeight } = module
-  return ['Viewlet.setBounds', uid, state[kLeft], state[kTop], state[kWidth], state[kHeight]]
+  const { kWidth, kHeight } = module
+  return ['Viewlet.setBounds', uid, 0, 0, state[kWidth], state[kHeight]]
 }
 
 const addPreviewBoundsCommand = (commands: any[], uid: number, state: LayoutState, module: LayoutModules.LayoutModule): void => {

--- a/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
@@ -101,6 +101,58 @@ test('getLayoutVirtualDom does not render the preview close button when preview 
   expect(dom.some((node) => node.className?.includes('PreviewCloseButton'))).toBe(false)
 })
 
+test.each([
+  ['left', SideBarLocationType.Left],
+  ['right', SideBarLocationType.Right],
+])('getLayoutVirtualDom wraps preview content with the side bar on the %s', (_name, sideBarLocation) => {
+  const state = {
+    activityBarVisible: false,
+    mainVisible: true,
+    mainId: 1,
+    panelSashVisible: false,
+    panelVisible: false,
+    panelId: -1,
+    previewActionsUid: 3,
+    previewSashVisible: false,
+    previewVisible: true,
+    previewId: 2,
+    secondarySideBarVisible: false,
+    secondarySideBarId: -1,
+    sideBarLocation,
+    sideBarSashVisible: false,
+    sideBarVisible: false,
+    sideBarId: -1,
+    statusBarVisible: false,
+    statusBarId: -1,
+    titleBarVisible: false,
+    titleBarId: -1,
+  }
+
+  // @ts-ignore
+  const dom = getLayoutVirtualDom(state)
+  const previewAreaIndex = dom.findIndex((node) => node.className === 'PreviewArea')
+
+  expect(dom.slice(previewAreaIndex, previewAreaIndex + 5)).toEqual([
+    {
+      childCount: 3,
+      className: 'PreviewArea',
+      type: 4,
+    },
+    { type: 100, uid: 2 },
+    { type: 100, uid: 3 },
+    expect.objectContaining({
+      ariaLabel: 'Close Preview',
+      childCount: 1,
+      className: 'IconButton PreviewCloseButton',
+    }),
+    {
+      childCount: 0,
+      className: 'MaskIcon MaskIconClose',
+      type: 4,
+    },
+  ])
+})
+
 test('getLayoutVirtualDom renders an independently closable secondary preview', () => {
   const state = {
     activityBarVisible: false,

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -398,8 +398,8 @@ test('showSecondaryPreview keeps an open primary preview mounted', async () => {
   expect(result.commands).toContainEqual([
     'Viewlet.setBounds',
     expect.any(Number),
-    result.newState.secondaryPreviewLeft,
-    result.newState.secondaryPreviewTop,
+    0,
+    0,
     result.newState.secondaryPreviewWidth,
     result.newState.secondaryPreviewHeight,
   ])
@@ -444,8 +444,8 @@ test('showPreview keeps code visible when voice chat is already open', async () 
   expect(result.commands).toContainEqual([
     'Viewlet.setBounds',
     expect.any(Number),
-    result.newState.previewLeft,
-    result.newState.previewTop,
+    0,
+    0,
     result.newState.previewWidth,
     result.newState.previewHeight,
   ])

--- a/static/css/parts/ViewletLayout.css
+++ b/static/css/parts/ViewletLayout.css
@@ -16,6 +16,24 @@
   /* flex-direction: column; */
 }
 
+.PreviewArea {
+  flex: 0 0 var(--PreviewWidth);
+  min-width: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.SecondaryPreviewArea {
+  flex-basis: var(--SecondaryPreviewWidth);
+}
+
+.PreviewArea > .Actions {
+  position: absolute;
+  right: 40px;
+  top: 4px;
+  z-index: 1;
+}
+
 .PreviewCloseButton,
 .SecondaryPreviewCloseButton {
   background: var(--TitleBarBackground, rgb(40, 46, 47));
@@ -26,7 +44,7 @@
 }
 
 .PreviewCloseButton {
-  right: calc(var(--SecondaryPreviewWidth, 0px) + 4px);
+  right: 4px;
 }
 
 .SecondaryPreviewCloseButton {


### PR DESCRIPTION
Wrap each preview view, its extension actions, and close button in a dedicated preview-area container. Keep preview DOM bounds local to that container so extension views cannot offset themselves outside the preview region.