### PR TITLE
fix: clear editor status when closing workspace

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -11,6 +11,7 @@ import * as Notification from '../Notification/Notification.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
+import * as StatusBarWorker from '../StatusBarWorker/StatusBarWorker.js'
 import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
 import * as WindowTitle from '../WindowTitle/WindowTitle.js'
 import * as WorkspaceBackend from '../WorkspaceBackend/WorkspaceBackend.js'
@@ -87,6 +88,7 @@ export const close = async () => {
     return
   }
   await setPath('')
+  await StatusBarWorker.invoke('StatusBar.handleEditorStatusChanged', undefined)
 }
 
 export { isTest } from '../IsTest/IsTest.js'

--- a/packages/renderer-worker/test/Workspace.test.ts
+++ b/packages/renderer-worker/test/Workspace.test.ts
@@ -34,8 +34,13 @@ jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/StatusBarWorker/StatusBarWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+const StatusBarWorker = await import('../src/parts/StatusBarWorker/StatusBarWorker.js')
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 const Command = await import('../src/parts/Command/Command.js')
 
@@ -177,6 +182,8 @@ test('close closes editors before clearing the workspace', async () => {
 
   expect(closeAllEditors).toHaveBeenCalledTimes(1)
   expect(hasDirtyTabs).toHaveBeenCalledTimes(1)
+  expect(StatusBarWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(StatusBarWorker.invoke).toHaveBeenCalledWith('StatusBar.handleEditorStatusChanged', undefined)
   expect(Workspace.state.workspacePath).toBe('')
 })
 
@@ -194,5 +201,6 @@ test('close keeps the workspace open when closing a dirty editor is canceled', a
   expect(hasDirtyTabs).toHaveBeenCalledTimes(1)
   expect(Workspace.state.workspacePath).toBe('/test')
   expect(Workspace.state.workspaceUri).toBe('file:///test')
+  expect(StatusBarWorker.invoke).not.toHaveBeenCalled()
   expect(RendererProcess.invoke).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
## Summary
- clear editor-specific status items after Workspace Close completes
- keep status untouched when a dirty-editor close is canceled
- cover both successful and canceled paths in Workspace tests

## Test
- `npm test -- --runInBand Workspace.test.ts` in `packages/renderer-worker` (6 passed, 3 skipped)
- `npm run type-check` in `packages/renderer-worker`
- `npm run lint` in `packages/renderer-worker`
- root `npm run type-check`