### PR TITLE
fix: skip workspace folder validation in tests

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -4,6 +4,7 @@ import * as FileSystem from '../FileSystem/FileSystem.js'
 import * as GetResolvedRoot from '../GetResolvedRoot/GetResolvedRoot.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
+import * as IsTest from '../IsTest/IsTest.js'
 import * as Location from '../Location/Location.js'
 import * as Notification from '../Notification/Notification.js'
 import * as Platform from '../Platform/Platform.js'
@@ -15,6 +16,9 @@ import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
 import { state } from '../WorkspaceState/WorkspaceState.js'
 
 const validateLocalPath = async (path) => {
+  if (IsTest.isTest()) {
+    return
+  }
   if (path && !(await FileSystem.exists(path))) {
     const message = `Workspace folder does not exist: '${path}'`
     await Notification.create('error', message)

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -5,6 +5,7 @@ const exists = jest.fn<(uri: string) => Promise<boolean>>(async () => true)
 const createNotification = jest.fn<(type: string, text: string) => Promise<void>>(async () => {})
 const setWindowTitle = jest.fn<(title: string) => Promise<void>>(async () => {})
 const disposeTextSearchWorker = jest.fn<() => Promise<void>>(async () => {})
+const isTest = jest.fn<() => boolean>(() => false)
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   exists,
@@ -13,6 +14,13 @@ jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
 
 jest.unstable_mockModule('../src/parts/Notification/Notification.js', () => ({
   create: createNotification,
+}))
+
+jest.unstable_mockModule('../src/parts/IsTest/IsTest.js', () => ({
+  isTest,
+  state: {
+    isTest: false,
+  },
 }))
 
 jest.unstable_mockModule('../src/parts/WindowTitle/WindowTitle.js', () => ({
@@ -37,6 +45,8 @@ beforeEach(() => {
   getPathSeparator.mockClear()
   setWindowTitle.mockClear()
   disposeTextSearchWorker.mockClear()
+  isTest.mockClear()
+  isTest.mockReturnValue(false)
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = ''
@@ -53,6 +63,16 @@ test('setPath uses the product name for an empty workspace', async () => {
 test('setPath uses the folder name for a workspace', async () => {
   await Workspace.setPath('/home/test/project')
 
+  expect(setWindowTitle).toHaveBeenCalledWith('project')
+})
+
+test('setPath skips folder validation during tests', async () => {
+  isTest.mockReturnValue(true)
+  exists.mockResolvedValue(false)
+
+  await Workspace.setPath('/remote/home/test/project')
+
+  expect(exists).not.toHaveBeenCalled()
   expect(setWindowTitle).toHaveBeenCalledWith('project')
 })
 


### PR DESCRIPTION
## Summary

- keep missing-folder validation enabled for production workspace changes
- skip filesystem existence validation for synthetic test workspaces
- cover the test-mode behavior in renderer-worker unit tests

## Validation

- renderer-worker WorkspaceSetUri tests (9 passed)
- renderer-worker type-check
- renderer-worker lint
- renderer-worker full unit test command