### PR TITLE
feature: style diagnostic lightbulb

### DIFF
--- a/static/css/parts/MaskIcon.css
+++ b/static/css/parts/MaskIcon.css
@@ -360,6 +360,10 @@
   mask-image: url(/icons/edit.svg);
 }
 
+.MaskIconLightBulb {
+  mask-image: url(/icons/lightbulb.svg);
+}
+
 .MaskIconSymbolFile,
 .IconSymbolFile {
   mask-image: url(/icons/symbol-file.svg);

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -204,6 +204,15 @@
   contain: content;
 }
 
+.LineNumberLightBulb {
+  background: var(--EditorLightBulbForeground, #ffcc00);
+  cursor: pointer;
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: 16px;
+  pointer-events: all;
+}
+
 .DiffEditorLineNumber {
   contain: strict;
 }


### PR DESCRIPTION
## Summary
- add a Codicon mask class for the diagnostic lightbulb
- style the gutter affordance with the existing theme-aware editor lightbulb color
- keep the affordance clickable while retaining the editor layer pointer behavior

The icon is supplied by the already pinned `@vscode/codicons` asset pipeline.

## Validation
- build package CSS/icon tests (3 suites, 21 tests passed)
- build package type-check
- renderer-worker type-check
- `npm run build:static`
- changed-file Prettier check and `git diff --check`