### PR TITLE
fix: add view-only worker disposal e2e

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/test.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.running-extensions-live-view/test.js
@@ -16,3 +16,11 @@ export const activateLiveViewExtension = async ({ expect, Locator }) => {
   await activityBarItem.click()
   await new Promise((resolve) => setTimeout(resolve, 500))
 }
+
+export const deactivateLiveViewExtension = async ({ expect, Locator }) => {
+  const activityBarItem = Locator(activityBarItemSelector)
+  await expect(activityBarItem).toBeVisible()
+  // eslint-disable-next-line e2e/no-direct-click
+  await activityBarItem.click()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+}

--- a/packages/extension-host-worker-tests/src/running-extensions.live-view-disposes-worker.ts
+++ b/packages/extension-host-worker-tests/src/running-extensions.live-view-disposes-worker.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+import {
+  activateLiveViewExtension,
+  addLiveViewExtension,
+  deactivateLiveViewExtension,
+  extensionId,
+  runningExtensionSelector,
+} from '../fixtures/sample.running-extensions-live-view/test.js'
+
+export const name = 'running-extensions.live-view-disposes-worker'
+
+export const test: Test = async ({ Command, expect, Locator, RunningExtensions, ...api }) => {
+  await addLiveViewExtension(api)
+  await RunningExtensions.show()
+  const runningExtension = Locator(runningExtensionSelector, { hasText: extensionId })
+
+  await activateLiveViewExtension({ expect, Locator })
+  const runningExtensionsAfterActivation = await Command.execute('ExtensionManagement.getRunningExtensions')
+  await RunningExtensions.setExtensions(runningExtensionsAfterActivation)
+  await expect(runningExtension).toBeVisible()
+
+  await deactivateLiveViewExtension({ expect, Locator })
+
+  const runningExtensionsAfterDisposal = await Command.execute('ExtensionManagement.getRunningExtensions')
+  await RunningExtensions.setExtensions(runningExtensionsAfterDisposal)
+  await expect(runningExtension).toBeHidden()
+
+  await activateLiveViewExtension({ expect, Locator })
+  const runningExtensionsAfterReactivation = await Command.execute('ExtensionManagement.getRunningExtensions')
+  await RunningExtensions.setExtensions(runningExtensionsAfterReactivation)
+  await expect(runningExtension).toBeVisible()
+}


### PR DESCRIPTION
Adds an end-to-end regression test for isolated extensions that activate only for a contributed view. The test verifies that closing the view removes the extension worker from the running extensions list and that reopening the view starts it again.\n\nLocal validation:\n- extension-host-worker-tests type-check\n- repository lint\n- static build