### PR TITLE
fix: simplify extension detail tab highlight

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -207,6 +207,30 @@ test('bundleCss preserves the extension detail sash divider', async () => {
   }
 }, 30_000)
 
+test('bundleCss keeps only the row separator for extension detail tabs', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletExtensionDetailTabs.css'), 'utf8')
+
+    expect(css).toContain(`.ExtensionDetailTabs {
+  display: flex;
+  gap: 10px;
+  contain: content;
+  border-bottom: 1px solid var(--PanelBorderTopColor, color-mix(in srgb, var(--WorkbenchForeground) 28%, transparent));`)
+    expect(css).toContain(`.ExtensionDetailTabSelected {
+  color: var(--PanelTabActiveForeground, var(--WorkbenchForeground));
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss preserves the color theme link foreground', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletExtensionDetailTabs.css
+++ b/static/css/parts/ViewletExtensionDetailTabs.css
@@ -35,6 +35,5 @@
 }
 
 .ExtensionDetailTabSelected {
-  border-bottom: 1px solid var(--PanelTabActiveForeground, var(--FocusBorder, currentColor));
   color: var(--PanelTabActiveForeground, var(--WorkbenchForeground));
 }


### PR DESCRIPTION
Remove the redundant active-tab underline from extension detail views while preserving the existing row separator and selected-tab foreground color.

Add focused CSS bundling coverage for the extension detail tab styling.