### PR TITLE
feature: add editor minimap

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.editor-minimap-disabled.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-minimap-disabled.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-minimap-disabled'
+
+export const test: Test = async ({ FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.js`
+  await FileSystem.writeFile(uri, 'const value = 1')
+  await Settings.update({
+    'editor.minimap.enabled': false,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  await expect(Locator('.EditorMinimap')).toHaveCount(0)
+  await expect(Locator('.EditorMinimapCanvas')).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-minimap-enabled.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-minimap-enabled.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-minimap-enabled'
+
+export const test: Test = async ({ FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.js`
+  const content = ['const value = 1', 'function add(a, b) {', '  return a + b', '}', 'add(value, 2)'].join('\n')
+  await FileSystem.writeFile(uri, content)
+  await Settings.update({
+    'editor.minimap.enabled': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  const minimap = Locator('.EditorMinimap')
+  await expect(minimap).toHaveCount(1)
+  await expect(minimap).toHaveCSS('width', '120px')
+  await expect(minimap).toHaveAttribute('data-line-count', '5')
+  await expect(Locator('.EditorMinimapCanvas')).toHaveCount(1)
+
+  await Settings.update({
+    'editor.minimap.enabled': false,
+  })
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-minimap-toggle-and-scroll.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-minimap-toggle-and-scroll.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-minimap-toggle-and-scroll'
+
+export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.js`
+  const content = Array.from({ length: 100 }, (_, index) => `const value${index} = ${index}`).join('\n')
+  await FileSystem.writeFile(uri, content)
+  await Settings.update({
+    'editor.minimap.enabled': false,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  await expect(Locator('.EditorMinimap')).toHaveCount(0)
+
+  await Settings.update({
+    'editor.minimap.enabled': true,
+  })
+  const minimap = Locator('.EditorMinimap')
+  await expect(minimap).toHaveAttribute('data-line-count', '100')
+  await expect(Locator('.EditorMinimapCanvas')).toHaveCount(1)
+
+  await Editor.setDeltaY(200)
+  await expect(minimap).toHaveAttribute('data-visible-start', '10')
+
+  await Settings.update({
+    'editor.minimap.enabled': false,
+  })
+  await expect(Locator('.EditorMinimap')).toHaveCount(0)
+  await expect(Locator('.EditorMinimapCanvas')).toHaveCount(0)
+}

--- a/packages/renderer-worker/src/parts/Editor/EditorRender.js
+++ b/packages/renderer-worker/src/parts/Editor/EditorRender.js
@@ -14,6 +14,7 @@ const renderAll = {
         command[0] === 'Viewlet.send' ||
         command[0] === 'Viewlet.createFunctionalRoot' ||
         command[0] === 'Viewlet.registerEventListeners' ||
+        command[0] === 'Viewlet.renderCanvas' ||
         command[0] === 'Viewlet.setDom2' ||
         command[0] === 'Viewlet.focusSelector' ||
         command[0] === 'Viewlet.setValueByName' ||

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.ipc.js
@@ -3,6 +3,7 @@ import * as ViewletEditorText from './ViewletEditorText.js'
 // prettier-ignore
 export const Events = {
   'languages.changed': ViewletEditorText.handleLanguagesChanged,
+  'preferences.changed': ViewletEditorText.handleSettingsChanged,
   // 'editor.change': ViewletEditorText.handleEditorChange,
   // 'tokenizer.changed': ViewletEditorText.handleTokenizeChange,
 }

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -293,6 +293,11 @@ export const handleLanguagesChanged = async (state) => {
   return state
 }
 
+export const handleSettingsChanged = async (state) => {
+  await EditorWorker.invoke('Editor.handleSettingsChanged', state.id)
+  return rerender(state)
+}
+
 export const hasFunctionalResize = true
 
 export const resize = async (state, dimensions) => {

--- a/packages/renderer-worker/test/EditorRender.test.ts
+++ b/packages/renderer-worker/test/EditorRender.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import * as Editor from '../src/parts/Editor/Editor.js'
+
+test('preserves canvas commands emitted by the editor worker', () => {
+  const command = ['Viewlet.renderCanvas', 42, '.EditorMinimap', 'EditorMinimapCanvas', 120, 600, [], '1:0']
+  const newState = {
+    commands: [command],
+    uid: 42,
+  }
+
+  const result = Editor.render[0].apply({}, newState)
+
+  expect(result).toEqual([command])
+  expect(newState.commands).toEqual([])
+})

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -50,6 +50,7 @@ jest.unstable_mockModule('../src/parts/Tokenizer/Tokenizer.js', () => ({
 }))
 
 const ViewletEditorText = await import('../src/parts/ViewletEditorText/ViewletEditorText.js')
+const ViewletEditorTextIpc = await import('../src/parts/ViewletEditorText/ViewletEditorText.ipc.js')
 const ViewletEditorTextSaveState = await import('../src/parts/ViewletEditorText/ViewletEditorTextSaveState.js')
 const Languages = await import('../src/parts/Languages/Languages.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
@@ -252,6 +253,31 @@ test('dispose', async () => {
   expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.dispose', 1)
   expect(layoutWidgetsReconcile).toHaveBeenCalledWith(commands)
   expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.sendMultiple', reconciledCommands)
+})
+
+test('handleSettingsChanged updates and rerenders the editor worker', async () => {
+  const commands = [['Viewlet.renderCanvas', '.EditorMinimap', 'EditorMinimapCanvas', 1, []]]
+  editorWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'Editor.handleSettingsChanged':
+        return undefined
+      case 'Editor.diff2':
+        return [1]
+      case 'Editor.render2':
+        return commands
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+  const state = ViewletEditorText.create(1, '/test/file.txt', 0, 0, 800, 600)
+
+  const newState = await ViewletEditorText.handleSettingsChanged(state)
+
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(1, 'Editor.handleSettingsChanged', 1)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(2, 'Editor.diff2', 1)
+  expect(editorWorkerInvoke).toHaveBeenNthCalledWith(3, 'Editor.render2', 1, [1])
+  expect(newState.commands).toEqual(commands)
+  expect(ViewletEditorTextIpc.Events['preferences.changed']).toBe(ViewletEditorText.handleSettingsChanged)
 })
 
 test('resize - increase height', async () => {

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -10,6 +10,7 @@
   "editor.letterSpacing": 0.5,
   "editor.fontLigatures": true,
   "editor.links": true,
+  "editor.minimap.enabled": false,
   "editor.tabSize": 2,
   "editor.hover": true,
 

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -24,8 +24,25 @@
 
 .EditorContent {
   contain: strict;
-  width: 100%;
+  flex: 1;
   height: 100%;
+  min-width: 0;
+}
+
+.EditorMinimap {
+  contain: strict;
+  flex: 0 0 120px;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.EditorMinimapCanvas {
+  display: block;
+}
+
+.EditorMinimapViewport {
+  color: rgba(121, 121, 121, 0.35);
 }
 
 .EditorLayers {


### PR DESCRIPTION
Add the disabled-by-default editor.minimap.enabled setting and render a syntax-colored editor minimap through the renderer canvas lifecycle. Refresh open editors when the setting changes, preserve canvas commands from the editor worker, and cover disabled, enabled, long-file, scroll, and live-toggle behavior in e2e tests.