### PR TITLE
feature: update renderer process to 30.38.1

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -58,7 +58,7 @@
         "@lvce-editor/quick-pick-worker": "^4.17.2",
         "@lvce-editor/references-view": "^2.16.0",
         "@lvce-editor/rename-worker": "^1.39.0",
-        "@lvce-editor/renderer-process": "^30.38.0",
+        "@lvce-editor/renderer-process": "^30.38.1",
         "@lvce-editor/running-extensions-view": "^1.25.0",
         "@lvce-editor/settings-view": "^2.26.2",
         "@lvce-editor/settings-worker": "^1.16.0",
@@ -1172,9 +1172,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/renderer-process": {
-      "version": "30.38.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/renderer-process/-/renderer-process-30.38.0.tgz",
-      "integrity": "sha512-EYFBl2jn7kNcx4e4Zm/fA8wqQWQPFHUjNGH8NtsYVMCiQO4XJPH8ZH5YXj2j0+VW7VUEvx/UDy/XidMcNWwTEQ==",
+      "version": "30.38.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/renderer-process/-/renderer-process-30.38.1.tgz",
+      "integrity": "sha512-Wnyf+ZLt6vdDBF3EPq5N0zpx6j/ZA/9XQG206IBO5KwH7zmMsJe3jfWTDmGZSvVFtcGhMOsUdZZR4LE+lPlYjw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/running-extensions-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -90,7 +90,7 @@
     "@lvce-editor/quick-pick-worker": "^4.17.2",
     "@lvce-editor/references-view": "^2.16.0",
     "@lvce-editor/rename-worker": "^1.39.0",
-    "@lvce-editor/renderer-process": "^30.38.0",
+    "@lvce-editor/renderer-process": "^30.38.1",
     "@lvce-editor/running-extensions-view": "^1.25.0",
     "@lvce-editor/settings-view": "^2.26.2",
     "@lvce-editor/settings-worker": "^1.16.0",


### PR DESCRIPTION
## Summary
- update renderer-process to 30.38.1
- enable MouseEvent-backed synthetic context-menu actions in current runtime tests

## Tests
- npm run build
- npm run type-check
- npm run lint