### PR TITLE
fix: allow remote file system websocket connections

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -709,7 +709,7 @@
   {
     "id": "fileSystemWorker",
     "fileName": "fileSystemWorkerMain.js",
-    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self'"],
+    "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self' ws://127.0.0.1:* ws://localhost:*"],
     "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/file-system-worker/dist/fileSystemWorkerMain.js",
     "productionPath": "/packages/file-system-worker/dist/fileSystemWorkerMain.js",
     "settingName": "develop.fileSystemWorkerPath",

--- a/packages/static-server/test/GetHeadersTerminalWorker.test.ts
+++ b/packages/static-server/test/GetHeadersTerminalWorker.test.ts
@@ -27,6 +27,19 @@ test('text search worker allows authenticated loopback websocket connections', (
   expect(headers['Content-Security-Policy']).toContain(`ws://127.0.0.1:* ws://localhost:*`)
 })
 
+test('file system worker allows authenticated loopback websocket connections', () => {
+  const headers = GetHeaders.getHeaders({
+    absolutePath: '/test/fileSystemWorkerMain.js',
+    etag: 'test-etag',
+    isImmutable: false,
+    isForElectronProduction: false,
+    applicationName: 'lvce',
+  })
+
+  expect(headers['Content-Security-Policy']).toContain(`connect-src 'self'`)
+  expect(headers['Content-Security-Policy']).toContain(`ws://127.0.0.1:* ws://localhost:*`)
+})
+
 test('process explorer worker allows authenticated loopback websocket connections', () => {
   const headers = GetHeaders.getHeaders({
     absolutePath: '/test/process-explorer-worker/index.js',


### PR DESCRIPTION
## Summary

- allow the file system worker to connect to authenticated loopback WebSocket endpoints
- keep the CSP scoped to `127.0.0.1` and `localhost`
- add regression coverage for the generated worker response header

## Testing

- `packages/static-server`: all 24 tests pass
- `packages/static-server`: type check passes
- `packages/renderer-worker`: type check passes

The package-wide renderer lint currently reports the repository baseline of 107,981 unrelated formatting/naming errors; this change only modifies JSON there.