### PR TITLE
fix: add spacing to source action items

### DIFF
--- a/static/css/parts/ViewletEditorSourceActions.css
+++ b/static/css/parts/ViewletEditorSourceActions.css
@@ -23,6 +23,7 @@
   padding: 0 10px;
   line-height: 24px;
   display: flex;
+  column-gap: 4px;
 }
 
 .SourceActionItem:where(:hover) {


### PR DESCRIPTION
Adds a small gap between each source action icon and its label while preserving the compact popup design.