### PR TITLE
fix: don't render empty file icons in legacy views

### DIFF
--- a/packages/renderer-worker/src/parts/GetLocationsVirtualDom/GetLocationsVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetLocationsVirtualDom/GetLocationsVirtualDom.js
@@ -63,20 +63,25 @@ const getCollapsedVirtualDom = (location) => {
 
 const getExpandedVirtualDom = (location) => {
   const { index, name, icon } = location
+  const fileIconDom = icon
+    ? [
+        {
+          type: VirtualDomElements.Img,
+          className: ClassNames.FileIcon,
+          src: icon,
+        },
+      ]
+    : []
   return [
     {
       type: VirtualDomElements.Div,
       className: ClassNames.TreeItem,
       ariaExpanded: true,
       id: `Reference-${index}`,
-      childCount: 2,
+      childCount: 1 + fileIconDom.length,
       paddingLeft: '1rem',
     },
-    {
-      type: VirtualDomElements.Img,
-      className: ClassNames.FileIcon,
-      src: icon,
-    },
+    ...fileIconDom,
     text(name),
   ]
 }

--- a/packages/renderer-worker/src/parts/GetSourceControlItemVirtualDom/GetSourceControlItemVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSourceControlItemVirtualDom/GetSourceControlItemVirtualDom.js
@@ -72,6 +72,19 @@ const createItemDirectory = (item) => {
 const createItemOther = (item) => {
   const { posInSet, setSize, icon, file, label, decorationIcon, decorationIconTitle, decorationStrikeThrough, detail, buttons } = item
   const labelClassName = getLabelClassName(decorationStrikeThrough)
+  const iconDom =
+    icon === ClassNames.ChevronRight
+      ? [
+          {
+            type: VirtualDomElements.Div,
+            className: ClassNames.Chevron,
+            childCount: 1,
+          },
+          GetIconVirtualDom.getIconVirtualDom(icon),
+        ]
+      : icon
+        ? [GetFileIconVirtualDom.getFileIconVirtualDom(icon)]
+        : []
   /**
    * @type {any[]}
    */
@@ -84,20 +97,11 @@ const createItemOther = (item) => {
       ariaPosInSet: posInSet,
       ariaSetSize: setSize,
       title: file,
-      childCount: 3,
+      childCount: 2 + (iconDom.length > 0 ? 1 : 0),
       paddingLeft: '1rem',
       paddingRight: '12px',
     },
-    ...(icon === ClassNames.ChevronRight
-      ? [
-          {
-            type: VirtualDomElements.Div,
-            className: ClassNames.Chevron,
-            childCount: 1,
-          },
-          GetIconVirtualDom.getIconVirtualDom(icon),
-        ]
-      : [GetFileIconVirtualDom.getFileIconVirtualDom(icon)]),
+    ...iconDom,
   )
   const labelDom = {
     type: VirtualDomElements.Div,

--- a/packages/renderer-worker/src/parts/GetTabDom/GetTabDom.js
+++ b/packages/renderer-worker/src/parts/GetTabDom/GetTabDom.js
@@ -7,14 +7,19 @@ import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
 
 const getIconDom = (icon) => {
-  if (icon.startsWith('MaskIcon')) {
-    return {
-      type: VirtualDomElements.Div,
-      className: `TabIcon ${icon}`,
-      childCount: 0,
-    }
+  if (!icon) {
+    return []
   }
-  return GetFileIconVirtualDom.getFileIconVirtualDom(icon)
+  if (icon.startsWith('MaskIcon')) {
+    return [
+      {
+        type: VirtualDomElements.Div,
+        className: `TabIcon ${icon}`,
+        childCount: 0,
+      },
+    ]
+  }
+  return [GetFileIconVirtualDom.getFileIconVirtualDom(icon)]
 }
 
 export const getTabDom = (tab) => {
@@ -27,6 +32,7 @@ export const getTabDom = (tab) => {
   // @ts-ignore
   const isHovered = flags & TabFlags.Hovered
   const actualTabWidth = fixedWidth || tabWidth
+  const iconDom = getIconDom(icon)
   const tabElement = {
     type: VirtualDomElements.Div,
     className: tabClassName,
@@ -35,7 +41,7 @@ export const getTabDom = (tab) => {
     width: actualTabWidth,
     ariaSelected: isActive,
     title,
-    childCount: 2,
+    childCount: 1 + iconDom.length,
     'data-dragUid': uid,
   }
   DragData.set(uid, {
@@ -46,7 +52,7 @@ export const getTabDom = (tab) => {
 
   dom.push(
     tabElement,
-    getIconDom(icon),
+    ...iconDom,
     {
       type: VirtualDomElements.Div,
       className: ClassNames.TabLabel,

--- a/packages/renderer-worker/test/GetLocationsVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLocationsVirtualDom.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals'
+import * as ClassNames from '../src/parts/ClassNames/ClassNames.js'
+import * as GetLocationsVirtualDom from '../src/parts/GetLocationsVirtualDom/GetLocationsVirtualDom.js'
+import * as LocationType from '../src/parts/LocationType/LocationType.js'
+
+test('does not render an empty file icon', () => {
+  const dom = GetLocationsVirtualDom.getLocationsVirtualDom(
+    [
+      {
+        icon: '',
+        index: 0,
+        name: 'file.js',
+        type: LocationType.Expanded,
+      },
+    ],
+    '1 result',
+  )
+
+  const location = dom[4]
+  expect(location.childCount).toBe(1)
+  expect(dom.some((node) => node.className === ClassNames.FileIcon)).toBe(false)
+})

--- a/packages/renderer-worker/test/GetSourceControlItemVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSourceControlItemVirtualDom.test.ts
@@ -46,3 +46,22 @@ test('wraps the filename in a separate span', () => {
     },
   ])
 })
+
+test('does not render an empty file icon', () => {
+  const dom = GetSourceControlItemVirtualDom.getSourceControlItemVirtualDom({
+    posInSet: 1,
+    setSize: 1,
+    icon: '',
+    file: '/workspace/src/file.js',
+    label: 'file.js',
+    decorationIcon: '/modified.svg',
+    decorationIconTitle: 'Modified',
+    decorationStrikeThrough: false,
+    detail: 'src/',
+    buttons: EmptySourceControlButtons.emptySourceControlButtons,
+    type: DirentType.File,
+  })
+
+  expect(dom[0].childCount).toBe(2)
+  expect(dom.some((node) => node.className === 'FileIcon')).toBe(false)
+})

--- a/packages/renderer-worker/test/GetTabDom.test.ts
+++ b/packages/renderer-worker/test/GetTabDom.test.ts
@@ -16,3 +16,20 @@ test('uses the pretty path as title', () => {
 
   expect(dom[0].title).toBe('~/Documents/file.txt')
 })
+
+test('does not render an empty file icon', () => {
+  const dom = GetTabDom.getTabDom({
+    fixedWidth: 0,
+    flags: 0,
+    icon: '',
+    isActive: true,
+    label: 'file.txt',
+    tabWidth: 100,
+    title: '~/Documents/file.txt',
+    uid: 1,
+    uri: 'file:///home/test/Documents/file.txt',
+  })
+
+  expect(dom[0].childCount).toBe(2)
+  expect(dom.some((node) => node.className === 'FileIcon')).toBe(false)
+})


### PR DESCRIPTION
## Summary

- omit empty file icon nodes from legacy tabs, Source Control, and References rendering
- preserve built-in mask icons and keep child counts aligned
- add focused regression coverage for all three fallback renderers

## Testing

- renderer-worker full test suite
- renderer-worker type-check
- focused Prettier check and regression tests