### PR TITLE
fix: preserve workspace when reloading electron

### DIFF
--- a/packages/renderer-worker/src/parts/Location/Location.js
+++ b/packages/renderer-worker/src/parts/Location/Location.js
@@ -36,6 +36,20 @@ export const setPathName = async (pathName) => {
   state.href = resolvedUrl.href
 }
 
+export const setWorkspaceUri = async (workspaceUri) => {
+  const { href } = state
+  if (!href) {
+    return RendererProcess.invoke(/* Location.setWorkspaceUri */ 'Location.setWorkspaceUri', /* workspaceUri */ workspaceUri)
+  }
+  const url = new URL(href)
+  url.searchParams.set('workspace', workspaceUri)
+  if (url.href === href) {
+    return
+  }
+  await RendererProcess.invoke(/* Location.setWorkspaceUri */ 'Location.setWorkspaceUri', /* workspaceUri */ workspaceUri)
+  state.href = url.href
+}
+
 export const hydrate = () => {
   return RendererProcess.invoke(/* Location.hydrate */ 'Location.hydrate')
 }

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -58,6 +58,9 @@ export const setUri = async (uri, providedPathSeparator, backend) => {
   }
   const pathSeparator = providedPathSeparator ?? (await FileSystem.getPathSeparator(uri))
   await updateWindowTitle(path, pathSeparator)
+  if (Platform.getPlatform() === PlatformType.Electron) {
+    await Location.setWorkspaceUri(uri)
+  }
   if (path !== state.workspacePath) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }

--- a/packages/renderer-worker/test/Location.test.ts
+++ b/packages/renderer-worker/test/Location.test.ts
@@ -92,3 +92,15 @@ test('setPathName - falls back to renderer process before initialization', async
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Location.setPathName', '/')
 })
+
+test('setWorkspaceUri updates the renderer URL once', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  Location.initialize('lvce-oss://-/?workspace=file%3A%2F%2F%2Ftmp%2Flocal')
+
+  await Location.setWorkspaceUri('remote-ssh://user@example.com/home')
+  await Location.setWorkspaceUri('remote-ssh://user@example.com/home')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Location.setWorkspaceUri', 'remote-ssh://user@example.com/home')
+})

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
 
 const getPathSeparator = jest.fn<(uri: string) => Promise<string>>(async () => '/')
 const exists = jest.fn<(uri: string) => Promise<boolean>>(async () => true)
@@ -6,6 +7,8 @@ const createNotification = jest.fn<(type: string, text: string) => Promise<void>
 const setWindowTitle = jest.fn<(title: string) => Promise<void>>(async () => {})
 const disposeTextSearchWorker = jest.fn<() => Promise<void>>(async () => {})
 const isTest = jest.fn<() => boolean>(() => false)
+const getPlatform = jest.fn(() => PlatformType.Test)
+const setWorkspaceUri = jest.fn(async (_uri: string) => {})
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   exists,
@@ -35,6 +38,15 @@ jest.unstable_mockModule('../src/parts/TextSearchWorker/TextSearchWorker.js', ()
   dispose: disposeTextSearchWorker,
 }))
 
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform,
+}))
+
+jest.unstable_mockModule('../src/parts/Location/Location.js', () => ({
+  setPathName: jest.fn(async () => {}),
+  setWorkspaceUri,
+}))
+
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
@@ -47,6 +59,9 @@ beforeEach(() => {
   disposeTextSearchWorker.mockClear()
   isTest.mockClear()
   isTest.mockReturnValue(false)
+  getPlatform.mockClear()
+  getPlatform.mockReturnValue(PlatformType.Test)
+  setWorkspaceUri.mockClear()
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = ''
@@ -153,4 +168,16 @@ test('setUri uses the remote backend workspace path', async () => {
   expect(Workspace.getWorkspaceUri()).toBe('remote-ssh://host/work')
   expect(Workspace.state.pathSeparator).toBe('/')
   expect(getPathSeparator).not.toHaveBeenCalled()
+})
+
+test('setUri persists the workspace uri in an Electron window', async () => {
+  getPlatform.mockReturnValue(PlatformType.Electron)
+
+  await Workspace.setUri('remote-ssh://host/work', '/', {
+    token: 'secret',
+    url: 'ws://127.0.0.1:45123',
+    workspacePath: '/work',
+  })
+
+  expect(setWorkspaceUri).toHaveBeenCalledWith('remote-ssh://host/work')
 })

--- a/packages/shared-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
+++ b/packages/shared-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
@@ -16,6 +16,7 @@ export const create = async (options: any): Promise<any> => {
   const { port1, port2 } = await GetPortTuple.getPortTuple()
   // TODO use uuid instead of name
   await TemporaryMessagePort.sendTo2(port2, options.targetRpcId, options.ipcId)
+  port1.name = options.name
   port1.start()
   return port1
 }

--- a/packages/shared-process/test/IpcParentWithElectronUtilityProcessCreate.test.ts
+++ b/packages/shared-process/test/IpcParentWithElectronUtilityProcessCreate.test.ts
@@ -1,0 +1,43 @@
+import { expect, jest, test } from '@jest/globals'
+
+const port1: any = {
+  close: jest.fn(),
+  start: jest.fn(),
+}
+const port2 = {}
+const createUtilityProcessRpc = jest.fn(async () => {})
+const sendTo2 = jest.fn(async () => {})
+const invoke = jest.fn<(method: string, name: string) => Promise<void>>(async () => {})
+
+jest.unstable_mockModule('../src/parts/CreateUtilityProcessRpc/CreateUtilityProcessRpc.js', () => ({
+  createUtilityProcessRpc,
+}))
+
+jest.unstable_mockModule('../src/parts/GetPortTuple/GetPortTuple.js', () => ({
+  getPortTuple: jest.fn(async () => ({ port1, port2 })),
+}))
+
+jest.unstable_mockModule('../src/parts/TemporaryMessagePort/TemporaryMessagePort.js', () => ({
+  sendTo2,
+}))
+
+jest.unstable_mockModule('../src/parts/MainProcess/MainProcess.js', () => ({
+  invoke,
+}))
+
+const IpcParentWithElectronUtilityProcess = await import('../src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.js')
+
+test('create preserves the utility process name for disposal', async () => {
+  const rawIpc = await IpcParentWithElectronUtilityProcess.create({
+    ipcId: 1,
+    name: 'Extension Host',
+    targetRpcId: 2,
+  })
+  const ipc = IpcParentWithElectronUtilityProcess.wrap(rawIpc)
+
+  ipc.dispose()
+
+  expect(port1.start).toHaveBeenCalledTimes(1)
+  expect(port1.close).toHaveBeenCalledTimes(1)
+  expect(invoke).toHaveBeenCalledWith('TemporaryMessagePort.dispose', 'Extension Host')
+})


### PR DESCRIPTION
Fix Window: Reload when a folder or Remote SSH workspace is open.\n\n- retain the utility-process port name so disposal cannot crash the shared process\n- persist the active workspace URI in Electron before reload\n- cover both lifecycle paths with regression tests\n\nValidated against local-folder and Remote SSH workspaces in the real Electron app.