### PR TITLE
feature: update chat-view-model to version 10.15.0

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -19,7 +19,7 @@
         "@lvce-editor/chat-storage-worker": "^3.13.0",
         "@lvce-editor/chat-tool-worker": "^9.21.0",
         "@lvce-editor/chat-view": "^10.15.0",
-        "@lvce-editor/chat-view-model": "^10.14.0",
+        "@lvce-editor/chat-view-model": "^10.15.0",
         "@lvce-editor/clipboard-worker": "^1.28.2",
         "@lvce-editor/color-picker-worker": "^3.15.0",
         "@lvce-editor/completion-worker": "^4.17.0",

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -51,7 +51,7 @@
     "@lvce-editor/chat-storage-worker": "^3.13.0",
     "@lvce-editor/chat-tool-worker": "^9.21.0",
     "@lvce-editor/chat-view": "^10.15.0",
-    "@lvce-editor/chat-view-model": "^10.14.0",
+    "@lvce-editor/chat-view-model": "^10.15.0",
     "@lvce-editor/clipboard-worker": "^1.28.2",
     "@lvce-editor/color-picker-worker": "^3.15.0",
     "@lvce-editor/completion-worker": "^4.17.0",


### PR DESCRIPTION
## Summary

- update `@lvce-editor/chat-view-model` to 10.15.0
- consume the published drop-session integration used for file-system-handle chat drops
- keep the independently merged Explorer 7.28.0 update from #14147

## Validation

- `npm run type-check` in `packages/renderer-worker`
- `npm test -- --runInBand` in `packages/renderer-worker`
- `git diff --check`