### PR TITLE
Prefer Promise.withResolvers in CLI

### DIFF
--- a/packages/build/src/parts/Template/template_linux_cli_js.txt
+++ b/packages/build/src/parts/Template/template_linux_cli_js.txt
@@ -46,10 +46,10 @@ const launchElectron = async (args) => {
   })
 
   if (!foreground) {
-    await new Promise((resolve, reject) => {
-      child.once('error', reject)
-      child.once('spawn', resolve)
-    })
+    const { promise, resolve, reject } = Promise.withResolvers()
+    child.once('error', reject)
+    child.once('spawn', resolve)
+    await promise
     child.unref()
     return 0
   }
@@ -60,10 +60,10 @@ const launchElectron = async (args) => {
     forwardElectronStderr(child.stderr)
   }
 
-  return new Promise((resolve, reject) => {
-    child.once('error', reject)
-    child.once('exit', (code) => resolve(code ?? 1))
-  })
+  const { promise, resolve, reject } = Promise.withResolvers()
+  child.once('error', reject)
+  child.once('exit', (code) => resolve(code ?? 1))
+  return promise
 }
 
 const main = async () => {

--- a/packages/build/test/LinuxCliTemplate.test.ts
+++ b/packages/build/test/LinuxCliTemplate.test.ts
@@ -75,6 +75,13 @@ describe('linux cli templates', () => {
     expect(cli).toContain("stdio: foreground ? ['inherit', 'inherit', 'pipe'] : 'ignore'")
   })
 
+  test('uses promise resolvers for child process events', async () => {
+    const cli = await readTemplate('linux_cli_js')
+
+    expect(cli).toContain('Promise.withResolvers()')
+    expect(cli).not.toContain('new Promise')
+  })
+
   test('only filters structured Electron diagnostics for non-verbose cli commands', async () => {
     const cli = await readTemplate('linux_cli_js')
 


### PR DESCRIPTION
Simplify CLI child-process event handling by using Promise.withResolvers() for spawn and exit promises.