### PR TITLE
fix: keep preview hidden while loading

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -543,9 +543,11 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
   const height = intermediateState[kHeight]
   const uid = state.uid
   const childUid = Id.create()
+  // Keep preview visibility unrendered until its root creation commands are ready.
   if (module === LayoutModules.Preview) {
     ViewletStates.setState(uid, {
       ...intermediateState,
+      previewVisible: state.previewVisible,
       previewActionsEventListeners: [],
       previewActionsUid: -1,
       previewId: childUid,
@@ -553,6 +555,7 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
   } else if (module === LayoutModules.SecondaryPreview) {
     ViewletStates.setState(uid, {
       ...intermediateState,
+      secondaryPreviewVisible: state.secondaryPreviewVisible,
       secondaryPreviewActionsEventListeners: [],
       secondaryPreviewActionsUid: -1,
       secondaryPreviewId: childUid,
@@ -595,6 +598,7 @@ const show = async (state: LayoutState, module, currentViewletId, restore?: bool
     newState: {
       ...intermediateState,
       ...latestState,
+      [kVisible]: intermediateState[kVisible],
       [kId]: childUid,
     },
     commands,

--- a/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutPreview.test.ts
@@ -328,6 +328,45 @@ test('showPreview enables preview sash', async () => {
   })
 })
 
+test('showPreview keeps the preview hidden until its viewlet has loaded', async () => {
+  let resolveLoad: (commands: unknown[][]) => void = () => {}
+  const loading = new Promise<unknown[][]>((resolve) => {
+    resolveLoad = resolve
+  })
+  let latestState
+  // @ts-ignore
+  ViewletManager.load.mockReturnValue(loading)
+  // @ts-ignore
+  ViewletStates.setState.mockImplementation((_uid, state) => {
+    latestState = state
+  })
+  // @ts-ignore
+  ViewletStates.getState.mockImplementation(() => latestState)
+  const state = {
+    ...ViewletLayout.create(1),
+    activityBarVisible: true,
+    activityBarWidth: 48,
+    statusBarHeight: 20,
+    titleBarHeight: 35,
+    windowHeight: 800,
+    windowWidth: 1200,
+  }
+
+  const resultPromise = ViewletLayout.showPreview(state, 'file:///test.html')
+
+  expect(latestState).toMatchObject({
+    previewVisible: false,
+    previewUri: 'file:///test.html',
+  })
+
+  resolveLoad([['Viewlet.createFunctionalRoot', 'Preview', 2, true]])
+  const result = await resultPromise
+  expect(result.newState).toMatchObject({
+    previewVisible: true,
+    previewUri: 'file:///test.html',
+  })
+})
+
 test('showPreview opens the simple browser in the preview area', async () => {
   const state = {
     ...ViewletLayout.create(1),


### PR DESCRIPTION
## Summary
- keep preview visibility unpublished while its child viewlet is loading
- publish visibility only when the child root and layout DOM commands are ready to send together
- cover the loading-state invariant with a deferred regression test

## Tests
- renderer-worker: 1623 passed, 231 skipped
- renderer-worker type-check
- root lint
- preview-worker E2E with source-equivalent override: 65 passed, 35 skipped