### PR TITLE
fix: render pending source control updates

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
@@ -8,6 +8,10 @@ Object.defineProperty(Commands, '__directEventRpcId', {
   value: 'SourceControl',
 })
 
+Object.defineProperty(Commands, '__renderPending', {
+  value: WrapSourceControlCommand.renderPendingSourceControl,
+})
+
 export const getCommands = async () => {
   const commands = await SourceControlWorker.invoke('SourceControl.getCommandIds')
   for (const command of commands) {

--- a/packages/renderer-worker/src/parts/WrapSourceControlCommand/WrapSourceControlCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapSourceControlCommand/WrapSourceControlCommand.ts
@@ -3,34 +3,38 @@ import * as Command from '../Command/Command.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 
-export const wrapSourceControlCommand = (key: string) => {
-  const fn = async (state, ...args) => {
-    await SourceControlWorker.invoke(`SourceControl.${key}`, state.uid, ...args)
-    const diffResult = await SourceControlWorker.invoke('SourceControl.diff2', state.uid)
-    if (diffResult.length === 0) {
-      return state
-    }
-    const commands = await SourceControlWorker.invoke('SourceControl.render2', state.uid, diffResult)
-    const badgeCount = await SourceControlWorker.invoke('SourceControl.getBadgeCount', state.uid, diffResult)
-    if (commands.length === 0) {
-      return state
-    }
-    if (state.badgeCount !== badgeCount) {
-      const newState = {
-        ...state,
-        commands,
-        badgeCount,
-      }
-
-      ViewletStates.setState(state.uid, newState)
-      ViewletStates.setRenderedState(state.uid, newState)
-      await Command.execute('Layout.setBadgeCount', ViewletModuleId.SourceControl, badgeCount)
-    }
-    return {
+export const renderPendingSourceControl = async (state) => {
+  const diffResult = await SourceControlWorker.invoke('SourceControl.diff2', state.uid)
+  if (diffResult.length === 0) {
+    return state
+  }
+  const commands = await SourceControlWorker.invoke('SourceControl.render2', state.uid, diffResult)
+  const badgeCount = await SourceControlWorker.invoke('SourceControl.getBadgeCount', state.uid, diffResult)
+  if (commands.length === 0) {
+    return state
+  }
+  if (state.badgeCount !== badgeCount) {
+    const newState = {
       ...state,
       commands,
       badgeCount,
     }
+
+    ViewletStates.setState(state.uid, newState)
+    ViewletStates.setRenderedState(state.uid, newState)
+    await Command.execute('Layout.setBadgeCount', ViewletModuleId.SourceControl, badgeCount)
+  }
+  return {
+    ...state,
+    commands,
+    badgeCount,
+  }
+}
+
+export const wrapSourceControlCommand = (key: string) => {
+  const fn = async (state, ...args) => {
+    await SourceControlWorker.invoke(`SourceControl.${key}`, state.uid, ...args)
+    return renderPendingSourceControl(state)
   }
   return fn
 }

--- a/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const sourceControlWorkerInvoke = jest.fn()
+
+jest.unstable_mockModule('../src/parts/SourceControlWorker/SourceControlWorker.js', () => ({
+  invoke: sourceControlWorkerInvoke,
+}))
+
+const ViewletSourceControlCommands = await import('../src/parts/ViewletSourceControl/ViewletSourceControlCommands.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('renders pending source control worker state without replaying a command', async () => {
+  const state = {
+    badgeCount: 2,
+    commands: [],
+    uid: 42,
+  }
+  sourceControlWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'SourceControl.diff2':
+        return [1]
+      case 'SourceControl.render2':
+        return [['Viewlet.setDom2', 42, ['div']]]
+      case 'SourceControl.getBadgeCount':
+        return 2
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const result = await ViewletSourceControlCommands.Commands.__renderPending(state)
+
+  expect(Object.keys(ViewletSourceControlCommands.Commands)).not.toContain('__renderPending')
+  expect(sourceControlWorkerInvoke.mock.calls).toEqual([
+    ['SourceControl.diff2', 42],
+    ['SourceControl.render2', 42, [1]],
+    ['SourceControl.getBadgeCount', 42, [1]],
+  ])
+  expect(result).toEqual({
+    ...state,
+    commands: [['Viewlet.setDom2', 42, ['div']]],
+  })
+})


### PR DESCRIPTION
## Summary

- expose the internal pending-render hook for the legacy Source Control view adapter
- reuse the existing diff/render pipeline without replaying the triggering command
- cover pending worker state synchronization

## Testing

- renderer-worker focused Jest test
- renderer-worker TypeScript check
- source-control commit-multiple browser test passes from its URL