### PR TITLE
fix: preserve layout when status bar is hidden

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -82,7 +82,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
     const p1 = /* Top */ 0
     let p2 = /* End of Title Bar */ 0
     let p3 = /* End of Main */ 0
-    let p4 = /* End of Panel */ 0
+    let p4 = /* End of Panel */ windowHeight
     // @ts-ignore
     const p5 = /* End of StatusBar */ windowHeight
 
@@ -230,7 +230,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
     const p1 = /* Top */ 0
     let p2 = /* End of Title Bar */ 0
     let p3 = /* End of Main */ 0
-    let p4 = /* End of Panel */ 0
+    let p4 = /* End of Panel */ windowHeight
     // @ts-ignore
     const p5 = /* End of StatusBar */ windowHeight
 

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -319,6 +319,33 @@ test.each([
 test.each([
   ['left', SideBarLocationType.Left],
   ['right', SideBarLocationType.Right],
+])('hidden status bar leaves the main and preview areas at full height with the side bar on the %s', (_name, sideBarLocation) => {
+  const state = LayoutPoints.getPoints(
+    {
+      ...ViewletLayout.create(1),
+      previewMinWidth: 100,
+      previewVisible: true,
+      previewWidth: 400,
+      statusBarHeight: 20,
+      statusBarVisible: false,
+      titleBarHeight: 35,
+      titleBarVisible: true,
+      windowHeight: 800,
+      windowWidth: 1200,
+    },
+    sideBarLocation,
+  )
+
+  expect(state).toMatchObject({
+    mainHeight: 765,
+    previewHeight: 765,
+    statusBarTop: 800,
+  })
+})
+
+test.each([
+  ['left', SideBarLocationType.Left],
+  ['right', SideBarLocationType.Right],
 ])('primary and secondary previews form three columns with the side bar on the %s', (_name, sideBarLocation) => {
   const state = LayoutPoints.getPoints(
     {


### PR DESCRIPTION
Initialize the panel boundary at the window bottom so hiding the status bar keeps the main and preview regions at full height. Adds regression coverage for both sidebar positions.