### PR TITLE
Support the workbench icon theme setting

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.explorer-icon-theme-disabled.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.explorer-icon-theme-disabled.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-icon-theme-disabled'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Settings, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.js`, '')
+  await Workspace.setPath(tmpDir)
+
+  const fileIcon = Locator('.TreeItem[aria-label="file.js"] .FileIcon')
+  await expect(fileIcon).toBeVisible()
+
+  await Settings.update({
+    'workbench.iconTheme': null,
+  })
+  await expect(fileIcon).toHaveCount(0)
+
+  await Settings.update({
+    'workbench.iconTheme': 'vscode-icons',
+  })
+  await expect(fileIcon).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/IconTheme/IconTheme.js
+++ b/packages/renderer-worker/src/parts/IconTheme/IconTheme.js
@@ -1,11 +1,25 @@
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as GetIconThemeEtag from '../GetIconThemeEtag/GetIconThemeEtag.js'
+import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as HandleIconThemeChange from '../HandleIconThemeChange/HandleIconThemeChange.js'
 import * as IconThemeWorker from '../IconThemeWorker/IconThemeWorker.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import { VError } from '../VError/VError.js'
 import * as Workspace from '../Workspace/Workspace.js'
+
+const FALLBACK_ICON_THEME_ID = 'vscode-icons'
+
+const state = {
+  assetDir: '',
+  iconThemeId: undefined,
+  platform: PlatformType.Web,
+}
+
+const getPreferredIconThemeId = () => {
+  const configuredIconThemeId = Preferences.get('workbench.iconTheme')
+  return configuredIconThemeId === undefined ? FALLBACK_ICON_THEME_ID : configuredIconThemeId
+}
 
 export const getIconThemePlatform = (platform, assetDir) => {
   if (platform === PlatformType.Electron && !assetDir) {
@@ -17,7 +31,7 @@ export const getIconThemePlatform = (platform, assetDir) => {
 export const setIconTheme = async (iconThemeId, platform, assetDir) => {
   try {
     const useCache = Preferences.get('icon-theme.cache') ?? true
-    const extensions = await ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, platform)
+    const extensions = iconThemeId === null ? [] : await ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, platform)
     const iconThemePlatform = getIconThemePlatform(platform, assetDir)
     const etag = GetIconThemeEtag.getIconThemeEtag(iconThemeId)
     await IconThemeWorker.invoke('IconTheme.getIconThemeJson', extensions, iconThemeId, assetDir, iconThemePlatform, useCache, etag)
@@ -31,9 +45,23 @@ export const setIconTheme = async (iconThemeId, platform, assetDir) => {
   }
 }
 
+export const handlePreferencesChanged = async () => {
+  const iconThemeId = getPreferredIconThemeId()
+  const { assetDir, iconThemeId: currentIconThemeId, platform } = state
+  if (iconThemeId === currentIconThemeId) {
+    return
+  }
+  state.iconThemeId = iconThemeId
+  await setIconTheme(iconThemeId, platform, assetDir)
+}
+
 export const hydrate = async (platform, assetDir) => {
   // TODO do this all in worker
-  const iconThemeId = Preferences.get('workbench.iconTheme') || 'vscode-icons'
+  state.platform = platform
+  state.assetDir = assetDir
+  GlobalEventBus.addListener('preferences.changed', handlePreferencesChanged)
+  const iconThemeId = getPreferredIconThemeId()
+  state.iconThemeId = iconThemeId
   await setIconTheme(iconThemeId, platform, assetDir)
 }
 

--- a/packages/renderer-worker/test/IconTheme.test.ts
+++ b/packages/renderer-worker/test/IconTheme.test.ts
@@ -24,12 +24,15 @@ jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
 
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const GetIconThemeEtag = await import('../src/parts/GetIconThemeEtag/GetIconThemeEtag.js')
+const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+const HandleIconThemeChange = await import('../src/parts/HandleIconThemeChange/HandleIconThemeChange.js')
 const IconTheme = await import('../src/parts/IconTheme/IconTheme.js')
 const IconThemeWorker = await import('../src/parts/IconThemeWorker/IconThemeWorker.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
+  GlobalEventBus.state.listenerMap = Object.create(null)
   ExtensionManagementWorker.invoke.mockResolvedValue([])
   GetIconThemeEtag.getIconThemeEtag.mockReturnValue('')
 })
@@ -43,7 +46,15 @@ test('setIconTheme uses remote icon paths in the Electron development server', a
 test('setIconTheme keeps optimized icon paths in a packaged Electron app', async () => {
   await IconTheme.setIconTheme('vscode-icons', PlatformType.Electron, '/static/commit')
 
-  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '/static/commit', PlatformType.Electron, true, '')
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith(
+    'IconTheme.getIconThemeJson',
+    [],
+    'vscode-icons',
+    '/static/commit',
+    PlatformType.Electron,
+    true,
+    '',
+  )
 })
 
 test('setIconTheme passes the production icon theme content etag to the worker', async () => {
@@ -74,4 +85,36 @@ test('hydrate uses the configured workbench icon theme', async () => {
 
   expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.getAllExtensions', '/static', PlatformType.Remote)
   expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'custom-icons', '/static', PlatformType.Remote, true, '')
+})
+
+test('hydrate uses the default icon theme when the setting is absent', async () => {
+  Preferences.get.mockReturnValue(undefined)
+
+  await IconTheme.hydrate(PlatformType.Remote, '/static')
+
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], 'vscode-icons', '/static', PlatformType.Remote, true, '')
+})
+
+test('hydrate disables file icons when the workbench icon theme is null', async () => {
+  Preferences.get.mockImplementation((key) => (key === 'workbench.iconTheme' ? null : undefined))
+
+  await IconTheme.hydrate(PlatformType.Remote, '/static')
+
+  expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], null, '/static', PlatformType.Remote, true, '')
+  expect(HandleIconThemeChange.handleIconThemeChange).toHaveBeenCalledTimes(1)
+})
+
+test('updates the icon theme when the workbench icon theme setting changes', async () => {
+  let iconThemeId = 'custom-icons'
+  Preferences.get.mockImplementation((key) => (key === 'workbench.iconTheme' ? iconThemeId : undefined))
+  await IconTheme.hydrate(PlatformType.Remote, '/static')
+  jest.clearAllMocks()
+
+  iconThemeId = null
+  await GlobalEventBus.emitEvent('preferences.changed')
+
+  expect(ExtensionManagementWorker.invoke).not.toHaveBeenCalled()
+  expect(IconThemeWorker.invoke).toHaveBeenCalledWith('IconTheme.getIconThemeJson', [], null, '/static', PlatformType.Remote, true, '')
+  expect(HandleIconThemeChange.handleIconThemeChange).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
Honor icon-theme ids from `workbench.iconTheme`, treat an explicit `null` as no file icons, and refresh active views when the setting changes. Includes renderer coverage and an Explorer browser regression.