### PR TITLE
fix: make window title draggable

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-app-regions.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-app-regions.ts
@@ -10,6 +10,9 @@ export const test = async ({ Locator, expect }) => {
   const titleBarMenuEntry = Locator('.TitleBarTopLevelEntry').first()
   await expect(titleBarMenuEntry).toHaveCSS('app-region', 'no-drag')
 
+  const titleBarTitle = Locator('.TitleBarTitle')
+  await expect(titleBarTitle).toHaveCSS('app-region', 'drag')
+
   const titleBarButtons = Locator('.TitleBarButtons')
   await expect(titleBarButtons).toHaveCSS('app-region', 'drag')
 }

--- a/static/css/parts/ViewletTitleBarTitle.css
+++ b/static/css/parts/ViewletTitleBarTitle.css
@@ -1,4 +1,6 @@
 .TitleBarTitle {
+  -webkit-app-region: drag;
+  app-region: drag;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Marks the visible window title as a draggable Electron app region while preserving interactive title bar controls. Extends the existing title bar app-region acceptance test to cover the title.