### PR TITLE
fix: preserve terminals when panel closes

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-panel-persistence.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-panel-persistence.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.terminal-panel-persistence'
+
+export const test: Test = async ({ Command, KeyBoard, Locator, Settings, expect }) => {
+  await Settings.update({
+    'terminal.backend': 'mock',
+  })
+
+  await Command.execute('Layout.showPanel', 'Terminals')
+  const terminal = Locator('.XtermTerminal')
+  await expect(terminal).toBeVisible()
+
+  for (const character of 'touch persistent-terminal.txt') {
+    await KeyBoard.press(character === ' ' ? 'Space' : character)
+  }
+  await KeyBoard.press('Enter')
+  await KeyBoard.press('l')
+  await KeyBoard.press('s')
+  await KeyBoard.press('Enter')
+  await expect(terminal).toContainText('persistent-terminal.txt')
+
+  await Command.execute('Layout.hidePanel')
+  await expect(terminal).toHaveCount(0)
+
+  await Command.execute('Layout.showPanel', 'Terminals')
+  const reopenedTerminal = Locator('.XtermTerminal')
+  await expect(reopenedTerminal).toBeVisible()
+  await expect(reopenedTerminal).toContainText('ls')
+  await expect(reopenedTerminal).toContainText('persistent-terminal.txt')
+}

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -6,6 +6,7 @@ import * as Preferences from '../Preferences/Preferences.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 export const create = (id, uri, x, y, width, height) => {
   Assert.number(id)
@@ -100,9 +101,37 @@ const sendCommands = async (commands) => {
   }
 }
 
+const restoreExistingTerminals = async (state, terminalTabsEnabled) => {
+  const existingInstance = ViewletStates.getInstance(ViewletModuleId.Terminals)
+  const existingState = existingInstance?.state
+  if (!existingState || existingState.uid === state.uid) {
+    return undefined
+  }
+  if (existingState.tabs.length === 0) {
+    ViewletStates.remove(existingState.uid)
+    return undefined
+  }
+  const restoredState = {
+    ...existingState,
+    uid: state.uid,
+    x: state.x,
+    y: state.y,
+    width: state.width,
+    height: state.height,
+    terminalTabsEnabled,
+  }
+  await sendCommands(await resizeTerminals(restoredState, restoredState.childUids))
+  ViewletStates.remove(existingState.uid)
+  return restoredState
+}
+
 export const loadContent = async (state) => {
   const { cwd } = state
   const terminalTabsEnabled = Preferences.get('terminal.tabs.enabled') !== false
+  const restoredState = await restoreExistingTerminals(state, terminalTabsEnabled)
+  if (restoredState) {
+    return restoredState
+  }
   const spawnOptions = await GetTerminalSpawnOptions.getTerminalSpawnOptions()
   const childUid = Id.create()
   const newState = {

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -5,6 +5,8 @@ const rendererProcessInvoke = jest.fn()
 const viewletDisposeFunctional = jest.fn((uid) => [['Viewlet.dispose', uid]])
 const viewletExecuteViewletCommand = jest.fn()
 const viewletResize = jest.fn(async (uid, dimensions) => [['Viewlet.setBounds', uid, dimensions]])
+const viewletStatesGetInstance = jest.fn()
+const viewletStatesRemove = jest.fn()
 let nextId = 42
 let terminalTabsPreference: boolean | undefined
 const terminalSpawnOptions = {
@@ -16,6 +18,7 @@ beforeEach(() => {
   jest.clearAllMocks()
   nextId = 42
   terminalTabsPreference = undefined
+  viewletStatesGetInstance.mockReturnValue(undefined)
   terminalSpawnOptions.args = ['-i']
   terminalSpawnOptions.command = 'bash'
 })
@@ -64,6 +67,13 @@ jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => {
     disposeFunctional: viewletDisposeFunctional,
     executeViewletCommand: viewletExecuteViewletCommand,
     resize: viewletResize,
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => {
+  return {
+    getInstance: viewletStatesGetInstance,
+    remove: viewletStatesRemove,
   }
 })
 
@@ -128,6 +138,68 @@ test('loadContent preserves an explicit disabled terminal tabs preference', asyn
     [terminalSpawnOptions],
   )
   expect(newState.terminalTabsEnabled).toBe(false)
+})
+
+test('loadContent reuses running terminals when the panel is reopened', async () => {
+  const existingState = {
+    ...createLoadedState(),
+    height: 200,
+    uid: 7,
+    width: 600,
+    x: 1,
+    y: 2,
+  }
+  viewletStatesGetInstance.mockReturnValue({ state: existingState })
+  const state = ViewletTerminals.create(9, 'file:///workspace/folder', 10, 20, 800, 400)
+
+  const newState = await ViewletTerminals.loadContent(state)
+
+  expect(commandExecute).not.toHaveBeenCalled()
+  expect(viewletResize).toHaveBeenCalledWith(41, {
+    height: 400,
+    width: 800,
+    x: 10,
+    y: 20,
+  })
+  expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
+    ['Viewlet.setBounds', 41, { height: 400, width: 800, x: 10, y: 20 }],
+  ])
+  expect(viewletStatesRemove).toHaveBeenCalledWith(7)
+  expect(newState).toMatchObject({
+    childUid: 41,
+    childUids: [41],
+    selectedIndex: 0,
+    tabs: existingState.tabs,
+    uid: 9,
+  })
+})
+
+test('loadContent creates a terminal after the previous terminal was killed', async () => {
+  const existingState = {
+    ...createLoadedState(),
+    activeTerminalUids: [],
+    childUid: -1,
+    childUids: [],
+    selectedIndex: -1,
+    tabs: [],
+    uid: 7,
+  }
+  viewletStatesGetInstance.mockReturnValue({ state: existingState })
+  const state = ViewletTerminals.create(9, 'file:///workspace/folder', 10, 20, 800, 400)
+
+  const newState = await ViewletTerminals.loadContent(state)
+
+  expect(commandExecute).toHaveBeenCalledWith(
+    'Layout.createViewlet',
+    ViewletModuleId.Terminal2,
+    42,
+    0,
+    expect.anything(),
+    'file:///workspace/folder',
+    [terminalSpawnOptions],
+  )
+  expect(viewletStatesRemove).toHaveBeenCalledWith(7)
+  expect(newState.childUid).toBe(42)
 })
 
 test('loadContent derives the terminal label and icon from the shell executable', async () => {


### PR DESCRIPTION
Preserve running terminal sessions and their xterm scrollback when the panel is closed or another panel view is selected. Reopening Terminals now reattaches the existing terminal tree, while an explicitly killed final terminal still starts fresh next time. Adds focused renderer coverage and an Electron e2e close/reopen regression.