### PR TITLE
fix: avoid clipboard test blob reader handle

### DIFF
--- a/packages/renderer-worker/test/ClipBoard.test.ts
+++ b/packages/renderer-worker/test/ClipBoard.test.ts
@@ -190,7 +190,12 @@ test.skip('writeImage', async () => {
 
 test('writeImageUrl fetches and writes the image blob', async () => {
   const blob = new Blob(['image'], { type: 'image/png' })
-  const fetchImage = jest.fn<typeof fetch>(async () => new Response(blob))
+  const fetchImage = jest.fn<typeof fetch>(async () => {
+    return {
+      blob: async () => blob,
+      ok: true,
+    } as Response
+  })
   // @ts-ignore
   ClipBoardWorker.invoke.mockResolvedValue(undefined)
 


### PR DESCRIPTION
The release matrix intermittently fails after all renderer-worker assertions pass because constructing a real Node Response around a Blob leaves an undici BLOBREADER resource visible to Jest open-handle detection.

Mock only the response contract exercised by writeImageUrl. This keeps the test focused on clipboard behavior and avoids creating the unrelated undici reader.

Validation:
- targeted ClipBoard test: 3 passed
- full renderer-worker suite with detectOpenHandles: 1,605 passed
- renderer-worker type-check
- Prettier check