### PR TITLE
Show an error for missing workspace folders

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -5,6 +5,7 @@ import * as GetResolvedRoot from '../GetResolvedRoot/GetResolvedRoot.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as Location from '../Location/Location.js'
+import * as Notification from '../Notification/Notification.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
@@ -19,7 +20,9 @@ import { state } from '../WorkspaceState/WorkspaceState.js'
 export const setPath = async (path) => {
   Assert.string(path)
   if (path && !(await FileSystem.exists(path))) {
-    throw new Error(`Workspace folder does not exist: '${path}'`)
+    const message = `Workspace folder does not exist: '${path}'`
+    await Notification.create('error', message)
+    throw new Error(message)
   }
   // TODO not in electron
   const pathSeparator = await FileSystem.getPathSeparator(path)

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -2,12 +2,17 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const getPathSeparator = jest.fn<(uri: string) => Promise<string>>(async () => '/')
 const exists = jest.fn<(uri: string) => Promise<boolean>>(async () => true)
+const createNotification = jest.fn<(type: string, text: string) => Promise<void>>(async () => {})
 const setWindowTitle = jest.fn<(title: string) => Promise<void>>(async () => {})
 const disposeTextSearchWorker = jest.fn<() => Promise<void>>(async () => {})
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   exists,
   getPathSeparator,
+}))
+
+jest.unstable_mockModule('../src/parts/Notification/Notification.js', () => ({
+  create: createNotification,
 }))
 
 jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
@@ -26,6 +31,7 @@ const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
+  createNotification.mockClear()
   exists.mockClear()
   exists.mockResolvedValue(true)
   getPathSeparator.mockClear()
@@ -60,6 +66,7 @@ test('setPath preserves the current workspace when the folder does not exist', a
   )
 
   expect(exists).toHaveBeenCalledWith('/home/test/missing')
+  expect(createNotification).toHaveBeenCalledWith('error', "Workspace folder does not exist: '/home/test/missing'")
   expect(getPathSeparator).not.toHaveBeenCalled()
   expect(setWindowTitle).not.toHaveBeenCalled()
   expect(disposeTextSearchWorker).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- show an error notification when a selected workspace folder no longer exists
- retain the existing rejection and workspace-preservation behavior
- verify the notification alongside the unchanged title, workspace state, and workers

## Context

Official Debian acceptance for #14052 confirmed that stale Open Recent entries no longer replace the current workspace, but the rejected action had no visible explanation.

## Testing

- `npm test -- WorkspaceSetUri.test.ts --runInBand`
- renderer-worker full suite: 342 passed suites, 1,515 passed tests
- `npm run type-check` in `packages/renderer-worker`
- root `npm run lint`
- `git diff --check`
