### PR TITLE
feature: open simple browser links in tabs

### DIFF
--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -123,6 +123,24 @@
   },
   {
     "category": "features",
+    "description": "Controls whether links that request a new window open in a simple browser tab or the system browser",
+    "heading": "Simple Browser External Links",
+    "id": "simpleBrowser.openExternalLinks",
+    "options": [
+      {
+        "id": "newTab",
+        "label": "New Tab"
+      },
+      {
+        "id": "externalBrowser",
+        "label": "External Browser"
+      }
+    ],
+    "type": 1,
+    "value": "newTab"
+  },
+  {
+    "category": "features",
     "description": "Shows search suggestions in the simple browser",
     "heading": "Simple Browser Suggestions",
     "id": "simpleBrowser.suggestions",

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -101,6 +101,7 @@ export const commandMap = {
   'ElectronBrowserView.handlePageFaviconUpdated': lazy('ElectronBrowserView.handlePageFaviconUpdated'),
   'ElectronBrowserView.handleTitleUpdated': lazy('ElectronBrowserView.handleTitleUpdated'),
   'ElectronBrowserView.handleWillNavigate': lazy('ElectronBrowserView.handleWillNavigate'),
+  'ElectronBrowserView.handleWindowOpen': lazy('ElectronBrowserView.handleWindowOpen'),
   'ElectronClipBoard.writeText': lazy('ElectronClipBoard.writeText'),
   'ElectronContentTracing.startRecording': lazy('ElectronContentTracing.startRecording'),
   'ElectronContentTracing.stopRecording': lazy('ElectronContentTracing.stopRecording'),

--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
@@ -7,4 +7,5 @@ export const Commands = {
   handlePageFaviconUpdated: ElectronBrowserView.handlePageFaviconUpdated,
   handleTitleUpdated: ElectronBrowserView.handleTitleUpdated,
   handleWillNavigate: ElectronBrowserView.handleWillNavigate,
+  handleWindowOpen: ElectronBrowserView.handleWindowOpen,
 }

--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.js
@@ -13,6 +13,8 @@ export const handleTitleUpdated = dispatch('browser-view-title-updated')
 
 export const handleWillNavigate = dispatch('browser-view-will-navigate')
 
+export const handleWindowOpen = dispatch('browser-view-window-open')
+
 export const isOpen = () => {
   return false
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -278,6 +278,38 @@ export const createNewTab = async (state) => {
   return { ...newState, focusAddressVersion: newState.focusAddressVersion + 1 }
 }
 
+export const handleWindowOpen = async (state, browserViewId, url, disposition) => {
+  const { hasSuggestionsOverlay, tabs: oldTabs, tabsEnabled } = state
+  const ownsWebContentsView = oldTabs.some((tab) => tab.browserViewId === Number(browserViewId))
+  const openExternalLinks = Preferences.get('simpleBrowser.openExternalLinks') === 'externalBrowser'
+  if (!ownsWebContentsView) {
+    return state
+  }
+  if (openExternalLinks || !tabsEnabled) {
+    await Command.execute('Open.openExternal', url)
+    return state
+  }
+  const currentState = hasSuggestionsOverlay ? await closeSuggestions(state) : state
+  const emptyTab = await createEmptyTab(currentState)
+  const tab = {
+    ...emptyTab,
+    iframeSrc: url,
+    inputValue: url,
+    isLoading: true,
+  }
+  void ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, url)
+  const tabs = [...currentState.tabs, tab]
+  if (disposition === 'background-tab') {
+    return { ...currentState, tabs }
+  }
+  if (currentState.browserViewId) {
+    await ElectronWebContentsViewFunctions.hide(currentState.browserViewId)
+  }
+  await ElectronWebContentsViewFunctions.show(tab.browserViewId)
+  await ElectronWebContentsViewFunctions.focus(tab.browserViewId)
+  return activateTab(currentState, tabs, currentState.tabs.length)
+}
+
 export const selectTab = async (state, index) => {
   const selectedTabIndex = Number(index)
   if (selectedTabIndex === state.selectedTabIndex || selectedTabIndex < 0 || selectedTabIndex >= state.tabs.length) {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -47,4 +47,5 @@ export const Events = {
   'browser-view-page-favicon-updated': SimpleBrowser.handlePageFaviconUpdated,
   'browser-view-title-updated': SimpleBrowser.handleTitleUpdated,
   'browser-view-will-navigate': SimpleBrowser.handleWillNavigate,
+  'browser-view-window-open': SimpleBrowser.handleWindowOpen,
 }

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -24,6 +24,7 @@ test('registers the simple browser suggestion event bridge commands', () => {
 
 test('registers the simple browser favicon event bridge command', () => {
   expect(commandMap['ElectronBrowserView.handlePageFaviconUpdated']).toBeDefined()
+  expect(commandMap['ElectronBrowserView.handleWindowOpen']).toBeDefined()
 })
 
 test('registers the panel maximize commands', () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -198,6 +198,82 @@ test('creates and selects an empty tab while keeping the original view alive', a
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
 })
 
+test('opens a target blank link in a new selected tab by default', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(13)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
+    browserViewId: 12,
+    tabs: [{ browserViewId: 12, iframeSrc: 'https://example.com', inputValue: 'https://example.com', title: 'Example' }],
+  }
+
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'foreground-tab')
+
+  expect(newState).toMatchObject({ browserViewId: 13, iframeSrc: 'https://example.com/docs', selectedTabIndex: 1 })
+  expect(newState.tabs).toHaveLength(2)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, 'https://example.com/docs')
+  expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
+  expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
+  expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(13)
+})
+
+test('keeps a target blank background tab hidden', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(13)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
+    browserViewId: 12,
+    tabs: [{ browserViewId: 12, iframeSrc: 'https://example.com', inputValue: 'https://example.com', title: 'Example' }],
+  }
+
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'background-tab')
+
+  expect(newState).toMatchObject({ browserViewId: 12, selectedTabIndex: 0 })
+  expect(newState.tabs).toHaveLength(2)
+  expect(ElectronWebContentsViewFunctions.show).not.toHaveBeenCalled()
+})
+
+test('opens a target blank link in the system browser when configured', async () => {
+  Preferences.state['simpleBrowser.openExternalLinks'] = 'externalBrowser'
+  const state = {
+    ...ViewletSimpleBrowser.create(),
+    browserViewId: 12,
+    tabs: [{ browserViewId: 12 }],
+  }
+
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'foreground-tab')
+
+  expect(newState).toBe(state)
+  expect(Command.execute).toHaveBeenCalledWith('Open.openExternal', 'https://example.com/docs')
+  delete Preferences.state['simpleBrowser.openExternalLinks']
+})
+
+test('ignores a target blank event from another simple browser instance', async () => {
+  const state = {
+    ...ViewletSimpleBrowser.create(),
+    browserViewId: 12,
+    tabs: [{ browserViewId: 12 }],
+  }
+
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 99, 'https://example.com/docs', 'foreground-tab')
+
+  expect(newState).toBe(state)
+  expect(ElectronWebContentsView.createWebContentsView).not.toHaveBeenCalled()
+  expect(Command.execute).not.toHaveBeenCalled()
+})
+
 test('switches tabs by hiding only the previous active view', async () => {
   // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)


### PR DESCRIPTION
Opens links that request a new window in a Simple Browser tab by default and adds a setting to use the external browser instead.