### PR TITLE
fix: declare core settings

### DIFF
--- a/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
+++ b/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
@@ -12,6 +12,8 @@ interface SettingsFile {
   readonly settings: readonly SettingsContribution[]
 }
 
+const rendererSettingsPath = 'packages/renderer-worker/settings.json'
+
 export const deduplicateSettingsContributions = (files: readonly SettingsFile[]): readonly SettingsFile[] => {
   const seenSettings = new Map<string, string>()
   const result: SettingsFile[] = []
@@ -84,7 +86,12 @@ export const getSettingsContributionCandidates = (workers: readonly any[]): read
 }
 
 export const bundleBuiltinSettings = async ({ workers, toRoot }): Promise<void> => {
-  const settingsFiles: SettingsFile[] = []
+  const settingsFiles: SettingsFile[] = [
+    {
+      fileName: 'renderer-worker.json',
+      settings: await JsonFile.readJson(Path.absolute(rendererSettingsPath)),
+    },
+  ]
   for (const candidate of getSettingsContributionCandidates(workers)) {
     const from = getSourcePath(candidate.sourcePath)
     if (!from) {

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -36,7 +36,7 @@ test('gets one settings contribution candidate per worker package', () => {
   ])
 })
 
-test('does not expose renderer worker defaults as settings contributions', async () => {
+test('bundles schema-complete renderer settings contributions', async () => {
   const toRoot = await mkdtemp(join(tmpdir(), 'lvce-builtin-settings-'))
   try {
     await bundleBuiltinSettings({
@@ -45,9 +45,41 @@ test('does not expose renderer worker defaults as settings contributions', async
     })
 
     const index = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'index.json'), 'utf8'))
+    const settings = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'renderer-worker.json'), 'utf8'))
     const fileNames = await readdir(join(toRoot, 'builtin-settings'))
-    expect(index).toEqual([])
-    expect(fileNames).toEqual(['index.json'])
+    expect(index).toEqual(['renderer-worker.json'])
+    expect(fileNames).toEqual(['index.json', 'renderer-worker.json'])
+    expect(settings).toEqual(
+      expect.arrayContaining([
+        {
+          category: 'workbench',
+          description: 'Controls the location of the side bar',
+          heading: 'Side Bar Location',
+          id: 'workbench.sideBarLocation',
+          type: 2,
+          value: 'right',
+        },
+      ]),
+    )
+    expect(settings.every(({ category, description, heading, id, type }) => category && description && heading && id && type)).toBe(true)
+  } finally {
+    await rm(toRoot, { force: true, recursive: true })
+  }
+})
+
+test('declares every default setting', async () => {
+  const defaultSettingsUrl = new URL('../../../static/config/defaultSettings.json', import.meta.url)
+  const workersUrl = new URL('../../renderer-worker/src/parts/Workers/Workers.json', import.meta.url)
+  const defaultSettings = JSON.parse(await readFile(defaultSettingsUrl, 'utf8'))
+  const workers = JSON.parse(await readFile(workersUrl, 'utf8'))
+  const toRoot = await mkdtemp(join(tmpdir(), 'lvce-builtin-settings-'))
+  try {
+    await bundleBuiltinSettings({ toRoot, workers })
+    const index = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'index.json'), 'utf8'))
+    const settings = await Promise.all(index.map(async (fileName) => JSON.parse(await readFile(join(toRoot, 'builtin-settings', fileName), 'utf8'))))
+    const declaredIds = new Set(settings.flat().map(({ id }) => id))
+
+    expect(Object.keys(defaultSettings).filter((id) => !declaredIds.has(id))).toEqual([])
   } finally {
     await rm(toRoot, { force: true, recursive: true })
   }

--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -1,0 +1,252 @@
+[
+  {
+    "category": "applications",
+    "description": "Controls how application updates are installed",
+    "heading": "Update Mode",
+    "id": "application.updateMode",
+    "type": 2,
+    "value": "none"
+  },
+  {
+    "category": "workbench",
+    "description": "Stores the cached color theme",
+    "heading": "Color Theme Cache",
+    "id": "colorTheme.cache",
+    "type": 2,
+    "value": ""
+  },
+  {
+    "category": "text-editor",
+    "description": "Controls the delay in milliseconds before completions are loaded",
+    "heading": "Completions Loading Delay",
+    "id": "completions.loadingDelay",
+    "minimum": 0,
+    "type": 5,
+    "value": 1200
+  },
+  {
+    "category": "workbench",
+    "description": "Watches the active color theme for changes during development",
+    "heading": "Watch Color Theme",
+    "id": "development.watchColorTheme",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "workbench",
+    "description": "Enables the development file watcher",
+    "heading": "File Watcher",
+    "id": "develop.fileWatcher",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "text-editor",
+    "description": "Caches editor state for faster restoration",
+    "heading": "Editor Cache",
+    "id": "editor.cache",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "text-editor",
+    "description": "Controls whether semantic tokens are shown in the editor",
+    "heading": "Semantic Tokens",
+    "id": "editor.semanticTokens",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "extensions",
+    "description": "Controls whether extensions are updated automatically",
+    "heading": "Auto Update",
+    "id": "extensions.autoUpdate",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "text-editor",
+    "description": "Controls when files are saved automatically",
+    "heading": "Auto Save",
+    "id": "files.autoSave",
+    "type": 2,
+    "value": "off"
+  },
+  {
+    "category": "text-editor",
+    "description": "Treats JavaScript files as JSX files",
+    "heading": "JavaScript Files As JSX",
+    "id": "languages.jsFilesAsJsx",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "workbench",
+    "description": "Overrides the backend URL used by the layout",
+    "heading": "Layout Backend URL",
+    "id": "layout.backendUrl",
+    "type": 7,
+    "value": ""
+  },
+  {
+    "category": "workbench",
+    "description": "Caches the active file icon theme",
+    "heading": "Icon Theme Cache",
+    "id": "icon-theme.cache",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "features",
+    "description": "Controls the number of worker threads used for search",
+    "heading": "Search Threads",
+    "id": "search.threads",
+    "minimum": 1,
+    "type": 5,
+    "value": 1
+  },
+  {
+    "category": "workbench",
+    "description": "Records the current session for replay",
+    "heading": "Session Replay",
+    "id": "sessionReplay.enabled",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "features",
+    "description": "Shows search suggestions in the simple browser",
+    "heading": "Simple Browser Suggestions",
+    "id": "simpleBrowser.suggestions",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "features",
+    "description": "Configures keyboard shortcuts handled by the simple browser",
+    "heading": "Simple Browser Shortcuts",
+    "id": "simpleBrowser.shortcuts",
+    "type": 4,
+    "value": []
+  },
+  {
+    "category": "features",
+    "description": "Controls whether the simple browser uses tabs",
+    "heading": "Simple Browser Tabs",
+    "id": "simpleBrowser.tabs.enabled",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "features",
+    "description": "Selects the terminal backend",
+    "heading": "Terminal Backend",
+    "id": "terminal.backend",
+    "type": 2,
+    "value": "real"
+  },
+  {
+    "category": "features",
+    "description": "Uses a separate connection for terminal communication",
+    "heading": "Separate Terminal Connection",
+    "id": "terminal.separateConnection",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "features",
+    "description": "Controls whether the terminal uses tabs",
+    "heading": "Terminal Tabs",
+    "id": "terminal.tabs.enabled",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "window",
+    "description": "Controls the zoom level of the window",
+    "heading": "Zoom Level",
+    "id": "window.zoomLevel",
+    "type": 5,
+    "value": 0
+  },
+  {
+    "category": "workbench",
+    "description": "Cleans up worker resources after they finish loading",
+    "heading": "Clean Up Workers After Load",
+    "id": "Workers.cleanUpAfterLoad",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "workbench",
+    "description": "Specifies the workbench color theme",
+    "heading": "Color Theme",
+    "id": "workbench.colorTheme",
+    "type": 2,
+    "value": "slime"
+  },
+  {
+    "category": "workbench",
+    "description": "Specifies the workbench file icon theme",
+    "heading": "Icon Theme",
+    "id": "workbench.iconTheme",
+    "type": 2,
+    "value": "vscode-icons"
+  },
+  {
+    "category": "workbench",
+    "description": "Controls whether the activity bar is visible",
+    "heading": "Activity Bar Visibility",
+    "id": "workbench.activityBar.visible",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "workbench",
+    "description": "Shows editor tabs while their content is loading",
+    "heading": "Show Tabs While Loading",
+    "id": "workbench.editor.showTabsWhileLoading",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "workbench",
+    "description": "Controls whether the side bar is visible",
+    "heading": "Side Bar Visibility",
+    "id": "workbench.sideBar.visible",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "workbench",
+    "description": "Controls the location of the side bar",
+    "heading": "Side Bar Location",
+    "id": "workbench.sideBarLocation",
+    "type": 2,
+    "value": "right"
+  },
+  {
+    "category": "workbench",
+    "description": "Saves workbench state when the window visibility changes",
+    "heading": "Save State On Visibility Change",
+    "id": "workbench.saveStateOnVisibilityChange",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "workbench",
+    "description": "Specifies the workspace opened when no other workspace is selected",
+    "heading": "Default Workspace",
+    "id": "workspace.defaultWorkspace",
+    "type": 7,
+    "value": "fetch:///playground"
+  },
+  {
+    "category": "workbench",
+    "description": "Configures keybindings that fall through to browser views",
+    "heading": "Browser View Keybindings",
+    "id": "keyBindings.fallTroughBrowserView",
+    "type": 4,
+    "value": ["ctrl+p", "ctrl+shift+p", "ctrl+b", "ctrl+m", "ctrl+Tab"]
+  }
+]


### PR DESCRIPTION
Adds schema-complete renderer and layout setting declarations so every shipped default is recognized in settings.json. Adds regression coverage requiring every default setting to be contributed.