### PR TITLE
fix: support provider media blob urls

### DIFF
--- a/packages/renderer-worker/src/parts/BlobSrc/BlobSrc.js
+++ b/packages/renderer-worker/src/parts/BlobSrc/BlobSrc.js
@@ -1,7 +1,7 @@
-import * as Command from '../Command/Command.js'
 import * as FileSystem from '../FileSystem/FileSystem.js'
 import * as Mime from '../Mime/Mime.js'
 import * as Protocol from '../Protocol/Protocol.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 
 export const getSrc = (uri) => {
   const mimeType = Mime.getMediaMimeType(uri)
@@ -10,6 +10,6 @@ export const getSrc = (uri) => {
 
 export const disposeSrc = async (src) => {
   if (src.startsWith(Protocol.Blob)) {
-    await Command.execute('Url.revokeObjectUrl', src)
+    await RendererProcess.invoke('ObjectUrl.revoke', src)
   }
 }

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
@@ -4,6 +4,7 @@ import * as ExtensionHostCommandType from '../ExtensionHostCommandType/Extension
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
 import * as FileSystemProtocol from '../FileSystemProtocol/FileSystemProtocol.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as ExtensionHostShared from './ExtensionHostShared.js'
 
 const notifyWorkspaceChanged = async (changes) => {
@@ -62,7 +63,7 @@ export const getBlob = async (uri, type = '') => {
 
 export const getBlobUrl = async (uri, type = '') => {
   const blob = await getBlob(uri, type)
-  return URL.createObjectURL(blob)
+  return RendererProcess.invoke('ObjectUrl.create', blob)
 }
 
 export const remove = async (uri) => {

--- a/packages/renderer-worker/test/BlobSrc.test.ts
+++ b/packages/renderer-worker/test/BlobSrc.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const getBlobUrl = jest.fn<(uri: string, type: string) => Promise<string>>()
+const invoke = jest.fn<(...args: readonly any[]) => Promise<any>>()
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   getBlobUrl,
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke,
 }))
 
 const BlobSrc = await import('../src/parts/BlobSrc/BlobSrc.js')
@@ -17,4 +22,16 @@ test('getSrc creates an SVG blob with its media type', async () => {
 
   await expect(BlobSrc.getSrc('memfs:///workspace/image.svg')).resolves.toBe('blob:https://example.com/image-id')
   expect(getBlobUrl).toHaveBeenCalledWith('memfs:///workspace/image.svg', 'image/svg+xml')
+})
+
+test('disposeSrc revokes blob urls in the renderer process', async () => {
+  await BlobSrc.disposeSrc('blob:https://example.com/image-id')
+
+  expect(invoke).toHaveBeenCalledWith('ObjectUrl.revoke', 'blob:https://example.com/image-id')
+})
+
+test('disposeSrc ignores non-blob urls', async () => {
+  await BlobSrc.disposeSrc('/remote/workspace/image.svg')
+
+  expect(invoke).not.toHaveBeenCalled()
 })

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -3,6 +3,7 @@ import * as DirentType from '../src/parts/DirentType/DirentType.js'
 
 const invoke = jest.fn<(...args: readonly any[]) => Promise<any>>()
 const execute = jest.fn<(...args: readonly any[]) => Promise<any>>()
+const rendererInvoke = jest.fn<(...args: readonly any[]) => Promise<any>>()
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -15,6 +16,10 @@ jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManage
 
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
   execute,
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: rendererInvoke,
 }))
 
 jest.unstable_mockModule('../src/parts/ExtensionHost/ExtensionHostShared.js', () => {
@@ -75,13 +80,13 @@ test('getBlob converts text provider content using the requested mime type', asy
   await expect(blob.text()).resolves.toBe('test content')
 })
 
-test('getBlobUrl creates an object url for provider content', async () => {
-  const createObjectURL = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:recording')
+test('getBlobUrl creates an object url in the renderer process', async () => {
   const audio = new Blob(['recorded audio'], { type: 'audio/webm' })
   invoke.mockResolvedValue({ found: true, result: audio })
+  rendererInvoke.mockResolvedValue('blob:recording')
 
   await expect(ExtensionHostFileSystem.getBlobUrl('gpt-voice-audio:///message.webm', 'video/webm')).resolves.toBe('blob:recording')
-  expect(createObjectURL).toHaveBeenCalledWith(audio)
+  expect(rendererInvoke).toHaveBeenCalledWith('ObjectUrl.create', audio)
 })
 
 test('remove', async () => {

--- a/packages/shared-process/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
+++ b/packages/shared-process/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
@@ -41,7 +41,7 @@ export const value = GetContentSecurityPolicy.getContentSecurityPolicy([
   ...getConnectSrc(),
   `font-src 'self'`,
   `img-src 'self' https: data: blob:`, // TODO maybe disallow https and data images
-  `media-src 'self'`,
+  `media-src 'self' blob:`,
   `script-src 'self'`,
   `style-src 'self' 'unsafe-inline'`,
   ...getFrameAncestors(),

--- a/packages/shared-process/test/GetTestRequestResponse.test.ts
+++ b/packages/shared-process/test/GetTestRequestResponse.test.ts
@@ -88,6 +88,7 @@ test('getTestRequestResponse - _all.html serves index html', async () => {
       status: 200,
     },
   })
+  expect(result.init.headers['Content-Security-Policy']).toContain(`media-src 'self' blob:`)
   expect(result.body).toContain('<title>Tests</title>')
 })
 

--- a/packages/static-server/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
+++ b/packages/static-server/src/parts/ContentSecurityPolicyDocument/ContentSecurityPolicyDocument.ts
@@ -44,7 +44,7 @@ export const getValue = ({ isForElectronProduction, applicationName = defaultApp
     ...getConnectSrc({ isForElectronProduction }),
     `font-src 'self'`,
     `img-src 'self' https: data: blob:`, // TODO maybe disallow https and data images
-    `media-src 'self'`,
+    `media-src 'self' blob:`,
     `script-src 'self'`,
     `style-src 'self' 'unsafe-inline'`,
     ...getFrameAncestors(),

--- a/packages/static-server/test/GetHeadersDocument.test.ts
+++ b/packages/static-server/test/GetHeadersDocument.test.ts
@@ -12,6 +12,7 @@ test('uses default application name when missing', () => {
   expect(headers['Content-Security-Policy']).toContain(`style-src 'self' 'unsafe-inline'`)
   expect(headers['Content-Security-Policy']).toContain(`connect-src 'self' https: wss:`)
   expect(headers['Content-Security-Policy']).toContain(`ws://127.0.0.1:* ws://localhost:*`)
+  expect(headers['Content-Security-Policy']).toContain(`media-src 'self' blob:`)
   expect(headers['Content-Security-Policy']).not.toContain('undefined-webview:')
 })
 


### PR DESCRIPTION
Move extension-provider Blob URL ownership to the renderer process and allow blob media in document CSP for playable provider-backed recordings.