### PR TITLE
fix: remove stylesheets for hidden views

### DIFF
--- a/packages/renderer-worker/src/parts/Css/Css.js
+++ b/packages/renderer-worker/src/parts/Css/Css.js
@@ -28,6 +28,26 @@ export const loadCssStyleSheets = (css) => {
   return Promise.all(css.map(loadCssStyleSheet))
 }
 
+export const acquireCssStyleSheet = async (css) => {
+  CssState.addReference(css)
+  try {
+    await loadCssStyleSheet(css)
+  } catch (error) {
+    CssState.removeReference(css)
+    CssState.remove(css)
+    throw error
+  }
+}
+
+export const releaseCssStyleSheet = (css) => {
+  const count = CssState.removeReference(css)
+  if (count !== 0) {
+    return []
+  }
+  CssState.remove(css)
+  return [['Css.removeCssStyleSheet', GetCssId.getCssId(css)]]
+}
+
 export const addCssStyleSheet = (id, css) => {
   return RendererProcess.invoke('Css.addCssStyleSheet', id, css)
 }
@@ -42,6 +62,26 @@ export const addDynamicCss = (id, getCss, preferences) => {
     CssState.set(id, actuallyAddDynamicCss(id, getCss, preferences))
   }
   return CssState.get(id)
+}
+
+export const acquireDynamicCss = async (id, getCss, preferences) => {
+  CssState.addReference(id)
+  try {
+    await addDynamicCss(id, getCss, preferences)
+  } catch (error) {
+    CssState.removeReference(id)
+    CssState.remove(id)
+    throw error
+  }
+}
+
+export const releaseDynamicCss = (id) => {
+  const count = CssState.removeReference(id)
+  if (count !== 0) {
+    return []
+  }
+  CssState.remove(id)
+  return [['Css.removeCssStyleSheet', id]]
 }
 
 export const reload = async (css) => {

--- a/packages/renderer-worker/src/parts/CssState/CssState.js
+++ b/packages/renderer-worker/src/parts/CssState/CssState.js
@@ -1,5 +1,6 @@
 export const state = {
   pending: Object.create(null),
+  references: Object.create(null),
 }
 
 export const get = (id) => {
@@ -12,4 +13,25 @@ export const has = (id) => {
 
 export const set = (id, value) => {
   state.pending[id] = value
+}
+
+export const remove = (id) => {
+  delete state.pending[id]
+}
+
+export const addReference = (id) => {
+  const count = (state.references[id] || 0) + 1
+  state.references[id] = count
+  return count
+}
+
+export const removeReference = (id) => {
+  const count = state.references[id] || 0
+  if (count <= 1) {
+    delete state.references[id]
+    return 0
+  }
+  const newCount = count - 1
+  state.references[id] = newCount
+  return newCount
 }

--- a/packages/renderer-worker/src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js
+++ b/packages/renderer-worker/src/parts/NormalizeRendererCommands/NormalizeRendererCommands.js
@@ -1,4 +1,5 @@
 const kDispose = 'Viewlet.dispose'
+const kRemoveCssStyleSheet = 'Css.removeCssStyleSheet'
 const kSetCss = 'Viewlet.setCss'
 const kSetPatches = 'Viewlet.setPatches'
 
@@ -31,7 +32,7 @@ const normalizeCommand = (command) => {
   if (command[0] === kSetCss) {
     return normalizeSetCss(command)
   }
-  if (command[0] === kDispose) {
+  if (command[0] === kDispose || command[0] === kRemoveCssStyleSheet) {
     state.cssTexts.delete(command[1])
   }
   return command

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -12,6 +12,7 @@ import * as SimpleBrowserOverlay from '../SimpleBrowserOverlay/SimpleBrowserOver
 import * as UpdateDynamicFocusContext from '../UpdateDynamicFocusContext/UpdateDynamicFocusContext.js'
 import { VError } from '../VError/VError.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
+import * as ViewletManagerVisitor from '../ViewletManagerVisitor/ViewletManagerVisitor.js'
 import * as ViewletModule from '../ViewletModule/ViewletModule.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
@@ -19,6 +20,14 @@ import * as ViewletElectron from './ViewletElectron.js'
 
 const getKeyBindingSetId = (instance, fallback) => {
   return instance.moduleId || fallback
+}
+
+const getCssDisposeCommands = (instance) => {
+  if (!instance.cssLoaded) {
+    return []
+  }
+  instance.cssLoaded = false
+  return ViewletManagerVisitor.disposeInstance(instance.moduleId, instance.factory)
 }
 
 export const getTitle = (id) => {
@@ -187,8 +196,9 @@ export const dispose = async (id) => {
     if (instance.factory.dispose) {
       await instance.factory.dispose(instance.state)
     }
-    if (widgetDisposeCommands.length > 0) {
-      await RendererProcess.invoke('Viewlet.sendMultiple', [...widgetDisposeCommands, ['Viewlet.dispose', instanceUid]])
+    const cssDisposeCommands = getCssDisposeCommands(instance)
+    if (widgetDisposeCommands.length > 0 || cssDisposeCommands.length > 0) {
+      await RendererProcess.invoke('Viewlet.sendMultiple', [...widgetDisposeCommands, ['Viewlet.dispose', instanceUid], ...cssDisposeCommands])
     } else {
       await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     }
@@ -226,7 +236,11 @@ export const disposeFunctional = (id) => {
     }
     const uid = instance.state.uid
     Assert.number(uid)
-    const commands = [...LayoutWidgets.removeOwnedWidgets(uid), [/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid]]
+    const commands = [
+      ...LayoutWidgets.removeOwnedWidgets(uid),
+      [/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid],
+      ...getCssDisposeCommands(instance),
+    ]
 
     if (instance.factory.getKeyBindings) {
       KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, id))
@@ -256,8 +270,12 @@ export const disposeFunctional = (id) => {
   }
 }
 
-export const showFunctional = (id) => {
+export const showFunctional = async (id) => {
   const instance = ViewletStates.getInstance(id)
+  if (!instance.cssLoaded) {
+    await ViewletManagerVisitor.loadInstance(instance.moduleId, instance.factory)
+    instance.cssLoaded = true
+  }
   const initialState = instance.factory.create()
   // TODO resize
   const commands = ViewletManager.render(instance.factory, initialState, instance.state)
@@ -289,14 +307,19 @@ export const hideFunctional = (id) => {
     }
     if (instance.factory.hide) {
       instance.factory.hide(instance.state)
-      return []
+      instance.status = 'hidden'
+      return getCssDisposeCommands(instance)
     }
     if (instance.factory.dispose) {
       instance.factory.dispose(instance.state)
     }
     const uid = instance.state.uid
     Assert.number(uid)
-    const commands = [...LayoutWidgets.removeOwnedWidgets(uid), [/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid]]
+    const commands = [
+      ...LayoutWidgets.removeOwnedWidgets(uid),
+      [/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ uid],
+      ...getCssDisposeCommands(instance),
+    ]
 
     if (instance.factory.getKeyBindings) {
       KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, id))
@@ -620,7 +643,7 @@ export const disposeWidgetWithValue = async (id, value) => {
     }
     const { parentUid, uid } = instance.state
     Assert.number(uid)
-    const commands = [...LayoutWidgets.removeWidget(uid)]
+    const commands = [...LayoutWidgets.removeWidget(uid), ...getCssDisposeCommands(instance)]
     if (instance.factory.getKeyBindings) {
       KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, uid))
     }

--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMainFocusIndex.js
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMainFocusIndex.js
@@ -44,7 +44,7 @@ export const focusIndex = async (state, index) => {
 
   const maybeHiddenEditorInstance = ViewletStates.getInstance(editor.uid)
   if (maybeHiddenEditorInstance) {
-    const commands = Viewlet.showFunctional(editor.uid)
+    const commands = await Viewlet.showFunctional(editor.uid)
     const allCommands = [...disposeCommands, ...commands]
     return {
       newState,

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -694,6 +694,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     if (viewlet.disposed) {
       return
     }
+    await ViewletManagerVisitor.loadInstance(viewlet.id, module)
     state = ViewletState.ContentLoaded
     if (viewlet.show === false) {
     } else {
@@ -712,6 +713,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
 
     const instance = {
       actionsUid: viewlet.actionsUid,
+      cssLoaded: true,
       state: newState,
       renderedState: viewletState,
       factory: module,

--- a/packages/renderer-worker/src/parts/ViewletManagerVisitor/ViewletManagerVisitor.js
+++ b/packages/renderer-worker/src/parts/ViewletManagerVisitor/ViewletManagerVisitor.js
@@ -1,10 +1,18 @@
 import * as ViewletManagerVisitorCss from '../ViewletManagerVisitorCss/ViewletManagerVisitorCss.js'
 import * as ViewletManagerVisitorMenuEntries from '../ViewletManagerVisitorMenuEntries/ViewletManagerVisitorMenuEntries.js'
 
-const visitors = [ViewletManagerVisitorCss, ViewletManagerVisitorMenuEntries]
+const visitors = [ViewletManagerVisitorMenuEntries]
 
 export const loadModule = async (id, module) => {
   for (const visitor of visitors) {
     await visitor.loadModule(id, module)
   }
+}
+
+export const loadInstance = (id, module) => {
+  return ViewletManagerVisitorCss.loadInstance(id, module)
+}
+
+export const disposeInstance = (id, module) => {
+  return ViewletManagerVisitorCss.disposeInstance(id, module)
 }

--- a/packages/renderer-worker/src/parts/ViewletManagerVisitorCss/ViewletManagerVisitorCss.js
+++ b/packages/renderer-worker/src/parts/ViewletManagerVisitorCss/ViewletManagerVisitorCss.js
@@ -1,13 +1,26 @@
 import * as Css from '../Css/Css.js'
 import * as Preferences from '../Preferences/Preferences.js'
 
-export const loadModule = async (id, module) => {
+export const loadInstance = async (id, module) => {
   if (module.Css) {
-    // this is a memory leak but it is not too important
-    // because javascript modules also cannot be unloaded
-    await (Array.isArray(module.Css) ? Css.loadCssStyleSheets(module.Css) : Css.loadCssStyleSheet(module.Css))
+    const styleSheets = Array.isArray(module.Css) ? module.Css : [module.Css]
+    await Promise.all(styleSheets.map(Css.acquireCssStyleSheet))
   }
   if (module.getDynamicCss) {
-    await Css.addDynamicCss(id, module.getDynamicCss, Preferences.state)
+    await Css.acquireDynamicCss(id, module.getDynamicCss, Preferences.state)
   }
+}
+
+export const disposeInstance = (id, module) => {
+  const commands = []
+  if (module.Css) {
+    const styleSheets = Array.isArray(module.Css) ? module.Css : [module.Css]
+    for (const styleSheet of styleSheets) {
+      commands.push(...Css.releaseCssStyleSheet(styleSheet))
+    }
+  }
+  if (module.getDynamicCss) {
+    commands.push(...Css.releaseDynamicCss(id))
+  }
+  return commands
 }

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -132,8 +132,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   // TODO set it in layout
   const { childUid: currentChildUid, currentViewletId } = state
   const requestId = state.currentViewletRequestId + 1
-  const savePromise =
-    restore && currentChildUid !== -1 ? SaveState.saveViewletStateWithStorageId(currentChildUid, currentViewletId) : undefined
+  const savePromise = restore && currentChildUid !== -1 ? SaveState.saveViewletStateWithStorageId(currentChildUid, currentViewletId) : undefined
   state.currentViewletRequestId = requestId
   state.currentViewletId = moduleId
 
@@ -180,7 +179,10 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
     restore ? undefined : { restore: false },
   )
   if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
-    Viewlet.disposeFunctional(childUid)
+    const disposeCommands = Viewlet.disposeFunctional(childUid)
+    if (disposeCommands.length > 0) {
+      await RendererProcess.invoke('Viewlet.sendMultiple', disposeCommands)
+    }
     await savePromise
     return state
   }
@@ -189,6 +191,9 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   let actionsUid = -1
   let title = Character.EmptyString
   if (commands) {
+    if (currentChildUid !== -1) {
+      commands.unshift(...Viewlet.disposeFunctional(currentChildUid))
+    }
     const actionsDomIndex = commands.findIndex((command) => command[2] === 'setActionsDom')
     if (actionsDomIndex >= 0) {
       const nextActionsDom = commands[actionsDomIndex][3]
@@ -215,7 +220,10 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
       commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid])
     }
     if (state.currentViewletRequestId !== requestId || state.currentViewletId !== moduleId) {
-      Viewlet.disposeFunctional(childUid)
+      const disposeCommands = Viewlet.disposeFunctional(childUid)
+      if (disposeCommands.length > 0) {
+        await RendererProcess.invoke('Viewlet.sendMultiple', disposeCommands)
+      }
       await savePromise
       return state
     }
@@ -301,6 +309,10 @@ export const openViewlet = async (state, moduleId, focus = false, args) => {
 
 export const dispose = (state) => {
   // state.currentViewletId = undefined
+}
+
+export const getOwnedViewletIds = (state) => {
+  return state.childUid === -1 ? [] : [state.childUid]
 }
 
 export const openDefaultViewlet = async (state) => {

--- a/packages/renderer-worker/test/Css.test.ts
+++ b/packages/renderer-worker/test/Css.test.ts
@@ -26,6 +26,7 @@ beforeEach(() => {
     throw new Error('not implemented')
   }
   CssState.state.pending = Object.create(null)
+  CssState.state.references = Object.create(null)
 })
 
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => {
@@ -87,4 +88,42 @@ test('loadCssStyleSheet - twice', async () => {
     'Css-test-Component',
     '/* /test/Component.css (Css-test-Component) */\nh1 { font-size: 20px; }',
   )
+})
+
+test('acquireCssStyleSheet keeps a shared stylesheet until its last view releases it', async () => {
+  // @ts-ignore
+  globalThis.fetch = jest.fn(() => {
+    return new Response({
+      ok: true,
+      statusText: 'ok',
+      // @ts-ignore
+      text: 'h1 { font-size: 20px; }',
+    })
+  })
+
+  await Css.acquireCssStyleSheet('/test/Component.css')
+  await Css.acquireCssStyleSheet('/test/Component.css')
+
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(Css.releaseCssStyleSheet('/test/Component.css')).toEqual([])
+  expect(Css.releaseCssStyleSheet('/test/Component.css')).toEqual([['Css.removeCssStyleSheet', 'Css-test-Component']])
+})
+
+test('acquireCssStyleSheet adopts a stylesheet again after its last view released it', async () => {
+  // @ts-ignore
+  globalThis.fetch = jest.fn(() => {
+    return new Response({
+      ok: true,
+      statusText: 'ok',
+      // @ts-ignore
+      text: 'h1 { font-size: 20px; }',
+    })
+  })
+
+  await Css.acquireCssStyleSheet('/test/Component.css')
+  Css.releaseCssStyleSheet('/test/Component.css')
+  await Css.acquireCssStyleSheet('/test/Component.css')
+
+  expect(fetch).toHaveBeenCalledTimes(2)
+  expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
 })

--- a/packages/renderer-worker/test/NormalizeRendererCommands.test.ts
+++ b/packages/renderer-worker/test/NormalizeRendererCommands.test.ts
@@ -44,6 +44,14 @@ test('disposal clears stylesheet state', () => {
   expect(NormalizeRendererCommands.normalizeCommands([command])).toEqual([command])
 })
 
+test('stylesheet removal clears stylesheet state', () => {
+  NormalizeRendererCommands.setCssText('Css-Explorer', '.Explorer {}')
+
+  NormalizeRendererCommands.normalizeCommands([['Css.removeCssStyleSheet', 'Css-Explorer']])
+
+  expect(NormalizeRendererCommands.getCssText('Css-Explorer')).toBeUndefined()
+})
+
 test('tracks stylesheets independently by id', () => {
   const css = '.item {}'
 

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -31,6 +31,10 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
     runLoadContentLater: jest.fn(),
   }
 })
+jest.unstable_mockModule('../src/parts/ViewletManagerVisitor/ViewletManagerVisitor.js', () => ({
+  disposeInstance: jest.fn(() => []),
+  loadInstance: jest.fn(),
+}))
 jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
   return {
     create: jest.fn(),
@@ -47,6 +51,7 @@ jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => ({
 }))
 
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const ViewletManagerVisitor = await import('../src/parts/ViewletManagerVisitor/ViewletManagerVisitor.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const Id = await import('../src/parts/Id/Id.js')
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
@@ -260,6 +265,30 @@ test('disposeFunctional disposes owned runtime viewlets', () => {
   expect(ViewletStates.getInstance(10)).toBeUndefined()
   expect(ViewletStates.getInstance(11)).toBeUndefined()
   expect(ViewletStates.getInstance(12)).toBeUndefined()
+})
+
+test('hideFunctional releases view css and showFunctional acquires it again', async () => {
+  const factory = {
+    create: jest.fn(() => ({ uid: 2 })),
+    hide: jest.fn(),
+    show: jest.fn(),
+  }
+  ViewletStates.set(2, {
+    cssLoaded: true,
+    factory,
+    moduleId: 'SimpleBrowser',
+    renderedState: { uid: 2 },
+    state: { uid: 2 },
+  })
+  jest.mocked(ViewletManagerVisitor.disposeInstance).mockReturnValue([['Css.removeCssStyleSheet', 'Css-ViewletSimpleBrowser']])
+  jest.mocked(ViewletManager.render).mockReturnValue([])
+
+  expect(Viewlet.hideFunctional(2)).toEqual([['Css.removeCssStyleSheet', 'Css-ViewletSimpleBrowser']])
+  expect(ViewletStates.getInstance(2).cssLoaded).toBe(false)
+
+  await expect(Viewlet.showFunctional(2)).resolves.toEqual([])
+  expect(ViewletManagerVisitor.loadInstance).toHaveBeenCalledWith('SimpleBrowser', factory)
+  expect(ViewletStates.getInstance(2).cssLoaded).toBe(true)
 })
 
 test('getFocusCommands returns focus render commands without sending them', async () => {

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -40,11 +40,13 @@ const RendererProcess = await import('../src/parts/RendererProcess/RendererProce
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const ViewletSideBar = await import('../src/parts/ViewletSideBar/ViewletSideBar.js')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const JsonRpcVersion = await import('../src/parts/JsonRpcVersion/JsonRpcVersion.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
+  ViewletStates.reset()
   Command.execute.mockResolvedValue('Search')
   RendererProcess.invoke.mockResolvedValue(undefined)
   SaveState.saveViewletState.mockResolvedValue(undefined)
@@ -172,6 +174,34 @@ test('handleSideBarViewletChange saves the concrete sidebar child under the view
 
   expect(SaveState.saveViewletStateWithStorageId).toHaveBeenCalledWith(99, 'Search')
   expect(SaveState.saveViewletState).not.toHaveBeenCalled()
+})
+
+test('handleSideBarViewletChange disposes the previously visible child', async () => {
+  const childState = { uid: 99 }
+  ViewletStates.set(99, {
+    factory: {},
+    moduleId: 'Search',
+    renderedState: childState,
+    state: childState,
+  })
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    childUid: 99,
+    currentViewletId: 'Search',
+  }
+
+  await ViewletSideBar.handleSideBarViewletChange(state, 'Explorer')
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.dispose', 99],
+    ['Viewlet.createFunctionalRoot', 'Explorer', 2, true],
+  ])
+  expect(ViewletStates.getInstance(99)).toBeUndefined()
+})
+
+test('getOwnedViewletIds returns the visible sidebar child', () => {
+  expect(ViewletSideBar.getOwnedViewletIds({ childUid: 99 })).toEqual([99])
+  expect(ViewletSideBar.getOwnedViewletIds({ childUid: -1 })).toEqual([])
 })
 
 test('handleSideBarViewletChange gives an opted-out extension view the full sidebar', async () => {


### PR DESCRIPTION
Reference-count view stylesheets so shared CSS remains while any owning view is visible and is removed after the last view is hidden. Dispose replaced sidebar children so inactive Explorer/Search styles no longer remain adopted.