### PR TITLE
feature: expose user data directory uri

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -305,6 +305,7 @@ export const commandMap = {
   'PersistentFileHandle.addHandle': lazy('PersistentFileHandle.addHandle'),
   'PersistentFileHandle.getHandle': lazy('PersistentFileHandle.getHandle'),
   'PersistentFileHandle.removeHandle': lazy('PersistentFileHandle.removeHandle'),
+  'Platform.getUserDataDir': lazy('PlatformPaths.getUserDataDir'),
   'PlatformPaths.getCachePath': lazy('PlatformPaths.getCachePath'),
   'PlatformPaths.getCacheUri': lazy('PlatformPaths.getCacheUri'),
   'PlatformPaths.getBuiltinExtensionsPath': lazy('PlatformPaths.getBuiltinExtensionsPath'),

--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.ipc.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.ipc.js
@@ -10,4 +10,5 @@ export const Commands = {
   getCacheUri: PlatformPaths.getCacheUri,
   getDisabledExtensionsJsonPath: PlatformPaths.getDisabledExtensionsJsonPath,
   getConfigJsonPath: PlatformPaths.getConfigJsonPath,
+  getUserDataDir: PlatformPaths.getUserDataDir,
 }

--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.js
@@ -79,6 +79,13 @@ export const getConfigPath = () => {
   return SharedProcess.invoke(/* Platform.getConfigDir */ 'Platform.getConfigDir')
 }
 
+export const getUserDataDir = (platform = Platform.getPlatform()) => {
+  if (platform === PlatformType.Web) {
+    throw new Error('User data directory is not available on web')
+  }
+  return SharedProcess.invoke(/* Platform.getConfigUri */ 'Platform.getConfigUri')
+}
+
 export const getCachePath = () => {
   return SharedProcess.invoke(/* Platform.getCacheDir */ 'Platform.getCacheDir')
 }

--- a/packages/renderer-worker/test/PlatformPaths.test.ts
+++ b/packages/renderer-worker/test/PlatformPaths.test.ts
@@ -101,6 +101,24 @@ test('getConfigJsonPath - electron', async () => {
   expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getConfigJsonPath')
 })
 
+test('getUserDataDir - remote', async () => {
+  // @ts-ignore
+  SharedProcess.invoke.mockImplementation((method) => {
+    if (method === 'Platform.getConfigUri') {
+      return 'file:///home/test/.config/lvce-oss'
+    }
+    throw new Error('unexpected message')
+  })
+
+  expect(await PlatformPaths.getUserDataDir(PlatformType.Remote)).toBe('file:///home/test/.config/lvce-oss')
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('Platform.getConfigUri')
+})
+
+test('getUserDataDir - web', async () => {
+  expect(() => PlatformPaths.getUserDataDir(PlatformType.Web)).toThrow('User data directory is not available on web')
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+})
+
 test('getApplicationName - web', () => {
   expect(PlatformPaths.getApplicationName(PlatformType.Web)).toBe('lvce-oss')
   expect(SharedProcess.invoke).not.toHaveBeenCalled()

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -249,6 +249,7 @@ export const getModuleId = (commandId: any): any => {
     case 'Platform.getCommit':
     case 'Platform.getConfigDir':
     case 'Platform.getConfigJsonPath':
+    case 'Platform.getConfigUri':
     case 'Platform.getDataDir':
     case 'Platform.getDate':
     case 'Platform.getDisabledExtensionsPath':

--- a/packages/shared-process/src/parts/Platform/Platform.ipc.ts
+++ b/packages/shared-process/src/parts/Platform/Platform.ipc.ts
@@ -14,6 +14,7 @@ export const Commands = {
   getCommit: Platform.getCommit,
   getConfigDir: PlatformPaths.getConfigDir,
   getConfigJsonPath: PlatformPaths.getConfigJsonPath,
+  getConfigUri: PlatformPaths.getConfigUri,
   getDataDir: PlatformPaths.getDataDir,
   getDate: Platform.getDate,
   getDisabledExtensionsPath: PlatformPaths.getDisabledExtensionsPath,

--- a/packages/shared-process/src/parts/PlatformPaths/PlatformPaths.ts
+++ b/packages/shared-process/src/parts/PlatformPaths/PlatformPaths.ts
@@ -141,6 +141,10 @@ export const getConfigDir = (): any => {
   return configDir
 }
 
+export const getConfigUri = (): any => {
+  return pathToFileURL(configDir).toString()
+}
+
 export const getConfigJsonPath = (): any => {
   return GetConfigJsonPath.getConfigJsonPath({
     getStaticPath: StaticPath.getStaticPath,

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -6,6 +6,10 @@ test('getModuleId - Platform.getConfigJsonPath', () => {
   expect(ModuleMap.getModuleId('Platform.getConfigJsonPath')).toBe(ModuleId.Platform)
 })
 
+test('getModuleId - Platform.getConfigUri', () => {
+  expect(ModuleMap.getModuleId('Platform.getConfigUri')).toBe(ModuleId.Platform)
+})
+
 test('getModuleId - SendMessagePortToMainProcess.sendMessagePortToMainProcess', () => {
   expect(ModuleMap.getModuleId('SendMessagePortToMainProcess.sendMessagePortToMainProcess')).toBe(ModuleId.SendMessagePortToMainProcess)
 })

--- a/packages/shared-process/test/PlatformPaths.test.ts
+++ b/packages/shared-process/test/PlatformPaths.test.ts
@@ -22,6 +22,10 @@ test('configDir', () => {
   expect(PlatformPaths.configDir).toEqual(expect.any(String))
 })
 
+test('getConfigUri', () => {
+  expect(PlatformPaths.getConfigUri()).toBe(pathToFileURL(PlatformPaths.configDir).toString())
+})
+
 test('cacheDir', () => {
   expect(PlatformPaths.cacheDir).toEqual(expect.any(String))
 })


### PR DESCRIPTION
Expose the canonical user data directory as a file URI for extensions, and reject the request on the web platform.