### PR TITLE
fix: rerender related editors after direct events

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -115,14 +115,7 @@ const loadContentLater = async (editor) => {
   await Command.execute('Viewlet.executeViewletCommand', editor.uid, 'updateDiagnostics')
 }
 
-const renderPending = async (editor) => {
-  const diffResult = await EditorWorker.invoke('Editor.diff2', editor.uid)
-  const commands = await EditorWorker.invoke('Editor.render2', editor.uid, diffResult)
-  return {
-    ...editor,
-    commands,
-  }
-}
+const renderPending = WrapEditorCommands.renderPendingEditors
 
 const executeWidgetCommand = WrapEditorCommands.wrapEditorCommand('Editor.executeWidgetCommand')
 const closeColorPicker = WrapEditorCommands.wrapEditorCommand('Editor.closeColorPicker')
@@ -138,6 +131,7 @@ const handleColorPickerSliderKeyDown = (editor, ...args) => {
 export const getCommands = async () => {
   const commandIds = await EditorWorker.invoke('Editor.getCommandIds')
   Object.assign(Commands, WrapEditorCommands.wrapEditorCommands(commandIds), WrapEditorCommands.wrapEditorCommands(subWidgetCommandIds), {
+    __renderPending: renderPending,
     handleUriChange,
     loadContentLater,
     renderPending,

--- a/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
+++ b/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
@@ -46,14 +46,18 @@ const renderEditor = async (uid, sourceUid) => {
   return uid === sourceUid ? commands : adjustCommands(commands, uid)
 }
 
-const runEditorCommand = async (editor, fullId, restArgs) => {
-  await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
+export const renderPendingEditors = async (editor) => {
   const editorUids = await getExistingEditorUids(editor)
   const commandLists = await Promise.all(editorUids.map((uid) => renderEditor(uid, editor.uid)))
   return {
     ...editor,
     commands: commandLists.flat(),
   }
+}
+
+const runEditorCommand = async (editor, fullId, restArgs) => {
+  await EditorWorker.invoke(fullId, editor.uid, ...restArgs)
+  return renderPendingEditors(editor)
 }
 
 export const wrapEditorCommand = (id) => {

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -56,6 +56,7 @@ test('getCommands registers worker commands, sub-widget commands, and local comm
   expect(commands['ColorPicker.handleSliderPointerUp']).toBeDefined()
   expect(commands.handleUriChange).toBeDefined()
   expect(commands.loadContentLater).toBeDefined()
+  expect(commands.__renderPending).toBeDefined()
   expect(commands.renderPending).toBeDefined()
   expect(commands.showOverlayMessage).toBeDefined()
   expect(commands.hotReload).toBeDefined()
@@ -158,7 +159,7 @@ test('renderPending renders editor-worker state changed by an asynchronous effec
   })
 
   const commands = await ViewletEditorTextCommands.getCommands()
-  const result = await commands.renderPending(editor)
+  const result = await commands.__renderPending(editor)
 
   expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.diff2', 42)
   expect(editorWorkerInvoke).toHaveBeenNthCalledWith(3, 'Editor.render2', 42, [1])

--- a/packages/renderer-worker/test/WrapEditorCommands.test.ts
+++ b/packages/renderer-worker/test/WrapEditorCommands.test.ts
@@ -78,6 +78,37 @@ test('renders every text editor showing the same uri', async () => {
   ])
 })
 
+test('renders pending state for every text editor showing the same uri', async () => {
+  ViewletStates.set(2, {
+    factory: {},
+    moduleId: 'Editor',
+    renderedState: { uid: 2 },
+    state: {
+      uid: 2,
+      uri: 'file:///same.txt',
+    },
+  })
+  EditorWorker.invoke.mockImplementation((method: string, uid: number) => {
+    if (method === 'Editor.getKeys') {
+      return Promise.resolve(['1', '2'])
+    }
+    if (method === 'Editor.diff2') {
+      return Promise.resolve([uid])
+    }
+    if (method === 'Editor.render2') {
+      return Promise.resolve(uid === 1 ? [['setText', 'left']] : [['setText', 'right']])
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  const result = await WrapEditorCommands.renderPendingEditors({ uid: 1, uri: 'file:///same.txt' })
+
+  expect(result.commands).toEqual([
+    ['setText', 'left'],
+    ['Viewlet.send', 2, 'setText', 'right'],
+  ])
+})
+
 test('renders one hundred text editors showing the same uri', async () => {
   for (let uid = 1; uid <= 100; uid++) {
     ViewletStates.set(uid, {


### PR DESCRIPTION
Handle direct Editor Worker render requests without replaying their event. Render every open editor displaying the same URI so sibling groups remain synchronized.