### PR TITLE
fix: remove helper release publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,8 +354,6 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish --access public
-        working-directory: ./packages/build/.tmp/server/extension-host-helper-process
-      - run: npm publish --access public
         working-directory: ./packages/build/.tmp/server/static-server
       - run: npm publish --access public
         working-directory: ./packages/build/.tmp/server/shared-process

--- a/packages/build/test/ReleaseWorkflow.test.ts
+++ b/packages/build/test/ReleaseWorkflow.test.ts
@@ -1,0 +1,9 @@
+import { readFile } from 'node:fs/promises'
+import { expect, test } from '@jest/globals'
+
+test('release workflow does not publish the retired extension host helper process', async () => {
+  const releaseWorkflowUrl = new URL('../../../.github/workflows/release.yml', import.meta.url)
+  const releaseWorkflow = await readFile(releaseWorkflowUrl, 'utf8')
+
+  expect(releaseWorkflow).not.toContain('extension-host-helper-process')
+})


### PR DESCRIPTION
## Summary

- stop the release workflow from publishing the retired extension host helper process
- add a regression test that keeps the removed helper out of the release workflow

## Validation

- `packages/build`: focused `ReleaseWorkflow.test.ts` passes
- `packages/build`: `npm run type-check`
- `packages/build`: `npm run lint`
- `git diff --check`

The v0.108.0 artifact builders succeeded, but its final publish job failed because this stale working directory no longer exists.