### PR TITLE
fix: avoid renderer platform temporal dead zone

### DIFF
--- a/packages/build/src/parts/BundleRendererProcess/BundleRendererProcess.ts
+++ b/packages/build/src/parts/BundleRendererProcess/BundleRendererProcess.ts
@@ -5,6 +5,7 @@ import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Replace from '../Replace/Replace.ts'
 
 const workersJsonPath = 'packages/renderer-worker/src/parts/Workers/Workers.json'
+const electronPlatformCode = '2'
 
 const getWorkerPathReplacements = async () => {
   const workers = await JsonFile.readJson(workersJsonPath)
@@ -37,7 +38,7 @@ const replaceWorkerPaths = async (path) => {
 const getPlatformCode = (platform) => {
   switch (platform) {
     case 'electron':
-      return `Electron`
+      return electronPlatformCode
     case 'remote':
       return `Remote`
     case 'web':

--- a/packages/build/test/BundleRendererProcess.test.ts
+++ b/packages/build/test/BundleRendererProcess.test.ts
@@ -1,0 +1,24 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { bundleRendererProcess } from '../src/parts/BundleRendererProcess/BundleRendererProcess.ts'
+
+test('inlines the electron platform without introducing a temporal-dead-zone reference', async () => {
+  const cachePath = await mkdtemp(join(tmpdir(), 'lvce-renderer-process-bundle-'))
+  try {
+    await bundleRendererProcess({
+      assetDir: '/test-asset-dir',
+      cachePath,
+      commitHash: 'test-commit',
+      platform: 'electron',
+    })
+
+    const bundle = await readFile(join(cachePath, 'dist', 'rendererProcessMain.js'), 'utf8')
+
+    const platformDeclaration = bundle.match(/const platform = [^;]+;/)?.[0]
+    expect(platformDeclaration).toBe('const platform = 2;')
+  } finally {
+    await rm(cachePath, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
Fix Electron startup after renderer-process 30.41.0/30.41.1 by preventing the build rewrite from injecting a symbolic Electron identifier that resolves to a later RPC transport constant.

The regression test copies and transforms the actual renderer-process artifact, then asserts that the generated platform declaration uses the stable numeric Electron platform value.

Tests:
- packages/build: 28 suites, 92 tests
- packages/build type-check
- repository lint
- electron Debian x64 build
- deterministic installed-Electron startup repro: PASS