### PR TITLE
fix: ignore disposed editors while rendering

### DIFF
--- a/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
+++ b/packages/renderer-worker/src/parts/WrapEditorCommands/WrapEditorCommands.js
@@ -40,10 +40,26 @@ const adjustCommands = (commands, uid) => {
   })
 }
 
+const isEditorDisposed = async (uid) => {
+  try {
+    const keys = await EditorWorker.invoke('Editor.getKeys')
+    return Array.isArray(keys) && !keys.some((key) => Number(key) === uid)
+  } catch {
+    return false
+  }
+}
+
 const renderEditor = async (uid, sourceUid) => {
-  const diffResult = await EditorWorker.invoke('Editor.diff2', uid)
-  const commands = await EditorWorker.invoke('Editor.render2', uid, diffResult)
-  return uid === sourceUid ? commands : adjustCommands(commands, uid)
+  try {
+    const diffResult = await EditorWorker.invoke('Editor.diff2', uid)
+    const commands = await EditorWorker.invoke('Editor.render2', uid, diffResult)
+    return uid === sourceUid ? commands : adjustCommands(commands, uid)
+  } catch (error) {
+    if (await isEditorDisposed(uid)) {
+      return []
+    }
+    throw error
+  }
 }
 
 export const renderPendingEditors = async (editor) => {

--- a/packages/renderer-worker/test/WrapEditorCommands.test.ts
+++ b/packages/renderer-worker/test/WrapEditorCommands.test.ts
@@ -109,6 +109,38 @@ test('renders pending state for every text editor showing the same uri', async (
   ])
 })
 
+test('ignores an editor disposed while rendering pending state', async () => {
+  EditorWorker.invoke.mockImplementation((method: string) => {
+    if (method === 'Editor.diff2') {
+      return Promise.reject(new Error('Editor not found'))
+    }
+    if (method === 'Editor.getKeys') {
+      return Promise.resolve([])
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  const result = await WrapEditorCommands.renderPendingEditors({ uid: 1, uri: 'file:///same.txt' })
+
+  expect(result.commands).toEqual([])
+  expect(EditorWorker.invoke).not.toHaveBeenCalledWith('Editor.render2', 1, expect.anything())
+})
+
+test('rethrows a render error when the editor still exists', async () => {
+  const renderError = new Error('render failed')
+  EditorWorker.invoke.mockImplementation((method: string) => {
+    if (method === 'Editor.diff2') {
+      return Promise.reject(renderError)
+    }
+    if (method === 'Editor.getKeys') {
+      return Promise.resolve(['1'])
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  await expect(WrapEditorCommands.renderPendingEditors({ uid: 1, uri: 'file:///same.txt' })).rejects.toBe(renderError)
+})
+
 test('renders one hundred text editors showing the same uri', async () => {
   for (let uid = 1; uid <= 100; uid++) {
     ViewletStates.set(uid, {


### PR DESCRIPTION
## Summary

- recheck editor liveness when pending rendering races with disposal
- ignore only errors from editors confirmed removed from the editor worker
- preserve and rethrow render errors for editors that still exist
- add regression coverage for both outcomes