### PR TITLE
fix: include worker manifest in Electron bundle

### DIFF
--- a/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
+++ b/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
@@ -2,6 +2,7 @@ import { chmod, readFile, readdir, rm, stat, writeFile } from 'fs/promises'
 import { join } from 'path'
 import * as BundleJs from '../BundleJsRollup/BundleJsRollup.ts'
 import * as Copy from '../Copy/Copy.ts'
+import * as CopySharedProcessWorkerManifest from '../CopySharedProcessWorkerManifest/CopySharedProcessWorkerManifest.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Path from '../Path/Path.ts'
 import * as Platform from '../Platform/Platform.ts'
@@ -91,6 +92,7 @@ export const bundleSharedProcess = async ({
     to: `${cachePath}/package.json`,
   })
   await transpileTypescriptDirectory(`${cachePath}/src`)
+  await CopySharedProcessWorkerManifest.copySharedProcessWorkerManifest(cachePath)
   await Replace.replace({
     path: `${cachePath}/src/parts/PreloadUrl/PreloadUrl.js`,
     occurrence: `join(Root.root, 'packages', 'shared-process', 'node_modules', '@lvce-editor', 'preload', 'src', 'index.js')`,
@@ -226,17 +228,8 @@ export const getBuiltinExtensionsPath = () => {
     })
   }
   if (target === 'server') {
-    await Copy.copyFile({
-      from: 'packages/renderer-worker/src/parts/Workers/Workers.json',
-      to: `${cachePath}/src/parts/Workers/Workers.json`,
-    })
     await Replace.replace({
       path: `${cachePath}/src/parts/ExportStatic/ExportStatic.js`,
-      occurrence: `../../../../renderer-worker/src/parts/Workers/Workers.json`,
-      replacement: `../Workers/Workers.json`,
-    })
-    await Replace.replace({
-      path: `${cachePath}/src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js`,
       occurrence: `../../../../renderer-worker/src/parts/Workers/Workers.json`,
       replacement: `../Workers/Workers.json`,
     })

--- a/packages/build/src/parts/CopySharedProcessWorkerManifest/CopySharedProcessWorkerManifest.ts
+++ b/packages/build/src/parts/CopySharedProcessWorkerManifest/CopySharedProcessWorkerManifest.ts
@@ -1,0 +1,17 @@
+import * as Copy from '../Copy/Copy.ts'
+import * as Replace from '../Replace/Replace.ts'
+
+const workerManifestSource = 'packages/renderer-worker/src/parts/Workers/Workers.json'
+const workerManifestImport = '../../../../renderer-worker/src/parts/Workers/Workers.json'
+
+export const copySharedProcessWorkerManifest = async (cachePath: string): Promise<void> => {
+  await Copy.copyFile({
+    from: workerManifestSource,
+    to: `${cachePath}/src/parts/Workers/Workers.json`,
+  })
+  await Replace.replace({
+    path: `${cachePath}/src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js`,
+    occurrence: workerManifestImport,
+    replacement: '../Workers/Workers.json',
+  })
+}

--- a/packages/build/test/CopySharedProcessWorkerManifest.test.ts
+++ b/packages/build/test/CopySharedProcessWorkerManifest.test.ts
@@ -1,0 +1,27 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Copy/Copy.ts', () => ({
+  copyFile: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Replace/Replace.ts', () => ({
+  replace: jest.fn(),
+}))
+
+const Copy = await import('../src/parts/Copy/Copy.ts')
+const CopySharedProcessWorkerManifest = await import('../src/parts/CopySharedProcessWorkerManifest/CopySharedProcessWorkerManifest.ts')
+const Replace = await import('../src/parts/Replace/Replace.ts')
+
+test('copies the worker manifest and makes the linked-worker import package-local', async () => {
+  await CopySharedProcessWorkerManifest.copySharedProcessWorkerManifest('/tmp/shared-process')
+
+  expect(Copy.copyFile).toHaveBeenCalledWith({
+    from: 'packages/renderer-worker/src/parts/Workers/Workers.json',
+    to: '/tmp/shared-process/src/parts/Workers/Workers.json',
+  })
+  expect(Replace.replace).toHaveBeenCalledWith({
+    path: '/tmp/shared-process/src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js',
+    occurrence: '../../../../renderer-worker/src/parts/Workers/Workers.json',
+    replacement: '../Workers/Workers.json',
+  })
+})


### PR DESCRIPTION
## Summary

- copy the renderer worker manifest into every packaged shared process
- rewrite the linked-worker preference import to the package-local manifest for Electron as well as server builds
- add focused build-contract coverage

## Root cause

The shared process began importing `Workers.json` for runtime worker links, but the copy and import rewrite were scoped to the `server` target. Official v0.105.10 Electron packages therefore start the main and utility processes but never create a renderer window because the shared process cannot load its missing JSON dependency.

## Validation

- red/green `CopySharedProcessWorkerManifest.test.ts`
- focused test passes
- `packages/build` type-check passes
- Prettier and diff checks pass
- complete package suite: 25/27 suites passed; two pre-existing fixture/bootstrap-dependent suites fail in the isolated worktree because builtin extensions and workspace package links are not present