### PR TITLE
fix: dispose terminals after process exit

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-panel-persistence.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-panel-persistence.ts
@@ -28,4 +28,14 @@ export const test: Test = async ({ Command, KeyBoard, Locator, Settings, expect 
   await expect(reopenedTerminal).toBeVisible()
   await expect(reopenedTerminal).toContainText('ls')
   await expect(reopenedTerminal).toContainText('persistent-terminal.txt')
+
+  for (const character of 'exit') {
+    await KeyBoard.press(character)
+  }
+  await KeyBoard.press('Enter')
+  await expect(reopenedTerminal).toHaveCount(0)
+
+  await Command.execute('Layout.hidePanel')
+  await Command.execute('Layout.showPanel', 'Terminals')
+  await expect(Locator('.XtermTerminal')).toBeVisible()
 }

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -439,6 +439,7 @@ export const commandMap = {
   'Terminals.handleClickTab': lazy('Terminals.handleClickTab'),
   'Terminals.handleClickTerminalTabAction': lazy('Terminals.handleClickTerminalTabAction'),
   'Terminals.handleMouseDown': lazy('Terminals.handleMouseDown'),
+  'Terminals.handleTerminalExit': lazy('Terminals.handleTerminalExit'),
   'Terminals.killTerminal': lazy('Terminals.killTerminal'),
   'Terminals.sendText': lazy('Terminals.sendText'),
   'Terminals.splitTerminal': lazy('Terminals.splitTerminal'),

--- a/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as Command from '../Command/Command.js'
 import * as Focus from '../Focus/Focus.js'
 import * as GetTerminalSpawnOptions from '../GetTerminalSpawnOptions/GetTerminalSpawnOptions.js'
 import * as Preferences from '../Preferences/Preferences.js'
@@ -51,6 +52,11 @@ export const handleInput = async (state, data) => {
 
 export const handleData = async (state, data) => {
   await RendererProcess.invoke('Viewlet.send', state.uid, 'write', data)
+  return state
+}
+
+export const handleExit = async (state) => {
+  await Command.execute('Terminals.handleTerminalExit', state.uid)
   return state
 }
 

--- a/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2Commands.ts
+++ b/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2Commands.ts
@@ -3,6 +3,7 @@ import * as ViewletTerminal from './ViewletTerminal2.ts'
 export const Commands = {
   clear: ViewletTerminal.clear,
   handleBlur: ViewletTerminal.handleBlur,
+  handleExit: ViewletTerminal.handleExit,
   handleInput: ViewletTerminal.handleInput,
   handleKeyDown: ViewletTerminal.handleKeyDown,
   handleMouseDown: ViewletTerminal.handleMouseDown,

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -233,55 +233,74 @@ export const handleMouseDown = (state, childUid) => {
   }
 }
 
-export const killTerminal = async (state) => {
-  const { activeTerminalUids: oldActiveTerminalUids, childUid, focusVersion, selectedIndex, tabs: oldTabs } = state
-  if (childUid === -1 || selectedIndex === -1) {
+const removeTerminal = async (state, terminalUid) => {
+  const { activeTerminalUids: oldActiveTerminalUids, childUid: oldChildUid, focusVersion, selectedIndex: oldSelectedIndex, tabs: oldTabs } = state
+  if (terminalUid === -1) {
     return state
   }
-  const tab = oldTabs[selectedIndex]
+  const terminalTabIndex = oldTabs.findIndex((tab) => getTerminalUids(tab).includes(terminalUid))
+  if (terminalTabIndex === -1) {
+    return state
+  }
+  const tab = oldTabs[terminalTabIndex]
   const terminalUids = getTerminalUids(tab)
-  const terminalIndex = terminalUids.indexOf(childUid)
-  if (terminalIndex === -1) {
-    return state
-  }
+  const terminalIndex = terminalUids.indexOf(terminalUid)
 
-  const remainingTerminalUids = terminalUids.filter((uid) => uid !== childUid)
+  const remainingTerminalUids = terminalUids.filter((uid) => uid !== terminalUid)
   let tabs = oldTabs
   let activeTerminalUids = oldActiveTerminalUids
-  let newSelectedIndex = selectedIndex
-  let childUids = remainingTerminalUids
-  let newChildUid
+  let selectedIndex = oldSelectedIndex
 
   if (remainingTerminalUids.length > 0) {
-    newChildUid = remainingTerminalUids[Math.min(terminalIndex, remainingTerminalUids.length - 1)]
-    tabs = tabs.with(selectedIndex, {
+    const oldActiveTerminalUid = oldActiveTerminalUids[terminalTabIndex]
+    const activeTerminalUid = remainingTerminalUids.includes(oldActiveTerminalUid)
+      ? oldActiveTerminalUid
+      : remainingTerminalUids[Math.min(terminalIndex, remainingTerminalUids.length - 1)]
+    tabs = tabs.with(terminalTabIndex, {
       ...tab,
       terminalUids: remainingTerminalUids,
     })
-    activeTerminalUids = activeTerminalUids.with(selectedIndex, newChildUid)
+    activeTerminalUids = activeTerminalUids.with(terminalTabIndex, activeTerminalUid)
   } else {
-    tabs = tabs.toSpliced(selectedIndex, 1)
-    activeTerminalUids = activeTerminalUids.toSpliced(selectedIndex, 1)
-    newSelectedIndex = tabs.length === 0 ? -1 : Math.min(selectedIndex, tabs.length - 1)
-    childUids = newSelectedIndex === -1 ? [] : getTerminalUids(tabs[newSelectedIndex])
-    newChildUid = newSelectedIndex === -1 ? -1 : activeTerminalUids[newSelectedIndex] || childUids[0]
+    tabs = tabs.toSpliced(terminalTabIndex, 1)
+    activeTerminalUids = activeTerminalUids.toSpliced(terminalTabIndex, 1)
+    if (tabs.length === 0) {
+      selectedIndex = -1
+    } else if (terminalTabIndex < oldSelectedIndex) {
+      selectedIndex = oldSelectedIndex - 1
+    } else if (terminalTabIndex === oldSelectedIndex) {
+      selectedIndex = Math.min(oldSelectedIndex, tabs.length - 1)
+    }
   }
+
+  const childUids = selectedIndex === -1 ? [] : getTerminalUids(tabs[selectedIndex])
+  const childUid = selectedIndex === -1 ? -1 : activeTerminalUids[selectedIndex] || childUids[0]
 
   const newState = {
     ...state,
     activeTerminalUids,
-    childUid: newChildUid,
+    childUid,
     childUids,
-    focusVersion: newChildUid === -1 ? focusVersion : focusVersion + 1,
-    selectedIndex: newSelectedIndex,
+    focusVersion: childUid !== -1 && childUid !== oldChildUid ? focusVersion + 1 : focusVersion,
+    selectedIndex,
     tabs,
   }
-  const commands = Viewlet.disposeFunctional(childUid)
-  if (childUids.length > 0) {
-    commands.push(...(await resizeTerminals(newState, childUids)))
+  const commands = Viewlet.disposeFunctional(terminalUid)
+  const terminalUidsToResize = remainingTerminalUids.length > 0 ? remainingTerminalUids : childUids
+  if (terminalUidsToResize.length > 0) {
+    commands.push(...(await resizeTerminals(newState, terminalUidsToResize)))
   }
   await sendCommands(commands)
   return newState
+}
+
+export const handleTerminalExit = (state, terminalUid) => {
+  Assert.number(terminalUid)
+  return removeTerminal(state, terminalUid)
+}
+
+export const killTerminal = (state) => {
+  return removeTerminal(state, state.childUid)
 }
 
 export const handleClickTab = (state, index) => {

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminalsCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminalsCommands.js
@@ -6,6 +6,7 @@ export const Commands = {
   handleClickTab: ViewletTerminals.handleClickTab,
   handleClickTerminalTabAction: ViewletTerminals.handleClickTerminalTabAction,
   handleMouseDown: ViewletTerminals.handleMouseDown,
+  handleTerminalExit: ViewletTerminals.handleTerminalExit,
   killTerminal: ViewletTerminals.killTerminal,
   sendText: ViewletTerminals.sendText,
   splitTerminal: ViewletTerminals.splitTerminal,

--- a/packages/renderer-worker/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminal2.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
+const commandExecute = jest.fn()
 const focusSetFocus = jest.fn()
 const rendererProcessInvoke = jest.fn()
 const terminalWorkerInvoke = jest.fn()
 
 beforeEach(() => {
   focusSetFocus.mockClear()
+  commandExecute.mockClear()
   rendererProcessInvoke.mockClear()
   terminalWorkerInvoke.mockClear()
+})
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
+  return {
+    execute: commandExecute,
+  }
 })
 
 jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => {
@@ -119,6 +127,14 @@ test('handleData forwards pty output to renderer-process xterm', async () => {
   const data = new Uint8Array([97, 98, 99])
   await expect(ViewletTerminal2.handleData(state, data)).resolves.toBe(state)
   expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.send', 4, 'write', data)
+})
+
+test('handleExit removes the exited terminal from its parent', async () => {
+  const state = ViewletTerminal2.create(10)
+
+  await expect(ViewletTerminal2.handleExit(state)).resolves.toBe(state)
+
+  expect(commandExecute).toHaveBeenCalledWith('Terminals.handleTerminalExit', 10)
 })
 
 test('resizeEffect forwards xterm dimensions to the terminal worker', async () => {

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -161,9 +161,7 @@ test('loadContent reuses running terminals when the panel is reopened', async ()
     x: 10,
     y: 20,
   })
-  expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [
-    ['Viewlet.setBounds', 41, { height: 400, width: 800, x: 10, y: 20 }],
-  ])
+  expect(rendererProcessInvoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.setBounds', 41, { height: 400, width: 800, x: 10, y: 20 }]])
   expect(viewletStatesRemove).toHaveBeenCalledWith(7)
   expect(newState).toMatchObject({
     childUid: 41,
@@ -414,6 +412,68 @@ test('killTerminal disposes the active split and expands the remaining split', a
     focusVersion: 1,
     tabs: [{ terminalUids: [41] }],
   })
+})
+
+test('handleTerminalExit disposes an exited split and keeps the active split focused', async () => {
+  const state = {
+    ...createLoadedState(),
+    activeTerminalUids: [42],
+    childUid: 42,
+    childUids: [41, 42],
+    tabs: [{ icon: 'terminal-bash', label: 'bash', terminalUids: [41, 42], uid: 41 }],
+  }
+
+  const newState = await ViewletTerminals.handleTerminalExit(state, 41)
+
+  expect(viewletDisposeFunctional).toHaveBeenCalledWith(41)
+  expect(viewletResize).toHaveBeenCalledWith(42, {
+    height: 400,
+    width: 800,
+    x: 10,
+    y: 20,
+  })
+  expect(newState).toMatchObject({
+    activeTerminalUids: [42],
+    childUid: 42,
+    childUids: [42],
+    focusVersion: 0,
+    tabs: [{ terminalUids: [42] }],
+  })
+})
+
+test('handleTerminalExit removes a background tab without changing the selected terminal', async () => {
+  const state = {
+    ...createLoadedState(),
+    activeTerminalUids: [41, 42],
+    childUid: 42,
+    childUids: [42],
+    selectedIndex: 1,
+    tabs: [
+      { icon: 'terminal-bash', label: 'bash', terminalUids: [41], uid: 41 },
+      { icon: 'terminal-bash', label: 'bash', terminalUids: [42], uid: 42 },
+    ],
+  }
+
+  const newState = await ViewletTerminals.handleTerminalExit(state, 41)
+
+  expect(viewletDisposeFunctional).toHaveBeenCalledWith(41)
+  expect(newState).toMatchObject({
+    activeTerminalUids: [42],
+    childUid: 42,
+    childUids: [42],
+    focusVersion: 0,
+    selectedIndex: 0,
+    tabs: [{ terminalUids: [42] }],
+  })
+})
+
+test('handleTerminalExit ignores a terminal that is no longer owned', async () => {
+  const state = createLoadedState()
+
+  await expect(ViewletTerminals.handleTerminalExit(state, 99)).resolves.toBe(state)
+
+  expect(viewletDisposeFunctional).not.toHaveBeenCalled()
+  expect(rendererProcessInvoke).not.toHaveBeenCalled()
 })
 
 test('killTerminal removes an empty tab and selects the next terminal tab', async () => {


### PR DESCRIPTION
## Summary

Dispose the terminal view and xterm only after its process exits or the user kills it. Extend the panel persistence e2e to cover exit cleanup and creating a fresh terminal afterward.