### PR TITLE
fix: expose the active text document

### DIFF
--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.ipc.js
@@ -7,6 +7,7 @@ export const Commands = {
   getDiagnostics: GetActiveEditor.getDiagnostics,
   getOpenEditorUris: GetActiveEditor.getOpenEditorUris,
   getSelections: GetActiveEditor.getSelections,
+  getTextDocument: GetActiveEditor.getTextDocument,
   setSelections: GetActiveEditor.setSelections,
   updateAllDiagnostics: GetActiveEditor.updateAllDiagnostics,
   updateDiagnostics: GetActiveEditor.updateDiagnostics,

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -28,6 +28,23 @@ export const getDiagnostics = async () => {
   return getDiagnosticsWithInvoke(EditorWorker.invoke)
 }
 
+export const getTextDocumentWithInvoke = async (invoke) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
+  if (!instance) {
+    return undefined
+  }
+  const { id, uri } = instance.state
+  const text = await invoke('Editor.getText', id)
+  return {
+    text,
+    uri,
+  }
+}
+
+export const getTextDocument = async () => {
+  return getTextDocumentWithInvoke(EditorWorker.invoke)
+}
+
 export const getSelectionsWithInvoke = async (invoke) => {
   const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
   if (!instance) {

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -55,6 +55,32 @@ test('getDiagnostics returns an empty array when there is no active editor', asy
   expect(invoke).not.toHaveBeenCalled()
 })
 
+test('getTextDocument returns the active text document', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.js',
+    },
+  })
+  const invoke = jest.fn(async () => 'debugger')
+
+  await expect(GetActiveEditor.getTextDocumentWithInvoke(invoke)).resolves.toEqual({
+    text: 'debugger',
+    uri: 'file:///test.js',
+  })
+  expect(invoke).toHaveBeenCalledWith('Editor.getText', 42)
+})
+
+test('getTextDocument returns undefined when there is no active editor', async () => {
+  const invoke = jest.fn()
+
+  await expect(GetActiveEditor.getTextDocumentWithInvoke(invoke)).resolves.toBeUndefined()
+  expect(invoke).not.toHaveBeenCalled()
+})
+
 test('getSelections returns selections for the active editor', async () => {
   ViewletStates.set(1, {
     factory: {},


### PR DESCRIPTION
Expose the active editor's URI and current text through the existing GetActiveEditor command bridge. This lets extension commands launched from Quick Pick recover their document context when no argument is supplied.