### PR TITLE
fix: remove color picker focus outline

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.editor-color-picker-outline.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-color-picker-outline.ts
@@ -1,0 +1,16 @@
+export const name = 'viewlet.editor-color-picker-outline'
+
+export const test = async ({ Editor, expect, FileSystem, Locator, Main }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'abc')
+  await Main.openUri(`${tmpDir}/file.txt`)
+
+  // act
+  await Editor.openColorPicker()
+
+  // assert
+  const colorPicker = Locator('.ColorPicker')
+  await expect(colorPicker).toBeVisible()
+  await expect(colorPicker).toHaveCSS('outline-style', 'none')
+}

--- a/static/css/parts/ViewletColorPicker.css
+++ b/static/css/parts/ViewletColorPicker.css
@@ -10,6 +10,7 @@
   display: flex;
   flex-direction: column;
   background: var(--MainBackground);
+  outline: none;
   padding: 0 0;
   pointer-events: all;
   position: absolute;


### PR DESCRIPTION
Removes the browser focus outline from the color picker while preserving its keyboard focus behavior. Adds an end-to-end regression assertion for the rendered outline style.