### PR TITLE
Revert unrelated built-in predev sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "postinstall": "lerna bootstrap --ci && node scripts/postinstall.js",
     "test": "lerna run test",
-    "predev": "node scripts/download-builtin-extensions.js",
     "dev": "nodemon",
     "diagnose:gpu": "node scripts/diagnose-gpu-process.mjs",
     "e2e": "lerna run e2e",

--- a/packages/build/test/DevScript.test.ts
+++ b/packages/build/test/DevScript.test.ts
@@ -1,9 +1,0 @@
-import { expect, test } from '@jest/globals'
-import { readFile } from 'node:fs/promises'
-
-test('dev startup refreshes built-in extensions', async () => {
-  const packageJsonUrl = new URL('../../../package.json', import.meta.url)
-  const packageJson = JSON.parse(await readFile(packageJsonUrl, 'utf8'))
-
-  expect(packageJson.scripts.predev).toBe('node scripts/download-builtin-extensions.js')
-})


### PR DESCRIPTION
Removes the built-in extension refresh added for the wrong development path. The reported sidebar issue was in the Gpt Voice repository checkout, which was behind the audio-debug feature.