### PR TITLE
fix: preserve canceled workspace close

### DIFF
--- a/packages/renderer-worker/src/parts/WorkerViewletAdapterMain/WorkerViewletAdapterMain.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapterMain/WorkerViewletAdapterMain.js
@@ -47,6 +47,17 @@ export const extendModule = (workerViewlet) => ({
   saveWithoutFormatting,
 })
 
-export const wrapCommand = (command) => {
+const wrapReturnValueCommand = (command, worker) => {
+  const fn = (state, ...args) => {
+    return worker.invoke(`MainArea.${command}`, state.uid, ...args)
+  }
+  fn.returnValue = true
+  return fn
+}
+
+export const wrapCommand = (command, _defaultWrapCommand, { worker }) => {
+  if (command === 'hasDirtyTabs') {
+    return wrapReturnValueCommand(command, worker)
+  }
   return wrapMainAreaCommand(command)
 }

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -193,6 +193,30 @@ test('returns preview runtime diagnostics without treating them as viewlet state
   expect(invoke).toHaveBeenCalledWith('Preview.getRuntimeDiagnostics', 12)
 })
 
+test('returns the main-area dirty-tab status without treating it as viewlet state', async () => {
+  const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
+    if (method === 'MainArea.getCommandIds') {
+      return ['hasDirtyTabs']
+    }
+    if (method === 'MainArea.hasDirtyTabs') {
+      return true
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('mainArea'),
+    config: getWorkerViewletConfig('mainArea'),
+    context: { assetDir: '/test', platform: 1 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(13, '', 0, 0, 640, 480)
+
+  expect(commands.hasDirtyTabs.returnValue).toBe(true)
+  await expect(commands.hasDirtyTabs(state)).resolves.toBe(true)
+  expect(invoke).toHaveBeenCalledWith('MainArea.hasDirtyTabs', 13)
+})
+
 test('forwards preview bounds changes to the preview worker', async () => {
   const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
     if (method === 'Preview.diff2' || method === 'Preview.render2') {


### PR DESCRIPTION
## Summary
- preserve the boolean result of the main-area dirty-tab getter across the renderer viewlet adapter
- allow Workspace Close to observe a canceled dirty-editor close and keep the workspace open
- add a regression for the return-value command contract

## Validation
- focused renderer tests: 24 passed, 3 skipped
- renderer type-check and lint
- locally built Debian package
- real Electron UI: Cancel keeps the dirty workspace and unchanged disk file; Don't Save closes with unchanged disk; Save closes with changed disk; editor status clears after successful close