### PR TITLE
feature: enable TypeScript diagnostics

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -412,8 +412,7 @@
     "name": "builtin.language-features-typescript",
     "repository": "github.com/lvce-editor/language-features-typescript",
     "version": "5.18.0",
-    "created": "2022-06-16",
-    "enabled": false
+    "created": "2022-06-16"
   },
   {
     "name": "builtin.prettier",

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -80,7 +80,7 @@ test('includes the built-in GPT Voice extension', async () => {
   })
 })
 
-test('disables the built-in TypeScript language features extension by default', async () => {
+test('enables the built-in TypeScript language features extension by default', async () => {
   const extensions = await getAllExtensionsJson({
     commitHash: 'test-commit',
     pathPrefix: '/test-prefix',
@@ -89,7 +89,7 @@ test('disables the built-in TypeScript language features extension by default', 
 
   expect(extension).toMatchObject({
     builtin: true,
-    disabled: true,
+    disabled: false,
     path: '/test-prefix/test-commit/extensions/builtin.language-features-typescript',
   })
 })

--- a/packages/extension-host-worker-tests/src/typescript.diagnostics-enabled.ts
+++ b/packages/extension-host-worker-tests/src/typescript.diagnostics-enabled.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'typescript.diagnostics-enabled'
+
+export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/main.ts`
+  await FileSystem.writeFile(uri, 'const foo: string = 123\n\nconsole.log(foo)\n')
+  await Settings.update({ 'editor.diagnostics': true })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  const expectedDiagnostics = [
+    {
+      code: 2322,
+      columnIndex: 6,
+      endColumnIndex: 9,
+      endRowIndex: 0,
+      message: "Type 'number' is not assignable to type 'string'.",
+      rowIndex: 0,
+      source: 'ts',
+      type: 'error',
+      uri,
+    },
+  ] as const
+  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
+}

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -152,6 +152,7 @@ export const loadContent = async (state, savedState, context) => {
     const useCache = Preferences.get('editor.cache') ?? true
     await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath, useCache)
     await EditorWorker.invoke('Editor.loadContent', id, savedState?.editorState)
+    await EditorWorker.invoke('Editor.updateDiagnostics', id)
     const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)
     const selectionRender = await rerender(newState2)
@@ -194,6 +195,7 @@ export const loadContent = async (state, savedState, context) => {
       y,
       useFunctionalRendering,
     })
+    await EditorWorker.invoke('Editor.updateDiagnostics', id)
   }
 
   // TODO send render commands directly from editor worker

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -100,6 +100,7 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   expect(editorMethods).toEqual([
     'Editor.create2',
     'Editor.loadContent',
+    'Editor.updateDiagnostics',
     'Editor.diff2',
     'Editor.render2',
     'Editor.setSelections2',


### PR DESCRIPTION
## Summary

- enable the bundled TypeScript language-features extension
- request diagnostics after integrated editor loading, when extension management is available
- cover the shipped manifest and a real TS2322 initial-open flow

## Verification

- build manifest tests: 8 passed
- renderer-worker: 345 suites / 1,526 tests passed
- `npm run lint`
- `npm run type-check` (6 projects)
- `npm run build:static`
- integrated browser e2e `typescript.diagnostics-enabled`: TS2322 appears immediately without manual extension activation

## Related

- TypeScript related metadata: lvce-editor/language-features-typescript#670
- clickable related rows: lvce-editor/problems-view#312