### PR TITLE
fix: initialize ipc tracing before worker creation

### DIFF
--- a/packages/renderer-worker/src/parts/IpcTrace/IpcTrace.js
+++ b/packages/renderer-worker/src/parts/IpcTrace/IpcTrace.js
@@ -7,6 +7,8 @@ import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 const flushRecordCount = 100
 const flushDelay = 100
 
+const createEmptyOptions = () => ({ error: '', selectors: new Set() })
+
 /** @type {any} */
 export const state = {
   batches: new Map(),
@@ -16,7 +18,7 @@ export const state = {
   getArgv: Process.getArgv,
   getTransferrables: GetIpcTraceTransferrables.getIpcTraceTransferrables,
   now: () => performance.now(),
-  optionsPromise: undefined,
+  options: createEmptyOptions(),
   pendingRecordCount: 0,
   serialize: SerializeIpcTraceMessage.serializeIpcTraceMessage,
   setTimeout: (callback, delay) => globalThis.setTimeout(callback, delay),
@@ -43,20 +45,17 @@ const reportError = (error) => {
   void Promise.resolve(state.writeStderr(`IPC tracing disabled: ${message}\n`)).catch(() => {})
 }
 
-const getOptions = async () => {
-  state.optionsPromise ||= Promise.resolve(state.getArgv())
-    .then((argv) => {
-      const options = IpcTraceConfig.parseTraceIpc(argv)
-      if (options.error) {
-        reportError(new Error(options.error))
-      }
-      return options
-    })
-    .catch((error) => {
-      reportError(error)
-      return { error: '', selectors: new Set() }
-    })
-  return state.optionsPromise
+export const initialize = async () => {
+  try {
+    const argv = await state.getArgv()
+    state.options = IpcTraceConfig.parseTraceIpc(argv)
+    if (state.options.error) {
+      reportError(new Error(state.options.error))
+    }
+  } catch (error) {
+    reportError(error)
+    state.options = createEmptyOptions()
+  }
 }
 
 const getWorkerId = (traceId, name, runtimeId) => {
@@ -157,8 +156,7 @@ export const maybeCreateProxy = async ({ id, name = '', port, traceId = '' }) =>
   if (!port || state.disabled) {
     return port
   }
-  const options = await getOptions()
-  if (state.disabled || !IpcTraceConfig.shouldTrace(options.selectors, traceId)) {
+  if (!IpcTraceConfig.shouldTrace(state.options.selectors, traceId)) {
     return port
   }
   const workerId = getWorkerId(traceId, name, id)
@@ -183,7 +181,7 @@ export const reset = () => {
   state.connectionId = 0
   state.disabled = false
   state.flushTimer = undefined
-  state.optionsPromise = undefined
+  state.options = createEmptyOptions()
   state.pendingRecordCount = 0
   state.writeChain = Promise.resolve()
 }

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -15,6 +15,7 @@ import * as IconTheme from '../IconTheme/IconTheme.js'
 import * as Id from '../Id/Id.js'
 import * as InitData from '../InitData/InitData.js'
 import * as IpcState from '../IpcState/IpcState.js'
+import * as IpcTrace from '../IpcTrace/IpcTrace.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as Languages from '../Languages/Languages.js'
 import * as LaunchSharedProcess from '../LaunchSharedProcess/LaunchSharedProcess.js'
@@ -126,6 +127,7 @@ export const startup = async (platform, assetDir) => {
   Location.initialize(initData.Location.href)
   if (platform !== PlatformType.Web) {
     await LaunchSharedProcess.launchSharedProcess()
+    await IpcTrace.initialize()
   }
 
   LifeCycle.mark(LifeCyclePhase.One)

--- a/packages/renderer-worker/test/IpcTrace.test.ts
+++ b/packages/renderer-worker/test/IpcTrace.test.ts
@@ -28,7 +28,7 @@ globalThis.MessageChannel = FakeMessageChannel
 
 const IpcTrace = await import('../src/parts/IpcTrace/IpcTrace.js')
 
-beforeEach(() => {
+beforeEach(async () => {
   IpcTrace.reset()
   IpcTrace.state.getArgv = jest.fn(async () => ['/usr/bin/lvce', '--trace-ipc=builtin.eslint'])
   IpcTrace.state.getTransferrables = jest.fn(() => [])
@@ -38,6 +38,24 @@ beforeEach(() => {
   IpcTrace.state.wallTime = jest.fn(() => '2026-08-15T21:55:00.000Z')
   IpcTrace.state.write = jest.fn(async () => undefined)
   IpcTrace.state.writeStderr = jest.fn(async () => undefined)
+  await IpcTrace.initialize()
+})
+
+test('does not request trace configuration while creating a worker proxy', async () => {
+  IpcTrace.reset()
+  const getArgv = jest.fn(async () => ['/usr/bin/lvce', '--trace-ipc=builtin.eslint'])
+  IpcTrace.state.getArgv = getArgv
+  const parentChannel = new FakeMessageChannel()
+
+  const port = await IpcTrace.maybeCreateProxy({
+    id: 42,
+    name: 'ESLint Worker',
+    port: parentChannel.port2,
+    traceId: 'builtin.eslint',
+  })
+
+  expect(port).toBe(parentChannel.port2)
+  expect(getArgv).not.toHaveBeenCalled()
 })
 
 test('forwards selected worker messages in both directions and records them', async () => {


### PR DESCRIPTION
## Summary

- load IPC trace selectors after the shared-process connection is ready
- keep worker creation on an in-memory configuration path
- cover worker creation before tracing initialization

This prevents worker creation from issuing a nested `Process.getArgv` RPC, which deadlocks fresh-page component e2e commands.

## Tests

- renderer-worker: 345 suites passed, 1,529 tests passed
- renderer-worker type-check
- extension-detail focused fresh-page regression isolated against server 0.101.15/0.101.16