### PR TITLE
fix: update search action states

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-actions-update.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-actions-update.ts
@@ -1,0 +1,22 @@
+export const name = 'viewlet.search-actions-update'
+
+export const test = async ({ FileSystem, Locator, Search, SideBar, Workspace, expect }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'search action result')
+  await Workspace.setPath(tmpDir)
+  await SideBar.open('Search')
+  const actions = Locator('.SideBarTitleArea')
+  const refresh = actions.locator('[name="Refresh"]')
+  const clear = actions.locator('[name="ClearAll"]')
+  await expect(refresh).toHaveAttribute('disabled', '')
+  await expect(clear).toHaveAttribute('disabled', '')
+
+  // act
+  await Search.setValue('search action result')
+
+  // assert
+  await expect(Locator('.Search .TreeItem')).toHaveCount(2)
+  await expect(refresh).toHaveAttribute('disabled', null)
+  await expect(clear).toHaveAttribute('disabled', null)
+}

--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -157,6 +157,19 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     return adapter.transformState(initialState)
   }
 
+  const applyOutputs = async (state, invocation, isHotReload = false) => {
+    const newState = { ...state }
+    for (const output of config.outputs || []) {
+      if (isHotReload && output.hotReload === false) {
+        continue
+      }
+      invocation.state = newState
+      invocation.results[output.stateField] = await invokeConfiguredMethod(worker, output.method, invocation)
+      newState[output.stateField] = invocation.results[output.stateField]
+    }
+    return newState
+  }
+
   const runRenderPipeline = async (
     currentState,
     invocationArguments = {},
@@ -167,18 +180,11 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     const invocation = createInvocation(currentState, context, invocationArguments)
     invocation.results.diff = await invokeConfiguredMethod(worker, diffMethod, invocation)
     invocation.results.commands = await invokeConfiguredMethod(worker, renderMethod, invocation)
-    const newState = {
+    const renderedState = {
       ...currentState,
       commands: invocation.results.commands,
     }
-    for (const output of config.outputs || []) {
-      if (isHotReload && output.hotReload === false) {
-        continue
-      }
-      invocation.state = newState
-      invocation.results[output.stateField] = await invokeConfiguredMethod(worker, output.method, invocation)
-      newState[output.stateField] = invocation.results[output.stateField]
-    }
+    const newState = await applyOutputs(renderedState, invocation, isHotReload)
     return adapter.transformRenderedState(newState)
   }
 
@@ -208,10 +214,12 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     if (config.commandReturnStateWhenCommandsEmpty && invocation.results.commands.length === 0) {
       return currentState
     }
-    return adapter.transformRenderedState({
+    const renderedState = {
       ...currentState,
       commands: invocation.results.commands,
-    })
+    }
+    const newState = await applyOutputs(renderedState, invocation)
+    return adapter.transformRenderedState(newState)
   }
 
   Object.defineProperty(Commands, '__renderPending', {

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -143,6 +143,34 @@ test('creates command wrappers through the same lifecycle seam', async () => {
   expect(result.commands).toEqual([['setText', 'selected']])
 })
 
+test('recomputes configured outputs after commands', async () => {
+  const config: any = createConfig()
+  config.outputs = [{ method: { name: 'Example.renderActions', parameters: [stateParameter('uid')] }, stateField: 'actionsDom' }]
+  const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
+    if (method === 'Example.getCommandIds') {
+      return ['select']
+    }
+    if (method === 'Example.diff3') {
+      return ['diff']
+    }
+    if (method === 'Example.render3') {
+      return [['setText', 'selected']]
+    }
+    if (method === 'Example.renderActions') {
+      return [['enabled-button']]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({ config, context: { platform: 1 }, worker: { invoke, restart: jest.fn() } })
+  const commands = await viewlet.getCommands!()
+  const state = { ...viewlet.create(9, '', 0, 0, 0, 0), actionsDom: [['disabled-button']] }
+
+  const result = await commands.select(state, 'item-1')
+
+  expect(invoke).toHaveBeenCalledWith('Example.renderActions', 9)
+  expect(result.actionsDom).toEqual([['enabled-button']])
+})
+
 test('renders pending worker state without replaying a command', async () => {
   const invoke = jest.fn(async (method: string) => {
     if (method === 'Example.diff3') {


### PR DESCRIPTION
Summary:
- Recompute worker view outputs after rendered commands so Search toolbar actions stay synchronized.
- Add unit and end-to-end regression coverage for actions becoming enabled when results arrive.