### PR TITLE
fix: register linked extension config command

### DIFF
--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -115,6 +115,7 @@ export const getModuleId = (commandId: any): any => {
     case 'ExtensionManagement.getAllExtensions':
     case 'ExtensionManagement.getExtensions':
     case 'ExtensionManagement.getExtensionsEtag':
+    case 'ExtensionManagement.getLinkedExtensionDevelopmentConfig':
     case 'ExtensionManagement.install':
     case 'ExtensionManagement.uninstall':
       return ModuleId.ExtensionManagement

--- a/packages/shared-process/test/ModuleMap.test.ts
+++ b/packages/shared-process/test/ModuleMap.test.ts
@@ -39,3 +39,7 @@ test('getModuleId - HandleMessagePortForExtensionNodeProcess.handleMessagePortFo
     ModuleId.HandleMessagePortForExtensionNodeProcess,
   )
 })
+
+test('getModuleId - ExtensionManagement.getLinkedExtensionDevelopmentConfig', () => {
+  expect(ModuleMap.getModuleId('ExtensionManagement.getLinkedExtensionDevelopmentConfig')).toBe(ModuleId.ExtensionManagement)
+})


### PR DESCRIPTION
Register `ExtensionManagement.getLinkedExtensionDevelopmentConfig` in the shared-process module map so packaged Electron builds can complete workbench startup. Adds focused regression coverage for the command lookup.