### PR TITLE
fix: prioritize explicit editor providers

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -11,6 +11,21 @@ const mapExtToEditorType = {
   '.opus': ViewletModuleId.Audio,
 }
 
+const getModuleIdForOpener = async (opener) => {
+  if (!opener) {
+    return undefined
+  }
+  const extensionViews = await GetExtensionViews.getExtensionViews()
+  if (GetExtensionViews.findExtensionView(extensionViews, opener)) {
+    return ViewletModuleId.ExtensionView
+  }
+  const webViews = await GetWebViews.getWebViews()
+  if (webViews.some((webView) => webView?.id === opener)) {
+    return ViewletModuleId.WebView
+  }
+  return undefined
+}
+
 export const getModuleId = async (uri, opener) => {
   // TODO rename scheme to keybindings://
   if (uri === 'app://keybindings') {
@@ -67,22 +82,22 @@ export const getModuleId = async (uri, opener) => {
   if (uri.startsWith('iframe-inspector://')) {
     return ViewletModuleId.IframeInspector
   }
+  const openerModuleId = await getModuleIdForOpener(opener)
+  if (openerModuleId) {
+    return openerModuleId
+  }
   if (uri.endsWith('.css') || uri.endsWith('.json') || uri.endsWith('.js') || uri.endsWith('.ts')) {
     return ViewletModuleId.EditorText
   }
 
   const extensionViews = await GetExtensionViews.getExtensionViews()
-  if ((opener && GetExtensionViews.findExtensionView(extensionViews, opener)) || GetExtensionViews.findExtensionView(extensionViews, uri)) {
+  if (GetExtensionViews.findExtensionView(extensionViews, uri)) {
     return ViewletModuleId.ExtensionView
   }
 
   // TODO only request webviews once
   const webViews = await GetWebViews.getWebViews()
   for (const webView of webViews) {
-    if (webView && webView.id === opener) {
-      // TODO can return webview directly here?
-      return ViewletModuleId.WebView
-    }
     for (const selector of webView.selector || []) {
       if (uri.endsWith(selector)) {
         // TODO configure webviews so that some open by default (video, image)

--- a/packages/renderer-worker/test/ViewletMapExtensionViews.test.ts
+++ b/packages/renderer-worker/test/ViewletMapExtensionViews.test.ts
@@ -57,6 +57,30 @@ test('an explicit extension view opener uses the extension view renderer', async
   await expect(ViewletMap.getModuleId('/workspace/file.unknown', 'builtin.media-preview')).resolves.toBe(ViewletModuleId.ExtensionView)
 })
 
+test('an explicit extension view opener overrides the default JSON editor', async () => {
+  state.views = [
+    {
+      id: 'builtin.cpu-profile-view',
+      selector: ['.json'],
+      type: 'preview',
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/profile.json', 'builtin.cpu-profile-view')).resolves.toBe(ViewletModuleId.ExtensionView)
+})
+
+test('an explicit webview opener overrides the default JSON editor', async () => {
+  state.views = []
+  state.webViews = [
+    {
+      id: 'builtin.json-preview',
+      selector: ['.json'],
+    },
+  ]
+
+  await expect(ViewletMap.getModuleId('/workspace/file.json', 'builtin.json-preview')).resolves.toBe(ViewletModuleId.WebView)
+})
+
 test('video documents use a matching preview extension view', async () => {
   state.views = [
     {


### PR DESCRIPTION
Makes an explicitly selected Reopen Editor With provider take precedence over built-in file-extension defaults such as the JSON text editor.

Adds focused coverage for extension-view and legacy webview providers overriding JSON.