### PR TITLE
fix: load user data directory command

### DIFF
--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -137,6 +137,7 @@ export const getModuleId = (commandId) => {
       return ModuleId.PersistentFileHandle
     case 'Preferences':
       return ModuleId.Preferences
+    case 'Platform':
     case 'PlatformPaths':
       return ModuleId.PlatformPaths
     case 'Prompt':

--- a/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.ipc.js
+++ b/packages/renderer-worker/src/parts/PlatformPaths/PlatformPaths.ipc.js
@@ -3,6 +3,7 @@ import * as PlatformPaths from './PlatformPaths.js'
 export const name = 'PlatformPaths'
 
 export const Commands = {
+  'Platform.getUserDataDir': PlatformPaths.getUserDataDir,
   getBuiltinExtensionsPath: PlatformPaths.getBuiltinExtensionsPath,
   getLogsDir: PlatformPaths.getLogsDir,
   getTmpDir: PlatformPaths.getTmpDir,

--- a/packages/renderer-worker/test/ModuleMap.test.ts
+++ b/packages/renderer-worker/test/ModuleMap.test.ts
@@ -37,3 +37,13 @@ test('getModule - layout runtime context', async () => {
   expect(Layout.Commands.getAssetDir()).toBe('')
   expect(Layout.Commands.getPlatform()).toBe(PlatformType.Test)
 })
+
+test('getModule - public user data directory command', async () => {
+  const moduleId = ModuleMap.getModuleId('Platform.getUserDataDir')
+  const loadedModule = await Module.load(moduleId)
+  const commands = (loadedModule as { Commands: Record<string, unknown> })
+    .Commands
+
+  expect(moduleId).toBe(ModuleId.PlatformPaths)
+  expect(commands['Platform.getUserDataDir']).toBeDefined()
+})


### PR DESCRIPTION
Register `Platform.getUserDataDir` with the lazy renderer command loader used by isolated extensions.

The eager command map exposed the command, but lazy loading rejected the `Platform` module prefix before it could run. Add a regression test for resolving and loading the public command.