### PR TITLE
Feature: Toggle preview area orientation

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -128,6 +128,9 @@ test('bundleCss keeps the main workbench column separate from the full-height pr
   overflow: hidden;
   position: relative;
 }`)
+    expect(css).toContain(`.PreviewAreasVertical {
+  flex-direction: column;
+}`)
     expect(css).toContain(`.Panel {
   background: var(--PanelBackground);
   height: var(--PanelHeight);
@@ -136,6 +139,10 @@ test('bundleCss keeps the main workbench column separate from the full-height pr
     expect(css).toContain(`.SashPanel {
   top: calc(var(--SashPanelTop) - 2px);
   width: var(--PanelWidth);
+}`)
+    expect(css).toContain(`.SashHorizontal.SashSecondaryPreview {
+  left: 0;
+  top: calc(var(--SashSecondaryPreviewTop) - 2px);
 }`)
   } finally {
     await rm(dir, { recursive: true, force: true })
@@ -153,7 +160,7 @@ test('bundleCss centers quick pick in the non-preview area', async () => {
 
     const css = await readFile(join(dir, 'App.css'), 'utf8')
 
-    expect(css).toContain('left: calc((100% - var(--PreviewWidth, 0px) - var(--SecondaryPreviewWidth, 0px)) / 2);')
+    expect(css).toContain('left: calc((100% - var(--PreviewAreasWidth, 0px)) / 2);')
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -1,6 +1,7 @@
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
 import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
+import * as PreviewOrientation from '../PreviewOrientation/PreviewOrientation.js'
 import type { LayoutState } from '../ViewletLayout/LayoutState.ts'
 
 const getMainContentsVirtualDom = (state: LayoutState) => {
@@ -83,10 +84,10 @@ const getSashPreviewDom = () => {
   }
 }
 
-const getSashSecondaryPreviewDom = () => {
+const getSashSecondaryPreviewDom = (horizontal = false) => {
   return {
     type: VirtualDomElements.Div,
-    className: 'Viewlet Sash SashVertical SashSecondaryPreview',
+    className: `Viewlet Sash ${horizontal ? 'SashHorizontal' : 'SashVertical'} SashSecondaryPreview`,
     tabIndex: -1,
     role: 'none',
     onPointerDown: DomEventListenerFunctions.HandleSashSecondaryPreviewPointerDown,
@@ -246,6 +247,20 @@ const getPreviewAreaDom = (previewId: number, previewActionsUid: number | undefi
     previewDom,
     ...actionsDom,
     ...closeButtonDom,
+  ]
+}
+
+const getVerticalPreviewAreasDom = (state: LayoutState) => {
+  const secondaryPreviewSashDom = state.secondaryPreviewSashVisible ? [getSashSecondaryPreviewDom(true)] : []
+  return [
+    {
+      childCount: 2 + secondaryPreviewSashDom.length,
+      className: 'PreviewAreas PreviewAreasVertical',
+      type: VirtualDomElements.Div,
+    },
+    ...getPreviewAreaDom(state.previewId, state.previewActionsUid, false),
+    ...secondaryPreviewSashDom,
+    ...getPreviewAreaDom(state.secondaryPreviewId, state.secondaryPreviewActionsUid, true),
   ]
 }
 
@@ -430,6 +445,24 @@ const getWorkbenchBodyDom = (state: LayoutState) => {
   } = state
   const children: any[] = [...getWorkbenchMainDom(state)]
   let childCount = 1
+  const previewsAreVertical = state.previewOrientation === PreviewOrientation.Vertical && state.previewVisible && state.secondaryPreviewVisible
+
+  if (previewsAreVertical) {
+    if (previewSashVisible) {
+      childCount++
+      children.push(getSashPreviewDom())
+    }
+    childCount++
+    children.push(...getVerticalPreviewAreasDom(state))
+    return [
+      {
+        childCount,
+        className: 'WorkbenchBody',
+        type: VirtualDomElements.Div,
+      },
+      ...children,
+    ]
+  }
 
   if (previewSashVisible) {
     childCount++

--- a/packages/renderer-worker/src/parts/PreviewOrientation/PreviewOrientation.js
+++ b/packages/renderer-worker/src/parts/PreviewOrientation/PreviewOrientation.js
@@ -1,0 +1,2 @@
+export const Horizontal = 'horizontal'
+export const Vertical = 'vertical'

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutPoints.ts
@@ -1,10 +1,22 @@
 import * as Clamp from '../Clamp/Clamp.js'
 import * as GetDefaultTitleBarHeight from '../GetDefaultTitleBarHeight/GetDefaultTitleBarHeight.js'
 import * as LayoutKeys from '../LayoutKeys/LayoutKeys.js'
+import * as PreviewOrientation from '../PreviewOrientation/PreviewOrientation.js'
 import * as SideBarLocationType from '../SideBarLocationType/SideBarLocationType.js'
 import type { LayoutState } from './LayoutState.ts'
 
 const mainMinWidth = 100
+
+const getPreviewHeights = (source: LayoutState, totalHeight: number): readonly [number, number] => {
+  if (source.previewOrientation !== PreviewOrientation.Vertical || !source.previewVisible || !source.secondaryPreviewVisible) {
+    return [totalHeight, totalHeight]
+  }
+  const previewMinHeight = Math.min(source.previewMinHeight, totalHeight / 2)
+  const secondaryPreviewMinHeight = Math.min(source.secondaryPreviewMinHeight, totalHeight / 2)
+  const preferredPreviewHeight = source.previewHeight > 0 ? source.previewHeight : totalHeight / 2
+  const previewHeight = Clamp.clamp(preferredPreviewHeight, previewMinHeight, totalHeight - secondaryPreviewMinHeight)
+  return [previewHeight, totalHeight - previewHeight]
+}
 
 export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarLocation ?? SideBarLocationType.Right): LayoutState => {
   const activityBarVisible = source[LayoutKeys.ActivityBarVisible]
@@ -38,12 +50,24 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
   const newPanelHeight = Clamp.clamp(panelHeight, panelMinHeight, panelMaxHeight) // TODO check that it is in bounds of window
   const preferredPreviewWidth = previewWidth > 0 ? previewWidth : windowWidth / 2
   const preferredSecondaryPreviewWidth = secondaryPreviewWidth > 0 ? secondaryPreviewWidth : windowWidth / 3
-  const destinationSecondaryPreviewWidth = secondaryPreviewVisible
-    ? Math.min(windowWidth, Math.max(secondaryPreviewMinWidth, preferredSecondaryPreviewWidth))
-    : 0
+  const previewsAreVertical = source.previewOrientation === PreviewOrientation.Vertical && previewVisible && secondaryPreviewVisible
+  const preferredVerticalPreviewWidth = Math.max(preferredPreviewWidth, preferredSecondaryPreviewWidth)
+  const verticalPreviewMinWidth = Math.max(previewMinWidth, secondaryPreviewMinWidth)
+  const verticalPreviewWidth = Math.min(windowWidth, Math.max(verticalPreviewMinWidth, preferredVerticalPreviewWidth))
+  const destinationSecondaryPreviewWidth = previewsAreVertical
+    ? verticalPreviewWidth
+    : secondaryPreviewVisible
+      ? Math.min(windowWidth, Math.max(secondaryPreviewMinWidth, preferredSecondaryPreviewWidth))
+      : 0
   const widthBeforeSecondaryPreview = windowWidth - destinationSecondaryPreviewWidth
-  const destinationPreviewWidth = previewVisible ? Math.min(widthBeforeSecondaryPreview, Math.max(previewMinWidth, preferredPreviewWidth)) : 0
-  const availableWidth = Math.max(0, widthBeforeSecondaryPreview - destinationPreviewWidth)
+  const destinationPreviewWidth = previewsAreVertical
+    ? verticalPreviewWidth
+    : previewVisible
+      ? Math.min(widthBeforeSecondaryPreview, Math.max(previewMinWidth, preferredPreviewWidth))
+      : 0
+  const availableWidth = previewsAreVertical
+    ? Math.max(0, windowWidth - verticalPreviewWidth)
+    : Math.max(0, widthBeforeSecondaryPreview - destinationPreviewWidth)
 
   if (source.sideBarFocusMode) {
     const contentTop = titleBarVisible ? titleBarHeight : 0
@@ -169,15 +193,13 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
 
     const destinationPreviewTop = p2
     const destinationPreviewLeft = previewVisible ? availableWidth : 0
-    const destinationPreviewHeight =
-      p3 - p2 + (previewVisible && panelVisible ? destinationPanelHeight : 0) + (previewVisible && statusBarVisible ? statusBarHeight : 0)
+    const anyPreviewVisible = previewVisible || secondaryPreviewVisible
+    const totalPreviewHeight =
+      p3 - p2 + (anyPreviewVisible && panelVisible ? destinationPanelHeight : 0) + (anyPreviewVisible && statusBarVisible ? statusBarHeight : 0)
+    const [destinationPreviewHeight, destinationSecondaryPreviewHeight] = getPreviewHeights(source, totalPreviewHeight)
     const destinationPreviewVisible = previewVisible
-    const destinationSecondaryPreviewLeft = availableWidth + destinationPreviewWidth
-    const destinationSecondaryPreviewHeight =
-      p3 -
-      p2 +
-      (secondaryPreviewVisible && panelVisible ? destinationPanelHeight : 0) +
-      (secondaryPreviewVisible && statusBarVisible ? statusBarHeight : 0)
+    const destinationSecondaryPreviewLeft = previewsAreVertical ? availableWidth : availableWidth + destinationPreviewWidth
+    const destinationSecondaryPreviewTop = previewsAreVertical ? destinationPreviewTop + destinationPreviewHeight : destinationPreviewTop
     return {
       ...source,
       activityBarTop: destinationActivityBarTop,
@@ -221,7 +243,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
       previewHeight: destinationPreviewHeight,
       previewVisible: destinationPreviewVisible,
       secondaryPreviewLeft: destinationSecondaryPreviewLeft,
-      secondaryPreviewTop: destinationPreviewTop,
+      secondaryPreviewTop: destinationSecondaryPreviewTop,
       secondaryPreviewWidth: destinationSecondaryPreviewWidth,
       secondaryPreviewHeight: destinationSecondaryPreviewHeight,
       secondaryPreviewVisible,
@@ -310,15 +332,13 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
 
     const destinationPreviewTop = p2
     const destinationPreviewLeft = previewVisible ? availableWidth : 0
-    const destinationPreviewHeight =
-      p3 - p2 + (previewVisible && panelVisible ? destinationPanelHeight : 0) + (previewVisible && statusBarVisible ? statusBarHeight : 0)
+    const anyPreviewVisible = previewVisible || secondaryPreviewVisible
+    const totalPreviewHeight =
+      p3 - p2 + (anyPreviewVisible && panelVisible ? destinationPanelHeight : 0) + (anyPreviewVisible && statusBarVisible ? statusBarHeight : 0)
+    const [destinationPreviewHeight, destinationSecondaryPreviewHeight] = getPreviewHeights(source, totalPreviewHeight)
     const destinationPreviewVisible = previewVisible
-    const destinationSecondaryPreviewLeft = availableWidth + destinationPreviewWidth
-    const destinationSecondaryPreviewHeight =
-      p3 -
-      p2 +
-      (secondaryPreviewVisible && panelVisible ? destinationPanelHeight : 0) +
-      (secondaryPreviewVisible && statusBarVisible ? statusBarHeight : 0)
+    const destinationSecondaryPreviewLeft = previewsAreVertical ? availableWidth : availableWidth + destinationPreviewWidth
+    const destinationSecondaryPreviewTop = previewsAreVertical ? destinationPreviewTop + destinationPreviewHeight : destinationPreviewTop
     return {
       ...source,
       activityBarTop: destinationActivityBarTop,
@@ -362,7 +382,7 @@ export const getPoints = (source: LayoutState, sideBarLocation = source.sideBarL
       previewHeight: destinationPreviewHeight,
       previewVisible: destinationPreviewVisible,
       secondaryPreviewLeft: destinationSecondaryPreviewLeft,
-      secondaryPreviewTop: destinationPreviewTop,
+      secondaryPreviewTop: destinationSecondaryPreviewTop,
       secondaryPreviewWidth: destinationSecondaryPreviewWidth,
       secondaryPreviewHeight: destinationSecondaryPreviewHeight,
       secondaryPreviewVisible,

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -71,6 +71,7 @@ export interface LayoutState {
   readonly previewMaxWidth: number
   readonly previewMinHeight: number
   readonly previewMinWidth: number
+  readonly previewOrientation: 'horizontal' | 'vertical'
   readonly previewSashId: number
   readonly previewSashVisible: boolean
   readonly previewTop: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -20,6 +20,7 @@ import * as PanelWorker from '../PanelWorker/PanelWorker.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as PreviewOrientation from '../PreviewOrientation/PreviewOrientation.js'
 import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
 import * as Product from '../Product/Product.js'
 import * as RenderMainAreaPending from '../RenderMainAreaPending/RenderMainAreaPending.ts'
@@ -42,6 +43,15 @@ import { getPoints } from './LayoutPoints.ts'
 import type { LayoutState, LayoutStateResult, SideBarFocusModeLayoutStateSnapshot } from './LayoutState.ts'
 
 const mainMinWidth = 100
+
+const getTwoPreviewAreasWidth = (state: LayoutState): number => {
+  return state.previewOrientation === PreviewOrientation.Vertical ? state.windowWidth / 2 : state.windowWidth / 3
+}
+
+const getTwoPreviewAreasHeight = (state: LayoutState): number => {
+  const previewTop = state.titleBarVisible ? state.titleBarHeight : 0
+  return Math.max(0, state.windowHeight - previewTop) / 2
+}
 
 const getInitialBackendUrl = () => {
   return Preferences.get('layout.backendUrl') || Product.getBackendUrl()
@@ -198,6 +208,7 @@ export const create = (id: number): LayoutState => {
     previewMaxWidth: 0,
     previewMinHeight: 0,
     previewMinWidth: 0,
+    previewOrientation: PreviewOrientation.Horizontal,
     secondaryPreviewMaxHeight: 0,
     secondaryPreviewMaxWidth: 0,
     secondaryPreviewMinHeight: 0,
@@ -255,6 +266,8 @@ export const saveState = (state: LayoutState) => {
     previewViewletId,
     previewVisible,
     previewWidth,
+    previewHeight,
+    previewOrientation,
     secondaryPreviewUri,
     secondaryPreviewViewletId,
     secondaryPreviewVisible,
@@ -275,6 +288,8 @@ export const saveState = (state: LayoutState) => {
     previewViewletId,
     previewVisible,
     previewWidth,
+    previewHeight,
+    previewOrientation,
     secondaryPreviewUri,
     secondaryPreviewViewletId,
     secondaryPreviewVisible,
@@ -307,6 +322,8 @@ const getSavedPoints = (savedState) => {
       secondarySideBarVisible: false,
       secondarySideBarWidth: 300,
       previewWidth: 0,
+      previewHeight: 0,
+      previewOrientation: 'horizontal' as const,
       previewVisible: false,
       secondaryPreviewWidth: 0,
       secondaryPreviewVisible: false,
@@ -320,6 +337,8 @@ const getSavedPoints = (savedState) => {
     secondarySideBarVisible,
     secondarySideBarWidth,
     previewWidth,
+    previewHeight,
+    previewOrientation,
     previewVisible,
     secondaryPreviewWidth,
     secondaryPreviewVisible,
@@ -333,6 +352,8 @@ const getSavedPoints = (savedState) => {
     secondarySideBarVisible: secondarySideBarVisible ?? false,
     secondarySideBarWidth: secondarySideBarWidth ?? 300,
     previewWidth: previewWidth ?? 0,
+    previewHeight: previewHeight ?? 0,
+    previewOrientation: previewOrientation === PreviewOrientation.Vertical ? ('vertical' as const) : ('horizontal' as const),
     previewVisible: previewVisible ?? false,
     secondaryPreviewWidth: secondaryPreviewWidth ?? 0,
     secondaryPreviewVisible: secondaryPreviewVisible ?? false,
@@ -417,6 +438,8 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
     secondarySideBarWidth,
     previewVisible,
     previewWidth,
+    previewHeight,
+    previewOrientation,
     secondaryPreviewVisible,
     secondaryPreviewWidth,
   } = getSavedPoints(stateToRestore)
@@ -447,16 +470,17 @@ export const loadContent = (state: LayoutState, savedState: any): LayoutState =>
     statusBarHeight: 20,
     statusBarVisible: true,
     previewVisible,
-    previewHeight: 350,
+    previewHeight: previewHeight || 350,
+    previewOrientation,
 
-    previewMinHeight: Math.max(200, windowHeight / 2),
+    previewMinHeight: 200,
     previewMaxHeight: 1200,
     previewWidth,
     previewMinWidth: 100,
     previewMaxWidth: Math.max(1800, windowWidth / 2),
     secondaryPreviewVisible,
     secondaryPreviewHeight: 350,
-    secondaryPreviewMinHeight: Math.max(200, windowHeight / 2),
+    secondaryPreviewMinHeight: 200,
     secondaryPreviewMaxHeight: 1200,
     secondaryPreviewWidth,
     secondaryPreviewMinWidth: 100,
@@ -840,8 +864,10 @@ export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<L
     }
     const secondaryPreviewState = {
       ...state,
-      previewWidth: state.previewVisible ? state.windowWidth / 3 : state.previewWidth,
-      secondaryPreviewWidth: state.previewVisible ? state.windowWidth / 3 : state.windowWidth / 2,
+      previewHeight:
+        state.previewOrientation === PreviewOrientation.Vertical && state.previewVisible ? getTwoPreviewAreasHeight(state) : state.previewHeight,
+      previewWidth: state.previewVisible ? getTwoPreviewAreasWidth(state) : state.previewWidth,
+      secondaryPreviewWidth: state.previewVisible ? getTwoPreviewAreasWidth(state) : state.windowWidth / 2,
     }
     const result = await showSecondaryPreview(secondaryPreviewState, sideBarView)
     const focusCommands = await Viewlet.getFocusCommands(sideBarView)
@@ -856,7 +882,11 @@ export const toggleSideBarView = async (state: LayoutState, moduleId): Promise<L
     }
     const previewState = {
       ...state,
-      previewWidth: state.previewWidthBeforeClose || (state.secondaryPreviewVisible ? state.windowWidth / 3 : state.windowWidth / 2),
+      previewHeight:
+        state.previewOrientation === PreviewOrientation.Vertical && state.secondaryPreviewVisible
+          ? getTwoPreviewAreasHeight(state)
+          : state.previewHeight,
+      previewWidth: state.previewWidthBeforeClose || (state.secondaryPreviewVisible ? getTwoPreviewAreasWidth(state) : state.windowWidth / 2),
     }
     const previewResult = await showPreview(previewState, sideBarView, ViewletModuleId.ExtensionView)
     const focusCommands = await Viewlet.getFocusCommands(sideBarView)
@@ -1174,7 +1204,7 @@ const movePreviewToSecondaryPreview = async (state: LayoutState): Promise<Layout
     previewId: -1,
     previewSashVisible: false,
     previewVisible: false,
-    previewWidth: state.windowWidth / 3,
+    previewWidth: getTwoPreviewAreasWidth(state),
     secondaryPreviewActionsEventListeners: state.previewActionsEventListeners,
     secondaryPreviewActionsUid: state.previewActionsUid,
     secondaryPreviewId: state.previewId,
@@ -1182,7 +1212,7 @@ const movePreviewToSecondaryPreview = async (state: LayoutState): Promise<Layout
     secondaryPreviewUri: state.previewUri,
     secondaryPreviewViewletId: state.previewViewletId,
     secondaryPreviewVisible: true,
-    secondaryPreviewWidth: state.windowWidth / 3,
+    secondaryPreviewWidth: getTwoPreviewAreasWidth(state),
   })
   ViewletStates.setState(state.uid, newState)
   const commands = await getResizeCommands(state, newState)
@@ -1222,8 +1252,12 @@ export const showPreview = async (
     !stateWithRestoredWidth.previewVisible && stateWithRestoredWidth.secondaryPreviewVisible
       ? {
           ...stateWithRestoredWidth,
-          previewWidth: stateWithRestoredWidth.windowWidth / 3,
-          secondaryPreviewWidth: stateWithRestoredWidth.windowWidth / 3,
+          previewHeight:
+            stateWithRestoredWidth.previewOrientation === PreviewOrientation.Vertical
+              ? getTwoPreviewAreasHeight(stateWithRestoredWidth)
+              : stateWithRestoredWidth.previewHeight,
+          previewWidth: getTwoPreviewAreasWidth(stateWithRestoredWidth),
+          secondaryPreviewWidth: getTwoPreviewAreasWidth(stateWithRestoredWidth),
         }
       : stateWithRestoredWidth
   const { previewVisible, previewId, uid } = state
@@ -1334,8 +1368,10 @@ export const showSecondaryPreview = async (initialState: LayoutState, uri: strin
     !initialState.secondaryPreviewVisible && initialState.previewVisible
       ? {
           ...initialState,
-          previewWidth: initialState.windowWidth / 3,
-          secondaryPreviewWidth: initialState.windowWidth / 3,
+          previewHeight:
+            initialState.previewOrientation === PreviewOrientation.Vertical ? getTwoPreviewAreasHeight(initialState) : initialState.previewHeight,
+          previewWidth: getTwoPreviewAreasWidth(initialState),
+          secondaryPreviewWidth: getTwoPreviewAreasWidth(initialState),
         }
       : initialState
   if (state.secondaryPreviewVisible && state.secondaryPreviewId !== -1) {
@@ -1381,6 +1417,26 @@ export const toggleSecondaryPreview = (state: LayoutState, uri: string = state.s
     return hideSecondaryPreview(state)
   }
   return showSecondaryPreview(state, uri)
+}
+
+export const togglePreviewOrientation = async (state: LayoutState): Promise<LayoutStateResult> => {
+  const previewOrientation: LayoutState['previewOrientation'] =
+    state.previewOrientation === PreviewOrientation.Vertical ? PreviewOrientation.Horizontal : PreviewOrientation.Vertical
+  const previewTop = state.titleBarVisible ? state.titleBarHeight : 0
+  const previewHeight = previewOrientation === PreviewOrientation.Vertical ? Math.max(0, state.windowHeight - previewTop) / 2 : state.previewHeight
+  const newState = getPoints(
+    {
+      ...state,
+      previewHeight,
+      previewOrientation,
+    },
+    state.sideBarLocation,
+  )
+  const commands = await getResizeCommands(state, newState)
+  return {
+    newState,
+    commands,
+  }
 }
 
 export const showTitleBar = (state: LayoutState) => {
@@ -1956,13 +2012,15 @@ const getNewStatePointerMovePanel = async (state: LayoutState, x: number, y: num
 }
 
 const getNewStatePointerMovePreview = async (state: LayoutState, x: number): Promise<{ newState: LayoutState; commands: any[] }> => {
-  const previewRight = state.secondaryPreviewVisible ? state.secondaryPreviewLeft : state.windowWidth
+  const previewsAreVertical = state.previewOrientation === PreviewOrientation.Vertical && state.secondaryPreviewVisible
+  const previewRight = previewsAreVertical ? state.windowWidth : state.secondaryPreviewVisible ? state.secondaryPreviewLeft : state.windowWidth
   const previewWidth = Math.max(state.previewMinWidth, previewRight - x)
   return {
     newState: getPoints(
       {
         ...state,
         previewWidth,
+        ...(previewsAreVertical ? { secondaryPreviewWidth: previewWidth } : {}),
       },
       state.sideBarLocation,
     ),
@@ -1970,7 +2028,24 @@ const getNewStatePointerMovePreview = async (state: LayoutState, x: number): Pro
   }
 }
 
-const getNewStatePointerMoveSecondaryPreview = async (state: LayoutState, x: number): Promise<{ newState: LayoutState; commands: any[] }> => {
+const getNewStatePointerMoveSecondaryPreview = async (
+  state: LayoutState,
+  x: number,
+  y: number,
+): Promise<{ newState: LayoutState; commands: any[] }> => {
+  if (state.previewOrientation === PreviewOrientation.Vertical && state.previewVisible) {
+    const previewHeight = y - state.previewTop
+    return {
+      newState: getPoints(
+        {
+          ...state,
+          previewHeight,
+        },
+        state.sideBarLocation,
+      ),
+      commands: [],
+    }
+  }
   const secondaryPreviewWidth = Math.max(state.secondaryPreviewMinWidth, state.windowWidth - x)
   return {
     newState: getPoints(
@@ -2000,7 +2075,7 @@ const getNewStatePointerMove = async (
     case SashType.Preview:
       return getNewStatePointerMovePreview(state, x)
     case SashType.SecondaryPreview:
-      return getNewStatePointerMoveSecondaryPreview(state, x)
+      return getNewStatePointerMoveSecondaryPreview(state, x, y)
     case SashType.ActivityBar:
       return getNewStatePointerMoveActivityBar(state, x, y)
     default:

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -108,6 +108,7 @@ export const CommandsWithSideEffects = {
   maximizePanel: ViewletLayout.maximizePanel,
   unmaximizePanel: ViewletLayout.unmaximizePanel,
   togglePreview: ViewletLayout.togglePreview,
+  togglePreviewOrientation: ViewletLayout.togglePreviewOrientation,
   toggleSecondaryPreview: ViewletLayout.toggleSecondaryPreview,
   toggleSideBar: ViewletLayout.toggleSideBar,
   toggleSecondarySideBar: ViewletLayout.toggleSecondarySideBar,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -75,6 +75,11 @@ export const getQuickPickMenuEntries = () => {
       label: 'Layout: Toggle Preview',
     },
     {
+      id: 'Layout.togglePreviewOrientation',
+      label: 'Preview: Toggle Orientation',
+      aliases: ['Toggle Preview Orientation', 'Stack Preview Areas'],
+    },
+    {
       id: 'Layout.hidePreview',
       label: 'Layout: Hide Preview',
     },

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutRender2.ts
@@ -1,5 +1,6 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as DomEventListenersFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
+import * as PreviewOrientation from '../PreviewOrientation/PreviewOrientation.js'
 import * as SashType from '../SashType/SashType.js'
 import type { LayoutState } from './LayoutState.ts'
 import * as ViewletLayoutRenderDom from './ViewletLayoutRenderDom.ts'
@@ -111,6 +112,7 @@ const renderDom = {
       oldState.panelSashVisible === newState.panelSashVisible &&
       oldState.sideBarSashVisible === newState.sideBarSashVisible &&
       oldState.previewVisible === newState.previewVisible &&
+      oldState.previewOrientation === newState.previewOrientation &&
       oldState.previewSashVisible === newState.previewSashVisible &&
       oldState.previewId === newState.previewId &&
       oldState.previewActionsUid === newState.previewActionsUid &&
@@ -149,9 +151,14 @@ const getCss = (newState: LayoutState) => {
   const secondarySideBarWidth = newState.secondarySideBarWidth
   const titleBarHeight = newState.titleBarHeight
   const previewLeft = newState.previewLeft
+  const previewHeight = newState.previewHeight
   const previewWidth = newState.previewWidth
   const secondaryPreviewLeft = newState.secondaryPreviewLeft
+  const secondaryPreviewTop = newState.secondaryPreviewTop
+  const secondaryPreviewHeight = newState.secondaryPreviewHeight
   const secondaryPreviewWidth = newState.secondaryPreviewWidth
+  const previewAreasWidth =
+    newState.previewOrientation === PreviewOrientation.Vertical ? Math.max(previewWidth, secondaryPreviewWidth) : previewWidth + secondaryPreviewWidth
   const sashSideBarLeft = newState.sideBarLeft
   const secondarySideBarLeft = newState.secondarySideBarLeft
   const sashPanelTop = newState.panelTop
@@ -162,9 +169,13 @@ const getCss = (newState: LayoutState) => {
   Assert.number(secondarySideBarWidth)
   Assert.number(titleBarHeight)
   Assert.number(previewLeft)
+  Assert.number(previewHeight)
   Assert.number(previewWidth)
   Assert.number(secondaryPreviewLeft)
+  Assert.number(secondaryPreviewTop)
+  Assert.number(secondaryPreviewHeight)
   Assert.number(secondaryPreviewWidth)
+  Assert.number(previewAreasWidth)
   Assert.number(sashSideBarLeft)
   Assert.number(secondarySideBarLeft)
   Assert.number(sashPanelTop)
@@ -186,8 +197,12 @@ const getCss = (newState: LayoutState) => {
   --SecondarySideBarWidth: ${getRoundedPixelValue(secondarySideBarWidth)};
   --TitleBarHeight: ${getPixelValue(titleBarHeight)};
   --SashPreviewLeft: ${getRoundedPixelValue(previewLeft)};
+  --PreviewAreasWidth: ${getPixelValue(previewAreasWidth)};
+  --PreviewHeight: ${getPixelValue(previewHeight)};
   --PreviewWidth: ${getPixelValue(previewWidth)};
   --SashSecondaryPreviewLeft: ${getRoundedPixelValue(secondaryPreviewLeft)};
+  --SashSecondaryPreviewTop: ${getRoundedPixelValue(secondaryPreviewTop)};
+  --SecondaryPreviewHeight: ${getPixelValue(secondaryPreviewHeight)};
   --SecondaryPreviewWidth: ${getPixelValue(secondaryPreviewWidth)};
   --SashSideBarLeft: ${getRoundedPixelValue(sashSideBarLeft)};
   --SashSecondarySideBarLeft: ${getRoundedPixelValue(sashSecondarySideBarLeft)};

--- a/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
@@ -202,6 +202,52 @@ test('getLayoutVirtualDom renders an independently closable secondary preview', 
   )
 })
 
+test('getLayoutVirtualDom groups vertically stacked preview areas', () => {
+  const state = {
+    activityBarVisible: false,
+    mainVisible: true,
+    mainId: 1,
+    panelSashVisible: false,
+    panelVisible: false,
+    panelId: -1,
+    previewActionsUid: -1,
+    previewOrientation: 'vertical',
+    previewSashVisible: true,
+    previewVisible: true,
+    previewId: 2,
+    secondaryPreviewActionsUid: -1,
+    secondaryPreviewSashVisible: true,
+    secondaryPreviewVisible: true,
+    secondaryPreviewId: 3,
+    secondarySideBarVisible: false,
+    secondarySideBarId: -1,
+    sideBarLocation: SideBarLocationType.Left,
+    sideBarSashVisible: false,
+    sideBarVisible: false,
+    sideBarId: -1,
+    statusBarVisible: false,
+    statusBarId: -1,
+    titleBarVisible: false,
+    titleBarId: -1,
+  }
+
+  // @ts-ignore
+  const workbench = parseVirtualDom(getLayoutVirtualDom(state))
+  const body = workbench.children[0]
+  const previewAreas = body.children[2]
+
+  expect(body.children.map(({ node }) => node.className)).toEqual([
+    'WorkbenchMain',
+    'Viewlet Sash SashVertical SashPreview',
+    'PreviewAreas PreviewAreasVertical',
+  ])
+  expect(previewAreas.children.map(({ node }) => node.className)).toEqual([
+    'PreviewArea',
+    'Viewlet Sash SashHorizontal SashSecondaryPreview',
+    'PreviewArea SecondaryPreviewArea',
+  ])
+})
+
 test('getLayoutVirtualDom renders visible widgets as the final Workbench children', () => {
   const state = {
     activityBarVisible: false,

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -40,6 +40,16 @@ test('getQuickPickMenuEntries includes reset view locations command', () => {
   })
 })
 
+test('getQuickPickMenuEntries includes preview orientation command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Layout.togglePreviewOrientation',
+    label: 'Preview: Toggle Orientation',
+    aliases: ['Toggle Preview Orientation', 'Stack Preview Areas'],
+  })
+})
+
 test('getQuickPickMenuEntries includes GPU info command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -96,7 +96,6 @@ test('loadContent restores both preview areas independently', () => {
     secondaryPreviewVisible: true,
     secondaryPreviewWidth: 400,
   })
-
   expect(result).toMatchObject({
     previewLeft: 400,
     previewSashVisible: true,
@@ -106,6 +105,41 @@ test('loadContent restores both preview areas independently', () => {
     secondaryPreviewSashVisible: true,
     secondaryPreviewUri: 'gpt-voice.views.default',
     secondaryPreviewVisible: true,
+  })
+})
+
+test('loadContent restores vertically stacked preview areas', () => {
+  const state = ViewletLayout.create(1)
+
+  const result = ViewletLayout.loadContent(state, {
+    Layout: {
+      bounds: {
+        windowWidth: 1200,
+        windowHeight: 800,
+      },
+    },
+    previewHeight: 300,
+    previewOrientation: 'vertical',
+    previewVisible: true,
+    previewWidth: 400,
+    secondaryPreviewVisible: true,
+    secondaryPreviewWidth: 400,
+  })
+
+  expect(result).toMatchObject({
+    previewHeight: 300,
+    previewLeft: 800,
+    previewOrientation: 'vertical',
+    previewTop: 20,
+    previewWidth: 400,
+    secondaryPreviewHeight: 480,
+    secondaryPreviewLeft: 800,
+    secondaryPreviewTop: 320,
+    secondaryPreviewWidth: 400,
+  })
+  expect(ViewletLayout.saveState(result)).toMatchObject({
+    previewHeight: 300,
+    previewOrientation: 'vertical',
   })
 })
 
@@ -412,6 +446,7 @@ test.each([
     previewWidth: 400,
     statusBarWidth: 800,
   })
+
 })
 
 test.each([
@@ -471,6 +506,94 @@ test.each([
     secondaryPreviewLeft: 800,
     secondaryPreviewWidth: 400,
     statusBarWidth: 400,
+  })
+})
+
+test.each([
+  ['left', SideBarLocationType.Left],
+  ['right', SideBarLocationType.Right],
+])('togglePreviewOrientation stacks both previews with the side bar on the %s', async (_name, sideBarLocation) => {
+  const state = LayoutPoints.getPoints(
+    {
+      ...ViewletLayout.create(1),
+      previewMinHeight: 100,
+      previewMinWidth: 100,
+      previewVisible: true,
+      previewWidth: 400,
+      secondaryPreviewMinHeight: 100,
+      secondaryPreviewMinWidth: 100,
+      secondaryPreviewVisible: true,
+      secondaryPreviewWidth: 400,
+      statusBarHeight: 20,
+      statusBarVisible: true,
+      titleBarHeight: 20,
+      titleBarVisible: true,
+      windowHeight: 800,
+      windowWidth: 1200,
+    },
+    sideBarLocation,
+  )
+
+  const result = await ViewletLayout.togglePreviewOrientation(state)
+
+  expect(result.newState).toMatchObject({
+    panelWidth: 800,
+    previewHeight: 390,
+    previewLeft: 800,
+    previewOrientation: 'vertical',
+    previewTop: 20,
+    previewWidth: 400,
+    secondaryPreviewHeight: 390,
+    secondaryPreviewLeft: 800,
+    secondaryPreviewTop: 410,
+    secondaryPreviewWidth: 400,
+    statusBarWidth: 800,
+  })
+
+  const horizontalResult = await ViewletLayout.togglePreviewOrientation(result.newState)
+
+  expect(horizontalResult.newState).toMatchObject({
+    panelWidth: 400,
+    previewHeight: 780,
+    previewLeft: 400,
+    previewOrientation: 'horizontal',
+    previewWidth: 400,
+    secondaryPreviewHeight: 780,
+    secondaryPreviewLeft: 800,
+    secondaryPreviewTop: 20,
+    secondaryPreviewWidth: 400,
+    statusBarWidth: 400,
+  })
+})
+
+test('resizing the divider between vertically stacked previews changes their heights', async () => {
+  const state = LayoutPoints.getPoints({
+    ...ViewletLayout.create(1),
+    previewHeight: 300,
+    previewMinHeight: 100,
+    previewMinWidth: 100,
+    previewOrientation: 'vertical',
+    previewVisible: true,
+    previewWidth: 400,
+    sashId: 'SecondaryPreview',
+    secondaryPreviewMinHeight: 100,
+    secondaryPreviewMinWidth: 100,
+    secondaryPreviewVisible: true,
+    secondaryPreviewWidth: 400,
+    statusBarHeight: 20,
+    statusBarVisible: true,
+    titleBarHeight: 20,
+    titleBarVisible: true,
+    windowHeight: 800,
+    windowWidth: 1200,
+  })
+
+  const result = await ViewletLayout.handleSashPointerMove(state, 800, 500)
+
+  expect(result.newState).toMatchObject({
+    previewHeight: 480,
+    secondaryPreviewHeight: 300,
+    secondaryPreviewTop: 500,
   })
 })
 

--- a/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutRender2.test.ts
@@ -33,8 +33,11 @@ test('renderCss serializes valid layout bounds', () => {
     titleBarHeight: 35,
     panelTop: 200,
     previewLeft: 799.6,
+    previewHeight: 765,
     previewWidth: 400,
     secondaryPreviewLeft: 1200,
+    secondaryPreviewTop: 35,
+    secondaryPreviewHeight: 765,
     secondaryPreviewWidth: 0,
     sideBarLeft: 48.4,
     secondarySideBarLeft: 700.2,
@@ -56,8 +59,12 @@ test('renderCss serializes valid layout bounds', () => {
   --SecondarySideBarWidth: 300px;
   --TitleBarHeight: 35px;
   --SashPreviewLeft: 800px;
+  --PreviewAreasWidth: 400px;
+  --PreviewHeight: 765px;
   --PreviewWidth: 400px;
   --SashSecondaryPreviewLeft: 1200px;
+  --SashSecondaryPreviewTop: 35px;
+  --SecondaryPreviewHeight: 765px;
   --SecondaryPreviewWidth: 0px;
   --SashSideBarLeft: 48px;
   --SashSecondarySideBarLeft: 1000px;
@@ -82,8 +89,11 @@ test('renderCss serializes explicit application bounds', () => {
     titleBarHeight: 35,
     panelTop: 200,
     previewLeft: 799.6,
+    previewHeight: 285,
     previewWidth: 400,
     secondaryPreviewLeft: 1200,
+    secondaryPreviewTop: 35,
+    secondaryPreviewHeight: 285,
     secondaryPreviewWidth: 0,
     sideBarLeft: 48.4,
     secondarySideBarLeft: 700.2,
@@ -105,8 +115,12 @@ test('renderCss serializes explicit application bounds', () => {
   --SecondarySideBarWidth: 300px;
   --TitleBarHeight: 35px;
   --SashPreviewLeft: 800px;
+  --PreviewAreasWidth: 400px;
+  --PreviewHeight: 285px;
   --PreviewWidth: 400px;
   --SashSecondaryPreviewLeft: 1200px;
+  --SashSecondaryPreviewTop: 35px;
+  --SecondaryPreviewHeight: 285px;
   --SecondaryPreviewWidth: 0px;
   --SashSideBarLeft: 48px;
   --SashSecondarySideBarLeft: 1000px;

--- a/static/css/parts/ViewletLayout.css
+++ b/static/css/parts/ViewletLayout.css
@@ -48,6 +48,32 @@
   min-width: 0;
 }
 
+.PreviewAreas {
+  display: flex;
+  flex: 0 0 var(--PreviewAreasWidth);
+  min-height: 0;
+  min-width: 0;
+  position: relative;
+}
+
+.PreviewAreasVertical {
+  flex-direction: column;
+}
+
+.PreviewAreasVertical > .PreviewArea {
+  flex: 0 0 var(--PreviewHeight);
+}
+
+.PreviewAreasVertical > .SecondaryPreviewArea {
+  flex-basis: var(--SecondaryPreviewHeight);
+}
+
+.PreviewAreasVertical .SecondaryPreview {
+  border-left: 0;
+  border-top: 1px solid var(--SeparatorBorder);
+  width: 100%;
+}
+
 .SecondaryPreviewArea {
   flex-basis: var(--SecondaryPreviewWidth);
 }

--- a/static/css/parts/ViewletQuickPick.css
+++ b/static/css/parts/ViewletQuickPick.css
@@ -6,7 +6,7 @@
   position: absolute;
   width: 600px;
   top: 50px;
-  left: calc((100% - var(--PreviewWidth, 0px) - var(--SecondaryPreviewWidth, 0px)) / 2);
+  left: calc((100% - var(--PreviewAreasWidth, 0px)) / 2);
   margin-left: -300px; /* TODO maybe this should be 301px because of padding to be centered */
   padding: 0 1px 6px;
   background: var(--QuickPickBackground);

--- a/static/css/parts/ViewletSash.css
+++ b/static/css/parts/ViewletSash.css
@@ -65,6 +65,11 @@
   left: var(--SashSecondaryPreviewLeft);
 }
 
+.SashHorizontal.SashSecondaryPreview {
+  left: 0;
+  top: calc(var(--SashSecondaryPreviewTop) - 2px);
+}
+
 .SashSecondarySideBar {
   left: var(--SashSecondarySideBarLeft);
 }


### PR DESCRIPTION
Adds a Preview: Toggle Orientation command that switches multiple preview areas between side-by-side and vertically stacked layouts. The selected orientation and vertical split are restored across sessions, and both outer and inner resize sashes follow the active layout.