### PR TITLE
fix: dim search input icons

### DIFF
--- a/extensions/builtin.theme-slime/color-theme.json
+++ b/extensions/builtin.theme-slime/color-theme.json
@@ -54,6 +54,7 @@
     "QuickPickBackground": "rgb(40, 46, 47)",
 
     "SideBarBackground": "#1b2020",
+    "SideBarForeground": "#bcbebe",
 
     "SplitButtonBackground": "#2f6260",
 

--- a/packages/extension-host-worker-tests/src/viewlet.search-input-icon-color.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-input-icon-color.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-input-icon-color'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.closeAllEditors()
+  await Main.openUri('search-editor://1/Search')
+  await Locator('.Main button[title="Toggle Replace"]').click()
+
+  const inputIcons = Locator('.Main .SearchField .SearchFieldButton .MaskIcon')
+  await waitFor(() => expect(inputIcons).toHaveCount(4))
+
+  for (let index = 0; index < 4; index++) {
+    await expect(inputIcons.nth(index)).toHaveCSS('color', 'rgb(188, 190, 190)')
+  }
+}

--- a/static/css/parts/SearchField.css
+++ b/static/css/parts/SearchField.css
@@ -38,7 +38,7 @@
   position: relative;
   background: transparent;
   border: 1px solid transparent;
-  color: white;
+  color: var(--SideBarForeground, var(--WorkbenchForeground, white));
   contain: strict;
   width: 20px;
   height: 20px;


### PR DESCRIPTION
Match Slime's VS Code search and replace input icon foreground by using the sidebar theme color. Add focused e2e coverage for the computed icon color.