### PR TITLE
fix: preserve simple browser input while typing

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -12,7 +12,6 @@ const renderDom = {
       oldState.canGoBack === newState.canGoBack &&
       oldState.canGoForward === newState.canGoForward &&
       oldState.isLoading === newState.isLoading &&
-      oldState.inputValue === newState.inputValue &&
       oldState.snapshot === newState.snapshot &&
       oldState.suggestions === newState.suggestions &&
       oldState.selectedSuggestionIndex === newState.selectedSuggestionIndex

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletSimpleBrowserRender from '../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js'
+
+const state = {
+  canGoBack: false,
+  canGoForward: false,
+  iframeSrc: 'https://example.com',
+  inputValue: 'w',
+  isLoading: false,
+  selectedSuggestionIndex: -1,
+  snapshot: '',
+  suggestions: [],
+}
+
+test('does not rerender the native address input while typing', () => {
+  const newState = {
+    ...state,
+    inputValue: 'wh',
+  }
+
+  expect(ViewletSimpleBrowserRender.render[0].isEqual(state, newState)).toBe(true)
+})
+
+test('rerenders when suggestions change', () => {
+  const newState = {
+    ...state,
+    suggestions: ['what is'],
+  }
+
+  expect(ViewletSimpleBrowserRender.render[0].isEqual(state, newState)).toBe(false)
+})


### PR DESCRIPTION
## Summary

- keep native Simple Browser address-field input updates out of virtual-DOM rerenders
- continue rerendering when navigation, screenshot, or suggestion state changes
- add focused regression coverage for typing and suggestion updates

## Testing

- focused renderer-worker Jest test
- renderer-worker typecheck
- targeted ESLint and Prettier checks

## Official package reproduction

In `v0.109.14`, ordinary multi-keystroke input was truncated because each input state update replaced the focused native input element.