### PR TITLE
fix: apply pending main area focus updates

### DIFF
--- a/packages/renderer-worker/src/parts/RenderMainAreaPending/RenderMainAreaPending.ts
+++ b/packages/renderer-worker/src/parts/RenderMainAreaPending/RenderMainAreaPending.ts
@@ -1,5 +1,6 @@
 import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as UpdateDynamicFocusContext from '../UpdateDynamicFocusContext/UpdateDynamicFocusContext.js'
 
 export const renderMainAreaPending = async (uid: number): Promise<void> => {
   const diffResult = await MainAreaWorker.invoke('MainArea.diff2', uid)
@@ -7,6 +8,7 @@ export const renderMainAreaPending = async (uid: number): Promise<void> => {
     return
   }
   const commands = await MainAreaWorker.invoke('MainArea.render2', uid, diffResult)
+  UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
   if (commands.length === 0) {
     return
   }

--- a/packages/renderer-worker/test/RenderMainAreaPending.test.ts
+++ b/packages/renderer-worker/test/RenderMainAreaPending.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const mainAreaWorkerInvoke = jest.fn()
 const rendererProcessInvoke = jest.fn()
+const updateDynamicFocusContext = jest.fn((commands: any[]) => {
+  const focusCommandIndex = commands.findIndex((command) => command[0] === 'Viewlet.setFocusContext')
+  if (focusCommandIndex !== -1) {
+    commands.splice(focusCommandIndex, 1)
+  }
+})
 
 jest.unstable_mockModule('../src/parts/MainAreaWorker/MainAreaWorker.js', () => ({
   invoke: mainAreaWorkerInvoke,
@@ -11,10 +17,14 @@ jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () =
   invoke: rendererProcessInvoke,
 }))
 
+jest.unstable_mockModule('../src/parts/UpdateDynamicFocusContext/UpdateDynamicFocusContext.js', () => ({
+  updateDynamicFocusContext,
+}))
+
 const { renderMainAreaPending } = await import('../src/parts/RenderMainAreaPending/RenderMainAreaPending.ts')
 
 beforeEach(() => {
-  jest.resetAllMocks()
+  jest.clearAllMocks()
 })
 
 test('renders the pending main area state', async () => {
@@ -43,5 +53,22 @@ test('does not render when the pending state has no diff', async () => {
   await renderMainAreaPending(7)
 
   expect(mainAreaWorkerInvoke).toHaveBeenCalledTimes(1)
+  expect(rendererProcessInvoke).not.toHaveBeenCalled()
+})
+
+test('consumes focus commands in the renderer worker', async () => {
+  mainAreaWorkerInvoke.mockImplementation((method) => {
+    if (method === 'MainArea.diff2') {
+      return [1]
+    }
+    if (method === 'MainArea.render2') {
+      return [['Viewlet.setFocusContext', 7, 12, 13]]
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  await renderMainAreaPending(7)
+
+  expect(updateDynamicFocusContext).toHaveBeenCalledTimes(1)
   expect(rendererProcessInvoke).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Apply delayed main-area focus commands inside the renderer worker before forwarding remaining render commands. Includes regression coverage for focus-only pending updates.