### PR TITLE
fix: read worker test context lazily

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -8,7 +8,9 @@ import * as Workspace from '../Workspace/Workspace.js'
 
 const createContext = (getPlatform) => ({
   assetDir: AssetDir.assetDir,
-  isTest: Workspace.isTest?.() ?? false,
+  get isTest() {
+    return Workspace.isTest?.() ?? false
+  },
   get platform() {
     return getPlatform()
   },

--- a/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
@@ -1,0 +1,41 @@
+import { expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn(async (method: string) => {
+  if (method === 'Explorer.diff2' || method === 'Explorer.render2') {
+    return []
+  }
+  return undefined
+})
+const isTest = jest.fn(() => false)
+
+jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
+  assetDir: 'test://assets',
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 2),
+}))
+
+jest.unstable_mockModule('../src/parts/WorkerInvokerMap/WorkerInvokerMap.js', () => ({
+  getWorkerInvoker: jest.fn(() => ({ invoke, restart: jest.fn() })),
+}))
+
+jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
+  getWorkspaceUri: jest.fn(() => 'file:///workspace'),
+  isTest,
+  state: {
+    workspacePath: '/workspace',
+  },
+}))
+
+const { createWorkerViewlet } = await import('../src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js')
+
+test('reads test mode when the worker viewlet is initialized', async () => {
+  const viewlet = createWorkerViewlet({ workerId: 'explorer' })
+  isTest.mockReturnValue(true)
+  const state = viewlet.create(7, 'test://explorer', 1, 2, 300, 200, undefined, 5)
+
+  await viewlet.loadContent(state, undefined)
+
+  expect(invoke.mock.calls[0]).toEqual(['Explorer.create', 7, 'test://explorer', 1, 2, 300, 200, null, 5, 2, 'test://assets', true])
+})


### PR DESCRIPTION
## Details

Keep the worker-viewlet `isTest` context dynamic so viewlets created after `/tests/` initialization receive test mode. This preserves mocked confirmation prompts in Explorer benchmark runs.

## Validation

- `npm test -- CreateWorkerViewletContext.test.ts CreateWorkerViewlet.test.ts --runInBand`
- `npm run type-check` in `packages/renderer-worker`
- `npm run lint`
- reproduced and passed `viewlet.explorer-accessibility-delete-updates-aria.js` in virtual-dom detailed benchmark