### PR TITLE
fix: remove duplicate watermark styles

### DIFF
--- a/static/css/parts/ViewletMainWaterMark.css
+++ b/static/css/parts/ViewletMainWaterMark.css
@@ -19,10 +19,8 @@
   mask-image: url(/icons/icon.svg);
   contain: strict;
   mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
   mask-size: 200px;
   mask-position: 50% 50%;
   pointer-events: none;
-  contain: strict;
   flex-shrink: 0;
 }


### PR DESCRIPTION
Remove duplicate containment and mask-repeat declarations from the editor watermark CSS while preserving the computed styling.