### PR TITLE
fix: validate recent workspace file uris

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -14,16 +14,20 @@ import * as WindowTitle from '../WindowTitle/WindowTitle.js'
 import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 import { state } from '../WorkspaceState/WorkspaceState.js'
 
-/**
- * @param {string|undefined} path
- */
-export const setPath = async (path) => {
-  Assert.string(path)
+const validateLocalPath = async (path) => {
   if (path && !(await FileSystem.exists(path))) {
     const message = `Workspace folder does not exist: '${path}'`
     await Notification.create('error', message)
     throw new Error(message)
   }
+}
+
+/**
+ * @param {string|undefined} path
+ */
+export const setPath = async (path) => {
+  Assert.string(path)
+  await validateLocalPath(path)
   // TODO not in electron
   const pathSeparator = await FileSystem.getPathSeparator(path)
   await updateWindowTitle(path, pathSeparator)
@@ -43,6 +47,9 @@ export const setPath = async (path) => {
 export const setUri = async (uri, providedPathSeparator, backend) => {
   const protocol = GetProtocol.getProtocol(uri)
   const path = backend?.workspacePath || (protocol === 'file' ? decodeURIComponent(uri.slice('file://'.length)) : uri)
+  if (protocol === 'file' && !backend) {
+    await validateLocalPath(path)
+  }
   const pathSeparator = providedPathSeparator ?? (await FileSystem.getPathSeparator(uri))
   await updateWindowTitle(path, pathSeparator)
   if (path !== state.workspacePath) {

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -80,7 +80,25 @@ test('setUri preserves the uri and decodes the workspace path', async () => {
   expect(Workspace.getWorkspacePath()).toBe('/home/test/my folder/#project?')
   expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/my%20folder/%23project%3F')
   expect(Workspace.state.pathSeparator).toBe('/')
+  expect(exists).toHaveBeenCalledWith('/home/test/my folder/#project?')
   expect(getPathSeparator).toHaveBeenCalledWith('file:///home/test/my%20folder/%23project%3F')
+  expect(setWindowTitle).toHaveBeenCalledWith('#project?')
+})
+
+test('setUri preserves the current workspace when a local folder does not exist', async () => {
+  Workspace.state.workspacePath = '/home/test/current'
+  Workspace.state.workspaceUri = 'file:///home/test/current'
+  exists.mockResolvedValue(false)
+
+  await expect(Workspace.setUri('file:///home/test/missing%20folder')).rejects.toThrow(
+    new Error("Workspace folder does not exist: '/home/test/missing folder'"),
+  )
+
+  expect(exists).toHaveBeenCalledWith('/home/test/missing folder')
+  expect(createNotification).toHaveBeenCalledWith('error', "Workspace folder does not exist: '/home/test/missing folder'")
+  expect(setWindowTitle).not.toHaveBeenCalled()
+  expect(Workspace.getWorkspacePath()).toBe('/home/test/current')
+  expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/current')
 })
 
 test('setUri preserves a custom uri as the workspace path', async () => {


### PR DESCRIPTION
Summary:
- validate decoded local filesystem paths when a workspace is opened from a file URI
- keep the existing workspace coherent and show the decoded missing-folder error when validation fails
- cover decoded workspace state, title, and stale-path behavior

Tests:
- renderer-worker WorkspaceSetUri suite (8 tests)
- renderer-worker type-check

Note: the renderer-worker XO command currently reports the repository's broad pre-existing style/config mismatch; the focused test and type-check pass.