### PR TITLE
fix: route secrets view test connections

### DIFF
--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -38,6 +38,7 @@ import * as ProcessExplorerWorker from '../ProcessExplorerWorker/ProcessExplorer
 import * as QuickPickWorker from '../QuickPickWorker/QuickPickWorker.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as RunningExtensionsViewWorker from '../RunningExtensionsViewWorker/RunningExtensionsViewWorker.ts'
+import * as SecretsViewWorker from '../SecretsViewWorker/SecretsViewWorker.ts'
 import * as SettingsWorker from '../SettingsWorker/SettingsWorker.js'
 import * as SettingsViewWorker from '../SettingsViewWorker/SettingsViewWorker.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
@@ -67,6 +68,7 @@ const directViewWorkers = {
   QuickPick: [QuickPickWorker, 'QuickPick.handleRendererProcessMessagePort'],
   RunningExtensions: [RunningExtensionsViewWorker, 'RunningExtensions.handleMessagePort'],
   SearchExtensions: [ExtensionSearchViewWorker, 'SearchExtensions.handleMessagePort'],
+  SecretsView: [SecretsViewWorker, 'SecretsView.handleMessagePort'],
   Settings: [SettingsViewWorker, 'Settings.handleMessagePort'],
   SourceControl: [SourceControlWorker, 'SourceControl.handleRendererProcessMessagePort'],
   StatusBar: [StatusBarWorker, 'StatusBar.handleMessagePort'],

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -41,6 +41,12 @@ jest.unstable_mockModule('../src/parts/SettingsWorker/SettingsWorker.js', () => 
   }
 })
 
+jest.unstable_mockModule('../src/parts/SecretsViewWorker/SecretsViewWorker.ts', () => {
+  return {
+    invokeAndTransfer: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/WorkspaceConnection/WorkspaceConnection.js', () => {
   return {
     connectMessagePort: jest.fn(async () => false),
@@ -51,6 +57,7 @@ const DialogWorker = await import('../src/parts/DialogWorker/DialogWorker.js')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const ExplorerViewWorker = await import('../src/parts/ExplorerViewWorker/ExplorerViewWorker.js')
 const MainAreaWorker = await import('../src/parts/MainAreaWorker/MainAreaWorker.js')
+const SecretsViewWorker = await import('../src/parts/SecretsViewWorker/SecretsViewWorker.ts')
 const SettingsWorker = await import('../src/parts/SettingsWorker/SettingsWorker.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const WorkspaceConnection = await import('../src/parts/WorkspaceConnection/WorkspaceConnection.js')
@@ -119,6 +126,14 @@ test('sendMessagePortToViewWorker forwards to the selected direct view worker', 
   await SendMessagePortToExtensionHostWorker.sendMessagePortToViewWorker(port, 'Explorer')
 
   expect(ExplorerViewWorker.invokeAndTransfer).toHaveBeenCalledWith('Explorer.handleMessagePort', port, false)
+})
+
+test('sendMessagePortToViewWorker forwards to the secrets view worker', async () => {
+  const port = {}
+
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToViewWorker(port, 'SecretsView')
+
+  expect(SecretsViewWorker.invokeAndTransfer).toHaveBeenCalledWith('SecretsView.handleMessagePort', port, false)
 })
 
 test('sendMessagePortToViewWorker rejects unknown workers', async () => {


### PR DESCRIPTION
Adds Secrets View to the direct-view worker router so test-worker message ports reach the registered Secrets worker.