### PR TITLE
feature: expose active text document command

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -214,6 +214,7 @@ export const commandMap = {
   'GetActiveEditor.getDiagnostics': lazy('GetActiveEditor.getDiagnostics'),
   'GetActiveEditor.getOpenEditorUris': lazy('GetActiveEditor.getOpenEditorUris'),
   'GetActiveEditor.getSelections': lazy('GetActiveEditor.getSelections'),
+  'GetActiveEditor.getTextDocument': lazy('GetActiveEditor.getTextDocument'),
   'GetActiveEditor.setSelections': lazy('GetActiveEditor.setSelections'),
   'GetActiveEditor.updateAllDiagnostics': lazy('GetActiveEditor.updateAllDiagnostics'),
   'GetActiveEditor.updateDiagnostics': lazy('GetActiveEditor.updateDiagnostics'),

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -35,6 +35,10 @@ test('registers the drop data command', () => {
   expect(commandMap['DropData.get']).toBeDefined()
 })
 
+test('registers the active text document command', () => {
+  expect(commandMap['GetActiveEditor.getTextDocument']).toBeDefined()
+})
+
 test('registers only direct extension node process commands', () => {
   expect(commandMap['ExtensionNodeRpc.createConnection']).toBeDefined()
   expect(commandMap['ExtensionNodeRpc.createMessagePort']).toBeDefined()


### PR DESCRIPTION
Expose the existing active text-document query through the renderer command map so extensions can read live editor contents.