### PR TITLE
fix: enable open recent command palette entry

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -351,7 +351,7 @@ export const getQuickPickMenuEntries = () => {
       label: 'File: Open Folder',
     },
     {
-      id: 'file.openRecent',
+      id: 'QuickPick.showRecent',
       label: 'File: Open Recent',
     },
     {

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -104,3 +104,12 @@ test('getQuickPickMenuEntries includes close all editors command', () => {
     label: 'Main: Close all Editors',
   })
 })
+
+test('getQuickPickMenuEntries includes executable open recent command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'QuickPick.showRecent',
+    label: 'File: Open Recent',
+  })
+})


### PR DESCRIPTION
Fix the File: Open Recent command palette entry to invoke the existing recent-workspace picker, with regression coverage for the executable command ID.