### PR TITLE
Fix extension enablement button text selection

### DIFF
--- a/packages/extension-host-worker-tests/src/extension.workspace-disable-menu.ts
+++ b/packages/extension-host-worker-tests/src/extension.workspace-disable-menu.ts
@@ -12,6 +12,7 @@ export const test: Test = async ({ expect, ExtensionDetail, Locator, ...api }) =
   const optionsButton = Locator('[name="DisableOptions"]')
   await expect(splitButton).toHaveCount(1)
   await expect(primaryButton).toBeVisible()
+  await expect(primaryButton).toHaveCSS('user-select', 'none')
   await expect(optionsButton).toHaveAttribute('aria-label', 'Disable options')
   await expect(optionsButton).toHaveAttribute('title', 'Disable options')
   await expect(optionsButton).toHaveClass('ExtensionEnablementSplitButtonDropDown')

--- a/packages/extension-host-worker-tests/src/extension.workspace-enable-menu.ts
+++ b/packages/extension-host-worker-tests/src/extension.workspace-enable-menu.ts
@@ -12,6 +12,7 @@ export const test: Test = async ({ expect, ExtensionDetail, Locator, ...api }) =
   const optionsButton = Locator('[name="EnableOptions"]')
   await expect(splitButton).toHaveCount(1)
   await expect(primaryButton).toBeVisible()
+  await expect(primaryButton).toHaveCSS('user-select', 'none')
   await expect(optionsButton).toHaveAttribute('aria-label', 'Enable options')
   await expect(optionsButton).toHaveAttribute('title', 'Enable options')
   await expect(optionsButton).toHaveClass('ExtensionEnablementSplitButtonDropDown')

--- a/static/css/parts/ViewletExtensionDetailHeader.css
+++ b/static/css/parts/ViewletExtensionDetailHeader.css
@@ -80,6 +80,11 @@
   padding-top: 10px;
 }
 
+.ExtensionDetailHeaderActions [name='Disable'],
+.ExtensionDetailHeaderActions [name='Enable'] {
+  user-select: none;
+}
+
 .ExtensionEnablementSplitButton {
   display: inline-flex;
 }


### PR DESCRIPTION
Prevent text selection on the extension detail Enable and Disable buttons, with e2e coverage for both states.