### PR TITLE
fix: forward main area rpc id

### DIFF
--- a/packages/renderer-worker/src/parts/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.js
+++ b/packages/renderer-worker/src/parts/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.js
@@ -6,7 +6,7 @@ import * as IpcTrace from '../IpcTrace/IpcTrace.js'
 
 /** @param {any} options */
 export const create = async (options) => {
-  const { url, name, port, id, traceId = '' } = options
+  const { url, name, port, id, rpcId, traceId = '' } = options
   // TODO no need to create port if worker
   // has been prelaunched in renderer process
   const { port1, port2 } = GetPortTuple.getPortTuple(port)
@@ -23,6 +23,7 @@ export const create = async (options) => {
     raw: true,
     port: workerPort,
     id,
+    ...(rpcId === undefined ? {} : { rpcId }),
   })
   return port1
 }

--- a/packages/renderer-worker/test/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.test.ts
+++ b/packages/renderer-worker/test/IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.test.ts
@@ -57,3 +57,28 @@ test('create', async () => {
     id: 0,
   })
 })
+
+test('create - forwards rpc id', async () => {
+  // @ts-ignore
+  RendererProcess.invokeAndTransfer.mockImplementation(() => {
+    return undefined
+  })
+  const ipc = await IpcParentWithModuleWorkerAndWorkaroundForChromeDevtoolsBug.create({
+    url: 'https://example.com/worker.js',
+    name: 'test worker',
+    port: undefined,
+    id: 0,
+    rpcId: 'MainArea',
+  })
+  expect(ipc).toBeInstanceOf(MessagePort)
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('IpcParent.create', {
+    method: RendererProcessIpcParentType.ModuleWorkerWithMessagePort,
+    name: 'test worker',
+    raw: true,
+    url: 'https://example.com/worker.js',
+    port: new MessagePort(),
+    id: 0,
+    rpcId: 'MainArea',
+  })
+})


### PR DESCRIPTION
## Summary

Forward the optional direct-view RPC identifier through the module-worker workaround so the Main area initializes and registers with the renderer process.

Add a regression test covering the transport boundary that previously dropped the identifier.