### PR TITLE
Fix stale built-in extensions in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "postinstall": "lerna bootstrap --ci && node scripts/postinstall.js",
     "test": "lerna run test",
+    "predev": "node scripts/download-builtin-extensions.js",
     "dev": "nodemon",
     "diagnose:gpu": "node scripts/diagnose-gpu-process.mjs",
     "e2e": "lerna run e2e",

--- a/packages/build/test/DevScript.test.ts
+++ b/packages/build/test/DevScript.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@jest/globals'
+import { readFile } from 'node:fs/promises'
+
+test('dev startup refreshes built-in extensions', async () => {
+  const packageJsonUrl = new URL('../../../package.json', import.meta.url)
+  const packageJson = JSON.parse(await readFile(packageJsonUrl, 'utf8'))
+
+  expect(packageJson.scripts.predev).toBe('node scripts/download-builtin-extensions.js')
+})


### PR DESCRIPTION
Refresh declared built-in extensions before starting the development server. This prevents newly bundled extension features, such as Gpt Voice audio debugging, from being hidden by an older extracted extension after pulling main.