### PR TITLE
fix: preserve initial editor render

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemHtml.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemHtml.js
@@ -14,6 +14,11 @@ import { VError } from '../VError/VError.js'
 
 const pathSeparator = '/'
 
+export const exists = async (uri) => {
+  const handle = await PersistentFileHandle.getHandle(uri)
+  return Boolean(handle)
+}
+
 const getDirent = (handle) => {
   const { name, kind } = handle
   const type = FileHandleTypeMap.getDirentType(kind)

--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorText.js
@@ -152,7 +152,6 @@ export const loadContent = async (state, savedState, context) => {
     const useCache = Preferences.get('editor.cache') ?? true
     await EditorWorker.invoke('Editor.create2', id, uri, x, y, width, height, platform, assetDir, languageId, tokenizePath, useCache)
     await EditorWorker.invoke('Editor.loadContent', id, savedState?.editorState)
-    await EditorWorker.invoke('Editor.updateDiagnostics', id)
     const initialRender = await rerender(newState2)
     await EditorWorker.invoke('Editor.setSelections2', id, savedSelections)
     const selectionRender = await rerender(newState2)
@@ -195,7 +194,6 @@ export const loadContent = async (state, savedState, context) => {
       y,
       useFunctionalRendering,
     })
-    await EditorWorker.invoke('Editor.updateDiagnostics', id)
   }
 
   // TODO send render commands directly from editor worker

--- a/packages/renderer-worker/test/FileSystemHtml.test.ts
+++ b/packages/renderer-worker/test/FileSystemHtml.test.ts
@@ -99,6 +99,18 @@ test('getPathSeparator', async () => {
   expect(FileSystemHtml.getPathSeparator()).toBe('/')
 })
 
+test('exists - exists', async () => {
+  // @ts-ignore
+  PersistentFileHandle.getHandle.mockResolvedValue({})
+  await expect(FileSystemHtml.exists('html:///test')).resolves.toBe(true)
+})
+
+test('exists - does not exist', async () => {
+  // @ts-ignore
+  PersistentFileHandle.getHandle.mockResolvedValue(undefined)
+  await expect(FileSystemHtml.exists('html:///test')).resolves.toBe(false)
+})
+
 test('readDirWithFileTypes', async () => {
   // @ts-ignore
   PersistentFileHandle.getHandle.mockImplementation(() => {

--- a/packages/renderer-worker/test/ViewletEditorText.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorText.test.ts
@@ -100,7 +100,6 @@ test('loadContent - restores the selection supplied by the opener', async () => 
   expect(editorMethods).toEqual([
     'Editor.create2',
     'Editor.loadContent',
-    'Editor.updateDiagnostics',
     'Editor.diff2',
     'Editor.render2',
     'Editor.setSelections2',


### PR DESCRIPTION
## Summary
- render editor contents before diagnostics can trigger an incremental rerender
- keep diagnostics in the existing post-render loadContentLater phase
- support workspace validation for persisted HTML filesystem handles

## Validation
- renderer-worker FileSystemHtml and ViewletEditorText tests
- renderer-worker type-check
- reproduced the editor fix against the upgraded drag-and-drop runtime with the close-editor retargeting e2e scenario
- reproduced the HTML filesystem regression with folder drop in explorer-view