### PR TITLE
fix: refresh disabled extension contributions

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/extension.json
@@ -5,7 +5,12 @@
   "version": "0.0.0",
   "browser": "main.js",
   "isolated": true,
-  "activation": ["onStatusBarItem"],
+  "activation": ["onSourceControl:memfs", "onStatusBarItem"],
+  "sourceControlProviders": [
+    {
+      "id": "extension-lifecycle-source-control"
+    }
+  ],
   "statusBarItems": [
     {
       "id": "extension-lifecycle"

--- a/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.extension-disable-lifecycle/main.js
@@ -21,6 +21,28 @@ const commandMap = {
     }
   },
   'ExtensionApi.disposeViewInstance'() {},
+  'ExtensionApi.executeSourceControlGetBadgeCount'() {
+    return 3
+  },
+  'ExtensionApi.executeSourceControlGetFeatures'() {
+    return {}
+  },
+  'ExtensionApi.executeSourceControlGetGroups'() {
+    return [
+      {
+        id: 'changes',
+        items: [
+          { file: 'first.txt', type: 8 },
+          { file: 'second.txt', type: 8 },
+          { file: 'third.txt', type: 8 },
+        ],
+        label: 'Changes',
+      },
+    ]
+  },
+  'ExtensionApi.executeSourceControlIsActive'(_id, scheme) {
+    return scheme === 'memfs'
+  },
   'ExtensionApi.getViewActions'() {
     return []
   },
@@ -36,6 +58,15 @@ const commandMap = {
         text: 'Lifecycle Ready',
       },
     ]
+  },
+  'ExtensionApi.getSourceControlProviderRegistrySnapshot'() {
+    return {
+      providers: [
+        {
+          id: 'extension-lifecycle-source-control',
+        },
+      ],
+    }
   },
   'ExtensionApi.getViewRegistrySnapshot'() {
     return {

--- a/packages/extension-host-worker-tests/src/extension.disable-refreshes-source-control-contributions.ts
+++ b/packages/extension-host-worker-tests/src/extension.disable-refreshes-source-control-contributions.ts
@@ -1,0 +1,41 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  addWorkspaceLifecycleExtension,
+  disableLifecycleExtension,
+  enableLifecycleExtension,
+  extensionId,
+  runningExtensionSelector,
+  statusBarItemSelector,
+} from '../fixtures/sample.extension-disable-lifecycle/test.js'
+
+export const name = 'extension.disable-refreshes-source-control-contributions'
+
+export const test: Test = async ({ Command, expect, Locator, RunningExtensions, SourceControl, ...api }) => {
+  await addWorkspaceLifecycleExtension({ Command, ...api })
+  await SourceControl.show()
+
+  const sourceControlItem = Locator('.ActivityBarItem[title="Source Control"]')
+  const sourceControlBadge = sourceControlItem.locator('.ActivityBarItemBadge')
+  const statusBarItem = Locator(statusBarItemSelector)
+  await expect(sourceControlBadge).toHaveText('3')
+  await expect(statusBarItem).toBeVisible()
+
+  await disableLifecycleExtension(api)
+
+  await expect(sourceControlBadge).toHaveCount(0)
+  const badgeCounts = await Command.execute('Layout.getBadgeCounts')
+  if (badgeCounts['Source Control'] !== 0) {
+    throw new Error(`Expected source control badge count to be 0, got ${badgeCounts['Source Control']}`)
+  }
+  await expect(statusBarItem).toBeHidden()
+
+  await SourceControl.show()
+  const message = Locator('.Viewlet.SourceControl > .Message')
+  await expect(message).toBeVisible()
+  await expect(message).toHaveText('All installed source control extensions are disabled.')
+
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+  await expect(runningExtension).toBeHidden()
+  await enableLifecycleExtension({ Command, ...api })
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2624,13 +2624,18 @@ const getActiveSideBarExtensionId = (state: LayoutState): string => {
 
 export const handleExtensionsChanged = async (state: LayoutState, extensionId?: string, disabled?: boolean): Promise<LayoutStateResult> => {
   const globalEventResult = await callGlobalEvent(state, 'handleExtensionsChanged')
-  if (!disabled || !extensionId || getActiveSideBarExtensionId(state) !== extensionId) {
-    return globalEventResult
+  const sourceControlBadgeResult = await refreshSourceControlBadgeCount(globalEventResult.newState)
+  const extensionChangeResult = {
+    newState: sourceControlBadgeResult.newState,
+    commands: [...globalEventResult.commands, ...sourceControlBadgeResult.commands],
   }
-  const fallbackResult = await showSideBar(globalEventResult.newState, ViewletModuleId.Explorer, false)
+  if (!disabled || !extensionId || getActiveSideBarExtensionId(extensionChangeResult.newState) !== extensionId) {
+    return extensionChangeResult
+  }
+  const fallbackResult = await showSideBar(extensionChangeResult.newState, ViewletModuleId.Explorer, false)
   return {
     newState: fallbackResult.newState,
-    commands: [...globalEventResult.commands, ...fallbackResult.commands],
+    commands: [...extensionChangeResult.commands, ...fallbackResult.commands],
   }
 }
 

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -147,6 +147,20 @@ export const handleWorkspaceChange = async (state) => {
   }
 }
 
+export const handleExtensionsChanged = async (state) => {
+  await SourceControlWorker.invoke('SourceControl.loadContent', state.uid, state.savedState)
+  const diffResult = await SourceControlWorker.invoke('SourceControl.diff2', state.uid)
+  const commands = await SourceControlWorker.invoke('SourceControl.render2', state.uid, diffResult)
+  const actionsDom = await SourceControlWorker.invoke('SourceControl.renderActions2', state.uid)
+  const badgeCount = await SourceControlWorker.invoke('SourceControl.getBadgeCount', state.uid)
+  return {
+    ...state,
+    actionsDom,
+    badgeCount,
+    commands,
+  }
+}
+
 export const handleMouseOut = (state, index) => {
   if (index === -1) {
     return {

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControlCommands.js
@@ -18,6 +18,7 @@ export const getCommands = async () => {
     Commands[command] = WrapSourceControlCommand.wrapSourceControlCommand(command)
   }
   Commands['loadContentLater'] = ViewletSourceControl.loadContentLater
+  Commands['handleExtensionsChanged'] = ViewletSourceControl.handleExtensionsChanged
   Commands['hotReload'] = ViewletSourceControl.hotReload
   Commands['getInfo'] = ({ uid }) => SourceControlWorker.invoke('SourceControl.getInfo', uid)
   Commands['focus'] = ViewletSourceControl.focus

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -30,6 +30,14 @@ jest.unstable_mockModule('../src/parts/SaveState/SaveState.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/SourceControlWorker/SourceControlWorker.js', () => {
+  return {
+    invoke: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
   return {
     disposeFunctional: jest.fn(() => []),
@@ -51,6 +59,7 @@ jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => {
 const ActivityBarWorker = await import('../src/parts/ActivityBarWorker/ActivityBarWorker.js')
 const GetExtensionViews = await import('../src/parts/GetExtensionViews/GetExtensionViews.ts')
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
+const SourceControlWorker = await import('../src/parts/SourceControlWorker/SourceControlWorker.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const LayoutPoints = await import('../src/parts/ViewletLayout/LayoutPoints.ts')
@@ -85,6 +94,10 @@ beforeEach(() => {
   ViewletStates.getInstance.mockReturnValue(undefined)
   // @ts-ignore
   ViewletStates.getState.mockReturnValue({ uid: 12 })
+  // @ts-ignore
+  SourceControlWorker.invoke.mockImplementation(() => {
+    throw new Error('not implemented')
+  })
 })
 
 test('setActionsDom creates preview actions with the child event listeners', () => {
@@ -267,6 +280,22 @@ test('handleExtensionsChanged preserves the active sidebar view when another ext
 
   expect(result.newState.sideBarView).toBe('sample.views.testing')
   expect(ActivityBarWorker.invoke).not.toHaveBeenCalled()
+})
+
+test('handleExtensionsChanged recomputes the source control badge count', async () => {
+  // @ts-ignore
+  SourceControlWorker.invoke.mockResolvedValue(0)
+  const state = {
+    ...ViewletLayout.create(1),
+    badgeCounts: {
+      'Source Control': 3,
+    },
+  }
+
+  const result = await ViewletLayout.handleExtensionsChanged(state, 'sample.extension', true)
+
+  expect(SourceControlWorker.invoke).toHaveBeenCalledWith('SourceControl.getWorkspaceBadgeCount', '', '', 4)
+  expect(result.newState.badgeCounts['Source Control']).toBe(0)
 })
 
 test('showSideBar disables restore when the layout disables restore', async () => {

--- a/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
@@ -7,6 +7,7 @@ jest.unstable_mockModule('../src/parts/SourceControlWorker/SourceControlWorker.j
 }))
 
 const ViewletSourceControlCommands = await import('../src/parts/ViewletSourceControl/ViewletSourceControlCommands.js')
+const ViewletSourceControl = await import('../src/parts/ViewletSourceControl/ViewletSourceControl.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -43,4 +44,56 @@ test('renders pending source control worker state without replaying a command', 
     ...state,
     commands: [['Viewlet.setDom2', 42, ['div']]],
   })
+})
+
+test('reloads source control contributions when extensions change', async () => {
+  const state = {
+    actionsDom: ['old-actions'],
+    badgeCount: 3,
+    commands: [],
+    savedState: {
+      inputValue: 'message',
+    },
+    uid: 42,
+  }
+  sourceControlWorkerInvoke.mockImplementation((method) => {
+    switch (method) {
+      case 'SourceControl.loadContent':
+        return undefined
+      case 'SourceControl.diff2':
+        return [1]
+      case 'SourceControl.render2':
+        return [['Viewlet.setDom2', 42, ['div']]]
+      case 'SourceControl.renderActions2':
+        return ['new-actions']
+      case 'SourceControl.getBadgeCount':
+        return 0
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  const result = await ViewletSourceControl.handleExtensionsChanged(state)
+
+  expect(sourceControlWorkerInvoke.mock.calls).toEqual([
+    ['SourceControl.loadContent', 42, { inputValue: 'message' }],
+    ['SourceControl.diff2', 42],
+    ['SourceControl.render2', 42, [1]],
+    ['SourceControl.renderActions2', 42],
+    ['SourceControl.getBadgeCount', 42],
+  ])
+  expect(result).toEqual({
+    ...state,
+    actionsDom: ['new-actions'],
+    badgeCount: 0,
+    commands: [['Viewlet.setDom2', 42, ['div']]],
+  })
+})
+
+test('registers the extension contribution refresh command', async () => {
+  sourceControlWorkerInvoke.mockImplementation(() => [])
+
+  const commands = await ViewletSourceControlCommands.getCommands()
+
+  expect(commands.handleExtensionsChanged).toBe(ViewletSourceControl.handleExtensionsChanged)
 })


### PR DESCRIPTION
Refresh Source Control and status bar contributions when an extension is disabled.

Recompute the Source Control badge, reload an existing Source Control view, and cover runtime, status item, badge, and disabled-provider cleanup with an isolated extension fixture.