### PR TITLE
Preserve remote workspace URIs in new windows

### DIFF
--- a/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
+++ b/packages/shared-process/src/parts/ResolveRoot/ResolveRoot.ts
@@ -30,29 +30,47 @@ const toUri = (path: any): any => {
   return pathToFileURL(path).toString()
 }
 
-const getWindowWorkspacePath = (href: string): string => {
+interface WindowWorkspace {
+  readonly path: string
+  readonly pathSeparator: string
+  readonly uri: string
+}
+
+const getWindowWorkspace = (href: string): WindowWorkspace | undefined => {
   if (!href) {
-    return ''
+    return undefined
   }
   const workspaceUri = new URL(href).searchParams.get('workspace')
   if (!workspaceUri) {
-    return ''
+    return undefined
   }
-  return fileURLToPath(workspaceUri)
+  const url = new URL(workspaceUri)
+  if (url.protocol === 'file:') {
+    return {
+      path: fileURLToPath(url),
+      pathSeparator: Platform.getPathSeparator(),
+      uri: url.href,
+    }
+  }
+  return {
+    path: url.href,
+    pathSeparator: '/',
+    uri: url.href,
+  }
 }
 
 export const resolveRoot = async (href = ''): Promise<any> => {
   if (IsElectron.isElectron) {
-    const windowWorkspacePath = getWindowWorkspacePath(href)
-    if (windowWorkspacePath) {
+    const windowWorkspace = getWindowWorkspace(href)
+    if (windowWorkspace) {
       return {
         homeDir: PlatformPaths.getHomeDir(),
         homeDirUri: toUri(PlatformPaths.getHomeDir()),
-        path: windowWorkspacePath,
-        pathSeparator: Platform.getPathSeparator(),
+        path: windowWorkspace.path,
+        pathSeparator: windowWorkspace.pathSeparator,
         source: WorkspaceSource.SharedProcessCliArg,
-        uri: toUri(windowWorkspacePath),
-        workspaceId: GetWorkspaceId.getWorkspaceId(windowWorkspacePath),
+        uri: windowWorkspace.uri,
+        workspaceId: GetWorkspaceId.getWorkspaceId(windowWorkspace.uri),
       }
     }
     const argv = await ParentIpc.invoke('Process.getArgv')

--- a/packages/shared-process/test/ResolveRoot.test.ts
+++ b/packages/shared-process/test/ResolveRoot.test.ts
@@ -63,6 +63,22 @@ test('resolveRoot - resolves the workspace for a second window', async () => {
   expect(MainProcess.invoke).not.toHaveBeenCalled()
 })
 
+test('resolveRoot - preserves a remote workspace uri for a second window', async () => {
+  const workspaceUri = 'remote-ssh://user@example.com:2222/home'
+  const url = new URL('lvce-oss://-/')
+  url.searchParams.set('workspace', workspaceUri)
+
+  const resolvedRoot = await ResolveRoot.resolveRoot(url.toString())
+
+  expect(resolvedRoot).toMatchObject({
+    path: workspaceUri,
+    pathSeparator: '/',
+    source: 'shared-process-cli-arg',
+    uri: workspaceUri,
+  })
+  expect(MainProcess.invoke).not.toHaveBeenCalled()
+})
+
 test('resolveRoot - uses cwd in prompt mode', async () => {
   // @ts-ignore
   MainProcess.invoke.mockResolvedValue(['/usr/lib/lvce-oss/lvce-oss', '--prompt', 'Fix the tests'])


### PR DESCRIPTION
Preserve non-file workspace URIs during shared-process window resolution so new Remote SSH windows restore the requested remote workspace.