### PR TITLE
fix: disable TypeScript extension by default

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -412,7 +412,8 @@
     "name": "builtin.language-features-typescript",
     "repository": "github.com/lvce-editor/language-features-typescript",
     "version": "5.18.0",
-    "created": "2022-06-16"
+    "created": "2022-06-16",
+    "enabled": false
   },
   {
     "name": "builtin.prettier",

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -80,6 +80,20 @@ test('includes the built-in GPT Voice extension', async () => {
   })
 })
 
+test('disables the built-in TypeScript language features extension by default', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+  const extension = extensions.find((item) => item.id === 'builtin.language-features-typescript')
+
+  expect(extension).toMatchObject({
+    builtin: true,
+    disabled: true,
+    path: '/test-prefix/test-commit/extensions/builtin.language-features-typescript',
+  })
+})
+
 test('excludes extensions that are not web compatible', async () => {
   const extensions = await getAllExtensionsJson({
     commitHash: 'test-commit',


### PR DESCRIPTION
Disable the built-in TypeScript language features extension by default until it is stable enough, while preserving the ability for users to enable it explicitly.