### PR TITLE
fix: reload icon theme when settings change

### DIFF
--- a/packages/renderer-worker/src/parts/Preferences/Preferences.js
+++ b/packages/renderer-worker/src/parts/Preferences/Preferences.js
@@ -44,15 +44,29 @@ const getPreferences = async () => {
   return preferences
 }
 
+const load = async () => {
+  const preferences = await getPreferences()
+  PreferencesState.setAll(preferences)
+}
+
 export const hydrate = async () => {
   try {
     // TODO should configuration be together with all other preferences (e.g. selecting color theme code is not needed on startup)
     // TODO probably not all preferences need to be kept in memory
-    const preferences = await getPreferences()
-    PreferencesState.setAll(preferences)
+    await load()
   } catch (error) {
     ErrorHandling.logError(error)
   }
+}
+
+export const reload = async () => {
+  try {
+    await load()
+  } catch (error) {
+    ErrorHandling.logError(error)
+    return
+  }
+  await GlobalEventBus.emitEvent('preferences.changed')
 }
 
 export const get = (key) => {

--- a/packages/renderer-worker/src/parts/PreferencesFileWatcher/PreferencesFileWatcher.js
+++ b/packages/renderer-worker/src/parts/PreferencesFileWatcher/PreferencesFileWatcher.js
@@ -1,0 +1,63 @@
+import * as FileWatcher from '../FileWatcher/FileWatcher.js'
+import * as GetPathDirName from '../GetPathDirName/GetPathDirName.js'
+import * as PathToFileUri from '../PathToFileUri/PathToFileUri.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformPaths from '../PlatformPaths/PlatformPaths.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as Preferences from '../Preferences/Preferences.js'
+
+const ReloadDelay = 100
+
+let reloadTimeout
+let settingsUri = ''
+let watcher
+
+const scheduleReload = () => {
+  if (reloadTimeout !== undefined) {
+    clearTimeout(reloadTimeout)
+  }
+  reloadTimeout = setTimeout(async () => {
+    reloadTimeout = undefined
+    await Preferences.reload()
+  }, ReloadDelay)
+}
+
+const handleEvent = (event) => {
+  if (event.detail.uri !== settingsUri) {
+    return
+  }
+  scheduleReload()
+}
+
+export const dispose = async () => {
+  if (reloadTimeout !== undefined) {
+    clearTimeout(reloadTimeout)
+    reloadTimeout = undefined
+  }
+  if (!watcher) {
+    return
+  }
+  const oldWatcher = watcher
+  watcher = undefined
+  oldWatcher.removeEventListener('watcher-event', handleEvent)
+  await FileWatcher.dispose(oldWatcher)
+}
+
+export const hydrate = async () => {
+  await dispose()
+  if (Platform.getPlatform() === PlatformType.Web) {
+    return
+  }
+  try {
+    const settingsPath = await PlatformPaths.getUserSettingsPath()
+    const settingsDirectory = GetPathDirName.getPathDirName(settingsPath)
+    settingsUri = PathToFileUri.pathToFileUri(settingsPath)
+    watcher = await FileWatcher.watch({
+      exclude: [],
+      roots: [PathToFileUri.pathToFileUri(settingsDirectory)],
+    })
+    watcher.addEventListener('watcher-event', handleEvent)
+  } catch (error) {
+    console.warn(`Failed to watch user settings: ${error}`)
+  }
+}

--- a/packages/renderer-worker/src/parts/PreferencesState/PreferencesState.js
+++ b/packages/renderer-worker/src/parts/PreferencesState/PreferencesState.js
@@ -1,6 +1,9 @@
 export const state = Object.create(null)
 
 export const setAll = (preferences) => {
+  for (const key of Object.keys(state)) {
+    delete state[key]
+  }
   Object.assign(state, preferences)
 }
 

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -31,6 +31,7 @@ import * as Performance from '../Performance/Performance.js'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as PreferencesFileWatcher from '../PreferencesFileWatcher/PreferencesFileWatcher.js'
 import * as PreferencesState from '../PreferencesState/PreferencesState.js'
 import * as PromptMode from '../PromptMode/PromptMode.js'
 import * as RecentlyOpened from '../RecentlyOpened/RecentlyOpened.js'
@@ -271,7 +272,12 @@ export const startup = async (platform, assetDir) => {
   await Location.hydrate()
   Performance.mark(PerformanceMarkerType.DidLoadLocation)
 
-  const watcherPromises = Promise.all([DevelopFileWatcher.hydrate(), WatchFilesForHotReload.watchFilesForHotReload(), WorkspaceFileWatcher.hydrate()])
+  const watcherPromises = Promise.all([
+    DevelopFileWatcher.hydrate(),
+    PreferencesFileWatcher.hydrate(),
+    WatchFilesForHotReload.watchFilesForHotReload(),
+    WorkspaceFileWatcher.hydrate(),
+  ])
 
   Performance.measure(PerformanceMarkerType.OpenWorkspace, PerformanceMarkerType.WillOpenWorkspace, PerformanceMarkerType.DidOpenWorkspace)
   Performance.measure(PerformanceMarkerType.LoadMain, PerformanceMarkerType.WillLoadMain, PerformanceMarkerType.DidLoadMain)

--- a/packages/renderer-worker/test/Preferences.test.ts
+++ b/packages/renderer-worker/test/Preferences.test.ts
@@ -4,6 +4,7 @@ import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
 beforeEach(() => {
   jest.resetAllMocks()
   IsTest.state.isTest = true
+  GlobalEventBus.state.listenerMap = Object.create(null)
   for (const key in Preferences.state) {
     delete Preferences.state[key]
   }
@@ -45,6 +46,7 @@ jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const ErrorHandling = await import('../src/parts/ErrorHandling/ErrorHandling.js')
+const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
 const IsTest = await import('../src/parts/IsTest/IsTest.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 
@@ -94,6 +96,31 @@ test('hydrate', async () => {
     'editor.fontSize': 14,
     'editor.fontFamily': "'Fira Code'",
   })
+})
+
+test('reload replaces preferences and emits a change event', async () => {
+  Object.assign(Preferences.state, {
+    'workbench.iconTheme': null,
+    stale: true,
+  })
+  // @ts-ignore
+  SharedProcess.invoke.mockImplementation((method) => {
+    if (method === 'Preferences.getAll') {
+      return {
+        'editor.fontSize': 14,
+      }
+    }
+    throw new Error('unexpected message')
+  })
+  const listener = jest.fn()
+  GlobalEventBus.addListener('preferences.changed', listener)
+
+  await Preferences.reload()
+
+  expect(Preferences.state).toEqual({
+    'editor.fontSize': 14,
+  })
+  expect(listener).toHaveBeenCalledTimes(1)
 })
 
 test.skip('hydrate - error', async () => {

--- a/packages/renderer-worker/test/PreferencesFileWatcher.test.ts
+++ b/packages/renderer-worker/test/PreferencesFileWatcher.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+const addEventListener = jest.fn()
+const removeEventListener = jest.fn()
+const watcher = {
+  addEventListener,
+  removeEventListener,
+}
+const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+jest.unstable_mockModule('../src/parts/FileWatcher/FileWatcher.js', () => ({
+  dispose: jest.fn(),
+  watch: jest.fn(() => watcher),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => PlatformType.Electron),
+}))
+
+jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
+  getUserSettingsPath: jest.fn(() => '/home/test/.config/lvce/settings.json'),
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  reload: jest.fn(),
+}))
+
+const FileWatcher = await import('../src/parts/FileWatcher/FileWatcher.js')
+const Platform = await import('../src/parts/Platform/Platform.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+const PreferencesFileWatcher = await import('../src/parts/PreferencesFileWatcher/PreferencesFileWatcher.js')
+
+beforeEach(async () => {
+  jest.useFakeTimers()
+  await PreferencesFileWatcher.dispose()
+  jest.clearAllMocks()
+  consoleWarn.mockImplementation(() => {})
+  // @ts-ignore
+  Platform.getPlatform.mockReturnValue(PlatformType.Electron)
+  // @ts-ignore
+  FileWatcher.watch.mockResolvedValue(watcher)
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('hydrate watches the user settings directory', async () => {
+  await PreferencesFileWatcher.hydrate()
+
+  expect(FileWatcher.watch).toHaveBeenCalledWith({
+    exclude: [],
+    roots: ['file:///home/test/.config/lvce'],
+  })
+  expect(addEventListener).toHaveBeenCalledWith('watcher-event', expect.any(Function))
+})
+
+test('hydrate skips the web platform', async () => {
+  // @ts-ignore
+  Platform.getPlatform.mockReturnValue(PlatformType.Web)
+
+  await PreferencesFileWatcher.hydrate()
+
+  expect(FileWatcher.watch).not.toHaveBeenCalled()
+})
+
+test('hydrate handles watcher setup errors', async () => {
+  const error = new Error('ENOENT')
+  // @ts-ignore
+  FileWatcher.watch.mockRejectedValue(error)
+
+  await expect(PreferencesFileWatcher.hydrate()).resolves.toBeUndefined()
+
+  expect(consoleWarn).toHaveBeenCalledWith('Failed to watch user settings: Error: ENOENT')
+})
+
+test('settings file changes reload preferences after a debounce', async () => {
+  await PreferencesFileWatcher.hydrate()
+  const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
+
+  handleEvent({
+    detail: {
+      eventName: 'change',
+      uri: 'file:///home/test/.config/lvce/settings.json',
+    },
+  })
+  expect(Preferences.reload).not.toHaveBeenCalled()
+
+  await jest.runAllTimersAsync()
+
+  expect(Preferences.reload).toHaveBeenCalledTimes(1)
+})
+
+test('settings file changes are debounced', async () => {
+  await PreferencesFileWatcher.hydrate()
+  const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
+
+  handleEvent({ detail: { eventName: 'unlink', uri: 'file:///home/test/.config/lvce/settings.json' } })
+  handleEvent({ detail: { eventName: 'add', uri: 'file:///home/test/.config/lvce/settings.json' } })
+  handleEvent({ detail: { eventName: 'change', uri: 'file:///home/test/.config/lvce/settings.json' } })
+  await jest.runAllTimersAsync()
+
+  expect(Preferences.reload).toHaveBeenCalledTimes(1)
+})
+
+test('changes to other files are ignored', async () => {
+  await PreferencesFileWatcher.hydrate()
+  const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
+
+  handleEvent({
+    detail: {
+      eventName: 'change',
+      uri: 'file:///home/test/.config/lvce/keybindings.json',
+    },
+  })
+  await jest.runAllTimersAsync()
+
+  expect(Preferences.reload).not.toHaveBeenCalled()
+})
+
+test('dispose stops watching and cancels a pending reload', async () => {
+  await PreferencesFileWatcher.hydrate()
+  const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
+  handleEvent({ detail: { eventName: 'change', uri: 'file:///home/test/.config/lvce/settings.json' } })
+
+  await PreferencesFileWatcher.dispose()
+  await jest.runAllTimersAsync()
+
+  expect(removeEventListener).toHaveBeenCalledWith('watcher-event', expect.any(Function))
+  expect(FileWatcher.dispose).toHaveBeenCalledWith(watcher)
+  expect(Preferences.reload).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary

- watch the native user settings directory and debounce settings-file changes
- reload the complete preference state and emit `preferences.changed`
- replace stale preference keys so removing `workbench.iconTheme` restores the default `vscode-icons` theme

## Testing

- renderer worker: 353 suites passed, 1,584 tests passed
- repository type-check passed
- repository lint passed
- Electron development build: default icons changed live to disabled on `null`, then changed live back to `vscode-icons` without restarting