### PR TITLE
fix: make linked extension dev server opt-in

### DIFF
--- a/packages/build/src/parts/Template/template_bash_completion.txt
+++ b/packages/build/src/parts/Template/template_bash_completion.txt
@@ -21,7 +21,7 @@ _@@APPNAME@@() {
     esac
 
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $( compgen -W "--built-in-self-test --hot-reload --link -h --help -v --version --wait install uninstall" -- "$cur" ) )
+        COMPREPLY=( $( compgen -W "--built-in-self-test --hot-reload --link --start-dev-server -h --help -v --version --wait install uninstall" -- "$cur" ) )
         return
     fi
 

--- a/packages/shared-process/src/parts/GetHelpString/GetHelpString.ts
+++ b/packages/shared-process/src/parts/GetHelpString/GetHelpString.ts
@@ -7,7 +7,8 @@ Usage:
   ${Platform.applicationName} [path]
 
 Extension development:
-  --link <path>              Link an extension for this run. May be repeated.
+  --link <path>             Link an extension for this run. May be repeated.
+  --start-dev-server        Run npm run dev in linked extension folders.
   --hot-reload              Restart linked extensions when their files change.
 
 Diagnostics:

--- a/packages/shared-process/src/parts/HandleElectronReady/HandleElectronReady.ts
+++ b/packages/shared-process/src/parts/HandleElectronReady/HandleElectronReady.ts
@@ -13,7 +13,9 @@ export const handleElectronReady = async (parsedArgs: any, workingDirectory: any
   Assert.string(workingDirectory)
   try {
     const links = await TransientLinkedExtensions.validate()
-    await LinkedExtensionDevServers.startDevServers(links)
+    if (parsedArgs['start-dev-server'] === true) {
+      await LinkedExtensionDevServers.startDevServers(links)
+    }
   } catch (error) {
     Logger.error(error)
     Process.exit(ExitCode.Error)

--- a/packages/shared-process/test/CliHelp.test.ts
+++ b/packages/shared-process/test/CliHelp.test.ts
@@ -28,7 +28,8 @@ Usage:
   lvce-oss [path]
 
 Extension development:
-  --link <path>              Link an extension for this run. May be repeated.
+  --link <path>             Link an extension for this run. May be repeated.
+  --start-dev-server        Run npm run dev in linked extension folders.
   --hot-reload              Restart linked extensions when their files change.
 
 Diagnostics:

--- a/packages/shared-process/test/HandleElectronReady.test.ts
+++ b/packages/shared-process/test/HandleElectronReady.test.ts
@@ -47,7 +47,7 @@ test('handleElectronReady - uses safe preferences when creating the app window',
   await HandleElectronReady.handleElectronReady({}, '/tmp')
 
   expect(TransientLinkedExtensions.validate).toHaveBeenCalledTimes(1)
-  expect(LinkedExtensionDevServers.startDevServers).toHaveBeenCalledTimes(1)
+  expect(LinkedExtensionDevServers.startDevServers).not.toHaveBeenCalled()
   expect(AppWindow.createAppWindow).toHaveBeenCalledTimes(1)
   expect(AppWindow.createAppWindow).toHaveBeenCalledWith({
     parsedArgs: {},
@@ -57,6 +57,18 @@ test('handleElectronReady - uses safe preferences when creating the app window',
     preloadUrl: 'file:///preload.js',
     workingDirectory: '/tmp',
   })
+})
+
+test('handleElectronReady - starts linked extension dev servers when enabled', async () => {
+  const links = [{ resolvedPath: '/extension' }]
+  // @ts-ignore
+  TransientLinkedExtensions.validate.mockResolvedValue(links)
+
+  await HandleElectronReady.handleElectronReady({ 'start-dev-server': true }, '/tmp')
+
+  expect(LinkedExtensionDevServers.startDevServers).toHaveBeenCalledTimes(1)
+  expect(LinkedExtensionDevServers.startDevServers).toHaveBeenCalledWith(links)
+  expect(AppWindow.createAppWindow).toHaveBeenCalledTimes(1)
 })
 
 test('handleElectronReady - exits with helpful error when transient link validation fails', async () => {


### PR DESCRIPTION
Summary:
- keep linked extension dev servers stopped by default
- add `--start-dev-server` to explicitly run linked `dev` scripts
- document and complete the new CLI flag