### PR TITLE
fix: pass linked worker urls to browser

### DIFF
--- a/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
+++ b/packages/build/src/parts/BundleSharedProcess/BundleSharedProcess.ts
@@ -149,13 +149,6 @@ export const getExtraHeaders = ({ pathName, fileExtension }) => {
     occurrence: `export const isProduction = false`,
     replacement: `export const isProduction = true`,
   })
-  await WriteFile.writeFile({
-    to: `${cachePath}/src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.js`,
-    content: `export const addCustomPathsToIndexHtml = async (content) => {
-    return content
-}
-`,
-  })
   if (isArchLinux) {
     await Replace.replace({
       path: `${cachePath}/src/parts/Platform/Platform.js`,

--- a/packages/renderer-worker/src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts
+++ b/packages/renderer-worker/src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts
@@ -1,7 +1,12 @@
 import * as IsProduction from '../IsProduction/IsProduction.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as RuntimeWorkerPaths from '../RuntimeWorkerPaths/RuntimeWorkerPaths.ts'
 
 export const getConfiguredWorkerUrl = (preferenceKey: string, fallback: string) => {
+  const runtimeWorkerUrl = RuntimeWorkerPaths.get(preferenceKey)
+  if (runtimeWorkerUrl) {
+    return runtimeWorkerUrl
+  }
   let configuredWorkerUrl = Preferences.get(preferenceKey) || ''
   if (configuredWorkerUrl) {
     const configuredUrlWithSlash = configuredWorkerUrl.startsWith('/') ? configuredWorkerUrl : '/' + configuredWorkerUrl

--- a/packages/renderer-worker/src/parts/RuntimeWorkerPaths/RuntimeWorkerPaths.ts
+++ b/packages/renderer-worker/src/parts/RuntimeWorkerPaths/RuntimeWorkerPaths.ts
@@ -1,0 +1,11 @@
+const state: { paths: Readonly<Record<string, string>> } = {
+  paths: {},
+}
+
+export const initialize = (paths: Readonly<Record<string, string>> = {}): void => {
+  state.paths = paths
+}
+
+export const get = (key: string): string => {
+  return state.paths[key] || ''
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -34,6 +34,7 @@ import * as PreferencesState from '../PreferencesState/PreferencesState.js'
 import * as PromptMode from '../PromptMode/PromptMode.js'
 import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as RuntimeWorkerPaths from '../RuntimeWorkerPaths/RuntimeWorkerPaths.ts'
 import * as SaveState from '../SaveState/SaveState.js'
 import * as SessionReplay from '../SessionReplay/SessionReplay.js'
 import { shouldInitializeAuth } from '../ShouldInitializeAuth/ShouldInitializeAuth.ts'
@@ -133,6 +134,7 @@ export const startup = async (platform, assetDir) => {
   LifeCycle.mark(LifeCyclePhase.One)
 
   IpcState.setConfig(initData.Config?.shouldLaunchMultipleWorkers)
+  RuntimeWorkerPaths.initialize(initData.Config?.workerUrls)
   ExtensionManagementWorker.hydrate()
 
   const promptOptions = platform === PlatformType.Electron ? await PromptMode.getPromptOptions() : undefined

--- a/packages/renderer-worker/test/GetConfiguredWorkerUrl.test.ts
+++ b/packages/renderer-worker/test/GetConfiguredWorkerUrl.test.ts
@@ -1,0 +1,15 @@
+import { beforeEach, expect, test } from '@jest/globals'
+import { getConfiguredWorkerUrl } from '../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as RuntimeWorkerPaths from '../src/parts/RuntimeWorkerPaths/RuntimeWorkerPaths.ts'
+
+beforeEach(() => {
+  RuntimeWorkerPaths.initialize()
+})
+
+test('prefers a runtime worker url', () => {
+  RuntimeWorkerPaths.initialize({
+    'develop.mainAreaWorkerPath': '/remote/test/main-area-worker.js',
+  })
+
+  expect(getConfiguredWorkerUrl('develop.mainAreaWorkerPath', '/fallback.js')).toBe('/remote/test/main-area-worker.js')
+})

--- a/packages/shared-process/src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.ts
+++ b/packages/shared-process/src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.ts
@@ -1,14 +1,19 @@
 import * as ApplyCustomWorkerPathCliOverride from '../ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts'
 import * as GetCustomPathsConfig from '../GetCustomPathsConfig/GetCustomPathsConfig.ts'
+import * as LinkedWorkerPreferences from '../LinkedWorkerPreferences/LinkedWorkerPreferences.ts'
 import * as Platform from '../Platform/Platform.ts'
 import * as Preferences from '../Preferences/Preferences.ts'
 
 export const addCustomPathsToIndexHtml = async (content: any): Promise<any> => {
-  if (Platform.isProduction) {
+  let preferences = {}
+  if (!Platform.isProduction) {
+    preferences = ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(await Preferences.getUserPreferences())
+  }
+  const linkedWorkerPreferences = await LinkedWorkerPreferences.getLinkedWorkerPreferences()
+  const config = GetCustomPathsConfig.getCustomPathsConfig({ ...preferences, ...linkedWorkerPreferences })
+  if (Object.keys(config).length === 0) {
     return content
   }
-  const preferences = ApplyCustomWorkerPathCliOverride.applyCustomWorkerPathCliOverride(await Preferences.getUserPreferences())
-  const config = GetCustomPathsConfig.getCustomPathsConfig(preferences)
   let newContent = content
   if (config.rendererProcessPath) {
     newContent = newContent

--- a/packages/shared-process/src/parts/ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts
+++ b/packages/shared-process/src/parts/ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts
@@ -4,7 +4,7 @@ const disableCustomWorkerPathsFlag = '--disable-custom-worker-paths'
 
 const workerPathSettingsWithoutWorkerInName = new Set(['develop.languageModelsViewPath', 'develop.runningExtensionsViewPath'])
 
-const isCustomWorkerPathSetting = (key: string): boolean => {
+export const isCustomWorkerPathSetting = (key: string): boolean => {
   const isDevelopmentSetting = key.startsWith('develop.') || key.startsWith('developer.')
   return isDevelopmentSetting && (key.endsWith('WorkerPath') || workerPathSettingsWithoutWorkerInName.has(key))
 }

--- a/packages/shared-process/src/parts/GetCustomPathsConfig/GetCustomPathsConfig.ts
+++ b/packages/shared-process/src/parts/GetCustomPathsConfig/GetCustomPathsConfig.ts
@@ -1,4 +1,9 @@
+import * as ApplyCustomWorkerPathCliOverride from '../ApplyCustomWorkerPathCliOverride/ApplyCustomWorkerPathCliOverride.ts'
 import * as GetRemoteUrl from '../GetRemoteUrl/GetRemoteUrl.ts'
+
+const isWorkerPath = ([key, value]: [string, unknown]): boolean => {
+  return typeof value === 'string' && ApplyCustomWorkerPathCliOverride.isCustomWorkerPathSetting(key)
+}
 
 export const getCustomPathsConfig = (preferences: any): any => {
   const config = Object.create(null)
@@ -7,6 +12,14 @@ export const getCustomPathsConfig = (preferences: any): any => {
   }
   if (preferences['develop.editorWorkerPath']) {
     config.editorWorkerUrl = GetRemoteUrl.getRemoteUrl(preferences['develop.editorWorkerPath'])
+  }
+  const workerUrls = Object.fromEntries(
+    Object.entries(preferences)
+      .filter(isWorkerPath)
+      .map(([key, value]) => [key, GetRemoteUrl.getRemoteUrl(value as string)]),
+  )
+  if (Object.keys(workerUrls).length > 0) {
+    config.workerUrls = workerUrls
   }
   return config
 }

--- a/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
+++ b/packages/shared-process/test/AddCustomPathsToIndexHtml.test.ts
@@ -11,7 +11,12 @@ jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
   }),
 }))
 
+jest.unstable_mockModule('../src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js', () => ({
+  getLinkedWorkerPreferences: jest.fn(() => ({})),
+}))
+
 const AddCustomPathsToIndexHtml = await import('../src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.js')
+const LinkedWorkerPreferences = await import('../src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
 const originalArgv = process.argv
@@ -38,4 +43,17 @@ test('addCustomPathsToIndexHtml - excludes custom worker paths when disabled fro
   expect(result).toContain(`"rendererProcessPath": "${rendererProcessUrl}"`)
   expect(result).not.toContain('editorWorkerUrl')
   expect(result).not.toContain('extensionHostWorkerUrl')
+})
+
+test('addCustomPathsToIndexHtml - adds linked worker urls', async () => {
+  jest.mocked(Preferences.getUserPreferences).mockResolvedValue({})
+  jest.mocked(LinkedWorkerPreferences.getLinkedWorkerPreferences).mockResolvedValue({
+    'develop.mainAreaWorkerPath': '/test/main-area-worker',
+  })
+  const content = '<title>Test</title>'
+  const mainAreaWorkerUrl = GetRemoteUrl.getRemoteUrl('/test/main-area-worker')
+
+  const result = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(content)
+
+  expect(result).toContain(`"develop.mainAreaWorkerPath": "${mainAreaWorkerUrl}"`)
 })

--- a/packages/shared-process/test/AddCustomPathsToIndexHtmlProduction.test.ts
+++ b/packages/shared-process/test/AddCustomPathsToIndexHtmlProduction.test.ts
@@ -1,0 +1,31 @@
+import { expect, jest, test } from '@jest/globals'
+import * as GetRemoteUrl from '../src/parts/GetRemoteUrl/GetRemoteUrl.js'
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  isProduction: true,
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  getUserPreferences: jest.fn(() => {
+    throw new Error('not implemented')
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/LinkedWorkerPreferences/LinkedWorkerPreferences.js', () => ({
+  getLinkedWorkerPreferences: jest.fn(() => ({
+    'develop.mainAreaWorkerPath': '/test/main-area-worker',
+  })),
+}))
+
+const AddCustomPathsToIndexHtml = await import('../src/parts/AddCustomPathsToIndexHtml/AddCustomPathsToIndexHtml.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+
+test('addCustomPathsToIndexHtml - adds linked worker urls in production', async () => {
+  const content = '<title>Test</title>'
+  const mainAreaWorkerUrl = GetRemoteUrl.getRemoteUrl('/test/main-area-worker')
+
+  const result = await AddCustomPathsToIndexHtml.addCustomPathsToIndexHtml(content)
+
+  expect(Preferences.getUserPreferences).not.toHaveBeenCalled()
+  expect(result).toContain(`"develop.mainAreaWorkerPath": "${mainAreaWorkerUrl}"`)
+})


### PR DESCRIPTION
Pass trusted runtime `--link` worker URLs through the production server config.

Initialize those URLs in the renderer before workers launch, while keeping production user preference overrides disabled.