### PR TITLE
fix: render editor before initial diagnostics

### DIFF
--- a/packages/extension-host-worker-tests/src/typescript.diagnostics-enabled.ts
+++ b/packages/extension-host-worker-tests/src/typescript.diagnostics-enabled.ts
@@ -2,13 +2,28 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'typescript.diagnostics-enabled'
 
-export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace }) => {
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Settings, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   const uri = `${tmpDir}/main.ts`
   await FileSystem.writeFile(uri, 'const foo: string = 123\n\nconsole.log(foo)\n')
   await Settings.update({ 'editor.diagnostics': true })
   await Workspace.setPath(tmpDir)
   await Main.openUri(uri)
+  await expect(Locator('.EditorContainer > .Viewlet.Editor')).toHaveCount(1)
 
   const expectedDiagnostics = [
     {
@@ -23,5 +38,5 @@ export const test: Test = async ({ Editor, FileSystem, Main, Settings, Workspace
       uri,
     },
   ] as const
-  await Editor.shouldHaveDiagnostics(expectedDiagnostics)
+  await waitFor(() => Editor.shouldHaveDiagnostics(expectedDiagnostics))
 }

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -152,7 +152,6 @@ export const loadContent = async (state, savedState, context) => {
     const useCache = Preferences.get('editor.cache') ?? true
     await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath, useCache)
     await EditorWorker.invoke('Editor.loadContent', id, savedState?.editorState)
-    await EditorWorker.invoke('Editor.updateDiagnostics', id)
     const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)
     const selectionRender = await rerender(newState2)
@@ -195,7 +194,6 @@ export const loadContent = async (state, savedState, context) => {
       y,
       useFunctionalRendering,
     })
-    await EditorWorker.invoke('Editor.updateDiagnostics', id)
   }
 
   // TODO send render commands directly from editor worker

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
   delete Preferences.state['editor.cache']
 })
 
-test('loadContent - restores the selection supplied by the opener', async () => {
+test('loadContent - renders before diagnostics are requested by loadContentLater', async () => {
   const initialCommands = [['Viewlet.setDom2']]
   const selectionCommands = [['Viewlet.setPatches']]
   let renderCount = 0
@@ -100,7 +100,6 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   expect(editorMethods).toEqual([
     'Editor.create2',
     'Editor.loadContent',
-    'Editor.updateDiagnostics',
     'Editor.diff2',
     'Editor.render2',
     'Editor.setSelections2',


### PR DESCRIPTION
## Summary

- defer initial diagnostics until after the editor DOM is rendered
- keep loadContentLater as the single initial diagnostics lifecycle
- cover both immediate editor rendering and eventually available TypeScript diagnostics

## Validation

- renderer-worker focused tests: 20 passed
- renderer-worker full tests: 1,526 passed, 231 skipped
- renderer-worker and extension-host-worker-tests type-checks
- TypeScript diagnostics browser e2e passed
- locally built Debian candidate renders editor rows, diagnostic squiggles, and the F8 diagnostic popup