### PR TITLE
feature: include preview extensions in server builds

### DIFF
--- a/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
+++ b/packages/build/src/parts/BuildStaticServer/BuildStaticServer.ts
@@ -463,6 +463,7 @@ const copyPlaygroundFiles = async ({ commitHash }) => {
 export const shouldBeCopied = (extensionName) => {
   return (
     extensionName === 'builtin.media-preview' ||
+    extensionName === 'builtin.video-preview' ||
     extensionName === 'builtin.vscode-icons' ||
     extensionName.startsWith('builtin.theme-') ||
     extensionName.startsWith('builtin.language-basics-')

--- a/packages/build/test/BuildStaticServer.test.ts
+++ b/packages/build/test/BuildStaticServer.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@jest/globals'
 import { shouldBeCopied } from '../src/parts/BuildStaticServer/BuildStaticServer.ts'
 
-test('includes media preview in server builds', () => {
+test('includes preview extensions in server builds', () => {
   expect(shouldBeCopied('builtin.media-preview')).toBe(true)
+  expect(shouldBeCopied('builtin.video-preview')).toBe(true)
 })
 
 test('excludes unrelated extensions from server builds', () => {
-  expect(shouldBeCopied('builtin.video-preview')).toBe(false)
+  expect(shouldBeCopied('builtin.markdown-preview')).toBe(false)
 })


### PR DESCRIPTION
Include the video preview extension in LVCE Editor server packages alongside the existing media preview extension. Keep focused coverage for the server extension allowlist.