### PR TITLE
Style diagnostics in editor scrollbar

### DIFF
--- a/packages/extension-host-worker-tests/src/typescript.diagnostics-enabled.ts
+++ b/packages/extension-host-worker-tests/src/typescript.diagnostics-enabled.ts
@@ -23,7 +23,8 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Se
   await Settings.update({ 'editor.diagnostics': true })
   await Workspace.setPath(tmpDir)
   await Main.openUri(uri)
-  await expect(Locator('.EditorContainer > .Viewlet.Editor')).toHaveCount(1)
+  const editor = Locator('.EditorContainer > .Viewlet.Editor')
+  await expect(editor).toHaveCount(1)
 
   const expectedDiagnostics = [
     {
@@ -39,4 +40,8 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Se
     },
   ] as const
   await waitFor(() => Editor.shouldHaveDiagnostics(expectedDiagnostics))
+  const scrollBarDiagnostics = editor.locator('.ScrollBarDiagnostic')
+  const errorScrollBarDiagnostics = editor.locator('.ScrollBarDiagnosticError')
+  await waitFor(() => expect(scrollBarDiagnostics).toHaveCount(expectedDiagnostics.length))
+  await expect(errorScrollBarDiagnostics).toHaveCount(expectedDiagnostics.length)
 }

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -134,13 +134,24 @@
   bottom: 0;
   position: absolute;
   width: 14px;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .ScrollBarDiagnostic {
-  height: 5px;
-  background: red;
-  width: 100%;
+  right: 1px;
+  width: 3px;
   position: absolute;
+  border-radius: 1px;
+  contain: strict;
+}
+
+.ScrollBarDiagnosticError {
+  background: var(--EditorErrorForeground, #f14c4c);
+}
+
+.ScrollBarDiagnosticWarning {
+  background: var(--EditorWarningForeground, #cca700);
 }
 
 .EditorInput {


### PR DESCRIPTION
Style editor scrollbar diagnostics as compact, severity-aware overview markers. Extend the TypeScript diagnostics browser test to assert the marker count in a non-scrollable editor.