### PR TITLE
fix: serialize title bar commands

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-menu-clear-highlight-on-focus-out.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-menu-clear-highlight-on-focus-out.ts
@@ -29,20 +29,22 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main, TitleBarMe
   const editorRow = Locator('.EditorRow').first()
   const editorInput = Locator('[name="editor"]')
 
-  await helpMenuItem.click()
-  await waitFor(() => expect(menu).toBeVisible())
+  for (let iteration = 0; iteration < 20; iteration++) {
+    await helpMenuItem.click()
+    await waitFor(() => expect(menu).toBeVisible())
 
-  await TitleBarMenuBar.handleKeyEscape()
-  await waitFor(() => expect(menu).toBeHidden())
-  await expect(helpMenuItem).toHaveAttribute('id', 'TitleBarEntryActive')
-  // The test locator's synthetic mouse click omits the browser's default button focus behavior.
-  await helpMenuItem.type('')
-  await waitFor(() => expect(helpMenuItem).toBeFocused())
+    await TitleBarMenuBar.handleKeyEscape()
+    await waitFor(() => expect(menu).toBeHidden())
+    await expect(helpMenuItem).toHaveAttribute('id', 'TitleBarEntryActive')
+    // The test locator's synthetic mouse click omits the browser's default button focus behavior.
+    await helpMenuItem.type('')
+    await waitFor(() => expect(helpMenuItem).toBeFocused())
 
-  await new Promise((resolve) => setTimeout(resolve, 200))
-  await editorRow.click()
-  await waitFor(() => expect(editorInput).toBeFocused())
-  await waitFor(() => expect(helpMenuItem).toHaveAttribute('id', null))
-  await waitFor(() => expect(helpMenuItem).toHaveAttribute('aria-expanded', 'false'))
-  await waitFor(() => expect(titleBarMenuBar).toHaveAttribute('aria-activedescendant', null))
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    await editorRow.click()
+    await waitFor(() => expect(editorInput).toBeFocused())
+    await waitFor(() => expect(helpMenuItem).toHaveAttribute('id', null))
+    await waitFor(() => expect(helpMenuItem).toHaveAttribute('aria-expanded', 'false'))
+    await waitFor(() => expect(titleBarMenuBar).toHaveAttribute('aria-activedescendant', null))
+  }
 }

--- a/packages/renderer-worker/src/parts/ViewletTitleBar/WrapTitleBarCommand.js
+++ b/packages/renderer-worker/src/parts/ViewletTitleBar/WrapTitleBarCommand.js
@@ -1,17 +1,35 @@
 import * as TitleBarWorker from '../TitleBarWorker/TitleBarWorker.js'
 
+const commandQueues = new Map()
+
+const runTitleBarCommand = async (key, state, args) => {
+  await TitleBarWorker.invoke(`TitleBar.${key}`, state.uid, ...args)
+  const diffResult = await TitleBarWorker.invoke('TitleBar.diff3', state.uid)
+  if (diffResult.length === 0) {
+    return state
+  }
+  const commands = await TitleBarWorker.invoke('TitleBar.render3', state.uid, diffResult)
+  return {
+    ...state,
+    commands,
+  }
+}
+
 export const wrapTitleBarCommand = (key) => {
-  const fn = async (state, ...args) => {
-    await TitleBarWorker.invoke(`TitleBar.${key}`, state.uid, ...args)
-    const diffResult = await TitleBarWorker.invoke('TitleBar.diff3', state.uid)
-    if (diffResult.length === 0) {
-      return state
+  return async (state, ...args) => {
+    const previous = commandQueues.get(state.uid)
+    const { promise: next, resolve } = Promise.withResolvers()
+    commandQueues.set(state.uid, next)
+    if (previous) {
+      await previous
     }
-    const commands = await TitleBarWorker.invoke('TitleBar.render3', state.uid, diffResult)
-    return {
-      ...state,
-      commands,
+    try {
+      return await runTitleBarCommand(key, state, args)
+    } finally {
+      resolve(undefined)
+      if (commandQueues.get(state.uid) === next) {
+        commandQueues.delete(state.uid)
+      }
     }
   }
-  return fn
 }

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -13,6 +13,7 @@ import { renderActions as renderExtensionActions } from '../ViewletExtensions/Vi
 import { getKeyBindings as getProblemsKeyBindings } from '../ViewletProblems/ViewletProblemsKeyBindings.js'
 import { menus as processExplorerMenus } from '../ViewletProcessExplorer/ViewletProcessExplorerMenuEntries.js'
 import { resize as resizeTitleBar } from '../ViewletTitleBar/ViewletTitleBarResize.js'
+import { wrapTitleBarCommand } from '../ViewletTitleBar/WrapTitleBarCommand.js'
 import { wrapActivityBarCommand } from '../WrapActivityBarCommand/WrapActivityBarCommand.ts'
 import { wrapDiffViewCommand } from '../WrapDiffViewCommand/WrapDiffViewCommand.ts'
 import { wrapExplorerCommand } from '../WrapExplorerCommand/WrapExplorerCommand.ts'
@@ -300,4 +301,5 @@ export const titleBar = {
       titleBarStyleCustom: Preferences.get('window.titleBarStyle') === 'custom',
     }
   },
+  wrapCommand: wrapTitleBarCommand,
 }

--- a/packages/renderer-worker/test/WrapTitleBarCommand.test.ts
+++ b/packages/renderer-worker/test/WrapTitleBarCommand.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/TitleBarWorker/TitleBarWorker.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const TitleBarWorker = await import('../src/parts/TitleBarWorker/TitleBarWorker.js')
+const { wrapTitleBarCommand } = await import('../src/parts/ViewletTitleBar/WrapTitleBarCommand.js')
+const invoke = jest.mocked(TitleBarWorker.invoke)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('serializes title bar commands through rendering', async () => {
+  const firstRenderStarted = Promise.withResolvers<void>()
+  const firstRender = Promise.withResolvers<void>()
+  let diffCount = 0
+  let renderCount = 0
+  invoke.mockImplementation(async (command: string) => {
+    if (command === 'TitleBar.diff3') {
+      return [++diffCount]
+    }
+    if (command === 'TitleBar.render3') {
+      renderCount++
+      if (renderCount === 1) {
+        firstRenderStarted.resolve()
+        await firstRender.promise
+      }
+      return [[`render-${renderCount}`]]
+    }
+    return undefined
+  })
+  const state = { uid: 7 }
+
+  const click = wrapTitleBarCommand('handleClickAt')(state)
+  await firstRenderStarted.promise
+  const focusOut = wrapTitleBarCommand('handleFocusOut')(state)
+  await Promise.resolve()
+
+  expect(invoke.mock.calls.map((call) => call[0])).toEqual(['TitleBar.handleClickAt', 'TitleBar.diff3', 'TitleBar.render3'])
+
+  firstRender.resolve()
+  await expect(Promise.all([click, focusOut])).resolves.toEqual([
+    { uid: 7, commands: [['render-1']] },
+    { uid: 7, commands: [['render-2']] },
+  ])
+  expect(invoke.mock.calls.map((call) => call[0])).toEqual([
+    'TitleBar.handleClickAt',
+    'TitleBar.diff3',
+    'TitleBar.render3',
+    'TitleBar.handleFocusOut',
+    'TitleBar.diff3',
+    'TitleBar.render3',
+  ])
+})


### PR DESCRIPTION
## Summary

Serialize title-bar command, diff, and render pipelines per title bar so click, Escape, and focus transitions cannot commit out of order. Strengthen the focus/highlight E2E regression with 20 consecutive cycles.