### PR TITLE
feature: support static on-load commands

### DIFF
--- a/packages/renderer-worker/src/parts/OnLoadCommands/OnLoadCommands.js
+++ b/packages/renderer-worker/src/parts/OnLoadCommands/OnLoadCommands.js
@@ -1,0 +1,37 @@
+import * as Ajax from '../Ajax/Ajax.js'
+import * as Command from '../Command/Command.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+
+const defaultDependencies = {
+  executeCommand: Command.execute,
+  getJson: Ajax.getJson,
+}
+
+export const getOnLoadCommands = async (assetDir, getJson = Ajax.getJson) => {
+  const commands = await getJson(`${assetDir}/config/onLoadCommands.json`)
+  if (!Array.isArray(commands)) {
+    throw new TypeError('on-load commands must be an array')
+  }
+  return commands
+}
+
+export const executeOnLoadCommands = async (commands, executeCommand = Command.execute) => {
+  for (const item of commands) {
+    const { args = [], command } = item
+    if (typeof command !== 'string') {
+      throw new TypeError('on-load command must have a command string')
+    }
+    if (!Array.isArray(args)) {
+      throw new TypeError(`on-load command arguments for ${command} must be an array`)
+    }
+    await executeCommand('ExtensionHost.executeCommand', command, ...args)
+  }
+}
+
+export const run = async (assetDir, platform, dependencies = defaultDependencies) => {
+  if (platform !== PlatformType.Web) {
+    return
+  }
+  const commands = await getOnLoadCommands(assetDir, dependencies.getJson)
+  await executeOnLoadCommands(commands, dependencies.executeCommand)
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -24,6 +24,7 @@ import * as LifeCyclePhase from '../LifeCyclePhase/LifeCyclePhase.js'
 import * as Location from '../Location/Location.js'
 import * as Module from '../Module/Module.js'
 import * as OpenInitialUri from '../OpenInitialUri/OpenInitialUri.js'
+import * as OnLoadCommands from '../OnLoadCommands/OnLoadCommands.js'
 import * as Performance from '../Performance/Performance.js'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
@@ -238,6 +239,7 @@ export const startup = async (platform, assetDir) => {
 
   await Promise.all(actions.map((action) => action(platform, assetDir)))
   await OpenInitialUri.openInitialUri(initData.Location.href)
+  await OnLoadCommands.run(assetDir, platform)
   await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
 
   LifeCycle.mark(LifeCyclePhase.Fifteen)

--- a/packages/renderer-worker/test/OnLoadCommands.test.ts
+++ b/packages/renderer-worker/test/OnLoadCommands.test.ts
@@ -1,0 +1,47 @@
+import { expect, jest, test } from '@jest/globals'
+import * as OnLoadCommands from '../src/parts/OnLoadCommands/OnLoadCommands.js'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+test('run executes configured extension commands in order', async () => {
+  const executeCommand = jest.fn<(...parameters: readonly unknown[]) => Promise<void>>(async () => {})
+  const getJson = jest.fn<(url: string) => Promise<readonly unknown[]>>(async () => {
+    return [
+      {
+        args: ['first'],
+        command: 'Sample.setup',
+        name: 'Setup sample',
+      },
+      {
+        command: 'Sample.open',
+        name: 'Open sample',
+      },
+    ]
+  })
+
+  await OnLoadCommands.run('/assets', PlatformType.Web, { executeCommand, getJson })
+
+  expect(getJson).toHaveBeenCalledWith('/assets/config/onLoadCommands.json')
+  expect(executeCommand).toHaveBeenNthCalledWith(1, 'ExtensionHost.executeCommand', 'Sample.setup', 'first')
+  expect(executeCommand).toHaveBeenNthCalledWith(2, 'ExtensionHost.executeCommand', 'Sample.open')
+})
+
+test('run does nothing outside the web platform', async () => {
+  const executeCommand = jest.fn<(...parameters: readonly unknown[]) => Promise<void>>(async () => {})
+  const getJson = jest.fn<(url: string) => Promise<readonly unknown[]>>(async () => [])
+
+  await OnLoadCommands.run('/assets', PlatformType.Electron, { executeCommand, getJson })
+
+  expect(getJson).not.toHaveBeenCalled()
+  expect(executeCommand).not.toHaveBeenCalled()
+})
+
+test('executeOnLoadCommands rejects invalid arguments', async () => {
+  await expect(
+    OnLoadCommands.executeOnLoadCommands([
+      {
+        args: 'invalid',
+        command: 'Sample.setup',
+      },
+    ]),
+  ).rejects.toThrow(new TypeError('on-load command arguments for Sample.setup must be an array'))
+})

--- a/packages/shared-process/index.ts
+++ b/packages/shared-process/index.ts
@@ -22,10 +22,10 @@ const toAbsoluteExtensionPath = (root: any, extensionPath: any): any => {
 }
 
 /**
- * @param {{extensionPath?: string, extensionPaths?: string[] | string, testPath?: string, root?: string}} [options]
+ * @param {{extensionPath?: string, extensionPaths?: string[] | string, onLoadCommands?: readonly unknown[], testPath?: string, root?: string}} [options]
  */
 export const exportStatic = async (options: any = {}): Promise<any> => {
-  const { extensionPath, extensionPaths = [], root = '', testPath = '' } = options
+  const { extensionPath, extensionPaths = [], onLoadCommands = [], root = '', testPath = '' } = options
   if (!root) {
     throw new Error(`root argument is required`)
   }
@@ -35,5 +35,5 @@ export const exportStatic = async (options: any = {}): Promise<any> => {
   const absoluteExtensionPath = toAbsoluteExtensionPath(root, defaultExtensionPath)
   const absoluteExtensionPaths = extensionPathList.map((extensionPath: any) => toAbsoluteExtensionPath(root, extensionPath))
   const pathPrefix = process.env.PATH_PREFIX || ''
-  return fn.exportStatic({ extensionPath: absoluteExtensionPath, extensionPaths: absoluteExtensionPaths, pathPrefix, root, testPath })
+  return fn.exportStatic({ extensionPath: absoluteExtensionPath, extensionPaths: absoluteExtensionPaths, onLoadCommands, pathPrefix, root, testPath })
 }

--- a/packages/shared-process/src/parts/ExportStatic/ExportStatic.ts
+++ b/packages/shared-process/src/parts/ExportStatic/ExportStatic.ts
@@ -673,11 +673,12 @@ const getExtensionPaths = (extensionPath: any, extensionPaths: any): any => {
 
 /**
  *
- * @param {{root:string, pathPrefix:string , extensionPath:string, extensionPaths?:string[], testPath:string, useSimpleWebExtensionFile?:boolean, serverStaticPath?:string }} param0
+ * @param {{root:string, pathPrefix:string , extensionPath:string, extensionPaths?:string[], onLoadCommands?:readonly unknown[], testPath:string, useSimpleWebExtensionFile?:boolean, serverStaticPath?:string }} param0
  */
 export const exportStatic = async ({
   extensionPath,
   extensionPaths,
+  onLoadCommands = [],
   pathPrefix,
   root,
   serverStaticPath,
@@ -728,6 +729,7 @@ export const exportStatic = async ({
   console.timeEnd('applyOverrides')
 
   await updateExtensionsJson({ commitHash, extraExtensions: [], pathPrefix, root })
+  await JsonFile.writeJson(Path.join(root, 'dist', commitHash, 'config', 'onLoadCommands.json'), onLoadCommands)
 
   for (const extensionPath of allExtensionPaths) {
     console.time('addExtension')

--- a/packages/shared-process/test/SharedProcessIndex.test.ts
+++ b/packages/shared-process/test/SharedProcessIndex.test.ts
@@ -29,8 +29,28 @@ test('exportStatic forwards multiple extension paths', async () => {
   expect(options).toEqual({
     extensionPath: undefined,
     extensionPaths: [join('/test/root', 'packages', 'extension-a'), join('/test/root', 'packages', 'extension-b')],
+    onLoadCommands: [],
     pathPrefix: '',
     root: '/test/root',
     testPath: '',
   })
+})
+
+test('exportStatic forwards on-load commands', async () => {
+  const onLoadCommands = [
+    {
+      args: ['ready'],
+      command: 'Sample.setup',
+      name: 'Setup sample',
+    },
+  ]
+
+  await SharedProcess.exportStatic({
+    onLoadCommands,
+    root: '/test/root',
+  })
+
+  // @ts-ignore
+  const [options] = ExportStatic.exportStatic.mock.calls[0]
+  expect(options.onLoadCommands).toBe(onLoadCommands)
 })


### PR DESCRIPTION
Adds a declarative startup-command list to static exports and runs those extension commands after web workbench restoration. This lets static demos initialize their workspace automatically on first load and reload.