### PR TITLE
feature: expire cache storage entries

### DIFF
--- a/packages/renderer-worker/src/parts/CacheExpiration/CacheExpiration.js
+++ b/packages/renderer-worker/src/parts/CacheExpiration/CacheExpiration.js
@@ -1,0 +1,5 @@
+export const duration = 90 * 24 * 60 * 60 * 1000
+
+export const getExpirationDate = (now = Date.now()) => {
+  return new Date(now + duration).toUTCString()
+}

--- a/packages/renderer-worker/src/parts/CacheExpiration/CacheExpiration.js
+++ b/packages/renderer-worker/src/parts/CacheExpiration/CacheExpiration.js
@@ -1,4 +1,4 @@
-export const duration = 90 * 24 * 60 * 60 * 1000
+const duration = 90 * 24 * 60 * 60 * 1000
 
 export const getExpirationDate = (now = Date.now()) => {
   return new Date(now + duration).toUTCString()

--- a/packages/renderer-worker/src/parts/CacheStorage/CacheStorage.js
+++ b/packages/renderer-worker/src/parts/CacheStorage/CacheStorage.js
@@ -1,3 +1,4 @@
+import * as CacheExpiration from '../CacheExpiration/CacheExpiration.js'
 import * as Character from '../Character/Character.js'
 import * as Logger from '../Logger/Logger.js'
 import * as MimeType from '../MimeType/MimeType.js'
@@ -83,9 +84,41 @@ const setResponse = async (key, value, contentType) => {
       headers: new Headers({
         'Content-Type': contentType,
         'Content-Length': `${value.length}`,
+        Expires: CacheExpiration.getExpirationDate(),
       }),
     }),
   )
+}
+
+const deleteExpiredEntriesFromCacheStorage = async (cacheStorage, now) => {
+  const cacheNames = await cacheStorage.keys()
+  for (const cacheName of cacheNames) {
+    const cache = await cacheStorage.open(cacheName)
+    const requests = await cache.keys()
+    for (const request of requests) {
+      const response = await cache.match(request)
+      const expires = response?.headers.get('Expires')
+      if (expires && Date.parse(expires) <= now) {
+        await cache.delete(request)
+      }
+    }
+  }
+}
+
+export const deleteExpiredEntries = async (now = Date.now()) => {
+  if (typeof caches !== 'undefined') {
+    await deleteExpiredEntriesFromCacheStorage(caches, now)
+  }
+  // @ts-ignore Storage Buckets are not included in all TypeScript DOM library versions.
+  const storageBuckets = typeof navigator === 'undefined' ? undefined : navigator.storageBuckets
+  if (typeof storageBuckets?.keys !== 'function') {
+    return
+  }
+  const bucketNames = await storageBuckets.keys()
+  for (const bucketName of bucketNames) {
+    const bucket = await storageBuckets.open(bucketName)
+    await deleteExpiredEntriesFromCacheStorage(bucket.caches, now)
+  }
 }
 
 export const setText = async (key, value, contentType) => {

--- a/packages/renderer-worker/src/parts/CleanExpiredCacheEntries/CleanExpiredCacheEntries.js
+++ b/packages/renderer-worker/src/parts/CleanExpiredCacheEntries/CleanExpiredCacheEntries.js
@@ -1,0 +1,28 @@
+import * as CacheStorage from '../CacheStorage/CacheStorage.js'
+import * as Logger from '../Logger/Logger.js'
+import * as WebStorage from '../WebStorage/WebStorage.js'
+import * as WebStorageType from '../WebStorageType/WebStorageType.js'
+
+const cleanupInterval = 24 * 60 * 60 * 1000
+const lastCleanupKey = 'cacheStorage.lastCleanup'
+
+export const shouldClean = (lastCleanup, now) => {
+  if (!lastCleanup) {
+    return true
+  }
+  const parsedLastCleanup = Number(lastCleanup)
+  return !Number.isFinite(parsedLastCleanup) || parsedLastCleanup > now || now - parsedLastCleanup >= cleanupInterval
+}
+
+export const cleanExpiredCacheEntries = async (now = Date.now()) => {
+  try {
+    const lastCleanup = await WebStorage.getText(WebStorageType.LocalStorage, lastCleanupKey)
+    if (!shouldClean(lastCleanup, now)) {
+      return
+    }
+    await CacheStorage.deleteExpiredEntries(now)
+    await WebStorage.setText(WebStorageType.LocalStorage, lastCleanupKey, `${now}`)
+  } catch (error) {
+    Logger.warn(`Failed to clean expired cache entries: ${error}`)
+  }
+}

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -2,6 +2,7 @@ import * as Bounds from '../Bounds/Bounds.js'
 import * as ColorTheme from '../ColorTheme/ColorTheme.js'
 import * as Command from '../Command/Command.js'
 import * as CleanAuthCallbackUrl from '../CleanAuthCallbackUrl/CleanAuthCallbackUrl.js'
+import * as CleanExpiredCacheEntries from '../CleanExpiredCacheEntries/CleanExpiredCacheEntries.js'
 import * as CleanUpWorkersAfterLoad from '../CleanUpWorkersAfterLoad/CleanUpWorkersAfterLoad.js'
 import * as DevelopFileWatcher from '../DevelopFileWatcher/DevelopFileWatcher.js'
 import * as ExecuteCurrentTest from '../ExecuteCurrentTest/ExecuteCurrentTest.js'
@@ -246,6 +247,10 @@ export const startup = async (platform, assetDir) => {
   await OnLoadCommands.run(assetDir, platform)
   await CleanUpWorkersAfterLoad.cleanUpWorkersAfterLoad()
 
+  if (!isTestRun) {
+    void CleanExpiredCacheEntries.cleanExpiredCacheEntries()
+  }
+
   LifeCycle.mark(LifeCyclePhase.Fifteen)
 
   if (Workspace.isTest()) {
@@ -266,11 +271,7 @@ export const startup = async (platform, assetDir) => {
   await Location.hydrate()
   Performance.mark(PerformanceMarkerType.DidLoadLocation)
 
-  const watcherPromises = Promise.all([
-    DevelopFileWatcher.hydrate(),
-    WatchFilesForHotReload.watchFilesForHotReload(),
-    WorkspaceFileWatcher.hydrate(),
-  ])
+  const watcherPromises = Promise.all([DevelopFileWatcher.hydrate(), WatchFilesForHotReload.watchFilesForHotReload(), WorkspaceFileWatcher.hydrate()])
 
   Performance.measure(PerformanceMarkerType.OpenWorkspace, PerformanceMarkerType.WillOpenWorkspace, PerformanceMarkerType.DidOpenWorkspace)
   Performance.measure(PerformanceMarkerType.LoadMain, PerformanceMarkerType.WillLoadMain, PerformanceMarkerType.DidLoadMain)

--- a/packages/renderer-worker/test/CacheExpiration.test.ts
+++ b/packages/renderer-worker/test/CacheExpiration.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@jest/globals'
+import * as CacheExpiration from '../src/parts/CacheExpiration/CacheExpiration.js'
+
+test('getExpirationDate returns an HTTP date three months in the future', () => {
+  const now = Date.UTC(2026, 7, 22, 12, 0, 0)
+
+  expect(CacheExpiration.getExpirationDate(now)).toBe('Fri, 20 Nov 2026 12:00:00 GMT')
+})

--- a/packages/renderer-worker/test/CacheStorage.test.ts
+++ b/packages/renderer-worker/test/CacheStorage.test.ts
@@ -14,6 +14,8 @@ afterEach(() => {
   delete globalThis.Response
   // @ts-ignore
   delete globalThis.Headers
+  // @ts-ignore
+  delete globalThis.navigator.storageBuckets
 })
 
 test('getJson', async () => {
@@ -81,15 +83,28 @@ test('setJson', async () => {
   // @ts-ignore
   globalThis.Response = class {
     value: any
+    options: any
+
+    constructor(value, options) {
+      this.value = value
+      this.options = options
+    }
+  }
+  // @ts-ignore
+  globalThis.Headers = class {
+    value: any
 
     constructor(value) {
       this.value = value
     }
   }
-  // @ts-ignore
-  globalThis.Headers = class {}
   await CacheStorage.setJson('sample-key-5', {})
-  expect(put).toHaveBeenCalledWith('sample-key-5', { value: '{}' })
+  const response = put.mock.calls[0][1] as {
+    readonly options: { readonly headers: { readonly value: { readonly Expires: string } } }
+    readonly value: string
+  }
+  expect(response.value).toBe('{}')
+  expect(Date.parse(response.options.headers.value.Expires)).toBeGreaterThan(Date.now())
 })
 
 test('setJson - error', async () => {
@@ -176,6 +191,87 @@ test('getText - caches are not available', async () => {
   // @ts-ignore
   delete globalThis.caches
   expect(await CacheStorage.getTextFromCache('sample-key-4')).toBeUndefined()
+})
+
+test('deleteExpiredEntries deletes entries whose Expires header has elapsed', async () => {
+  const expiredRequest = { url: 'https://example.com/expired' }
+  const freshRequest = { url: 'https://example.com/fresh' }
+  const persistentRequest = { url: 'https://example.com/persistent' }
+  const invalidRequest = { url: 'https://example.com/invalid' }
+  const deleteEntry = jest.fn()
+  const responses = new Map([
+    [expiredRequest, { headers: { get: () => 'Sat, 22 Aug 2026 11:59:59 GMT' } }],
+    [freshRequest, { headers: { get: () => 'Sat, 22 Aug 2026 12:00:01 GMT' } }],
+    [persistentRequest, { headers: { get: () => null } }],
+    [invalidRequest, { headers: { get: () => 'invalid' } }],
+  ])
+  const cache = {
+    delete: deleteEntry,
+    keys: () => [...responses.keys()],
+    match: (request) => responses.get(request),
+  }
+  globalThis.caches = {
+    // @ts-ignore
+    keys: () => ['cache-1'],
+    // @ts-ignore
+    open: () => cache,
+  }
+
+  await CacheStorage.deleteExpiredEntries(Date.UTC(2026, 7, 22, 12, 0, 0))
+
+  expect(deleteEntry).toHaveBeenCalledTimes(1)
+  expect(deleteEntry).toHaveBeenCalledWith(expiredRequest)
+})
+
+test('deleteExpiredEntries checks every cache', async () => {
+  const open = jest.fn((_cacheName: string) => ({
+    keys: () => [],
+  }))
+  globalThis.caches = {
+    // @ts-ignore
+    keys: () => ['cache-1', 'cache-2'],
+    // @ts-ignore
+    open,
+  }
+
+  await CacheStorage.deleteExpiredEntries()
+
+  expect(open).toHaveBeenCalledTimes(2)
+  expect(open).toHaveBeenNthCalledWith(1, 'cache-1')
+  expect(open).toHaveBeenNthCalledWith(2, 'cache-2')
+})
+
+test('deleteExpiredEntries cleans storage bucket caches', async () => {
+  const request = { url: 'https://example.com/expired' }
+  const deleteEntry = jest.fn()
+  const cacheStorage = {
+    keys: () => ['cache-1'],
+    open: () => ({
+      delete: deleteEntry,
+      keys: () => [request],
+      match: () => ({ headers: { get: () => 'Sat, 22 Aug 2026 11:59:59 GMT' } }),
+    }),
+  }
+  const openBucket = jest.fn((_bucketName: string) => ({ caches: cacheStorage }))
+  Object.defineProperty(globalThis.navigator, 'storageBuckets', {
+    configurable: true,
+    value: {
+      keys: () => ['bucket-1'],
+      open: openBucket,
+    },
+  })
+
+  await CacheStorage.deleteExpiredEntries(Date.UTC(2026, 7, 22, 12, 0, 0))
+
+  expect(openBucket).toHaveBeenCalledWith('bucket-1')
+  expect(deleteEntry).toHaveBeenCalledWith(request)
+})
+
+test('deleteExpiredEntries does nothing when cache storage is not available', async () => {
+  // @ts-ignore
+  delete globalThis.caches
+
+  await CacheStorage.deleteExpiredEntries()
 })
 
 test('clearCache', async () => {

--- a/packages/renderer-worker/test/CleanExpiredCacheEntries.test.ts
+++ b/packages/renderer-worker/test/CleanExpiredCacheEntries.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Cache cleanup tests use ESM module mocks for storage dependencies. */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const deleteExpiredEntries = jest.fn<(now: number) => Promise<void>>()
+const getText = jest.fn<() => Promise<string>>()
+const loggerWarn = jest.fn()
+const setText = jest.fn<(_storageType: number, _key: string, _value: string) => Promise<void>>()
+
+jest.unstable_mockModule('../src/parts/CacheStorage/CacheStorage.js', () => ({
+  deleteExpiredEntries,
+}))
+
+jest.unstable_mockModule('../src/parts/Logger/Logger.js', () => ({
+  warn: loggerWarn,
+}))
+
+jest.unstable_mockModule('../src/parts/WebStorage/WebStorage.js', () => ({
+  getText,
+  setText,
+}))
+
+const CleanExpiredCacheEntries = await import('../src/parts/CleanExpiredCacheEntries/CleanExpiredCacheEntries.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  getText.mockResolvedValue('')
+})
+
+test('shouldClean returns true when the cache has never been cleaned', () => {
+  expect(CleanExpiredCacheEntries.shouldClean('', 100_000)).toBe(true)
+})
+
+test('shouldClean returns false when the cache was cleaned less than one day ago', () => {
+  expect(CleanExpiredCacheEntries.shouldClean('100000', 100_000 + 24 * 60 * 60 * 1000 - 1)).toBe(false)
+})
+
+test('shouldClean returns true when the cache was cleaned one day ago', () => {
+  expect(CleanExpiredCacheEntries.shouldClean('100000', 100_000 + 24 * 60 * 60 * 1000)).toBe(true)
+})
+
+test('shouldClean returns true when the stored timestamp is in the future', () => {
+  expect(CleanExpiredCacheEntries.shouldClean('200000', 100_000)).toBe(true)
+})
+
+test('cleans expired entries and stores the successful cleanup time', async () => {
+  await CleanExpiredCacheEntries.cleanExpiredCacheEntries(100_000)
+
+  expect(deleteExpiredEntries).toHaveBeenCalledWith(100_000)
+  expect(setText).toHaveBeenCalledWith(1, 'cacheStorage.lastCleanup', '100000')
+})
+
+test('skips cleanup when it ran less than one day ago', async () => {
+  getText.mockResolvedValue('90000')
+
+  await CleanExpiredCacheEntries.cleanExpiredCacheEntries(100_000)
+
+  expect(deleteExpiredEntries).not.toHaveBeenCalled()
+  expect(setText).not.toHaveBeenCalled()
+})
+
+test('does not store the cleanup time when cleanup fails', async () => {
+  deleteExpiredEntries.mockRejectedValueOnce(new Error('cache unavailable'))
+
+  await CleanExpiredCacheEntries.cleanExpiredCacheEntries(100_000)
+
+  expect(setText).not.toHaveBeenCalled()
+  expect(loggerWarn).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Summary\n\n- add three-month expiration metadata to renderer cache writes\n- remove expired entries from default and bucket Cache Storage once per day after workbench startup\n- skip cleanup during test workbench runs and preserve entries without an expiration header