### PR TITLE
fix: synchronize linux cli sigint test

### DIFF
--- a/packages/build/test/LinuxCliTemplate.test.ts
+++ b/packages/build/test/LinuxCliTemplate.test.ts
@@ -86,11 +86,11 @@ describe('linux cli templates', () => {
       await writeFile(
         fakeElectronPath,
         `#!/usr/bin/env node
-console.log(\`ready \${process.pid}\`)
 process.on('SIGINT', () => {
   console.log('received SIGINT')
   process.exit(0)
 })
+console.log(\`ready \${process.pid}\`)
 setInterval(() => {}, 1000)
 `,
       )


### PR DESCRIPTION
The fake Electron fixture announced readiness before installing its SIGINT handler. Under release-run load, the test could signal that gap and observe the child’s default signal exit as CLI code 1.

Register the fixture handler before printing `ready`, so readiness means it is safe for the test to send SIGINT.

Validation:
- focused Linux CLI template suite: 8 passed
- 100 focused stress repetitions at concurrency 12: passed
- full `@lvce-editor/build` suite: 96 passed
- build package type-check: passed