### PR TITLE
fix: route linked index requests through shared process

### DIFF
--- a/packages/build/src/parts/BuildServer/BuildServer.ts
+++ b/packages/build/src/parts/BuildServer/BuildServer.ts
@@ -19,12 +19,14 @@ const getObjectDependencies = (obj) => {
   return [obj, ...Object.values(obj.dependencies).flatMap(getObjectDependencies)]
 }
 
-export const getServerIsStaticReplacement = (commitHash: string): string => `const isStatic = (url) => {
+export const getServerIsStaticReplacement = (commitHash: string): string => `const hasLinkedExtensions = argvSliced.some((arg) => arg === '--link' || arg.startsWith('--link='))
+
+const isStatic = (url) => {
   if (url === '/' || url.startsWith('/?')) {
-    return true
+    return !hasLinkedExtensions
   }
   if (url === '/index.html' || url.startsWith('/index.html?')) {
-    return true
+    return !hasLinkedExtensions
   }
   if (url.startsWith('/${commitHash}')) {
     return true

--- a/packages/build/test/BuildServer.test.ts
+++ b/packages/build/test/BuildServer.test.ts
@@ -15,7 +15,7 @@ const readJson = async (path: string): Promise<any> => {
 
 test('generated server sends index documents through the static server', () => {
   const replacement = getServerIsStaticReplacement('abcdefg')
-  const isStatic = runInNewContext(`${replacement}; isStatic`) as (url: string) => boolean
+  const isStatic = runInNewContext(`${replacement}; isStatic`, { argvSliced: [] }) as (url: string) => boolean
 
   expect(isStatic('/')).toBe(true)
   expect(isStatic('/?workspace=/test')).toBe(true)
@@ -23,6 +23,17 @@ test('generated server sends index documents through the static server', () => {
   expect(isStatic('/index.html?workspace=/test')).toBe(true)
   expect(isStatic('/abcdefg/packages/renderer-worker.js')).toBe(true)
   expect(isStatic('/api/status')).toBe(false)
+})
+
+test('generated server sends index documents through the shared process when extensions are linked', () => {
+  const replacement = getServerIsStaticReplacement('abcdefg')
+  const isStatic = runInNewContext(`${replacement}; isStatic`, { argvSliced: ['--link', '/test/extension'] }) as (url: string) => boolean
+
+  expect(isStatic('/')).toBe(false)
+  expect(isStatic('/?workspace=/test')).toBe(false)
+  expect(isStatic('/index.html')).toBe(false)
+  expect(isStatic('/index.html?workspace=/test')).toBe(false)
+  expect(isStatic('/abcdefg/packages/renderer-worker.js')).toBe(true)
 })
 
 test('setVersionsAndDependencies includes process explorer as shared-process dependency', async () => {


### PR DESCRIPTION
Route root and index requests through the shared process when `--link` is present.

This lets the production server inject trusted runtime worker URLs for normal development pages while retaining the static fast path otherwise.