### PR TITLE
fix: disable workspace file watcher by default

### DIFF
--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -74,6 +74,14 @@
   },
   {
     "category": "text-editor",
+    "description": "Controls whether changes to files in the workspace are watched",
+    "heading": "Workspace File Watching",
+    "id": "files.workspaceWatcher.enabled",
+    "type": 3,
+    "value": false
+  },
+  {
+    "category": "text-editor",
     "description": "Treats JavaScript files as JSX files",
     "heading": "JavaScript Files As JSX",
     "id": "languages.jsFilesAsJsx",

--- a/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
+++ b/packages/renderer-worker/src/parts/WorkspaceFileWatcher/WorkspaceFileWatcher.js
@@ -1,6 +1,7 @@
 import * as Command from '../Command/Command.js'
 import * as FileWatcher from '../FileWatcher/FileWatcher.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
+import * as Preferences from '../Preferences/Preferences.js'
 import * as Workspace from '../Workspace/Workspace.js'
 
 const RefreshDelay = 100
@@ -76,6 +77,9 @@ const handleWorkspaceChange = async () => {
 }
 
 export const hydrate = async () => {
+  if (Preferences.get('files.workspaceWatcher.enabled') !== true) {
+    return
+  }
   GlobalEventBus.addListener('workspace.change', handleWorkspaceChange)
   await watchWorkspace(Workspace.getWorkspaceUri())
 }

--- a/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
+++ b/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
@@ -7,7 +7,7 @@ const watcher = {
   removeEventListener,
 }
 const getWorkspaceUri = jest.fn(() => 'file:///workspace')
-const getPreference = jest.fn(() => false)
+const getPreference = jest.fn((_key: string) => false)
 
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
   execute: jest.fn(),

--- a/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
+++ b/packages/renderer-worker/test/WorkspaceFileWatcher.test.ts
@@ -7,6 +7,7 @@ const watcher = {
   removeEventListener,
 }
 const getWorkspaceUri = jest.fn(() => 'file:///workspace')
+const getPreference = jest.fn(() => false)
 
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
   execute: jest.fn(),
@@ -15,6 +16,10 @@ jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
 jest.unstable_mockModule('../src/parts/FileWatcher/FileWatcher.js', () => ({
   dispose: jest.fn(),
   watch: jest.fn(() => watcher),
+}))
+
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
+  get: getPreference,
 }))
 
 jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
@@ -32,15 +37,26 @@ beforeEach(async () => {
   GlobalEventBus.state.listenerMap = Object.create(null)
   jest.clearAllMocks()
   getWorkspaceUri.mockReturnValue('file:///workspace')
+  getPreference.mockReturnValue(false)
 })
 
 afterEach(() => {
   jest.useRealTimers()
 })
 
-test('hydrate - watches the current file workspace', async () => {
+test('hydrate - does not watch the current file workspace by default', async () => {
   await WorkspaceFileWatcher.hydrate()
 
+  expect(FileWatcher.watch).not.toHaveBeenCalled()
+  expect(GlobalEventBus.state.listenerMap['workspace.change']).toBeUndefined()
+})
+
+test('hydrate - watches the current file workspace when enabled', async () => {
+  getPreference.mockReturnValue(true)
+
+  await WorkspaceFileWatcher.hydrate()
+
+  expect(getPreference).toHaveBeenCalledWith('files.workspaceWatcher.enabled')
   expect(FileWatcher.watch).toHaveBeenCalledWith({
     exclude: ['.git', 'node_modules'],
     roots: ['file:///workspace'],
@@ -61,6 +77,7 @@ test('watchWorkspace - replaces the previous watcher', async () => {
 })
 
 test('workspace change - watches the new workspace uri and refreshes the source control badge count', async () => {
+  getPreference.mockReturnValue(true)
   await WorkspaceFileWatcher.hydrate()
   getWorkspaceUri.mockReturnValue('file:///other')
   const handleWorkspaceChange = GlobalEventBus.state.listenerMap['workspace.change'][0]

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -31,6 +31,7 @@
   "extensions.autoUpdate": true,
 
   "files.autoSave": "off",
+  "files.workspaceWatcher.enabled": false,
 
   "files.exclude": {
     "**/.git": true,


### PR DESCRIPTION
## Summary

- disable recursive workspace file watching by default to reduce memory usage in large workspaces
- add an opt-in `files.workspaceWatcher.enabled` setting
- preserve the existing watcher behavior when enabled