### PR TITLE
fix: route keyboard menu selection

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -265,6 +265,7 @@ export const commandMap = {
   'Menu.handleMouseEnter': lazy('Menu.handleMouseEnter'),
   'Menu.handleMouseLeave': lazy('Menu.handleMouseLeave'),
   'Menu.hide': lazy('Menu.hide'),
+  'Menu.selectCurrent': lazy('Menu.selectCurrent'),
   'Menu.selectIndex': lazy('Menu.selectIndex'),
   'Menu.selectItem': lazy('Menu.selectItem'),
   'Menu.show': lazy('Menu.show'),

--- a/packages/renderer-worker/src/parts/Menu/Menu.ipc.js
+++ b/packages/renderer-worker/src/parts/Menu/Menu.ipc.js
@@ -12,6 +12,7 @@ export const Commands = {
   handleMouseEnter: Menu.handleMouseEnter,
   handleMouseLeave: Menu.handleMouseLeave,
   hide: Menu.hide,
+  selectCurrent: Menu.selectCurrent,
   selectIndex: Menu.selectIndex,
   selectItem: Menu.selectItem,
   show: Menu.show,

--- a/packages/renderer-worker/src/parts/Menu/Menu.js
+++ b/packages/renderer-worker/src/parts/Menu/Menu.js
@@ -37,8 +37,8 @@ export const selectItem = async (text) => {
   await MenuWorker.invoke('Menu.selectItem', text)
 }
 
-export const selectCurrent = async (level) => {
-  await MenuWorker.invoke('Menu.selectCurrent', level)
+export const selectCurrent = async () => {
+  await MenuWorker.invoke('Menu.selectCurrent')
 }
 
 export const hide = async (restoreFocus = true) => {

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -21,3 +21,7 @@ test('registers the panel maximize commands', () => {
   expect(commandMap['Layout.maximizePanel']).toBeDefined()
   expect(commandMap['Layout.unmaximizePanel']).toBeDefined()
 })
+
+test('registers the menu select-current command', () => {
+  expect(commandMap['Menu.selectCurrent']).toBeDefined()
+})

--- a/packages/renderer-worker/test/Menu.test.ts
+++ b/packages/renderer-worker/test/Menu.test.ts
@@ -11,6 +11,7 @@ jest.unstable_mockModule('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay
 const MenuWorker = await import('../src/parts/MenuWorker/MenuWorker.js')
 const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
 const Menu = await import('../src/parts/Menu/Menu.js')
+const MenuIpc = await import('../src/parts/Menu/Menu.ipc.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -36,4 +37,14 @@ test('hide restores the Simple Browser even when hiding the menu fails', async (
 
   await expect(Menu.hide()).rejects.toThrow('failed')
   expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('menu')
+})
+
+test('selectCurrent invokes the menu worker command', async () => {
+  await Menu.selectCurrent()
+
+  expect(MenuWorker.invoke).toHaveBeenCalledWith('Menu.selectCurrent')
+})
+
+test('selectCurrent is exported through the menu IPC command map', () => {
+  expect(MenuIpc.Commands.selectCurrent).toBe(Menu.selectCurrent)
 })


### PR DESCRIPTION
## Summary

- register Menu.selectCurrent in the renderer command map
- expose it through the Menu IPC command map
- forward keyboard selection to menu-worker without an obsolete level argument

## Validation

- renderer-worker focused regression tests: 12 passed, 15 pre-existing skips
- renderer-worker full suite: 1,507 passed, 231 pre-existing skips
- type-check passed
- repository lint passed
- Prettier check passed for changed files
- static production build passed