### PR TITLE
Fix preview to span full workbench height

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -38,7 +38,7 @@ test('bundleCss does not add filename comment to App.css', async () => {
   }
 }, 30_000)
 
-test('bundleCss preserves the simple browser preview width', async () => {
+test('bundleCss lets the simple browser fill the preview area height', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 
   try {
@@ -49,8 +49,12 @@ test('bundleCss preserves the simple browser preview width', async () => {
 
     const css = await readFile(join(dir, 'parts', 'ViewletSimpleBrowser.css'), 'utf8')
 
-    expect(css).toContain(`.ContentArea > .SimpleBrowser {
-  flex: 0 0 var(--PreviewWidth);
+    expect(css).toContain(`.SimpleBrowser {
+  contain: strict;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }`)
   } finally {
     await rm(dir, { recursive: true, force: true })
@@ -89,7 +93,7 @@ test('bundleCss keeps the preview sash transparent', async () => {
   }
 }, 30_000)
 
-test('bundleCss keeps the panel and panel sash within the non-preview area', async () => {
+test('bundleCss keeps the main workbench column separate from the full-height preview', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 
   try {
@@ -100,7 +104,29 @@ test('bundleCss keeps the panel and panel sash within the non-preview area', asy
 
     const css = await readFile(join(dir, 'App.css'), 'utf8')
 
-    expect(css).toContain('contain: size layout style;')
+    expect(css).toContain(`.WorkbenchBody {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}`)
+    expect(css).toContain(`.WorkbenchMain {
+  contain: size layout style;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}`)
+    expect(css).toContain(`.PreviewArea {
+  display: flex;
+  flex: 0 0 var(--PreviewWidth);
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  position: relative;
+}`)
     expect(css).toContain(`.Panel {
   background: var(--PanelBackground);
   height: var(--PanelHeight);

--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -260,14 +260,6 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
     mainId,
     secondarySideBarVisible,
     secondarySideBarId,
-    previewActionsUid,
-    previewSashVisible,
-    previewVisible,
-    previewId,
-    secondaryPreviewActionsUid,
-    secondaryPreviewSashVisible,
-    secondaryPreviewVisible,
-    secondaryPreviewId,
   } = state
   const children: any[] = []
 
@@ -296,26 +288,6 @@ const getContentAreaVirtualDomLeft = (state: LayoutState) => {
     children.push(getSecondarySideBarDom(secondarySideBarId))
   }
 
-  if (previewSashVisible) {
-    children.push(getSashPreviewDom())
-  }
-
-  if (previewVisible) {
-    const previewAreaDom = getPreviewAreaDom(previewId, previewActionsUid, false)
-    children.push(...previewAreaDom)
-    delta -= previewAreaDom.length - 1
-  }
-
-  if (secondaryPreviewSashVisible) {
-    children.push(getSashSecondaryPreviewDom())
-  }
-
-  if (secondaryPreviewVisible) {
-    const previewAreaDom = getPreviewAreaDom(secondaryPreviewId, secondaryPreviewActionsUid, true)
-    children.push(...previewAreaDom)
-    delta -= previewAreaDom.length - 1
-  }
-
   return [
     {
       type: VirtualDomElements.Div,
@@ -337,14 +309,6 @@ const getContentAreaVirtualDomRight = (state: LayoutState) => {
     sideBarId,
     activityBarVisible,
     activityBarId,
-    previewActionsUid,
-    previewSashVisible,
-    previewVisible,
-    previewId,
-    secondaryPreviewActionsUid,
-    secondaryPreviewSashVisible,
-    secondaryPreviewVisible,
-    secondaryPreviewId,
   } = state
   const children: any[] = []
   let delta = 0
@@ -366,23 +330,6 @@ const getContentAreaVirtualDomRight = (state: LayoutState) => {
   if (activityBarVisible) {
     children.push(getActivityBarDom(activityBarId))
   }
-  if (previewSashVisible) {
-    children.push(getSashPreviewDom())
-  }
-  if (previewVisible) {
-    const previewAreaDom = getPreviewAreaDom(previewId, previewActionsUid, false)
-    children.push(...previewAreaDom)
-    delta -= previewAreaDom.length - 1
-  }
-  if (secondaryPreviewSashVisible) {
-    children.push(getSashSecondaryPreviewDom())
-  }
-  if (secondaryPreviewVisible) {
-    const previewAreaDom = getPreviewAreaDom(secondaryPreviewId, secondaryPreviewActionsUid, true)
-    children.push(...previewAreaDom)
-    delta -= previewAreaDom.length - 1
-  }
-
   return [
     {
       type: VirtualDomElements.Div,
@@ -445,18 +392,77 @@ const getContentAreaVirtualDom = (state: LayoutState) => {
   return getContentAreaVirtualDomRight(state)
 }
 
-export const getLayoutVirtualDom = (state: LayoutState) => {
+const getWorkbenchMainDom = (state: LayoutState) => {
+  const { panelVisible, panelId, statusBarVisible, statusBarId } = state
+  const children: any[] = [...getContentAreaVirtualDom(state)]
+  let childCount = 1
+
+  if (panelVisible) {
+    childCount++
+    children.push(getPanelDom(panelId))
+  }
+
+  if (statusBarVisible) {
+    childCount++
+    children.push(getStatusBarDom(statusBarId))
+  }
+
+  return [
+    {
+      childCount,
+      className: 'WorkbenchMain',
+      type: VirtualDomElements.Div,
+    },
+    ...children,
+  ]
+}
+
+const getWorkbenchBodyDom = (state: LayoutState) => {
   const {
-    titleBarVisible,
-    titleBarId,
-    statusBarVisible,
-    statusBarId,
-    panelSashVisible,
-    panelVisible,
-    panelId,
-    widgetReferences = [],
-    mountedViewletsBySource = {},
+    previewActionsUid,
+    previewId,
+    previewSashVisible,
+    previewVisible,
+    secondaryPreviewActionsUid,
+    secondaryPreviewId,
+    secondaryPreviewSashVisible,
+    secondaryPreviewVisible,
   } = state
+  const children: any[] = [...getWorkbenchMainDom(state)]
+  let childCount = 1
+
+  if (previewSashVisible) {
+    childCount++
+    children.push(getSashPreviewDom())
+  }
+
+  if (previewVisible) {
+    childCount++
+    children.push(...getPreviewAreaDom(previewId, previewActionsUid, false))
+  }
+
+  if (secondaryPreviewSashVisible) {
+    childCount++
+    children.push(getSashSecondaryPreviewDom())
+  }
+
+  if (secondaryPreviewVisible) {
+    childCount++
+    children.push(...getPreviewAreaDom(secondaryPreviewId, secondaryPreviewActionsUid, true))
+  }
+
+  return [
+    {
+      childCount,
+      className: 'WorkbenchBody',
+      type: VirtualDomElements.Div,
+    },
+    ...children,
+  ]
+}
+
+export const getLayoutVirtualDom = (state: LayoutState) => {
+  const { titleBarVisible, titleBarId, panelSashVisible, panelVisible, widgetReferences = [], mountedViewletsBySource = {} } = state
   const dom: any[] = []
   let workbenchChildCount = 0
 
@@ -474,21 +480,11 @@ export const getLayoutVirtualDom = (state: LayoutState) => {
   }
 
   workbenchChildCount++
-  dom.push(...getContentAreaVirtualDom(state))
+  dom.push(...getWorkbenchBodyDom(state))
 
   if (panelVisible && panelSashVisible) {
     workbenchChildCount++
     dom.push(getSashPanelDom())
-  }
-
-  if (panelVisible) {
-    workbenchChildCount++
-    dom.push(getPanelDom(panelId))
-  }
-  // Add StatusBar if visible
-  if (statusBarVisible) {
-    workbenchChildCount++
-    dom.push(getStatusBarDom(statusBarId))
   }
 
   const mountedSources = Object.values(mountedViewletsBySource)

--- a/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
@@ -3,6 +3,18 @@ import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctio
 import * as SideBarLocationType from '../src/parts/SideBarLocationType/SideBarLocationType.js'
 import { getLayoutVirtualDom } from '../src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts'
 
+const parseVirtualDom = (dom: readonly any[]) => {
+  let index = 0
+  const parseNode = (): any => {
+    const node = dom[index++]
+    const children = Array.from({ length: node.childCount || 0 }, parseNode)
+    return { children, node }
+  }
+  const root = parseNode()
+  expect(index).toBe(dom.length)
+  return root
+}
+
 test('getLayoutVirtualDom renders sashes with tabIndex -1', () => {
   const state = {
     activityBarVisible: false,
@@ -104,16 +116,16 @@ test('getLayoutVirtualDom does not render the preview close button when preview 
 test.each([
   ['left', SideBarLocationType.Left],
   ['right', SideBarLocationType.Right],
-])('getLayoutVirtualDom wraps preview content with the side bar on the %s', (_name, sideBarLocation) => {
+])('getLayoutVirtualDom places the preview beside the main workbench column with the side bar on the %s', (_name, sideBarLocation) => {
   const state = {
     activityBarVisible: false,
     mainVisible: true,
     mainId: 1,
     panelSashVisible: false,
-    panelVisible: false,
-    panelId: -1,
+    panelVisible: true,
+    panelId: 4,
     previewActionsUid: 3,
-    previewSashVisible: false,
+    previewSashVisible: true,
     previewVisible: true,
     previewId: 2,
     secondarySideBarVisible: false,
@@ -122,35 +134,25 @@ test.each([
     sideBarSashVisible: false,
     sideBarVisible: false,
     sideBarId: -1,
-    statusBarVisible: false,
-    statusBarId: -1,
-    titleBarVisible: false,
-    titleBarId: -1,
+    statusBarVisible: true,
+    statusBarId: 5,
+    titleBarVisible: true,
+    titleBarId: 10,
   }
 
   // @ts-ignore
   const dom = getLayoutVirtualDom(state)
-  const previewAreaIndex = dom.findIndex((node) => node.className === 'PreviewArea')
+  const workbench = parseVirtualDom(dom)
+  const body = workbench.children[1]
+  const mainColumn = body.children[0]
+  const contentArea = mainColumn.children[0]
+  const previewArea = body.children[2]
 
-  expect(dom.slice(previewAreaIndex, previewAreaIndex + 5)).toEqual([
-    {
-      childCount: 3,
-      className: 'PreviewArea',
-      type: 4,
-    },
-    { type: 100, uid: 2 },
-    { type: 100, uid: 3 },
-    expect.objectContaining({
-      ariaLabel: 'Close Preview',
-      childCount: 1,
-      className: 'IconButton PreviewCloseButton',
-    }),
-    {
-      childCount: 0,
-      className: 'MaskIcon MaskIconClose',
-      type: 4,
-    },
-  ])
+  expect(workbench.children.map(({ node }) => node.uid ?? node.className)).toEqual([10, 'WorkbenchBody'])
+  expect(body.children.map(({ node }) => node.className)).toEqual(['WorkbenchMain', 'Viewlet Sash SashVertical SashPreview', 'PreviewArea'])
+  expect(mainColumn.children.map(({ node }) => node.uid ?? node.className)).toEqual(['ContentArea', 4, 5])
+  expect(contentArea.children.map(({ node }) => node.uid)).toEqual([1])
+  expect(previewArea.children.map(({ node }) => node.uid ?? node.className)).toEqual([2, 3, 'IconButton PreviewCloseButton'])
 })
 
 test('getLayoutVirtualDom renders an independently closable secondary preview', () => {

--- a/static/css/parts/ViewletLayout.css
+++ b/static/css/parts/ViewletLayout.css
@@ -8,6 +8,22 @@
   flex-direction: column;
 }
 
+.WorkbenchBody {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.WorkbenchMain {
+  contain: size layout style;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
 .ContentArea {
   flex: 1;
   display: flex;
@@ -17,10 +33,19 @@
 }
 
 .PreviewArea {
+  display: flex;
   flex: 0 0 var(--PreviewWidth);
+  flex-direction: column;
+  min-height: 0;
   min-width: 0;
   overflow: hidden;
   position: relative;
+}
+
+.PreviewArea > :first-child {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
 }
 
 .SecondaryPreviewArea {

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -3,10 +3,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-}
-
-.ContentArea > .SimpleBrowser {
-  flex: 0 0 var(--PreviewWidth);
+  min-height: 0;
 }
 
 .SimpleBrowserHeader {


### PR DESCRIPTION
Moves content, panel, and status bar into a dedicated workbench column so preview areas sit beside them and stretch from the title bar to the bottom of the window.

Adds renderer DOM and bundled CSS regression coverage for the new layout.