### PR TITLE
Fix Open Recent for missing folders

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -18,6 +18,9 @@ import { state } from '../WorkspaceState/WorkspaceState.js'
  */
 export const setPath = async (path) => {
   Assert.string(path)
+  if (path && !(await FileSystem.exists(path))) {
+    throw new Error(`Workspace folder does not exist: '${path}'`)
+  }
   // TODO not in electron
   const pathSeparator = await FileSystem.getPathSeparator(path)
   await updateWindowTitle(path, pathSeparator)

--- a/packages/renderer-worker/test/ExtensionManagementWorkerWorkspace.test.ts
+++ b/packages/renderer-worker/test/ExtensionManagementWorkerWorkspace.test.ts
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js', 
 }))
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  exists: jest.fn(async () => true),
   getPathSeparator: jest.fn(async () => '/'),
 }))
 

--- a/packages/renderer-worker/test/Workspace.test.ts
+++ b/packages/renderer-worker/test/Workspace.test.ts
@@ -22,6 +22,7 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   canBeRestored: jest.fn(() => true),
+  exists: jest.fn(async () => true),
   getPathSeparator: jest.fn(async () => '/'),
 }))
 

--- a/packages/renderer-worker/test/WorkspaceBeforeChange.test.ts
+++ b/packages/renderer-worker/test/WorkspaceBeforeChange.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 const calls: any[] = []
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  exists: jest.fn(async () => true),
   getPathSeparator: jest.fn(async () => '/'),
 }))
 

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const getPathSeparator = jest.fn<(uri: string) => Promise<string>>(async () => '/')
+const exists = jest.fn<(uri: string) => Promise<boolean>>(async () => true)
 const setWindowTitle = jest.fn<(title: string) => Promise<void>>(async () => {})
 const disposeTextSearchWorker = jest.fn<() => Promise<void>>(async () => {})
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  exists,
   getPathSeparator,
 }))
 
@@ -24,6 +26,8 @@ const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
+  exists.mockClear()
+  exists.mockResolvedValue(true)
   getPathSeparator.mockClear()
   setWindowTitle.mockClear()
   disposeTextSearchWorker.mockClear()
@@ -44,6 +48,23 @@ test('setPath uses the folder name for a workspace', async () => {
   await Workspace.setPath('/home/test/project')
 
   expect(setWindowTitle).toHaveBeenCalledWith('project')
+})
+
+test('setPath preserves the current workspace when the folder does not exist', async () => {
+  Workspace.state.workspacePath = '/home/test/current'
+  Workspace.state.workspaceUri = '/home/test/current'
+  exists.mockResolvedValue(false)
+
+  await expect(Workspace.setPath('/home/test/missing')).rejects.toThrow(
+    new Error("Workspace folder does not exist: '/home/test/missing'"),
+  )
+
+  expect(exists).toHaveBeenCalledWith('/home/test/missing')
+  expect(getPathSeparator).not.toHaveBeenCalled()
+  expect(setWindowTitle).not.toHaveBeenCalled()
+  expect(disposeTextSearchWorker).not.toHaveBeenCalled()
+  expect(Workspace.getWorkspacePath()).toBe('/home/test/current')
+  expect(Workspace.getWorkspaceUri()).toBe('/home/test/current')
 })
 
 test('setUri preserves the uri and decodes the workspace path', async () => {


### PR DESCRIPTION
## Summary

- validate a workspace folder before changing any workspace-bound state
- keep the current title, workspace, and workers intact when a recent folder no longer exists
- cover the missing-folder case and update the focused workspace test fixtures

## Testing

- `npm test -- WorkspaceSetUri.test.ts --runInBand`
- renderer-worker full suite: 341 passed suites, 1,510 passed tests
- `npm run type-check` in `packages/renderer-worker`
- root `npm run lint`

The package-local `xo .` command still reports its existing repository-wide filename/style baseline; the canonical root lint passes.
