### PR TITLE
fix: avoid malformed builtin settings contributions

### DIFF
--- a/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
+++ b/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
@@ -3,55 +3,6 @@ import * as Copy from '../Copy/Copy.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Path from '../Path/Path.ts'
 
-const SettingTypeString = 2
-const SettingTypeBoolean = 3
-const SettingTypeArray = 4
-const SettingTypeNumber = 5
-
-interface SettingsContribution {
-  readonly id: string
-  readonly type: number
-  readonly value: unknown
-}
-
-const getSettingType = (value: unknown): number => {
-  if (typeof value === 'string') {
-    return SettingTypeString
-  }
-  if (typeof value === 'boolean') {
-    return SettingTypeBoolean
-  }
-  if (typeof value === 'number') {
-    return SettingTypeNumber
-  }
-  if (value && typeof value === 'object') {
-    return SettingTypeArray
-  }
-  throw new TypeError(`Unsupported default setting value: ${value}`)
-}
-
-export const createSettingsContribution = (defaultSettings: Readonly<Record<string, unknown>>): readonly SettingsContribution[] => {
-  return Object.entries(defaultSettings).map(([id, value]) => ({
-    id,
-    type: getSettingType(value),
-    value,
-  }))
-}
-
-export const createWorkerPathSettingsContribution = (workers: readonly any[]): readonly SettingsContribution[] => {
-  const settingNames = new Set<string>()
-  for (const worker of workers) {
-    if (worker.settingName) {
-      settingNames.add(worker.settingName)
-    }
-  }
-  return [...settingNames].sort().map((id) => ({
-    id,
-    type: SettingTypeString,
-    value: '',
-  }))
-}
-
 const stripLeadingSlash = (path: string): string => {
   return path.replaceAll('\\', '/').replace(/^\/+/, '')
 }
@@ -110,13 +61,6 @@ export const bundleBuiltinSettings = async ({ workers, toRoot }): Promise<void> 
     })
     fileNames.push(fileName)
   }
-  const defaultSettings = await JsonFile.readJson(Path.absolute('static/config/defaultSettings.json'))
-  const coreFileName = 'renderer-worker.json'
-  await JsonFile.writeJson({
-    to: Path.join(toRoot, 'builtin-settings', coreFileName),
-    value: [...createWorkerPathSettingsContribution(workers), ...createSettingsContribution(defaultSettings)],
-  })
-  fileNames.push(coreFileName)
   await JsonFile.writeJson({
     to: Path.join(toRoot, 'builtin-settings', 'index.json'),
     value: fileNames,

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -2,12 +2,7 @@ import { expect, test } from '@jest/globals'
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import {
-  bundleBuiltinSettings,
-  createSettingsContribution,
-  createWorkerPathSettingsContribution,
-  getSettingsContributionCandidates,
-} from '../src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts'
+import { bundleBuiltinSettings, getSettingsContributionCandidates } from '../src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts'
 
 test('gets one settings contribution candidate per worker package', () => {
   const workers = [
@@ -37,48 +32,7 @@ test('gets one settings contribution candidate per worker package', () => {
   ])
 })
 
-test('creates settings contributions with the correct types', () => {
-  expect(
-    createSettingsContribution({
-      array: ['value'],
-      boolean: true,
-      number: 1,
-      object: { key: true },
-      string: 'value',
-    }),
-  ).toEqual([
-    { id: 'array', type: 4, value: ['value'] },
-    { id: 'boolean', type: 3, value: true },
-    { id: 'number', type: 5, value: 1 },
-    { id: 'object', type: 4, value: { key: true } },
-    { id: 'string', type: 2, value: 'value' },
-  ])
-})
-
-test('creates one setting for each configurable worker path', () => {
-  expect(
-    createWorkerPathSettingsContribution([
-      { settingName: 'develop.editorWorkerPath' },
-      { settingName: 'develop.editorWorkerPath' },
-      { settingName: 'develop.explorerWorkerPath' },
-      {},
-    ]),
-  ).toEqual([
-    { id: 'develop.editorWorkerPath', type: 2, value: '' },
-    { id: 'develop.explorerWorkerPath', type: 2, value: '' },
-  ])
-})
-
-test('creates a contribution for every default setting', async () => {
-  const defaultSettingsUrl = new URL('../../../static/config/defaultSettings.json', import.meta.url)
-  const defaultSettings = JSON.parse(await readFile(defaultSettingsUrl, 'utf8'))
-  const contribution = createSettingsContribution(defaultSettings)
-
-  expect(Object.fromEntries(contribution.map(({ id, value }) => [id, value]))).toEqual(defaultSettings)
-  expect(new Set(contribution.map(({ id }) => id)).size).toBe(contribution.length)
-})
-
-test('bundles core and worker path settings', async () => {
+test('does not expose renderer worker defaults as settings contributions', async () => {
   const toRoot = await mkdtemp(join(tmpdir(), 'lvce-builtin-settings-'))
   try {
     await bundleBuiltinSettings({
@@ -87,38 +41,10 @@ test('bundles core and worker path settings', async () => {
     })
 
     const index = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'index.json'), 'utf8'))
-    const settings = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'renderer-worker.json'), 'utf8'))
-    expect(index).toEqual(['renderer-worker.json'])
-    expect(settings).toEqual(
-      expect.arrayContaining([
-        { id: 'develop.editorWorkerPath', type: 2, value: '' },
-        { id: 'editor.formatOnSave', type: 3, value: false },
-        { id: 'workbench.sideBarLocation', type: 2, value: 'right' },
-      ]),
-    )
+    const fileNames = await readdir(join(toRoot, 'builtin-settings'))
+    expect(index).toEqual([])
+    expect(fileNames).toEqual(['index.json'])
   } finally {
     await rm(toRoot, { force: true, recursive: true })
   }
-})
-
-test('covers every literal renderer preference', async () => {
-  const defaultSettingsUrl = new URL('../../../static/config/defaultSettings.json', import.meta.url)
-  const workersUrl = new URL('../../renderer-worker/src/parts/Workers/Workers.json', import.meta.url)
-  const rendererSourceUrl = new URL('../../renderer-worker/src/', import.meta.url)
-  const defaultSettings = JSON.parse(await readFile(defaultSettingsUrl, 'utf8'))
-  const workers = JSON.parse(await readFile(workersUrl, 'utf8'))
-  const knownSettings = new Set([...Object.keys(defaultSettings), ...createWorkerPathSettingsContribution(workers).map(({ id }) => id)])
-  const usedSettings = new Set<string>()
-  const fileNames = await readdir(rendererSourceUrl, { recursive: true })
-  for (const fileName of fileNames) {
-    if (!fileName.endsWith('.js') && !fileName.endsWith('.ts')) {
-      continue
-    }
-    const source = await readFile(new URL(fileName, rendererSourceUrl), 'utf8')
-    for (const match of source.matchAll(/Preferences\.get\(['"]([^'"]+)/g)) {
-      usedSettings.add(match[1])
-    }
-  }
-
-  expect([...usedSettings].filter((id) => !knownSettings.has(id)).toSorted((a, b) => a.localeCompare(b))).toEqual([])
 })


### PR DESCRIPTION
The generated renderer-worker settings file omits metadata required by the settings worker and can duplicate package-owned settings, causing Settings initialization to fail.

Only schema-complete package settings contributions are now indexed, with regression coverage for renderer worker defaults.