### PR TITLE
feature: add editor breadcrumbs

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-chevron-separators.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-chevron-separators.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-chevron-separators'
+
+export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/src`)
+  const uri = `${tmpDir}/src/App.ts`
+  await FileSystem.writeFile(
+    uri,
+    `class App {
+  render() {}
+}`,
+  )
+  await Settings.update({
+    'breadcrumbs.enabled': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Editor.setCursor(1, 4)
+
+  await expect(Locator('.EditorBreadcrumb')).toHaveCount(4)
+  const separators = Locator('.EditorBreadcrumbSeparator')
+  await expect(separators).toHaveCount(3)
+  await expect(separators.nth(0)).toHaveClass('EditorBreadcrumbSeparator MaskIcon MaskIconChevronRight')
+  await expect(separators.nth(1)).toHaveClass('EditorBreadcrumbSeparator MaskIcon MaskIconChevronRight')
+  await expect(separators.nth(2)).toHaveClass('EditorBreadcrumbSeparator MaskIcon MaskIconChevronRight')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-chevron-separators.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-chevron-separators.ts
@@ -22,7 +22,7 @@ export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, 
   await expect(Locator('.EditorBreadcrumb')).toHaveCount(4)
   const separators = Locator('.EditorBreadcrumbSeparator')
   await expect(separators).toHaveCount(3)
-  await expect(separators.nth(0)).toHaveClass('EditorBreadcrumbSeparator MaskIcon MaskIconChevronRight')
-  await expect(separators.nth(1)).toHaveClass('EditorBreadcrumbSeparator MaskIcon MaskIconChevronRight')
-  await expect(separators.nth(2)).toHaveClass('EditorBreadcrumbSeparator MaskIcon MaskIconChevronRight')
+  await expect(separators.nth(0)).toHaveClass('MaskIconChevronRight')
+  await expect(separators.nth(1)).toHaveClass('MaskIconChevronRight')
+  await expect(separators.nth(2)).toHaveClass('MaskIconChevronRight')
 }

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-disabled.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-disabled.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-disabled'
+
+export const test: Test = async ({ FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.ts`
+  await FileSystem.writeFile(uri, 'const value = 1')
+  await Settings.update({
+    'breadcrumbs.enabled': false,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  await expect(Locator('.EditorBreadcrumbs')).toHaveCount(0)
+  await expect(Locator('.EditorBreadcrumb')).toHaveCount(0)
+  await expect(Locator('.EditorBreadcrumbSeparator')).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-file-path.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-file-path.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-file-path'
+
+export const test: Test = async ({ FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/src`)
+  await FileSystem.mkdir(`${tmpDir}/src/components`)
+  const uri = `${tmpDir}/src/components/readme.txt`
+  await FileSystem.writeFile(uri, 'plain text')
+  await Settings.update({
+    'breadcrumbs.enabled': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  const items = Locator('.EditorBreadcrumb')
+  await expect(items).toHaveCount(3)
+  await expect(items.nth(0)).toHaveText('src')
+  await expect(items.nth(1)).toHaveText('components')
+  await expect(items.nth(2)).toHaveText('readme.txt')
+  await expect(Locator('.EditorBreadcrumbSymbol')).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-follow-cursor.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-follow-cursor.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-follow-cursor'
+
+export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/App.ts`
+  await FileSystem.writeFile(
+    uri,
+    `class App {
+  render() {
+    return 1
+  }
+
+  save() {
+    return 2
+  }
+}`,
+  )
+  await Settings.update({
+    'breadcrumbs.enabled': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  const symbols = Locator('.EditorBreadcrumbSymbol')
+  await Editor.setCursor(2, 6)
+  await expect(symbols.nth(1)).toHaveText('render')
+
+  await Editor.setCursor(6, 6)
+  await expect(symbols).toHaveCount(2)
+  await expect(symbols.nth(0)).toHaveText('App')
+  await expect(symbols.nth(1)).toHaveText('save')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-nested-symbols.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-nested-symbols.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-nested-symbols'
+
+export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/App.ts`
+  await FileSystem.writeFile(
+    uri,
+    `class App {
+  render() {
+    return 1
+  }
+}`,
+  )
+  await Settings.update({
+    'breadcrumbs.enabled': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Editor.setCursor(2, 6)
+
+  const symbols = Locator('.EditorBreadcrumbSymbol')
+  await expect(symbols).toHaveCount(2)
+  await expect(symbols.nth(0)).toHaveText('App')
+  await expect(symbols.nth(1)).toHaveText('render')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-toggle-setting.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-toggle-setting.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-toggle-setting'
+
+export const test: Test = async ({ FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/file.ts`
+  await FileSystem.writeFile(uri, 'const value = 1')
+  await Settings.update({
+    'breadcrumbs.enabled': false,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+
+  const breadcrumbs = Locator('.EditorBreadcrumbs')
+  await expect(breadcrumbs).toHaveCount(0)
+
+  await Settings.update({
+    'breadcrumbs.enabled': true,
+  })
+  await expect(breadcrumbs).toHaveCount(1)
+  await expect(Locator('.EditorBreadcrumb')).toHaveCount(2)
+
+  await Settings.update({
+    'breadcrumbs.enabled': false,
+  })
+  await expect(breadcrumbs).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-toggle-setting.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-toggle-setting.ts
@@ -19,7 +19,7 @@ export const test: Test = async ({ FileSystem, Locator, Main, Settings, Workspac
     'breadcrumbs.enabled': true,
   })
   await expect(breadcrumbs).toHaveCount(1)
-  await expect(Locator('.EditorBreadcrumb')).toHaveCount(2)
+  await expect(Locator('.EditorBreadcrumb')).toHaveCount(1)
 
   await Settings.update({
     'breadcrumbs.enabled': false,

--- a/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-typescript-symbol.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-breadcrumbs-typescript-symbol.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.editor-breadcrumbs-typescript-symbol'
+
+export const test: Test = async ({ Editor, FileSystem, Locator, Main, Settings, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/values.ts`
+  await FileSystem.writeFile(uri, 'const value = 1')
+  await Settings.update({
+    'breadcrumbs.enabled': true,
+  })
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(uri)
+  await Editor.setCursor(0, 8)
+
+  const items = Locator('.EditorBreadcrumb')
+  await expect(items).toHaveCount(2)
+  await expect(items.nth(0)).toHaveText('values.ts')
+  await expect(items.nth(1)).toHaveText('value')
+  await expect(items.nth(1)).toHaveAttribute('data-kind', 'symbol')
+}

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ipc.ts
@@ -9,6 +9,7 @@ export const Commands = {
   diagnostic: LanguageServer.diagnostic,
   dispose: LanguageServer.dispose,
   disposeAll: LanguageServer.disposeAll,
+  documentSymbols: LanguageServer.documentSymbols,
   format: LanguageServer.format,
   references: LanguageServer.references,
 }

--- a/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
+++ b/packages/shared-process/src/parts/LanguageServer/LanguageServer.ts
@@ -32,6 +32,8 @@ export interface DiagnosticOptions {
 
 export type DefinitionOptions = CompleteOptions
 
+export type DocumentSymbolOptions = DiagnosticOptions
+
 export type ReferencesOptions = CompleteOptions
 
 export interface FormatOptions {
@@ -120,6 +122,16 @@ export const definition = async ({ argv, extensionId, id, offset, rootUri, textD
   const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
   const connection = getConnection(`${id}:${normalizedRootUri}`, extensionId, uri, argv, normalizedRootUri)
   return connection.definition(normalizedDocument, offset)
+}
+
+export const documentSymbols = async ({ argv, extensionId, id, rootUri, textDocument, uri }: DocumentSymbolOptions): Promise<readonly unknown[]> => {
+  const normalizedDocument = {
+    ...textDocument,
+    uri: normalizeLanguageServerDocumentUri(textDocument.uri),
+  }
+  const normalizedRootUri = rootUri ? normalizeLanguageServerDocumentUri(rootUri) : getRootUri(normalizedDocument.uri)
+  const connection = getConnection(`${id}:${normalizedRootUri}`, extensionId, uri, argv, normalizedRootUri)
+  return connection.documentSymbols(normalizedDocument)
 }
 
 export const format = async ({ argv, extensionId, id, rootUri, textDocument, uri }: FormatOptions): Promise<readonly unknown[]> => {

--- a/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
+++ b/packages/shared-process/src/parts/LanguageServerConnection/LanguageServerConnection.ts
@@ -34,6 +34,7 @@ interface InitializeResult {
     readonly codeActionProvider?: unknown
     readonly diagnosticProvider?: unknown
     readonly documentFormattingProvider?: unknown
+    readonly documentSymbolProvider?: unknown
     readonly referencesProvider?: unknown
   }
 }
@@ -170,6 +171,7 @@ export class LanguageServerConnection {
   private stderr = ''
   private supportsCodeActions = false
   private supportsDocumentFormatting = false
+  private supportsDocumentSymbols = false
   private supportsPullDiagnostics = false
   private supportsReferences = false
 
@@ -294,6 +296,20 @@ export class LanguageServerConnection {
     })
   }
 
+  async documentSymbols(textDocument: TextDocument): Promise<readonly unknown[]> {
+    await this.ready
+    if (!this.supportsDocumentSymbols) {
+      return []
+    }
+    this.syncDocument(textDocument)
+    const result = await this.sendRequest('textDocument/documentSymbol', {
+      textDocument: {
+        uri: textDocument.uri,
+      },
+    })
+    return Array.isArray(result) ? result : []
+  }
+
   async format(textDocument: TextDocument): Promise<readonly unknown[]> {
     await this.ready
     if (!this.supportsDocumentFormatting) {
@@ -396,6 +412,10 @@ export class LanguageServerConnection {
             dynamicRegistration: false,
             relatedDocumentSupport: false,
           },
+          documentSymbol: {
+            dynamicRegistration: false,
+            hierarchicalDocumentSymbolSupport: true,
+          },
           publishDiagnostics: {
             relatedInformation: true,
           },
@@ -429,6 +449,7 @@ export class LanguageServerConnection {
     })) as InitializeResult
     this.supportsCodeActions = Boolean(result?.capabilities?.codeActionProvider)
     this.supportsDocumentFormatting = Boolean(result?.capabilities?.documentFormattingProvider)
+    this.supportsDocumentSymbols = Boolean(result?.capabilities?.documentSymbolProvider)
     this.supportsPullDiagnostics = Boolean(result?.capabilities?.diagnosticProvider)
     this.supportsReferences = Boolean(result?.capabilities?.referencesProvider)
     this.sendNotification('initialized', {})

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -219,6 +219,7 @@ export const getModuleId = (commandId: any): any => {
     case 'LanguageServer.diagnostic':
     case 'LanguageServer.dispose':
     case 'LanguageServer.disposeAll':
+    case 'LanguageServer.documentSymbols':
     case 'LanguageServer.format':
     case 'LanguageServer.references':
       return ModuleId.LanguageServer

--- a/packages/shared-process/test/LanguageServer.test.ts
+++ b/packages/shared-process/test/LanguageServer.test.ts
@@ -8,6 +8,7 @@ import {
   diagnostic,
   dispose,
   disposeAll,
+  documentSymbols,
   format,
   references,
   type CompleteOptions,
@@ -170,6 +171,54 @@ test('definition starts a stdio language server and synchronizes documents', asy
     },
     uri: `${normalizedDocumentUri}?definition=value%20%3D%201%0Amain%20%3D%20value`,
   })
+})
+
+test('documentSymbols starts a stdio language server and synchronizes documents', async () => {
+  const options = {
+    argv: [serverScript],
+    extensionId: 'sample.extension',
+    id: 'sample.document-symbol-fixture',
+    rootUri: 'file:///tmp',
+    textDocument: {
+      languageId: 'typescript',
+      text: 'class FixtureClass {}',
+      uri: '/tmp/Fixture.ts',
+    },
+    uri: pathToFileURL(process.execPath).href,
+  }
+
+  await expect(documentSymbols(options)).resolves.toEqual([
+    {
+      children: [],
+      detail: options.textDocument.text,
+      kind: 5,
+      name: 'FixtureClass',
+      range: {
+        end: { character: options.textDocument.text.length, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+      selectionRange: {
+        end: { character: 12, line: 0 },
+        start: { character: 0, line: 0 },
+      },
+    },
+  ])
+})
+
+test('documentSymbols returns no symbols when the language server does not support them', async () => {
+  await expect(
+    documentSymbols({
+      argv: [completionOnlyServerScript],
+      extensionId: 'sample.extension',
+      id: 'sample.completion-only-document-symbol-fixture',
+      textDocument: {
+        languageId: 'typescript',
+        text: 'const value = 1',
+        uri: '/tmp/sample.ts',
+      },
+      uri: pathToFileURL(process.execPath).href,
+    }),
+  ).resolves.toEqual([])
 })
 
 test('references starts a stdio language server and includes declarations', async () => {

--- a/packages/shared-process/test/fixtures/languageServer.js
+++ b/packages/shared-process/test/fixtures/languageServer.js
@@ -25,6 +25,7 @@ const handleMessage = (message) => {
             workspaceDiagnostics: false,
           },
           documentFormattingProvider: true,
+          documentSymbolProvider: true,
           referencesProvider: true,
           textDocumentSync: 1,
         },
@@ -91,6 +92,30 @@ const handleMessage = (message) => {
         },
         uri: `${message.params.textDocument.uri}?definition=${encodeURIComponent(text)}`,
       },
+    })
+    return
+  }
+  if (message.method === 'textDocument/documentSymbol') {
+    const text = documents.get(message.params.textDocument.uri)
+    send({
+      id: message.id,
+      jsonrpc: '2.0',
+      result: [
+        {
+          children: [],
+          detail: text,
+          kind: 5,
+          name: 'FixtureClass',
+          range: {
+            end: { character: text.length, line: 0 },
+            start: { character: 0, line: 0 },
+          },
+          selectionRange: {
+            end: { character: 12, line: 0 },
+            start: { character: 0, line: 0 },
+          },
+        },
+      ],
     })
     return
   }

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -1,4 +1,6 @@
 {
+  "breadcrumbs.enabled": false,
+
   "completions.loadingDelay": 1200,
 
   "development.watchColorTheme": true,

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -20,6 +20,50 @@
   cursor: text;
   font-weight: var(--EditorFontWeight);
   display: flex;
+  position: relative;
+}
+
+.EditorBreadcrumbs {
+  align-items: center;
+  color: var(--EditorForeground, #cccccc);
+  contain: strict;
+  display: flex;
+  font-family: sans-serif;
+  font-size: 13px;
+  height: 22px;
+  inset: 0 0 auto;
+  line-height: 22px;
+  overflow: hidden;
+  padding: 0 8px;
+  position: absolute;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.EditorBreadcrumb {
+  flex-shrink: 0;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.EditorBreadcrumbSymbol {
+  color: var(--EditorBreadcrumbSymbolForeground, #e0e0e0);
+}
+
+.EditorBreadcrumbSeparator {
+  --MaskIconSize: 14px;
+
+  color: var(--EditorBreadcrumbSeparatorForeground, #858585);
+  flex: 0 0 16px;
+  height: 16px;
+}
+
+.Editor:has(> .EditorBreadcrumbs) > .Gutter,
+.Editor:has(> .EditorBreadcrumbs) > .EditorContent,
+.Editor:has(> .EditorBreadcrumbs) > .EditorMinimap {
+  height: calc(100% - 22px);
+  margin-top: 22px;
 }
 
 .EditorContent {


### PR DESCRIPTION
Summary

- add non-interactive editor breadcrumbs behind the disabled-by-default `breadcrumbs.enabled` setting
- render workspace-relative file segments and the active document-symbol hierarchy with chevron separators
- support LSP `textDocument/documentSymbol` and hierarchical document-symbol capabilities
- cover disabled, file, symbol, nested, cursor, toggle, and separator behavior with e2e tests