### PR TITLE
fix: load simple browser tab favicons with cors

### DIFF
--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -52,6 +52,7 @@ export const getSimpleBrowserVirtualDom = (
         dom.push({
           type: VirtualDomElements.Img,
           className: 'SimpleBrowserTabFavicon',
+          crossOrigin: 'anonymous',
           src: tab.favicon,
           draggable: false,
           childCount: 0,

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -64,7 +64,9 @@ test('renders selectable tabs with favicon, title, close, and new tab controls',
   expect(dom).toContainEqual(
     expect.objectContaining({ className: 'SimpleBrowserTab SimpleBrowserTabSelected', onClick: 'handleClickSimpleBrowserTab', role: 'tab' }),
   )
-  expect(dom).toContainEqual(expect.objectContaining({ className: 'SimpleBrowserTabFavicon', src: 'https://example.com/favicon.png' }))
+  expect(dom).toContainEqual(
+    expect.objectContaining({ className: 'SimpleBrowserTabFavicon', crossOrigin: 'anonymous', src: 'https://example.com/favicon.png' }),
+  )
   expect(dom).toContainEqual(expect.objectContaining({ className: 'SimpleBrowserTabClose', onClick: 'handleClickSimpleBrowserTabClose' }))
   expect(dom).toContainEqual(expect.objectContaining({ className: 'SimpleBrowserNewTab', onClick: 'handleClickSimpleBrowserNewTab' }))
 })


### PR DESCRIPTION
Adds anonymous CORS mode to Simple Browser tab favicon images so they can load under the renderer’s cross-origin isolation policy. Includes regression coverage for the generated favicon element.