### PR TITLE
fix: deduplicate builtin settings contributions

### DIFF
--- a/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
+++ b/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
@@ -1,7 +1,43 @@
 import { existsSync } from 'node:fs'
-import * as Copy from '../Copy/Copy.ts'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Path from '../Path/Path.ts'
+
+interface SettingsContribution {
+  readonly id: string
+  readonly [key: string]: unknown
+}
+
+interface SettingsFile {
+  readonly fileName: string
+  readonly settings: readonly SettingsContribution[]
+}
+
+export const deduplicateSettingsContributions = (files: readonly SettingsFile[]): readonly SettingsFile[] => {
+  const seenSettings = new Map<string, string>()
+  const result: SettingsFile[] = []
+  for (const file of files) {
+    const uniqueSettings: SettingsContribution[] = []
+    for (const setting of file.settings) {
+      const serialized = JSON.stringify(setting)
+      const previous = seenSettings.get(setting.id)
+      if (previous === serialized) {
+        continue
+      }
+      if (previous) {
+        throw new TypeError(`Conflicting builtin setting ${setting.id}`)
+      }
+      seenSettings.set(setting.id, serialized)
+      uniqueSettings.push(setting)
+    }
+    if (uniqueSettings.length > 0) {
+      result.push({
+        fileName: file.fileName,
+        settings: uniqueSettings,
+      })
+    }
+  }
+  return result
+}
 
 const stripLeadingSlash = (path: string): string => {
   return path.replaceAll('\\', '/').replace(/^\/+/, '')
@@ -48,18 +84,24 @@ export const getSettingsContributionCandidates = (workers: readonly any[]): read
 }
 
 export const bundleBuiltinSettings = async ({ workers, toRoot }): Promise<void> => {
-  const fileNames: string[] = []
+  const settingsFiles: SettingsFile[] = []
   for (const candidate of getSettingsContributionCandidates(workers)) {
     const from = getSourcePath(candidate.sourcePath)
     if (!from) {
       continue
     }
-    const fileName = `${candidate.packageName}.json`
-    await Copy.copyFile({
-      from,
-      to: Path.join(toRoot, 'builtin-settings', fileName),
+    settingsFiles.push({
+      fileName: `${candidate.packageName}.json`,
+      settings: await JsonFile.readJson(Path.absolute(from)),
     })
-    fileNames.push(fileName)
+  }
+  const fileNames: string[] = []
+  for (const settingsFile of deduplicateSettingsContributions(settingsFiles)) {
+    await JsonFile.writeJson({
+      to: Path.join(toRoot, 'builtin-settings', settingsFile.fileName),
+      value: settingsFile.settings,
+    })
+    fileNames.push(settingsFile.fileName)
   }
   await JsonFile.writeJson({
     to: Path.join(toRoot, 'builtin-settings', 'index.json'),

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -2,7 +2,11 @@ import { expect, test } from '@jest/globals'
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { bundleBuiltinSettings, getSettingsContributionCandidates } from '../src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts'
+import {
+  bundleBuiltinSettings,
+  deduplicateSettingsContributions,
+  getSettingsContributionCandidates,
+} from '../src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts'
 
 test('gets one settings contribution candidate per worker package', () => {
   const workers = [
@@ -47,4 +51,28 @@ test('does not expose renderer worker defaults as settings contributions', async
   } finally {
     await rm(toRoot, { force: true, recursive: true })
   }
+})
+
+test('deduplicates identical settings contributions', () => {
+  const settingA = { category: 'chat', description: 'A setting', heading: 'A', id: 'chat.a', type: 3, value: true }
+  const settingB = { category: 'chat', description: 'B setting', heading: 'B', id: 'chat.b', type: 3, value: false }
+
+  expect(
+    deduplicateSettingsContributions([
+      { fileName: 'chat-view.json', settings: [settingA] },
+      { fileName: 'chat-view-model.json', settings: [settingA, settingB] },
+    ]),
+  ).toEqual([
+    { fileName: 'chat-view.json', settings: [settingA] },
+    { fileName: 'chat-view-model.json', settings: [settingB] },
+  ])
+})
+
+test('rejects conflicting settings contributions', () => {
+  expect(() =>
+    deduplicateSettingsContributions([
+      { fileName: 'first.json', settings: [{ id: 'chat.enabled', value: true }] },
+      { fileName: 'second.json', settings: [{ id: 'chat.enabled', value: false }] },
+    ]),
+  ).toThrow('Conflicting builtin setting chat.enabled')
 })


### PR DESCRIPTION
Settings initialization rejects duplicate IDs, while chat-view and chat-view-model currently publish identical setting contributions.

Deduplicate identical records during bundling, reject conflicting duplicates at build time, and cover both cases. The original gpt-voice Settings e2e passes against the locally built server.