### PR TITLE
fix: clear problems count when last editor closes

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2530,6 +2530,15 @@ export const refreshProblemsSummary = async (state: LayoutState): Promise<Layout
   }
 }
 
+const clearProblemsSummary = (state: LayoutState): Promise<LayoutStateResult> => {
+  return callGlobalEvent(state, 'handleProblemsSummaryChange', {
+    errorCount: 0,
+    hasEditor: false,
+    problemCount: 0,
+    warningCount: 0,
+  })
+}
+
 const callGlobalEventAndRefreshProblemsSummary = async (state: LayoutState, eventName: string, ...args): Promise<LayoutStateResult> => {
   const eventResult = await callGlobalEvent(state, eventName, ...args)
   const summaryResult = await refreshProblemsSummary(eventResult.newState)
@@ -2540,7 +2549,12 @@ const callGlobalEventAndRefreshProblemsSummary = async (state: LayoutState, even
 }
 
 export const handleActiveEditorChange = async (state: LayoutState, activeUri: string) => {
-  return callGlobalEventAndRefreshProblemsSummary(state, 'handleActiveEditorChange', activeUri)
+  const eventResult = await callGlobalEvent(state, 'handleActiveEditorChange', activeUri)
+  const summaryResult = activeUri ? await refreshProblemsSummary(eventResult.newState) : await clearProblemsSummary(eventResult.newState)
+  return {
+    newState: summaryResult.newState,
+    commands: [...eventResult.commands, ...summaryResult.commands],
+  }
 }
 
 export const handleDiagnosticsChange = async (state: LayoutState, uri: string) => {

--- a/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutGlobalEvent.test.ts
@@ -222,6 +222,34 @@ test('handleActiveEditorChange refreshes the problems summary for loaded viewlet
   })
 })
 
+test('handleActiveEditorChange clears the problems summary when the last editor closes', async () => {
+  const summaryHandler = jest.fn((state: { uid: number }, receivedSummary) => ({
+    ...state,
+    summary: receivedSummary,
+  }))
+  ViewletStates.set('panel', createInstance(1, 'handleProblemsSummaryChange', summaryHandler))
+
+  const state = ViewletLayout.create(1)
+  const result = await ViewletLayout.handleActiveEditorChange(state, '')
+
+  expect(problemsInvoke).not.toHaveBeenCalled()
+  expect(summaryHandler).toHaveBeenCalledWith(
+    { uid: 1 },
+    {
+      errorCount: 0,
+      hasEditor: false,
+      problemCount: 0,
+      warningCount: 0,
+    },
+  )
+  expect(result).toEqual({
+    commands: [['render.1']],
+    newState: {
+      ...state,
+    },
+  })
+})
+
 test('handleDiagnosticsChange forwards the changed uri to loaded viewlets', async () => {
   const handler = jest.fn((state: { uid: number }, uri: string) => {
     return {


### PR DESCRIPTION
## Summary
- publish an atomic empty Problems summary when the active editor URI becomes empty
- avoid re-querying the worker while the previous editor is still being disposed
- cover the close-last-editor race with a renderer regression test

## Root cause
The Problems view received the definitive empty active URI and cleared its rows, but the renderer immediately queried the Problems worker for a summary. During editor disposal, that query could still observe the old active editor and republish its diagnostic count, leaving `PROBLEMS 5` above an empty panel.

## Validation
- focused `ViewletLayoutGlobalEvent` suite: 9 tests passed
- full renderer-worker suite: 345 suites / 1,526 tests passed
- renderer-worker type-check
- root lint/knip
- changed-file Prettier and `git diff --check`
- `npm run build:static`