### PR TITLE
test: update simple browser bundled css expectation

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -55,6 +55,7 @@ test('bundleCss lets the simple browser fill the preview area height', async () 
   display: flex;
   flex-direction: column;
   min-height: 0;
+  position: relative;
 }`)
   } finally {
     await rm(dir, { recursive: true, force: true })


### PR DESCRIPTION
Updates the bundled CSS regression expectation for the Simple Browser’s new positioned overlay container. This is the release-only full-suite failure found after the feature PR merged.