### PR TITLE
fix: detect git repositories in html workspaces

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystemDirectoryHandle/FileSystemDirectoryHandle.js
+++ b/packages/renderer-worker/src/parts/FileSystemDirectoryHandle/FileSystemDirectoryHandle.js
@@ -17,6 +17,15 @@ export const getChildHandles = async (handle) => {
 }
 
 /**
+ * @param {FileSystemDirectoryHandle} handle
+ * @param {string} name
+ * @returns {Promise<FileSystemDirectoryHandle>}
+ */
+export const getDirectoryHandle = (handle, name) => {
+  return handle.getDirectoryHandle(name)
+}
+
+/**
  *
  * @param {FileSystemDirectoryHandle} handle
  * @param {string} name

--- a/packages/renderer-worker/src/parts/GetDirectoryHandle/GetDirectoryHandle.js
+++ b/packages/renderer-worker/src/parts/GetDirectoryHandle/GetDirectoryHandle.js
@@ -1,10 +1,11 @@
+import * as FileSystemDirectoryHandle from '../FileSystemDirectoryHandle/FileSystemDirectoryHandle.js'
 import * as Path from '../Path/Path.js'
 import * as PersistentFileHandle from '../PersistentFileHandle/PersistentFileHandle.js'
 
 const pathSeparator = '/'
 
-export const getDirectoryHandle = async (uri) => {
-  const handle = await PersistentFileHandle.getHandle(uri)
+export const getDirectoryHandleWithDependencies = async (uri, dependencies) => {
+  const handle = await dependencies.getHandle(uri)
   if (handle) {
     return handle
   }
@@ -12,5 +13,20 @@ export const getDirectoryHandle = async (uri) => {
   if (uri === dirname) {
     return undefined
   }
-  return getDirectoryHandle(dirname)
+  const parentHandle = await getDirectoryHandleWithDependencies(dirname, dependencies)
+  if (!parentHandle) {
+    return undefined
+  }
+  const baseName = Path.getBaseName(pathSeparator, uri)
+  const directoryHandle = await dependencies.getDirectoryHandle(parentHandle, baseName)
+  await dependencies.addHandle(uri, directoryHandle)
+  return directoryHandle
+}
+
+export const getDirectoryHandle = async (uri) => {
+  return getDirectoryHandleWithDependencies(uri, {
+    addHandle: PersistentFileHandle.addHandle,
+    getDirectoryHandle: FileSystemDirectoryHandle.getDirectoryHandle,
+    getHandle: PersistentFileHandle.getHandle,
+  })
 }

--- a/packages/renderer-worker/test/GetDirectoryHandle.test.ts
+++ b/packages/renderer-worker/test/GetDirectoryHandle.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as GetDirectoryHandle from '../src/parts/GetDirectoryHandle/GetDirectoryHandle.js'
+
+const addHandle = jest.fn<(uri: string, handle: object) => Promise<void>>()
+const getHandle = jest.fn<(uri: string) => Promise<object | undefined>>()
+const getDirectoryHandle = jest.fn<(handle: object, name: string) => Promise<object>>()
+const dependencies = {
+  addHandle,
+  getDirectoryHandle,
+  getHandle,
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('resolves an uncached directory from the nearest cached parent', async () => {
+  const workspaceHandle = {}
+  const gitDirectoryHandle = {}
+  getHandle.mockImplementation(async (uri) => {
+    if (uri === 'html:///workspace') {
+      return workspaceHandle
+    }
+    return undefined
+  })
+  getDirectoryHandle.mockResolvedValue(gitDirectoryHandle)
+
+  await expect(GetDirectoryHandle.getDirectoryHandleWithDependencies('html:///workspace/.git', dependencies)).resolves.toBe(gitDirectoryHandle)
+  expect(getDirectoryHandle).toHaveBeenCalledWith(workspaceHandle, '.git')
+  expect(addHandle).toHaveBeenCalledWith('html:///workspace/.git', gitDirectoryHandle)
+})


### PR DESCRIPTION
Allow browser-backed workspaces to resolve uncached nested directory handles.

This lets extensions read files such as `.git/config` before Explorer has enumerated the directory, so the GitHub pull requests view can detect the current repository.