### PR TITLE
feature: add simple browser search suggestions

### DIFF
--- a/packages/renderer-worker/src/parts/BrowserSearchSuggestionsFromGoogle/BrowserSearchSuggestionsFromGoogle.js
+++ b/packages/renderer-worker/src/parts/BrowserSearchSuggestionsFromGoogle/BrowserSearchSuggestionsFromGoogle.js
@@ -1,9 +1,11 @@
 import * as ElectronNet from '../ElectronNet/ElectronNet.js'
 
 export const get = async (query) => {
-  const language = 'en'
-  const autoCompleteUrl = `https://google.com/complete/search?client=chrome&q=${query}&gl=${language}`
+  const autoCompleteUrl = `https://suggestqueries.google.com/complete/search?client=chrome&hl=en&q=${encodeURIComponent(query)}`
   const json = await ElectronNet.getJson(autoCompleteUrl)
+  if (!Array.isArray(json) || !Array.isArray(json[1])) {
+    return []
+  }
   const suggestions = json[1]
-  return suggestions
+  return suggestions.filter((suggestion) => typeof suggestion === 'string' && suggestion.length > 0).slice(0, 7)
 }

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -1,15 +1,25 @@
 import * as ClassNames from '../ClassNames/ClassNames.js'
+import * as AriaRoles from '../AriaRoles/AriaRoles.js'
 import * as HtmlInputType from '../HtmlInputType/HtmlInputType.js'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
+import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
 
-export const getSimpleBrowserVirtualDom = (canGoBack, canGoForward, isLoading, value, snapshot = '') => {
+export const getSimpleBrowserVirtualDom = (
+  canGoBack,
+  canGoForward,
+  isLoading,
+  value,
+  snapshot = '',
+  suggestions = [],
+  selectedSuggestionIndex = -1,
+) => {
   /** @type {any[]} */
   const dom = [
     {
       type: VirtualDomElements.Div,
       className: 'Viewlet SimpleBrowser',
-      childCount: snapshot ? 2 : 1,
+      childCount: 1 + (snapshot ? 1 : 0) + (suggestions.length > 0 ? 1 : 0),
     },
     {
       type: VirtualDomElements.Div,
@@ -78,11 +88,41 @@ export const getSimpleBrowserVirtualDom = (canGoBack, canGoForward, isLoading, v
   if (snapshot) {
     dom.push({
       type: VirtualDomElements.Img,
-      className: 'SimpleBrowserSnapshot',
+      className: suggestions.length > 0 ? 'SimpleBrowserSnapshot SimpleBrowserSnapshotSearchSuggestions' : 'SimpleBrowserSnapshot',
       src: snapshot,
       draggable: false,
       childCount: 0,
     })
+  }
+  if (suggestions.length > 0) {
+    dom.push({
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserSuggestions',
+      role: AriaRoles.ListBox,
+      ariaLabel: 'Search suggestions',
+      childCount: suggestions.length,
+    })
+    for (let index = 0; index < suggestions.length; index++) {
+      const suggestion = suggestions[index]
+      const selected = index === selectedSuggestionIndex
+      dom.push(
+        {
+          type: VirtualDomElements.Button,
+          className: selected ? 'SimpleBrowserSuggestion SimpleBrowserSuggestionSelected' : 'SimpleBrowserSuggestion',
+          role: AriaRoles.Option,
+          ariaSelected: selected,
+          'data-value': suggestion,
+          onClick: 'handleClickSuggestion',
+          childCount: 2,
+        },
+        {
+          type: VirtualDomElements.Div,
+          className: 'MaskIcon MaskIconSearch SimpleBrowserSuggestionIcon',
+          childCount: 0,
+        },
+        text(suggestion),
+      )
+    }
   }
   return dom
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -1,12 +1,13 @@
 // based on vscode's simple browser by Microsoft (https://github.com/microsoft/vscode/blob/e8fe2d07d31f30698b9262dd5e1fcc59a85c6bb1/extensions/simple-browser/src/extension.ts, License MIT)
 
 import * as Assert from '../Assert/Assert.ts'
+import * as BrowserSearchSuggestions from '../BrowserSearchSuggestions/BrowserSearchSuggestions.js'
+import * as Command from '../Command/Command.js'
 import * as ElectronWebContentsView from '../ElectronWebContentsView/ElectronWebContentsView.js'
 import * as ElectronWebContentsViewFunctions from '../ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js'
 import * as GetFallThroughKeyBindings from '../GetFallThroughKeyBindings/GetFallThroughKeyBindings.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as IframeSrc from '../IframeSrc/IframeSrc.js'
-import * as IsEmptyString from '../IsEmptyString/IsEmptyString.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as KeyBindingsInitial from '../KeyBindingsInitial/KeyBindingsInitial.js'
 import * as Preferences from '../Preferences/Preferences.js'
@@ -30,6 +31,8 @@ export const create = (id, uri, x, y, width, height) => {
     canGoBack: true,
     isLoading: false,
     hasSuggestionsOverlay: false,
+    selectedSuggestionIndex: -1,
+    suggestions: [],
     overlayIds: [],
     snapshot: '',
     suggestionsEnabled: false,
@@ -56,6 +59,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   const { x, y, width, height, headerHeight } = state
   const iframeSrc = getUrlFromSavedState(savedState)
   const shortcuts = SimpleBrowserPreferences.getShortCuts()
+  const suggestionsEnabled = Preferences.get('simpleBrowser.suggestions')
   // TODO since browser view is not visible at this point
   // it is not necessary to load keybindings for it
   const keyBindings = await KeyBindingsInitial.getKeyBindings()
@@ -69,6 +73,8 @@ export const backgroundLoadContent = async (state, savedState) => {
     title: newTitle,
     uri: `simple-browser://${browserViewId}`,
     iframeSrc,
+    inputValue: iframeSrc,
+    suggestionsEnabled,
     shortcuts,
   }
 }
@@ -104,6 +110,7 @@ export const loadContent = async (state, savedState) => {
     return {
       ...state,
       iframeSrc,
+      inputValue: iframeSrc,
       title: 'Simple Browser',
       browserViewId: actualId,
       suggestionsEnabled,
@@ -121,6 +128,7 @@ export const loadContent = async (state, savedState) => {
   return {
     ...state,
     iframeSrc,
+    inputValue: iframeSrc,
     title,
     browserViewId,
     canGoBack,
@@ -190,22 +198,110 @@ export const hideOverlay = async (state, overlayId) => {
 }
 
 export const handleInput = async (state, value) => {
-  const { hasSuggestionsOverlay, suggestionsEnabled } = state
-  if (suggestionsEnabled) {
-    if (IsEmptyString.isEmptyString(value) && hasSuggestionsOverlay) {
-      return {
-        ...state,
-        inputValue: value,
-        hasSuggestionsOverlay: false,
-      }
+  const newState = {
+    ...state,
+    inputValue: value,
+    selectedSuggestionIndex: -1,
+  }
+  if (!state.suggestionsEnabled || !shouldRequestSuggestions(value)) {
+    if (state.hasSuggestionsOverlay) {
+      void Command.execute('SimpleBrowser.closeSuggestions')
     }
-    // TODO maybe show autocomplete for urls like browsers do
+    return newState
+  }
+  void requestSuggestions(state.uid, value)
+  return newState
+}
+
+const suggestionsOverlayId = 'search-suggestions'
+
+const shouldRequestSuggestions = (value) => {
+  const query = value.trim()
+  if (query.length < 2) {
+    return false
+  }
+  return !/^(?:[a-z][a-z\d+.-]*:\/\/|localhost(?::\d+)?(?:\/|$)|\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:\/|$))/i.test(query)
+}
+
+const requestSuggestions = async (uid, query) => {
+  let suggestions = []
+  try {
+    suggestions = await BrowserSearchSuggestions.get(query)
+  } catch {
+    // Provider failures should leave normal address-bar navigation available.
+  }
+  await Command.execute('SimpleBrowser.applySuggestions', uid, query, suggestions)
+}
+
+export const applySuggestions = async (state, uid, query, suggestions) => {
+  if (state.uid !== uid || state.inputValue !== query || !state.suggestionsEnabled) {
+    return state
+  }
+  if (!Array.isArray(suggestions) || suggestions.length === 0) {
+    return closeSuggestions(state)
+  }
+  const uniqueSuggestions = [query, ...suggestions.filter((suggestion) => suggestion !== query)].slice(0, 8)
+  const overlayState = await showOverlay(state, suggestionsOverlayId)
+  if (!overlayState.overlayIds.includes(suggestionsOverlayId)) {
+    return state
+  }
+  return {
+    ...overlayState,
+    hasSuggestionsOverlay: true,
+    selectedSuggestionIndex: 0,
+    suggestions: uniqueSuggestions,
+  }
+}
+
+export const closeSuggestions = async (state) => {
+  const overlayState = state.hasSuggestionsOverlay ? await hideOverlay(state, suggestionsOverlayId) : state
+  return {
+    ...overlayState,
+    hasSuggestionsOverlay: false,
+    selectedSuggestionIndex: -1,
+    suggestions: [],
+  }
+}
+
+export const selectNextSuggestion = (state) => {
+  if (!state.hasSuggestionsOverlay || state.suggestions.length === 0) {
+    return state
   }
   return {
     ...state,
-    inputValue: value,
-    hasSuggestionsOverlay: true,
+    selectedSuggestionIndex: Math.min(state.selectedSuggestionIndex + 1, state.suggestions.length - 1),
   }
+}
+
+export const selectPreviousSuggestion = (state) => {
+  if (!state.hasSuggestionsOverlay || state.suggestions.length === 0) {
+    return state
+  }
+  return {
+    ...state,
+    selectedSuggestionIndex: Math.max(state.selectedSuggestionIndex - 1, 0),
+  }
+}
+
+const navigate = (state, value) => {
+  const iframeSrc = IframeSrc.toIframeSrc(value, state.shortcuts)
+  void ElectronWebContentsViewFunctions.setIframeSrc(state.browserViewId, iframeSrc)
+  void ElectronWebContentsViewFunctions.focus(state.browserViewId)
+  return {
+    ...state,
+    iframeSrc,
+    inputValue: value,
+    isLoading: true,
+  }
+}
+
+export const acceptSuggestion = async (state, value) => {
+  const suggestion = typeof value === 'string' ? value : state.suggestions[state.selectedSuggestionIndex]
+  if (typeof suggestion !== 'string') {
+    return state
+  }
+  const newState = await closeSuggestions(state)
+  return navigate(newState, suggestion)
 }
 
 export const setUrl = async (state, value) => {
@@ -221,20 +317,11 @@ export const setUrl = async (state, value) => {
   }
 }
 
-export const go = (state) => {
-  const { inputValue, browserViewId, suggestionsEnabled, hasSuggestionsOverlay, shortcuts } = state
-  const iframeSrc = IframeSrc.toIframeSrc(inputValue, shortcuts)
-  // TODO await promises
-  void ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
-  void ElectronWebContentsViewFunctions.focus(browserViewId)
-  if (suggestionsEnabled && hasSuggestionsOverlay) {
-    // void ElectronBrowserViewSuggestions.disposeBrowserView()
+export const go = async (state) => {
+  if (state.hasSuggestionsOverlay && state.selectedSuggestionIndex >= 0) {
+    return acceptSuggestion(state)
   }
-  return {
-    ...state,
-    iframeSrc,
-    isLoading: true,
-  }
+  return navigate(state, state.inputValue)
 }
 
 export const handleWillNavigate = (state, url) => {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -4,6 +4,9 @@ import * as ViewletSimpleBrowserInsertCss from './ViewletSimpleBrowserInsertCss.
 import * as ViewletSimpleBrowserInsertJavaScript from './ViewletSimpleBrowserInsertJavaScript.js'
 
 export const Commands = {
+  acceptSuggestion: SimpleBrowser.acceptSuggestion,
+  applySuggestions: SimpleBrowser.applySuggestions,
+  closeSuggestions: SimpleBrowser.closeSuggestions,
   getDomTree: ViewletSimpleBrowserGetDomTree.getDomTree,
   go: SimpleBrowser.go,
   handleDidNavigate: SimpleBrowser.handleDidNavigate,
@@ -16,6 +19,8 @@ export const Commands = {
   insertCss: ViewletSimpleBrowserInsertCss.insertCss,
   insertJavaScript: ViewletSimpleBrowserInsertJavaScript.insertJavaScript,
   setUrl: SimpleBrowser.setUrl,
+  selectNextSuggestion: SimpleBrowser.selectNextSuggestion,
+  selectPreviousSuggestion: SimpleBrowser.selectPreviousSuggestion,
   showOverlay: SimpleBrowser.showOverlay,
 }
 

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserKeyBindings.js
@@ -5,6 +5,21 @@ import * as WhenExpression from '../WhenExpression/WhenExpression.js'
 export const getKeyBindings = () => {
   return [
     {
+      key: KeyCode.DownArrow,
+      command: 'SimpleBrowser.selectNextSuggestion',
+      when: WhenExpression.FocusSimpleBrowserInput,
+    },
+    {
+      key: KeyCode.UpArrow,
+      command: 'SimpleBrowser.selectPreviousSuggestion',
+      when: WhenExpression.FocusSimpleBrowserInput,
+    },
+    {
+      key: KeyCode.Escape,
+      command: 'SimpleBrowser.closeSuggestions',
+      when: WhenExpression.FocusSimpleBrowserInput,
+    },
+    {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyI,
       command: 'Developer.toggleDeveloperTools',
       when: WhenExpression.FocusSimpleBrowser,

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -12,7 +12,10 @@ const renderDom = {
       oldState.canGoBack === newState.canGoBack &&
       oldState.canGoForward === newState.canGoForward &&
       oldState.isLoading === newState.isLoading &&
-      oldState.snapshot === newState.snapshot
+      oldState.inputValue === newState.inputValue &&
+      oldState.snapshot === newState.snapshot &&
+      oldState.suggestions === newState.suggestions &&
+      oldState.selectedSuggestionIndex === newState.selectedSuggestionIndex
     )
   },
   apply(oldState, newState) {
@@ -20,8 +23,10 @@ const renderDom = {
       newState.canGoBack,
       newState.canGoForward,
       newState.isLoading,
-      newState.iframeSrc,
+      newState.inputValue,
       newState.snapshot,
+      newState.suggestions,
+      newState.selectedSuggestionIndex,
     )
     return ['Viewlet.setDom2', dom]
   },

--- a/packages/renderer-worker/test/BrowserSearchSuggestionsFromGoogle.test.ts
+++ b/packages/renderer-worker/test/BrowserSearchSuggestionsFromGoogle.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/ElectronNet/ElectronNet.js', () => ({
+  getJson: jest.fn(),
+}))
+
+const BrowserSearchSuggestionsFromGoogle = await import('../src/parts/BrowserSearchSuggestionsFromGoogle/BrowserSearchSuggestionsFromGoogle.js')
+const ElectronNet = await import('../src/parts/ElectronNet/ElectronNet.js')
+
+test('encodes the query and returns at most seven non-empty strings', async () => {
+  // @ts-ignore
+  ElectronNet.getJson.mockResolvedValue(['what is & why', ['one', '', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 9]])
+
+  await expect(BrowserSearchSuggestionsFromGoogle.get('what is & why')).resolves.toEqual(['one', 'two', 'three', 'four', 'five', 'six', 'seven'])
+  expect(ElectronNet.getJson).toHaveBeenCalledWith('https://suggestqueries.google.com/complete/search?client=chrome&hl=en&q=what%20is%20%26%20why')
+})
+
+test('returns an empty list for an unexpected response', async () => {
+  // @ts-ignore
+  ElectronNet.getJson.mockResolvedValue({ suggestions: ['one'] })
+
+  await expect(BrowserSearchSuggestionsFromGoogle.get('query')).resolves.toEqual([])
+})

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -14,3 +14,33 @@ test('renders a snapshot below the browser header', () => {
     childCount: 0,
   })
 })
+
+test('renders accessible search suggestions above an undimmed snapshot', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(
+    true,
+    true,
+    false,
+    'what is',
+    'data:image/png;base64,c25hcHNob3Q=',
+    ['what is', 'what is my ip'],
+    1,
+  )
+
+  expect(dom[0].childCount).toBe(3)
+  expect(dom).toContainEqual({
+    type: VirtualDomElements.Img,
+    className: 'SimpleBrowserSnapshot SimpleBrowserSnapshotSearchSuggestions',
+    src: 'data:image/png;base64,c25hcHNob3Q=',
+    draggable: false,
+    childCount: 0,
+  })
+  expect(dom).toContainEqual(
+    expect.objectContaining({
+      className: 'SimpleBrowserSuggestion SimpleBrowserSuggestionSelected',
+      role: 'option',
+      ariaSelected: true,
+      'data-value': 'what is my ip',
+      onClick: 'handleClickSuggestion',
+    }),
+  )
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -21,6 +21,9 @@ jest.unstable_mockModule('../src/parts/ElectronWebContentsViewFunctions/Electron
     forward: jest.fn(() => {
       throw new Error('not implemented')
     }),
+    focus: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
     backward: jest.fn(() => {
       throw new Error('not implemented')
     }),
@@ -62,7 +65,17 @@ jest.unstable_mockModule('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js'
   }
 })
 
+jest.unstable_mockModule('../src/parts/BrowserSearchSuggestions/BrowserSearchSuggestions.js', () => ({
+  get: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
 const ViewletSimpleBrowser = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js')
+const BrowserSearchSuggestions = await import('../src/parts/BrowserSearchSuggestions/BrowserSearchSuggestions.js')
+const Command = await import('../src/parts/Command/Command.js')
 const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
 const ElectronWebContentsView = await import('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js')
 
@@ -214,4 +227,145 @@ test('overlays share one snapshot and restore after the last overlay closes', as
     overlayIds: [],
     snapshot: '',
   })
+})
+
+test('handleInput does not request suggestions when disabled', async () => {
+  const state = { ...ViewletSimpleBrowser.create(7), suggestionsEnabled: false }
+
+  const newState = await ViewletSimpleBrowser.handleInput(state, 'what is')
+
+  expect(newState.inputValue).toBe('what is')
+  expect(BrowserSearchSuggestions.get).not.toHaveBeenCalled()
+})
+
+test('handleInput requests suggestions when enabled', async () => {
+  // @ts-ignore
+  BrowserSearchSuggestions.get.mockResolvedValue(['what is my ip'])
+  // @ts-ignore
+  Command.execute.mockResolvedValue(undefined)
+  const state = { ...ViewletSimpleBrowser.create(7), suggestionsEnabled: true }
+
+  const newState = await ViewletSimpleBrowser.handleInput(state, 'what is')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  expect(newState).toMatchObject({ inputValue: 'what is', selectedSuggestionIndex: -1 })
+  expect(BrowserSearchSuggestions.get).toHaveBeenCalledWith('what is')
+  expect(Command.execute).toHaveBeenCalledWith('SimpleBrowser.applySuggestions', 7, 'what is', ['what is my ip'])
+})
+
+test('handleInput does not disclose URL-like values to the suggestions provider', async () => {
+  const state = { ...ViewletSimpleBrowser.create(7), suggestionsEnabled: true }
+
+  await ViewletSimpleBrowser.handleInput(state, 'https://example.com/private')
+
+  expect(BrowserSearchSuggestions.get).not.toHaveBeenCalled()
+})
+
+test('applySuggestions ignores stale results', async () => {
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: 'new query',
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.applySuggestions(state, 7, 'old query', ['old query result'])
+
+  expect(newState).toBe(state)
+  expect(ElectronWebContentsViewFunctions.capturePage).not.toHaveBeenCalled()
+})
+
+test('applySuggestions captures the page and shows provider results', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: 'what is',
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.applySuggestions(state, 7, 'what is', ['what is my ip', 'what is love'])
+
+  expect(newState).toMatchObject({
+    hasSuggestionsOverlay: true,
+    overlayIds: ['search-suggestions'],
+    selectedSuggestionIndex: 0,
+    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    suggestions: ['what is', 'what is my ip', 'what is love'],
+  })
+})
+
+test('applySuggestions closes an existing popup after a provider failure', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    hasSuggestionsOverlay: true,
+    inputValue: 'what is',
+    overlayIds: ['search-suggestions'],
+    selectedSuggestionIndex: 0,
+    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    suggestions: ['what is'],
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.applySuggestions(state, 7, 'what is', [])
+
+  expect(newState).toMatchObject({
+    hasSuggestionsOverlay: false,
+    overlayIds: [],
+    selectedSuggestionIndex: -1,
+    snapshot: '',
+    suggestions: [],
+  })
+  expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(12)
+})
+
+test('suggestion selection stays within the available results', () => {
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    hasSuggestionsOverlay: true,
+    selectedSuggestionIndex: 0,
+    suggestions: ['one', 'two'],
+  }
+
+  const second = ViewletSimpleBrowser.selectNextSuggestion(state)
+  const stillSecond = ViewletSimpleBrowser.selectNextSuggestion(second)
+  const first = ViewletSimpleBrowser.selectPreviousSuggestion(stillSecond)
+
+  expect(second.selectedSuggestionIndex).toBe(1)
+  expect(stillSecond.selectedSuggestionIndex).toBe(1)
+  expect(first.selectedSuggestionIndex).toBe(0)
+})
+
+test('acceptSuggestion restores the page and navigates', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    hasSuggestionsOverlay: true,
+    overlayIds: ['search-suggestions'],
+    selectedSuggestionIndex: 1,
+    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    suggestions: ['what is', 'what is my ip'],
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.acceptSuggestion(state)
+
+  expect(newState).toMatchObject({
+    hasSuggestionsOverlay: false,
+    iframeSrc: 'https://www.google.com/search?q=what+is+my+ip',
+    inputValue: 'what is my ip',
+    isLoading: true,
+    snapshot: '',
+    suggestions: [],
+  })
+  expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(12)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, 'https://www.google.com/search?q=what+is+my+ip')
 })

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  position: relative;
 }
 
 .SimpleBrowserHeader {
@@ -34,4 +35,58 @@
   object-fit: fill;
   pointer-events: none;
   width: 100%;
+}
+
+.SimpleBrowserSnapshotSearchSuggestions {
+  filter: none;
+}
+
+.SimpleBrowserSuggestions {
+  background: var(--QuickPickBackground, var(--EditorBackground));
+  box-shadow: rgb(0 0 0 / 25%) 0 4px 12px;
+  color: var(--ListForeground, var(--WorkbenchForeground));
+  left: 90px;
+  max-height: min(352px, calc(100% - 38px));
+  overflow: auto;
+  padding: 4px;
+  position: absolute;
+  right: 30px;
+  top: 30px;
+  z-index: 2;
+}
+
+.SimpleBrowserSuggestion {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 3px;
+  color: inherit;
+  contain: content;
+  display: flex;
+  font: inherit;
+  gap: 8px;
+  height: 36px;
+  overflow: hidden;
+  padding: 0 10px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.SimpleBrowserSuggestion:hover {
+  background: var(--ListHoverBackground, color-mix(in srgb, var(--WorkbenchForeground) 8%, transparent));
+  color: var(--ListHoverForeground, var(--WorkbenchForeground));
+}
+
+.SimpleBrowserSuggestionSelected {
+  background: var(--ListActiveSelectionBackground, color-mix(in srgb, var(--FocusBorder, var(--WorkbenchForeground)) 34%, transparent));
+  color: var(--ListActiveSelectionForeground, var(--WorkbenchForeground));
+}
+
+.SimpleBrowserSuggestionIcon {
+  flex: 0 0 18px;
+  height: 18px;
+  pointer-events: none;
+  width: 18px;
 }


### PR DESCRIPTION
Adds opt-in Simple Browser search suggestions backed by Google’s suggestion endpoint. While suggestions are visible, the WebContentsView is replaced with a captured page image so the accessible popup can render above it; keyboard, mouse, stale-result, provider-failure, and disabled-state behavior are covered by focused tests.