### PR TITLE
Dim unfocused editor selections

### DIFF
--- a/packages/renderer-worker/src/parts/ColorTheme/Color.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/Color.js
@@ -114,8 +114,8 @@ export const EditorSelectionForeground = {
   highContrast: undefined,
 }
 
-export const EditorInactiveSelection = {
-  id: 'EditorSelectionBackground',
+export const EditorInactiveSelectionBackground = {
+  id: 'EditorInactiveSelectionBackground',
   dark: transparent('EditorSelectionBackground', 0.5),
   light: transparent('EditorSelectionBackground', 0.5),
   highContrast: transparent('EditorSelectionBackground', 0.5),

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -189,6 +189,10 @@
   background: var(--EditorSelectionBackground);
 }
 
+.SelectionUnfocused {
+  background: var(--EditorInactiveSelectionBackground, color-mix(in srgb, var(--EditorSelectionBackground) 50%, transparent));
+}
+
 .Token {
   contain: content;
 }

--- a/static/themes/fallback_theme.json
+++ b/static/themes/fallback_theme.json
@@ -12,6 +12,7 @@
     "EditorBackGround": "#1e2324",
     "EditorScrollBarBackground": "rgba(57, 71, 71, 0.6)",
     "EditorCursorBackground": "#a8df5a",
+    "EditorInactiveSelectionBackground": "rgba(255, 255, 255, 0.075)",
     "EditorSelectionBackground": "rgba(255, 255, 255, 0.15)",
 
     "InputBackground": "rgb(36, 41, 42)",


### PR DESCRIPTION
Dim editor selections when the editor loses focus by styling the worker-provided `SelectionUnfocused` class with an inactive selection color.

Add the inactive selection token to the fallback theme and correct its color registry identifier.