### PR TITLE
feature: update main-process to version 6.29.1

### DIFF
--- a/packages/main-process/package-lock.json
+++ b/packages/main-process/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/main-process": "^6.29.0"
+        "@lvce-editor/main-process": "^6.29.1"
       },
       "devDependencies": {
         "@jest/globals": "^30.4.1",
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@lvce-editor/main-process": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/main-process/-/main-process-6.29.0.tgz",
-      "integrity": "sha512-uMwgE7s9iVEsT4k9nGWoTjAvxHAma1TYDcPPE47Escjms3tnL7XeWwHbAR2JHcfdw0HEasfZjRrd3D179JSr9A==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/main-process/-/main-process-6.29.1.tgz",
+      "integrity": "sha512-UdLNmAsrGiK3nB+RSfDOrhiyWsmDWkTt4QViy+NPdZgecvQxKJYthPR9mv5Ll72nOGgDkt0VY0FggXosVYWchg==",
       "license": "MIT",
       "dependencies": {
         "electron": "43.4.1"

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -27,7 +27,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@lvce-editor/main-process": "^6.29.0"
+    "@lvce-editor/main-process": "^6.29.1"
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",


### PR DESCRIPTION
Summary:
- update main-process from 6.29.0 to 6.29.1
- bound Electron renderer close preparation so a stalled state save cannot keep the app open

Validation:
- main-process package tests and type-check
- LVCE static build
- native Electron close-button acceptance using the published npm package

Dependency fix: https://github.com/lvce-editor/main-process/pull/369