### PR TITLE
feature: contribute all builtin settings

### DIFF
--- a/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
+++ b/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
@@ -3,6 +3,55 @@ import * as Copy from '../Copy/Copy.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Path from '../Path/Path.ts'
 
+const SettingTypeString = 2
+const SettingTypeBoolean = 3
+const SettingTypeArray = 4
+const SettingTypeNumber = 5
+
+interface SettingsContribution {
+  readonly id: string
+  readonly type: number
+  readonly value: unknown
+}
+
+const getSettingType = (value: unknown): number => {
+  if (typeof value === 'string') {
+    return SettingTypeString
+  }
+  if (typeof value === 'boolean') {
+    return SettingTypeBoolean
+  }
+  if (typeof value === 'number') {
+    return SettingTypeNumber
+  }
+  if (value && typeof value === 'object') {
+    return SettingTypeArray
+  }
+  throw new TypeError(`Unsupported default setting value: ${value}`)
+}
+
+export const createSettingsContribution = (defaultSettings: Readonly<Record<string, unknown>>): readonly SettingsContribution[] => {
+  return Object.entries(defaultSettings).map(([id, value]) => ({
+    id,
+    type: getSettingType(value),
+    value,
+  }))
+}
+
+export const createWorkerPathSettingsContribution = (workers: readonly any[]): readonly SettingsContribution[] => {
+  const settingNames = new Set<string>()
+  for (const worker of workers) {
+    if (worker.settingName) {
+      settingNames.add(worker.settingName)
+    }
+  }
+  return [...settingNames].sort().map((id) => ({
+    id,
+    type: SettingTypeString,
+    value: '',
+  }))
+}
+
 const stripLeadingSlash = (path: string): string => {
   return path.replaceAll('\\', '/').replace(/^\/+/, '')
 }
@@ -61,6 +110,13 @@ export const bundleBuiltinSettings = async ({ workers, toRoot }): Promise<void> 
     })
     fileNames.push(fileName)
   }
+  const defaultSettings = await JsonFile.readJson(Path.absolute('static/config/defaultSettings.json'))
+  const coreFileName = 'renderer-worker.json'
+  await JsonFile.writeJson({
+    to: Path.join(toRoot, 'builtin-settings', coreFileName),
+    value: [...createWorkerPathSettingsContribution(workers), ...createSettingsContribution(defaultSettings)],
+  })
+  fileNames.push(coreFileName)
   await JsonFile.writeJson({
     to: Path.join(toRoot, 'builtin-settings', 'index.json'),
     value: fileNames,

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from '@jest/globals'
-import { getSettingsContributionCandidates } from '../src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  bundleBuiltinSettings,
+  createSettingsContribution,
+  createWorkerPathSettingsContribution,
+  getSettingsContributionCandidates,
+} from '../src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts'
 
 test('gets one settings contribution candidate per worker package', () => {
   const workers = [
@@ -27,4 +35,90 @@ test('gets one settings contribution candidate per worker package', () => {
       sourcePath: 'packages/renderer-worker/node_modules/@lvce-editor/explorer-view/dist/settings.json',
     },
   ])
+})
+
+test('creates settings contributions with the correct types', () => {
+  expect(
+    createSettingsContribution({
+      array: ['value'],
+      boolean: true,
+      number: 1,
+      object: { key: true },
+      string: 'value',
+    }),
+  ).toEqual([
+    { id: 'array', type: 4, value: ['value'] },
+    { id: 'boolean', type: 3, value: true },
+    { id: 'number', type: 5, value: 1 },
+    { id: 'object', type: 4, value: { key: true } },
+    { id: 'string', type: 2, value: 'value' },
+  ])
+})
+
+test('creates one setting for each configurable worker path', () => {
+  expect(
+    createWorkerPathSettingsContribution([
+      { settingName: 'develop.editorWorkerPath' },
+      { settingName: 'develop.editorWorkerPath' },
+      { settingName: 'develop.explorerWorkerPath' },
+      {},
+    ]),
+  ).toEqual([
+    { id: 'develop.editorWorkerPath', type: 2, value: '' },
+    { id: 'develop.explorerWorkerPath', type: 2, value: '' },
+  ])
+})
+
+test('creates a contribution for every default setting', async () => {
+  const defaultSettingsUrl = new URL('../../../static/config/defaultSettings.json', import.meta.url)
+  const defaultSettings = JSON.parse(await readFile(defaultSettingsUrl, 'utf8'))
+  const contribution = createSettingsContribution(defaultSettings)
+
+  expect(Object.fromEntries(contribution.map(({ id, value }) => [id, value]))).toEqual(defaultSettings)
+  expect(new Set(contribution.map(({ id }) => id)).size).toBe(contribution.length)
+})
+
+test('bundles core and worker path settings', async () => {
+  const toRoot = await mkdtemp(join(tmpdir(), 'lvce-builtin-settings-'))
+  try {
+    await bundleBuiltinSettings({
+      toRoot,
+      workers: [{ settingName: 'develop.editorWorkerPath' }],
+    })
+
+    const index = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'index.json'), 'utf8'))
+    const settings = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'renderer-worker.json'), 'utf8'))
+    expect(index).toEqual(['renderer-worker.json'])
+    expect(settings).toEqual(
+      expect.arrayContaining([
+        { id: 'develop.editorWorkerPath', type: 2, value: '' },
+        { id: 'editor.formatOnSave', type: 3, value: false },
+        { id: 'workbench.sideBarLocation', type: 2, value: 'right' },
+      ]),
+    )
+  } finally {
+    await rm(toRoot, { force: true, recursive: true })
+  }
+})
+
+test('covers every literal renderer preference', async () => {
+  const defaultSettingsUrl = new URL('../../../static/config/defaultSettings.json', import.meta.url)
+  const workersUrl = new URL('../../renderer-worker/src/parts/Workers/Workers.json', import.meta.url)
+  const rendererSourceUrl = new URL('../../renderer-worker/src/', import.meta.url)
+  const defaultSettings = JSON.parse(await readFile(defaultSettingsUrl, 'utf8'))
+  const workers = JSON.parse(await readFile(workersUrl, 'utf8'))
+  const knownSettings = new Set([...Object.keys(defaultSettings), ...createWorkerPathSettingsContribution(workers).map(({ id }) => id)])
+  const usedSettings = new Set<string>()
+  const fileNames = await readdir(rendererSourceUrl, { recursive: true })
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith('.js') && !fileName.endsWith('.ts')) {
+      continue
+    }
+    const source = await readFile(new URL(fileName, rendererSourceUrl), 'utf8')
+    for (const match of source.matchAll(/Preferences\.get\(['"]([^'"]+)/g)) {
+      usedSettings.add(match[1])
+    }
+  }
+
+  expect([...usedSettings].filter((id) => !knownSettings.has(id)).toSorted((a, b) => a.localeCompare(b))).toEqual([])
 })

--- a/packages/renderer-worker/src/parts/EditorPreferences/EditorPreferences.js
+++ b/packages/renderer-worker/src/parts/EditorPreferences/EditorPreferences.js
@@ -12,7 +12,7 @@ const kFormatOnSave = 'editor.formatOnSave'
 const kDiagnostics = 'editor.diagnostics'
 const kQuickSuggestions = 'editor.quickSuggestions'
 const kAutoClosingQuotes = 'editor.autoClosingQuotes'
-const kAutoClosingBrackets = 'editor.autoclosingBrackets'
+const kAutoClosingBrackets = 'editor.autoClosingBrackets'
 const kFontWeight = 'editor.fontWeight'
 const kHover = 'editor.hover'
 

--- a/packages/renderer-worker/test/EditorPreferences.test.ts
+++ b/packages/renderer-worker/test/EditorPreferences.test.ts
@@ -1,0 +1,17 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Editor preference tests use an ESM module mock. */
+import { expect, jest, test } from '@jest/globals'
+
+const getPreference = jest.fn()
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  get: getPreference,
+}))
+
+const EditorPreferences = await import('../src/parts/EditorPreferences/EditorPreferences.js')
+
+test('reads the documented auto-closing brackets setting', () => {
+  getPreference.mockReturnValue(true)
+
+  expect(EditorPreferences.isAutoClosingBracketsEnabled()).toBe(true)
+  expect(getPreference).toHaveBeenCalledWith('editor.autoClosingBrackets')
+})

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -1,9 +1,14 @@
 {
+  "application.updateMode": "none",
+
   "breadcrumbs.enabled": false,
+
+  "colorTheme.cache": "",
 
   "completions.loadingDelay": 1200,
 
   "development.watchColorTheme": true,
+  "develop.fileWatcher": false,
 
   "editor.fontSize": 15,
   "editor.fontFamily": "'Fira Code'",
@@ -21,6 +26,7 @@
   "editor.cache": true,
   "editor.diagnostics": true,
   "editor.quickSuggestions": false,
+  "editor.semanticTokens": false,
 
   "extensions.autoUpdate": true,
 
@@ -36,14 +42,24 @@
 
   "languages.jsFilesAsJsx": false,
 
+  "layout.backendUrl": "",
+
+  "icon-theme.cache": true,
+
   "search.threads": 1,
 
   "sessionReplay.enabled": false,
 
   "simpleBrowser.suggestions": false,
+  "simpleBrowser.shortcuts": [],
+
+  "statusBar.itemsVisible": false,
 
   "terminal.backend": "real",
   "terminal.separateConnection": false,
+  "terminal.tabs.enabled": true,
+
+  "titleBar.titleEnabled": false,
 
   "window.titleBarStyle": "custom",
   "window.zoomLevel": 0,


### PR DESCRIPTION
Generates JSON language settings contributions from the authoritative defaults and worker metadata.

Also fixes the auto-closing brackets preference key and adds completeness regression coverage.