### PR TITLE
fix: restore main area event connection

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchMainAreaWorker/LaunchMainAreaWorker.ts
@@ -1,8 +1,11 @@
 import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as GetPortTuple from '../GetPortTuple/GetPortTuple.js'
 import * as HandleIpc from '../HandleIpc/HandleIpc.js'
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as MainAreaWorkerUrl from '../MainAreaWorkerUrl/MainAreaWorkerUrl.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const launchMainAreaWorker = async () => {
   const configuredWorkerUrl = GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.mainAreaWorkerPath', MainAreaWorkerUrl.mainAreaWorkerUrl)
@@ -10,8 +13,12 @@ export const launchMainAreaWorker = async () => {
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
     url: configuredWorkerUrl,
     name: 'Main Area Worker',
-    rpcId: 'MainArea',
   })
   HandleIpc.handleIpc(ipc)
+  const { port1, port2 } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'MainArea.handleMessagePort', port1),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', port2, 'MainArea'),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
+++ b/packages/renderer-worker/test/LaunchDirectRendererWorkers.test.ts
@@ -96,18 +96,17 @@ test.each([
   expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', rpcId)
 })
 
-test('main area worker uses its native worker rpc for renderer process events', async () => {
+test('main area worker connects directly to the renderer process', async () => {
   await LaunchMainAreaWorker.launchMainAreaWorker()
 
   expect(IpcParent.create).toHaveBeenCalledWith({
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
     name: 'Main Area Worker',
-    rpcId: 'MainArea',
     url: 'file:///worker.js',
   })
-  expect(GetPortTuple.getPortTuple).not.toHaveBeenCalled()
-  expect(JsonRpc.invokeAndTransfer).not.toHaveBeenCalled()
-  expect(RendererProcess.invokeAndTransfer).not.toHaveBeenCalled()
+  expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'MainArea.handleMessagePort', 'worker-port')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'renderer-process-port', 'MainArea')
 })
 
 test('status bar worker listens for editor status changes over a direct connection', async () => {


### PR DESCRIPTION
## Summary

- restore the dedicated renderer-process message-port connection for main-area events
- route `Viewlet.executeViewletCommand` to `MainArea.handleMessagePort` again
- update the launcher regression test to verify both ends of the direct connection

## Testing

- `npm test -- --runInBand test/LaunchDirectRendererWorkers.test.ts` (21 passed)
- `npm test -- --runInBand` (1,537 passed)
- `npm run type-check`
- Prettier and `git diff --check`