### PR TITLE
fix: support audio-only WebM files

### DIFF
--- a/packages/renderer-worker/src/parts/MimeTypes/MimeTypes.js
+++ b/packages/renderer-worker/src/parts/MimeTypes/MimeTypes.js
@@ -57,6 +57,7 @@ export const mapExtToMediaMimes = {
   '.tif': 'image/tiff',
   '.tiff': 'image/tiff',
   '.wav': 'audio/x-wav',
+  '.weba': 'audio/webm',
   '.webm': 'video/webm',
   '.webp': 'image/webp',
   '.wma': 'audio/x-ms-wma',

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -9,6 +9,7 @@ const mapExtToEditorType = {
   '.mp3': ViewletModuleId.Audio,
   '.ogg': ViewletModuleId.Audio,
   '.opus': ViewletModuleId.Audio,
+  '.weba': ViewletModuleId.Audio,
 }
 
 const getModuleIdForOpener = async (opener) => {

--- a/packages/renderer-worker/test/Mime.test.ts
+++ b/packages/renderer-worker/test/Mime.test.ts
@@ -21,6 +21,10 @@ test('getMediaMimeType - webp', () => {
   expect(Mime.getMediaMimeType('/test/file.webp')).toBe('image/webp')
 })
 
+test('getMediaMimeType - audio-only webm', () => {
+  expect(Mime.getMediaMimeType('/test/file.weba')).toBe('audio/webm')
+})
+
 test('getMediaMimeType - x-icon', () => {
   expect(Mime.getMediaMimeType('/test/file.ico')).toBe('image/x-icon')
 })

--- a/packages/renderer-worker/test/ViewletMap.test.ts
+++ b/packages/renderer-worker/test/ViewletMap.test.ts
@@ -28,6 +28,10 @@ test('audio - opus', async () => {
   expect(await ViewletMap.getModuleId('/test/file.opus')).toBe(ViewletModuleId.Audio)
 })
 
+test('audio - audio-only webm', async () => {
+  expect(await ViewletMap.getModuleId('/test/file.weba')).toBe(ViewletModuleId.Audio)
+})
+
 test('process explorer', async () => {
   expect(await ViewletMap.getModuleId('process-explorer://')).toBe(ViewletModuleId.ProcessExplorer)
 })


### PR DESCRIPTION
Recognize .weba files as audio/webm and route them to the built-in audio editor.