### PR TITLE
feature: improve main area rpc connection

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts
@@ -1,11 +1,8 @@
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
-import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
-import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as MainAreaWorkerUrl from '../MainAreaWorkerUrl/MainAreaWorkerUrl.js'
-import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchMainAreaWorker = async () => {
   const configuredWorkerUrl = GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.mainAreaWorkerPath', MainAreaWorkerUrl.mainAreaWorkerUrl)
@@ -13,12 +10,8 @@ export const launchMainAreaWorker = async () => {
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
     url: configuredWorkerUrl,
     name: 'Main Area Worker',
+    rpcId: 'MainArea',
   })
   HandleIpc.handleIpc(ipc)
-  const { port1, port2 } = GetPortTuple.getPortTuple()
-  await Promise.all([
-    JsonRpc.invokeAndTransfer(ipc, 'MainArea.handleMessagePort', port1),
-    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'MainArea'),
-  ])
   return ipc
 }

--- a/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
+++ b/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
@@ -34,6 +34,8 @@ jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
 
 const GetPortTuple = await import('../src/parts/GetPortTuple/GetPortTuple.js')
 const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
+const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const IpcParentType = await import('../src/parts/IpcParentType/IpcParentType.js')
 const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
 const LaunchAboutViewWorker = await import('../src/parts/LaunchAboutViewWorker/LaunchAboutViewWorker.js')
 const LaunchActivityBarWorker = await import('../src/parts/LaunchActivityBarWorker/LaunchActivityBarWorker.ts')
@@ -70,7 +72,6 @@ test.each([
   ['extension search', LaunchExtensionSearchViewWorker.launchExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort', 'SearchExtensions'],
   ['keybindings', LaunchKeyBindingsViewWorker.launchKeyBindingsViewWorker, 'KeyBindings.handleMessagePort', 'KeyBindings'],
   ['language models', LaunchLanguageModelsViewWorker.launchLanguageModelsViewWorker, 'LanguageModels.handleMessagePort', 'LanguageModels'],
-  ['main area', LaunchMainAreaWorker.launchMainAreaWorker, 'MainArea.handleMessagePort', 'MainArea'],
   ['output', LaunchOutputViewWorker.launchOutputViewWorker, 'Output.handleMessagePort', 'Output'],
   ['panel', LaunchPanelWorker.launchPanelWorker, 'Panel.handleMessagePort', 'Panel'],
   ['problems', LaunchProblemsWorker.launchProblemsWorker, 'Problems.handleMessagePort', 'Problems'],
@@ -93,6 +94,20 @@ test.each([
   expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
   expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, command, 'worker-port')
   expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', rpcId)
+})
+
+test('main area worker uses its native worker rpc for renderer process events', async () => {
+  await LaunchMainAreaWorker.launchMainAreaWorker()
+
+  expect(IpcParent.create).toHaveBeenCalledWith({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Main Area Worker',
+    rpcId: 'MainArea',
+    url: 'file:///worker.js',
+  })
+  expect(GetPortTuple.getPortTuple).not.toHaveBeenCalled()
+  expect(JsonRpc.invokeAndTransfer).not.toHaveBeenCalled()
+  expect(RendererProcess.invokeAndTransfer).not.toHaveBeenCalled()
 })
 
 test('status bar worker listens for editor status changes over a direct connection', async () => {


### PR DESCRIPTION
## Summary

- connect renderer-process to main-area-worker through the native WebWorker RPC
- initialize the renderer-worker/main-area-worker RPC with the transferred MessagePort
- remove the redundant renderer-process/main-area-worker MessageChannel handshake

## Validation

- renderer-worker unit suite: 1,534 passed
- focused worker-launch suite: 21 passed
- repository type-check
- repository lint