### PR TITLE
fix: dispose preview sandbox worker

### DIFF
--- a/packages/renderer-worker/src/parts/PreviewSandBoxWorker/PreviewSandBoxWorker.js
+++ b/packages/renderer-worker/src/parts/PreviewSandBoxWorker/PreviewSandBoxWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import { launchPreviewSandBoxWorker } from '../LaunchPreviewSandBoxWorker/LaunchPreviewSandBoxWorker.js'
 
-const { invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(launchPreviewSandBoxWorker)
+const { dispose, invoke, invokeAndTransfer, restart } = GetOrCreateWorker.getOrCreateWorker(launchPreviewSandBoxWorker)
 
-export { invoke, invokeAndTransfer, restart }
+export { dispose, invoke, invokeAndTransfer, restart }

--- a/packages/renderer-worker/src/parts/ViewletPreview/ViewletPreview.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletPreview/ViewletPreview.ipc.js
@@ -1,7 +1,34 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
+import * as PreviewSandBoxWorker from '../PreviewSandBoxWorker/PreviewSandBoxWorker.js'
 
 export const {
-  Commands, Css, Events, Variables, create, decrement, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
-  increment, loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
+  Commands,
+  Css,
+  Events,
+  Variables,
+  create,
+  decrement,
+  getCommands,
+  getKeyBindings,
+  getMenus,
+  getQuickPickMenuEntries,
+  getStorageKey,
+  getTitle,
+  hasFunctionalEvents,
+  hasFunctionalRender,
+  hasFunctionalResize,
+  hasFunctionalRootRender,
+  hotReload,
+  increment,
+  loadContent,
+  menus,
+  name,
+  render,
+  renderActions,
+  renderEventListeners,
+  renderTitle,
+  resize,
+  saveState,
 } = createWorkerViewlet({ workerId: 'preview' })
+
+export const dispose = PreviewSandBoxWorker.dispose

--- a/packages/renderer-worker/test/ViewletPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletPreview.test.ts
@@ -1,0 +1,22 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Preview disposal tests use ESM module mocks for worker dependencies. */
+import { expect, jest, test } from '@jest/globals'
+
+const disposePreviewSandBoxWorker = jest.fn<() => Promise<void>>()
+
+jest.unstable_mockModule('../src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js', () => ({
+  createWorkerViewlet: jest.fn(() => ({})),
+}))
+
+jest.unstable_mockModule('../src/parts/GetOrCreateWorker/GetOrCreateWorker.js', () => ({
+  getOrCreateWorker: jest.fn(() => ({
+    dispose: disposePreviewSandBoxWorker,
+  })),
+}))
+
+const ViewletPreview = await import('../src/parts/ViewletPreview/ViewletPreview.js')
+
+test('dispose closes the preview sandbox worker', async () => {
+  await ViewletPreview.dispose()
+
+  expect(disposePreviewSandBoxWorker).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Close the preview sandbox worker when its Preview viewlet is disposed, releasing the sandbox worker and its memory after the preview closes. Adds focused renderer-worker regression coverage for the disposal path.