### PR TITLE
feature: connect editor status to status bar

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchStatusBarWorker/LaunchStatusBarWorker.js
@@ -1,6 +1,7 @@
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as ExtensionManagementRpcId from '../ExtensionManagementRpcId/ExtensionManagementRpcId.js'
+import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
@@ -8,6 +9,9 @@ import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as StatusBarWorkerUrl from '../StatusBarWorkerUrl/StatusBarWorkerUrl.js'
+
+const editorSelectionListenerType = 2
+const statusBarEditorRpcId = 2001
 
 export const launchStatusBarWorker = async () => {
   const name = 'Status Bar Worker'
@@ -22,6 +26,12 @@ export const launchStatusBarWorker = async () => {
     ExtensionManagementWorker.invokeAndTransfer('Extensions.handleMessagePort', port1, ExtensionManagementRpcId.StatusBarWorker),
     JsonRpc.invokeAndTransfer(ipc, 'StatusBar.handleExtensionManagementMessagePort', port2),
   ])
+  const { port1: editorWorkerPort, port2: statusBarWorkerPort } = new MessageChannel()
+  await Promise.all([
+    EditorWorker.invokeAndTransfer('HandleMessagePort.handleMessagePort', editorWorkerPort, statusBarEditorRpcId),
+    JsonRpc.invokeAndTransfer(ipc, 'StatusBar.handleMessagePort', statusBarWorkerPort, false),
+  ])
+  await EditorWorker.invoke('Listener.register', editorSelectionListenerType, statusBarEditorRpcId)
   const { port1: rendererWorkerPort, port2: rendererProcessPort } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'StatusBar.handleMessagePort', rendererWorkerPort),

--- a/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
+++ b/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
@@ -27,8 +27,13 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
   invokeAndTransfer: jest.fn(async () => undefined),
 }))
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
+  invoke: jest.fn(async () => undefined),
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
 
 const GetPortTuple = await import('../src/parts/GetPortTuple/GetPortTuple.js')
+const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
 const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchAboutViewWorker = await import('../src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js')
 const LaunchActivityBarWorker = await import('../src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts')
@@ -72,7 +77,12 @@ test.each([
   ['process explorer', LaunchProcessExplorerWorker.launchProcessExplorerWorker, 'ProcessExplorer.handleMessagePort', 'ProcessExplorer'],
   ['quick pick', LaunchQuickPickWorker.launchQuickPickWorker, 'QuickPick.handleRendererProcessMessagePort', 'QuickPick'],
   ['source control', LaunchSourceControlWorker.launchSourceControlWorker, 'SourceControl.handleRendererProcessMessagePort', 'SourceControl'],
-  ['running extensions', LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker, 'RunningExtensions.handleMessagePort', 'RunningExtensions'],
+  [
+    'running extensions',
+    LaunchRunningExtensionsViewWorker.launchRunningExtensionsViewWorker,
+    'RunningExtensions.handleMessagePort',
+    'RunningExtensions',
+  ],
   ['settings', LaunchSettingsViewWorker.launchSettingsViewWorker, 'Settings.handleMessagePort', 'Settings'],
   ['status bar', LaunchStatusBarWorker.launchStatusBarWorker, 'StatusBar.handleMessagePort', 'StatusBar'],
   ['text search', LaunchTextSearchViewWorker.launchTextSearchViewWorker, 'TextSearch.handleMessagePort', 'TextSearch'],
@@ -83,4 +93,12 @@ test.each([
   expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, command, 'worker-port')
   expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', rpcId)
+})
+
+test('status bar worker listens for editor status changes over a direct connection', async () => {
+  await LaunchStatusBarWorker.launchStatusBarWorker()
+
+  expect(EditorWorker.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', expect.any(MessagePort), 2001)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'StatusBar.handleMessagePort', expect.any(MessagePort), false)
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Listener.register', 2, 2001)
 })


### PR DESCRIPTION
Connects the editor and status bar workers directly so active editor status changes render without renderer-worker relaying.