### PR TITLE
feature: update gpt-voice to version v2.4.1

### DIFF
--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -26,7 +26,7 @@
   {
     "name": "builtin.gpt-voice",
     "repository": "github.com/lvce-editor/gpt-voice-extension",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "created": "2026-08-06",
     "enabled": false
   },


### PR DESCRIPTION
## Summary

- update the hidden built-in GPT Voice extension to v2.4.1
- include the RPC 6.19.2 remote WebSocket cleanup in future LVCE packages

## Validation

- built-in extension manifest parses as valid JSON
- GPT Voice v2.4.1 release CI passed
- packaged terminal-process test passed before release