### PR TITLE
fix: support avif and jpeg mime types

### DIFF
--- a/packages/shared-process/src/parts/GetMimeType/GetMimeType.ts
+++ b/packages/shared-process/src/parts/GetMimeType/GetMimeType.ts
@@ -2,6 +2,8 @@ import * as MimeType from '../MimeType/MimeType.ts'
 
 export const getMimeType = (fileExtension: any): any => {
   switch (fileExtension) {
+    case '.avif':
+      return MimeType.ImageAvif
     case '.css':
       return MimeType.TextCss
     case '.HEIC':
@@ -9,6 +11,7 @@ export const getMimeType = (fileExtension: any): any => {
       return MimeType.ImageHeic
     case '.html':
       return MimeType.TextHtml
+    case '.jpeg':
     case '.jpg':
       return MimeType.ImageJpg
     case '.js':

--- a/packages/shared-process/test/GetMimeType.test.ts
+++ b/packages/shared-process/test/GetMimeType.test.ts
@@ -21,6 +21,14 @@ test('jpg', () => {
   expect(GetMimeType.getMimeType('.jpg')).toBe('image/jpg')
 })
 
+test('jpeg', () => {
+  expect(GetMimeType.getMimeType('.jpeg')).toBe('image/jpg')
+})
+
+test('avif', () => {
+  expect(GetMimeType.getMimeType('.avif')).toBe('image/avif')
+})
+
 test('heic', () => {
   expect(GetMimeType.getMimeType('.heic')).toBe('image/heic')
 })

--- a/packages/static-server/src/parts/GetMimeType/GetMimeType.ts
+++ b/packages/static-server/src/parts/GetMimeType/GetMimeType.ts
@@ -2,6 +2,8 @@ import * as MimeType from '../MimeType/MimeType.ts'
 
 export const getMimeType = (fileExtension: string): string => {
   switch (fileExtension) {
+    case '.avif':
+      return MimeType.ImageAvif
     case '.html':
       return MimeType.TextHtml
     case '.css':
@@ -16,6 +18,8 @@ export const getMimeType = (fileExtension: string): string => {
       return MimeType.ImageSvgXml
     case '.png':
       return MimeType.ImagePng
+    case '.jpeg':
+      return MimeType.ImageJpg
     case '.json':
     case '.map':
       return MimeType.ApplicationJson

--- a/packages/static-server/test/GetMimeType.test.ts
+++ b/packages/static-server/test/GetMimeType.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import * as GetMimeType from '../src/parts/GetMimeType/GetMimeType.js'
+
+test('jpeg', () => {
+  expect(GetMimeType.getMimeType('.jpeg')).toBe('image/jpg')
+})
+
+test('avif', () => {
+  expect(GetMimeType.getMimeType('.avif')).toBe('image/avif')
+})


### PR DESCRIPTION
Support AVIF and JPEG file extensions in both shared-process and static-server response headers, avoiding unsupported-extension warnings when these image assets are served.