### PR TITLE
fix: protect dirty editors when closing workspace

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -1,5 +1,6 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as Character from '../Character/Character.js'
+import * as Command from '../Command/Command.js'
 import * as FileSystem from '../FileSystem/FileSystem.js'
 import * as GetResolvedRoot from '../GetResolvedRoot/GetResolvedRoot.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
@@ -79,8 +80,13 @@ export const getUri = () => {
   return state.workspaceUri
 }
 
-export const close = () => {
-  return setPath('')
+export const close = async () => {
+  await Command.execute('Main.closeAllEditorsAndSave')
+  const hasDirtyTabs = await Command.execute('Main.hasDirtyTabs')
+  if (hasDirtyTabs) {
+    return
+  }
+  await setPath('')
 }
 
 export { isTest } from '../IsTest/IsTest.js'

--- a/packages/renderer-worker/test/Workspace.test.ts
+++ b/packages/renderer-worker/test/Workspace.test.ts
@@ -164,3 +164,35 @@ test.skip('pathBaseName - windows', () => {
   Workspace.state.pathSeparator = '\\'
   expect(Workspace.pathBaseName('\\test\\file.txt')).toBe('file.txt')
 })
+
+test('close closes editors before clearing the workspace', async () => {
+  const closeAllEditors = jest.fn(async () => undefined)
+  const hasDirtyTabs = jest.fn(async () => false)
+  Command.register('Main.closeAllEditorsAndSave', closeAllEditors)
+  Command.register('Main.hasDirtyTabs', hasDirtyTabs)
+  jest.mocked(RendererProcess.invoke).mockResolvedValue(undefined)
+  Workspace.state.workspacePath = '/test'
+
+  await Workspace.close()
+
+  expect(closeAllEditors).toHaveBeenCalledTimes(1)
+  expect(hasDirtyTabs).toHaveBeenCalledTimes(1)
+  expect(Workspace.state.workspacePath).toBe('')
+})
+
+test('close keeps the workspace open when closing a dirty editor is canceled', async () => {
+  const closeAllEditors = jest.fn(async () => undefined)
+  const hasDirtyTabs = jest.fn(async () => true)
+  Command.register('Main.closeAllEditorsAndSave', closeAllEditors)
+  Command.register('Main.hasDirtyTabs', hasDirtyTabs)
+  Workspace.state.workspacePath = '/test'
+  Workspace.state.workspaceUri = 'file:///test'
+
+  await Workspace.close()
+
+  expect(closeAllEditors).toHaveBeenCalledTimes(1)
+  expect(hasDirtyTabs).toHaveBeenCalledTimes(1)
+  expect(Workspace.state.workspacePath).toBe('/test')
+  expect(Workspace.state.workspaceUri).toBe('file:///test')
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Closing a workspace now asks the main area to close editors through the save/discard/cancel flow before clearing the workspace path.

If a dirty-editor prompt is canceled, the workspace remains open. Regression tests cover both the successful and canceled paths.