### PR TITLE
feature: update gpt-voice to version v2.4.0

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -26,7 +26,7 @@
   {
     "name": "builtin.gpt-voice",
     "repository": "github.com/lvce-editor/gpt-voice-extension",
-    "version": "2.2.3",
+    "version": "2.4.0",
     "created": "2026-08-06",
     "enabled": false
   },


### PR DESCRIPTION
Update the disabled-by-default GPT Voice built-in to the self-hosting Node process release. The producer release succeeded, but disabled built-ins are not covered by the automated dependency update.