### PR TITLE
fix: register direct secrets view worker

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -60,7 +60,7 @@
         "@lvce-editor/rename-worker": "^1.39.0",
         "@lvce-editor/renderer-process": "^30.46.2",
         "@lvce-editor/running-extensions-view": "^1.26.0",
-        "@lvce-editor/secrets-view": "^0.1.1",
+        "@lvce-editor/secrets-view": "^0.2.1",
         "@lvce-editor/settings-view": "^2.26.2",
         "@lvce-editor/settings-worker": "^1.18.0",
         "@lvce-editor/simple-browser-view": "^2.13.0",
@@ -1064,6 +1064,12 @@
       "integrity": "sha512-aJFW73zQjwarS+1hTAlNGqOE26QSAFBVS5vmze8n+/sXwhz7bEp6ZIDAL+OXaJXW1mz8FweUEs4mVWLddDYuEQ==",
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/i18n": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/i18n/-/i18n-2.10.0.tgz",
+      "integrity": "sha512-P33F7/UFagkZyra/3KE068xrH3OdiFdlOruCTtyzKhcXQTa1QQqUAqpnIldzoF3eEUhMTdlcshMJtddDcqfR/A==",
+      "license": "MIT"
+    },
     "node_modules/@lvce-editor/icon-theme-worker": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/@lvce-editor/icon-theme-worker/-/icon-theme-worker-2.18.1.tgz",
@@ -1185,12 +1191,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/secrets-view": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/secrets-view/-/secrets-view-0.1.1.tgz",
-      "integrity": "sha512-u0mWP9BhVaDkNNypjGwNxC6p62W0Mhz8LFOd5Shm1PDW6bEYAm41msth00KQXmlx8mRh135oKOxnEyk+TJtGLA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/secrets-view/-/secrets-view-0.2.1.tgz",
+      "integrity": "sha512-cG6UtlOaTMIE54ywetpvlh7xxJC3J9MdtFyfgJvQnGGAk9vhW1cnUJbH4e8KOLCzuBAlG4B3zeXsGGb9gH4yRw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/constants": "^5.20.0"
+        "@lvce-editor/constants": "^5.29.0",
+        "@lvce-editor/i18n": "^2.10.0"
       }
     },
     "node_modules/@lvce-editor/settings-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -92,7 +92,7 @@
     "@lvce-editor/rename-worker": "^1.39.0",
     "@lvce-editor/renderer-process": "^30.46.2",
     "@lvce-editor/running-extensions-view": "^1.26.0",
-    "@lvce-editor/secrets-view": "^0.1.1",
+    "@lvce-editor/secrets-view": "^0.2.1",
     "@lvce-editor/settings-view": "^2.26.2",
     "@lvce-editor/settings-worker": "^1.18.0",
     "@lvce-editor/simple-browser-view": "^2.13.0",

--- a/packages/renderer-worker/src/parts/LaunchSecretsViewWorker/LaunchSecretsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchSecretsViewWorker/LaunchSecretsViewWorker.ts
@@ -5,16 +5,25 @@ import { handleSecretsViewMessagePort } from '../HandleSecretsViewMessagePort/Ha
 import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+import * as Platform from '../Platform/Platform.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import { secretsViewWorkerUrl } from '../SecretsViewWorkerUrl/SecretsViewWorkerUrl.ts'
 
-export const launchSecretsViewWorker = async () => {
+export const launchSecretsViewWorker = async (): Promise<any> => {
   const ipc = await IpcParent.create({
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
     name: 'Secrets View Worker',
     url: getConfiguredWorkerUrl('develop.secretsViewPath', secretsViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
-  const { port1, port2 } = GetPortTuple.getPortTuple()
-  await Promise.all([JsonRpc.invokeAndTransfer(ipc, 'SecretsView.handleMessagePort', port1), handleSecretsViewMessagePort(port2)])
+  await JsonRpc.invoke(ipc, 'SecretsView.initialize', Platform.getPlatform())
+  const { port1: bridgeWorkerPort, port2: bridgeHostPort } = GetPortTuple.getPortTuple()
+  const { port1: directWorkerPort, port2: directHostPort } = GetPortTuple.getPortTuple()
+  await Promise.all([
+    JsonRpc.invokeAndTransfer(ipc, 'SecretsView.handleMessagePort', bridgeWorkerPort),
+    handleSecretsViewMessagePort(bridgeHostPort),
+    JsonRpc.invokeAndTransfer(ipc, 'SecretsView.handleMessagePort', directWorkerPort, false),
+    RendererProcess.invokeAndTransfer('HandleMessagePort.handleMessagePort', directHostPort, 'SecretsView'),
+  ])
   return ipc
 }

--- a/packages/renderer-worker/test/LaunchSecretsViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchSecretsViewWorker.test.ts
@@ -6,7 +6,10 @@ jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorke
 }))
 
 jest.unstable_mockModule('../src/parts/GetPortTuple/GetPortTuple.js', () => ({
-  getPortTuple: jest.fn(() => ({ port1: 'worker-port', port2: 'host-port' })),
+  getPortTuple: jest
+    .fn()
+    .mockReturnValueOnce({ port1: 'bridge-worker-port', port2: 'bridge-host-port' })
+    .mockReturnValueOnce({ port1: 'direct-worker-port', port2: 'direct-host-port' }),
 }))
 
 jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => ({
@@ -22,6 +25,15 @@ jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => ({
 }))
 
 jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invoke: jest.fn(async () => undefined),
+  invokeAndTransfer: jest.fn(async () => undefined),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 2),
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
   invokeAndTransfer: jest.fn(async () => undefined),
 }))
 
@@ -31,6 +43,7 @@ const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
 const HandleSecretsViewMessagePort = await import('../src/parts/HandleSecretsViewMessagePort/HandleSecretsViewMessagePort.ts')
 const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
 const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const { launchSecretsViewWorker } = await import('../src/parts/LaunchSecretsViewWorker/LaunchSecretsViewWorker.ts')
 
 beforeEach(() => {
@@ -54,7 +67,10 @@ test('launches and connects the secrets view worker', async () => {
     url: 'file:///secrets-view-worker.js',
   })
   expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
-  expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(1)
-  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'SecretsView.handleMessagePort', 'worker-port')
-  expect(HandleSecretsViewMessagePort.handleSecretsViewMessagePort).toHaveBeenCalledWith('host-port' as any)
+  expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'SecretsView.initialize', 2)
+  expect(GetPortTuple.getPortTuple).toHaveBeenCalledTimes(2)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'SecretsView.handleMessagePort', 'bridge-worker-port')
+  expect(HandleSecretsViewMessagePort.handleSecretsViewMessagePort).toHaveBeenCalledWith('bridge-host-port' as any)
+  expect(JsonRpc.invokeAndTransfer).toHaveBeenCalledWith(ipc, 'SecretsView.handleMessagePort', 'direct-worker-port', false)
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', 'direct-host-port', 'SecretsView')
 })


### PR DESCRIPTION
Initializes the Secrets worker with the current platform and registers its direct renderer-process RPC alongside the main-process bridge used for secret storage.