### PR TITLE
feature: link worker packages at runtime

### DIFF
--- a/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
+++ b/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
@@ -235,6 +235,11 @@ export const getBuiltinExtensionsPath = () => {
       occurrence: `../../../../renderer-worker/src/parts/Workers/Workers.json`,
       replacement: `../Workers/Workers.json`,
     })
+    await Replace.replace({
+      path: `${cachePath}/src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js`,
+      occurrence: `../../../../renderer-worker/src/parts/Workers/Workers.json`,
+      replacement: `../Workers/Workers.json`,
+    })
     await Copy.copy({
       from: 'packages/shared-process/bin',
       to: `${cachePath}/bin`,

--- a/packages/shared-process/src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.ts
+++ b/packages/shared-process/src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.ts
@@ -1,0 +1,43 @@
+import workers from '../../../../renderer-worker/src/parts/Workers/Workers.json' with { type: 'json' }
+import * as FileSystem from '../FileSystem/FileSystem.ts'
+import * as Path from '../Path/Path.ts'
+import * as TransientLinkedExtensions from '../TransientLinkedExtensions/TransientLinkedExtensions.ts'
+
+interface Worker {
+  readonly defaultPath: string
+  readonly settingName: string
+}
+
+const getPackageName = (worker: Worker): string => {
+  const marker = '/node_modules/'
+  const index = worker.defaultPath.indexOf(marker)
+  if (index === -1) {
+    return ''
+  }
+  const packagePath = worker.defaultPath.slice(index + marker.length)
+  const parts = packagePath.split('/')
+  return packagePath.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+const workersByPackageName = new Map((workers as readonly Worker[]).map((worker) => [getPackageName(worker), worker]))
+
+const getPackageJson = async (path: string): Promise<any> => {
+  try {
+    return await FileSystem.readJson(Path.join(path, 'package.json'))
+  } catch {
+    return undefined
+  }
+}
+
+export const getLinkedWorkerPreferences = async (): Promise<Record<string, string>> => {
+  const preferences: Record<string, string> = {}
+  for (const link of TransientLinkedExtensions.getLinkedExtensions()) {
+    const packageJson = await getPackageJson(link.resolvedPath)
+    const worker = workersByPackageName.get(packageJson?.name)
+    if (!worker || typeof packageJson.main !== 'string') {
+      continue
+    }
+    preferences[worker.settingName] = Path.join(link.resolvedPath, packageJson.main)
+  }
+  return preferences
+}

--- a/packages/shared-process/src/parts/Preferences/Preferences.ts
+++ b/packages/shared-process/src/parts/Preferences/Preferences.ts
@@ -1,6 +1,7 @@
 import * as ApplyCustomWorkerPathCliOverride from '../ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts'
 import * as IsEnoentError from '../IsEnoentError/IsEnoentError.ts'
 import * as JsoncFile from '../JsoncFile/JsoncFile.ts'
+import * as LinkedWorkerPreferences from '../LinkedWorkerPreferences/LinkedWorkerPreferences.ts'
 import * as Logger from '../Logger/Logger.ts'
 import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
 import * as Process from '../Process/Process.ts'
@@ -82,7 +83,12 @@ export const getAll = async (): Promise<any> => {
     // } catch {
     //   // ignore
     // }
-    return ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(preferences)
+    const preferencesWithoutCustomWorkerPaths = ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(preferences)
+    const linkedWorkerPreferences = await LinkedWorkerPreferences.getLinkedWorkerPreferences()
+    return {
+      ...preferencesWithoutCustomWorkerPaths,
+      ...linkedWorkerPreferences,
+    }
   } catch (error) {
     throw new VError(error, 'Failed to get all preferences')
   }

--- a/packages/shared-process/test/LinkedWorkerPreferences.test.ts
+++ b/packages/shared-process/test/LinkedWorkerPreferences.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, test } from '@jest/globals'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as LinkedWorkerPreferences from '../src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.ts'
+
+const originalArgv = process.argv
+
+afterEach(() => {
+  process.argv = originalArgv
+})
+
+const createPackage = async (packageJson: unknown): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'linked-worker-'))
+  await mkdir(join(root, 'dist'), { recursive: true })
+  await writeFile(join(root, 'package.json'), JSON.stringify(packageJson))
+  return root
+}
+
+test('getLinkedWorkerPreferences - resolves a linked worker package', async () => {
+  const root = await createPackage({
+    name: '@lvce-editor/main-area-worker',
+    main: 'dist/mainAreaWorkerMain.js',
+  })
+  process.argv = [...originalArgv, '--link', root]
+
+  await expect(LinkedWorkerPreferences.getLinkedWorkerPreferences()).resolves.toEqual({
+    'develop.mainAreaWorkerPath': join(root, 'dist', 'mainAreaWorkerMain.js'),
+  })
+})
+
+test('getLinkedWorkerPreferences - ignores extension and unknown packages', async () => {
+  const extensionRoot = await mkdtemp(join(tmpdir(), 'linked-extension-'))
+  const unknownRoot = await createPackage({
+    name: '@lvce-editor/unknown-worker',
+    main: 'dist/unknownWorkerMain.js',
+  })
+  process.argv = [...originalArgv, '--link', extensionRoot, '--link', unknownRoot]
+
+  await expect(LinkedWorkerPreferences.getLinkedWorkerPreferences()).resolves.toEqual({})
+})

--- a/packages/shared-process/test/LinkedWorkerPreferences.test.ts
+++ b/packages/shared-process/test/LinkedWorkerPreferences.test.ts
@@ -19,8 +19,8 @@ const createPackage = async (packageJson: unknown): Promise<string> => {
 
 test('getLinkedWorkerPreferences - resolves a linked worker package', async () => {
   const root = await createPackage({
-    name: '@lvce-editor/main-area-worker',
     main: 'dist/mainAreaWorkerMain.js',
+    name: '@lvce-editor/main-area-worker',
   })
   process.argv = [...originalArgv, '--link', root]
 
@@ -32,8 +32,8 @@ test('getLinkedWorkerPreferences - resolves a linked worker package', async () =
 test('getLinkedWorkerPreferences - ignores extension and unknown packages', async () => {
   const extensionRoot = await mkdtemp(join(tmpdir(), 'linked-extension-'))
   const unknownRoot = await createPackage({
-    name: '@lvce-editor/unknown-worker',
     main: 'dist/unknownWorkerMain.js',
+    name: '@lvce-editor/unknown-worker',
   })
   process.argv = [...originalArgv, '--link', extensionRoot, '--link', unknownRoot]
 


### PR DESCRIPTION
Resolve linked LVCE worker packages through their package name and main entry so development servers can use local worker builds without patching installed server assets.