### PR TITLE
fix: update shared process shutdown dependencies

### DIFF
--- a/packages/shared-process/package-lock.json
+++ b/packages/shared-process/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/ipc": "^16.12.0",
+        "@lvce-editor/ipc": "^16.12.1",
         "@lvce-editor/json-rpc": "^8.7.0",
         "@lvce-editor/jsonc-parser": "^1.5.0",
         "@lvce-editor/pretty-error": "^2.0.0",
@@ -37,7 +37,7 @@
         "@lvce-editor/file-system-process": "^5.15.1",
         "@lvce-editor/file-watcher-process": "^4.13.0",
         "@lvce-editor/network-process": "^5.2.0",
-        "@lvce-editor/preload": "^1.5.0",
+        "@lvce-editor/preload": "^1.5.1",
         "@lvce-editor/preview-process": "^11.0.0",
         "@lvce-editor/process-explorer": "^3.19.0",
         "@lvce-editor/pty-host": "^8.8.0",

--- a/packages/shared-process/package.json
+++ b/packages/shared-process/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@lvce-editor/assert": "^1.9.0",
-    "@lvce-editor/ipc": "^16.12.0",
+    "@lvce-editor/ipc": "^16.12.1",
     "@lvce-editor/json-rpc": "^8.7.0",
     "@lvce-editor/jsonc-parser": "^1.5.0",
     "@lvce-editor/pretty-error": "^2.0.0",
@@ -39,7 +39,7 @@
     "@lvce-editor/file-system-process": "^5.15.1",
     "@lvce-editor/file-watcher-process": "^4.13.0",
     "@lvce-editor/network-process": "^5.2.0",
-    "@lvce-editor/preload": "^1.5.0",
+    "@lvce-editor/preload": "^1.5.1",
     "@lvce-editor/preview-process": "^11.0.0",
     "@lvce-editor/process-explorer": "^3.19.0",
     "@lvce-editor/pty-host": "^8.8.0",


### PR DESCRIPTION
## Summary

- require the fixed IPC package in the shared-process manifest
- require the persistent Electron preload bridge in the shared-process manifest
- keep the package lock root requirements aligned with the resolved fixed versions

## Context

The v0.108.9 lockfile resolved IPC 16.12.1 and preload 1.5.1, but the unchanged manifest ranges allowed the legacy Lerna bootstrap to retain restored 16.12.0/1.5.0 package directories. The resulting Debian artifact therefore still contained the one-shot preload bridge and timed out during normal window close. Explicit manifest requirements make dependency installation and packaged bytes deterministic.

## Verification

- `npm ci --ignore-scripts` in `packages/shared-process`
- installed IPC version: 16.12.1
- installed preload version: 1.5.1
- shared-process tests: 387 passed, 33 skipped
- shared-process type check passed