### PR TITLE
fix: register sidebar action event listeners

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -257,8 +257,13 @@ export const setActionsDom = (state, actionsDom, childUid, eventListeners = stat
     }
   }
   if (state.actionsUid !== -1) {
+    const commands = []
+    if (eventListeners.length > 0) {
+      commands.push(['Viewlet.registerEventListeners', state.actionsUid, eventListeners])
+    }
+    commands.push(['Viewlet.setDom2', state.actionsUid, actionsDom])
     return {
-      commands: [['Viewlet.setDom2', state.actionsUid, actionsDom]],
+      commands,
       handled: true,
       renderParent: false,
       statePatch: {
@@ -278,8 +283,8 @@ export const setActionsDom = (state, actionsDom, childUid, eventListeners = stat
   }
   const actionsUid = Id.create()
   const commands = [['Viewlet.createFunctionalRoot', state.currentViewletId, actionsUid, true]]
-  if (state.actionsEventListeners.length > 0) {
-    commands.push(['Viewlet.registerEventListeners', actionsUid, state.actionsEventListeners])
+  if (eventListeners.length > 0) {
+    commands.push(['Viewlet.registerEventListeners', actionsUid, eventListeners])
   }
   commands.push(['Viewlet.setDom2', actionsUid, actionsDom], ['Viewlet.setUid', actionsUid, childUid])
   return {

--- a/packages/renderer-worker/test/ViewletSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletSideBar.test.ts
@@ -298,12 +298,11 @@ test('setActionsDom updates an existing actions root', () => {
 test('setActionsDom creates an actions root when actions become available', () => {
   const state = {
     ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
-    actionsEventListeners: ['click'],
     childUid: 2,
     currentViewletId: 'sample.views.main',
   }
 
-  const result = ViewletSideBar.setActionsDom(state, ['new-actions'], 2)
+  const result = ViewletSideBar.setActionsDom(state, ['new-actions'], 2, ['click'])
 
   expect(result.commands).toEqual([
     ['Viewlet.createFunctionalRoot', 'sample.views.main', result.statePatch.actionsUid, true],
@@ -312,6 +311,28 @@ test('setActionsDom creates an actions root when actions become available', () =
     ['Viewlet.setUid', result.statePatch.actionsUid, 2],
   ])
   expect(result.statePatch.actionsUid).not.toBe(-1)
+})
+
+test('setActionsDom registers new listeners on an existing actions root', () => {
+  const state = {
+    ...ViewletSideBar.create(1, '', 0, 0, 300, 500),
+    actionsUid: 3,
+    childUid: 2,
+  }
+
+  const result = ViewletSideBar.setActionsDom(state, ['updated-actions'], 2, ['click'])
+
+  expect(result).toEqual({
+    commands: [
+      ['Viewlet.registerEventListeners', 3, ['click']],
+      ['Viewlet.setDom2', 3, ['updated-actions']],
+    ],
+    handled: true,
+    renderParent: false,
+    statePatch: {
+      actionsEventListeners: ['click'],
+    },
+  })
 })
 
 test('setActionsDom ignores updates from a stale child', () => {


### PR DESCRIPTION
Sidebar title actions can render after their functional root already exists. Register the incoming action listeners both when creating and when updating that root, instead of reading stale state.

Adds regression coverage for initial and existing-root listener registration. This enables extension-provided title actions such as Gpt Voice Clear All Recordings to dispatch clicks.