### PR TITLE
Preserve Blob results from extension file providers

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
@@ -52,6 +52,19 @@ export const readFile = (uri) => {
   })
 }
 
+export const getBlob = async (uri, type = '') => {
+  const content = await readFile(uri)
+  if (content instanceof Blob) {
+    return content
+  }
+  return new Blob([content], { type })
+}
+
+export const getBlobUrl = async (uri, type = '') => {
+  const blob = await getBlob(uri, type)
+  return URL.createObjectURL(blob)
+}
+
 export const remove = async (uri) => {
   const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
   const result = await executeProvider({

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -59,6 +59,31 @@ test('readFile - error', async () => {
   await expect(ExtensionHostFileSystem.readFile('memfs:///test.txt')).rejects.toThrow(new TypeError('x is not a function'))
 })
 
+test('getBlob preserves binary provider content', async () => {
+  const audio = new Blob(['recorded audio'], { type: 'audio/webm' })
+  invoke.mockResolvedValue({ found: true, result: audio })
+
+  await expect(ExtensionHostFileSystem.getBlob('gpt-voice-audio:///message.webm', 'video/webm')).resolves.toBe(audio)
+})
+
+test('getBlob converts text provider content using the requested mime type', async () => {
+  invoke.mockResolvedValue({ found: true, result: 'test content' })
+
+  const blob = await ExtensionHostFileSystem.getBlob('memfs:///test.txt', 'text/plain')
+
+  expect(blob.type).toBe('text/plain')
+  await expect(blob.text()).resolves.toBe('test content')
+})
+
+test('getBlobUrl creates an object url for provider content', async () => {
+  const createObjectURL = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:recording')
+  const audio = new Blob(['recorded audio'], { type: 'audio/webm' })
+  invoke.mockResolvedValue({ found: true, result: audio })
+
+  await expect(ExtensionHostFileSystem.getBlobUrl('gpt-voice-audio:///message.webm', 'video/webm')).resolves.toBe('blob:recording')
+  expect(createObjectURL).toHaveBeenCalledWith(audio)
+})
+
 test('remove', async () => {
   // @ts-ignore
   ExtensionHostShared.executeProvider.mockImplementation(() => {})


### PR DESCRIPTION
## Summary

- preserve Blob responses when renderer-worker opens extension-provided files
- continue converting legacy text responses into Blob objects
- cover both paths and object URL creation

## Tests

- renderer-worker focused test suite (22 tests)
- renderer-worker type-check

The renderer-worker package-wide legacy XO command currently reports 107,429 baseline violations across unchanged files; the changed source has no new finding, while three existing module-mock findings remain in its test file.