### PR TITLE
feature: add GitHub Pull Requests builtin extension

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -31,6 +31,13 @@
     "enabled": false
   },
   {
+    "name": "builtin.pull-request-github",
+    "repository": "github.com/lvce-editor/pull-request-github",
+    "version": "1.1.0",
+    "created": "2026-08-19",
+    "enabled": false
+  },
+  {
     "name": "builtin.language-basics-bat",
     "repository": "github.com/lvce-editor/language-basics-bat",
     "version": "0.13.0",

--- a/packages/build/test/GetAllExtensionsJson.test.ts
+++ b/packages/build/test/GetAllExtensionsJson.test.ts
@@ -80,6 +80,20 @@ test('includes the built-in GPT Voice extension', async () => {
   })
 })
 
+test('includes the built-in GitHub Pull Requests extension disabled by default', async () => {
+  const extensions = await getAllExtensionsJson({
+    commitHash: 'test-commit',
+    pathPrefix: '/test-prefix',
+  })
+  const extension = extensions.find((item) => item.id === 'github.pull-requests')
+
+  expect(extension).toMatchObject({
+    builtin: true,
+    disabled: true,
+    path: '/test-prefix/test-commit/extensions/builtin.pull-request-github',
+  })
+})
+
 test('enables the built-in TypeScript language features extension by default', async () => {
   const extensions = await getAllExtensionsJson({
     commitHash: 'test-commit',


### PR DESCRIPTION
## Summary

Bundle the GitHub Pull Requests extension with LVCE Editor and keep it disabled by default while it is staged.