### PR TITLE
fix: include simple browser uid in render commands

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -28,9 +28,9 @@ const renderDom = {
       newState.suggestions,
       newState.selectedSuggestionIndex,
     )
-    const commands = [['Viewlet.setDom2', dom]]
+    const commands = [['Viewlet.setDom2', newState.uid, dom]]
     if (newState.suggestions.length > 0) {
-      commands.push(['Viewlet.focusElementByName', InputName.SimpleBrowserAddress])
+      commands.push(['Viewlet.focusElementByName', newState.uid, InputName.SimpleBrowserAddress])
     }
     return commands
   },

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -10,6 +10,7 @@ const state = {
   selectedSuggestionIndex: -1,
   snapshot: '',
   suggestions: [],
+  uid: 42,
 }
 
 test('does not rerender the native address input while typing', () => {
@@ -38,7 +39,8 @@ test('restores address input focus while suggestions are visible', () => {
 
   const commands = ViewletSimpleBrowserRender.render[0].apply(state, newState)
 
-  expect(commands.at(-1)).toEqual(['Viewlet.focusElementByName', 'simple-browser-address'])
+  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setDom2', 42])
+  expect(commands.at(-1)).toEqual(['Viewlet.focusElementByName', 42, 'simple-browser-address'])
 })
 
 test('does not focus the address input after suggestions close', () => {


### PR DESCRIPTION
## Summary

- include the Simple Browser view UID in multi-command render output
- assert both DOM and focus commands target the owning view

## Testing

- renderer-worker focused Jest: 2 suites, 7 tests passed
- renderer-worker TypeScript check
- Prettier and git diff checks