### PR TITLE
fix: improve status bar icon spacing

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.status-bar-icon-spacing.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.status-bar-icon-spacing.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.status-bar-icon-spacing'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  await Command.execute('StatusBar.itemRightCreate', {
+    ariaLabel: 'Synchronize Changes',
+    elements: [
+      { type: 'icon', value: 'MaskIconSync' },
+      { type: 'text', value: '2↓ 0↑' },
+    ],
+    name: 'git.sync.spacing',
+    tooltip: 'Synchronize Changes',
+  })
+
+  const icon = Locator('.StatusBarItem[name="git.sync.spacing"] .StatusBarIcon')
+  await expect(icon).toHaveCSS('width', '16px')
+  await expect(icon).toHaveCSS('height', '16px')
+}

--- a/static/css/parts/ViewletStatusBar.css
+++ b/static/css/parts/ViewletStatusBar.css
@@ -78,8 +78,8 @@
 }
 
 .StatusBarIcon {
-  width: 30px;
-  height: 19px;
+  width: 16px;
+  height: 16px;
   contain: strict;
 }
 


### PR DESCRIPTION
Use compact 16px status bar icons to bring branch and sync item spacing in line with VS Code, with focused UI coverage.