### PR TITLE
test: stress explorer file opening

### DIFF
--- a/.github/workflows/flaky-explorer-file-opening.yml
+++ b/.github/workflows/flaky-explorer-file-opening.yml
@@ -1,0 +1,67 @@
+name: Flaky Explorer File Opening
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  explorer-file-opening:
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+      - name: Setup Python 3
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Compute node modules cache key
+        id: nodeModulesCacheKey
+        run: echo "value=$(node packages/build/src/parts/ComputeNodeModulesCacheKey/ComputeNodeModulesCacheKey.ts)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v6
+        id: npm-cache
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
+      - name: Install dependencies
+        run: node packages/build/src/parts/InstallDependencies/InstallDependencies.ts
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        env:
+          DOWNLOAD_BUILTIN_EXTENSIONS: 0
+      - name: Install Chromium
+        working-directory: ./packages/extension-host-worker-tests
+        run: npx playwright install chromium
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Build static site
+        run: npm run build:static:ignore-icon-theme
+        env:
+          PATH_PREFIX: /lvce-editor
+      - name: Prepare static test export
+        run: npm run test-static-export
+      - name: Run Explorer file-opening scenario
+        working-directory: ./packages/extension-host-worker-tests
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p artifacts
+          node src/_all.js --headless --ci --record-videos --test-name-prefix=viewlet.explorer-preview-replacement 2>&1 | tee artifacts/test.log
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Upload attempt evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: explorer-file-opening-attempt-${{ matrix.attempt }}
+          path: |
+            packages/extension-host-worker-tests/artifacts/test.log
+            packages/extension-host-worker-tests/videos
+          if-no-files-found: warn

--- a/.github/workflows/flaky-explorer-file-opening.yml
+++ b/.github/workflows/flaky-explorer-file-opening.yml
@@ -35,10 +35,20 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           DOWNLOAD_BUILTIN_EXTENSIONS: 0
+      - name: Compute builtin extensions cache key
+        id: builtinExtensionsCacheKey
+        run: echo "value=$(node packages/build/src/parts/ComputeBuiltinExtensionsCacheKey/ComputeBuiltinExtensionsCacheKey.ts)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v6
+        id: builtin-extensions-cache
+        with:
+          path: extensions
+          key: builtinExtensions-${{ steps.builtinExtensionsCacheKey.outputs.value }}
+      - name: Download builtin extensions
+        run: node packages/build/src/parts/DownloadBuiltinExtensions/DownloadBuiltinExtensions.ts
+        if: steps.builtin-extensions-cache.outputs.cache-hit != 'true'
       - name: Install Chromium
         working-directory: ./packages/extension-host-worker-tests
         run: npx playwright install chromium
-        if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build static site

--- a/.github/workflows/flaky-explorer-file-opening.yml
+++ b/.github/workflows/flaky-explorer-file-opening.yml
@@ -45,6 +45,8 @@ jobs:
         run: npm run build:static:ignore-icon-theme
         env:
           PATH_PREFIX: /lvce-editor
+      - name: Build server
+        run: npm run build:server
       - name: Prepare static test export
         run: npm run test-static-export
       - name: Run Explorer file-opening scenario


### PR DESCRIPTION
## Summary

- run the existing Explorer preview-replacement scenario in 20 independent CI attempts
- capture an attempt-specific browser video and test log
- keep this PR draft as diagnostic evidence; it is not intended to merge

## Context

This validates the merged initial-render fix for editor files intermittently opening blank with `Cannot navigate to child: child not found at index`.

## Validation

- focused scenario passed locally after a full static/server build
- 20/20 independent CI attempts passed in run 32419754477
- workflow formatting passed locally