### PR TITLE
fix: style secrets view errors

### DIFF
--- a/static/css/parts/ViewletSecrets.css
+++ b/static/css/parts/ViewletSecrets.css
@@ -26,6 +26,13 @@
   margin: 0;
 }
 
+.SecretsViewError {
+  background: color-mix(in srgb, var(--vscode-errorForeground, #f48771) 12%, transparent);
+  border: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
+  color: var(--vscode-errorForeground, #f48771);
+  padding: 8px 10px;
+}
+
 .SecretsViewList {
   contain: content;
   display: flex;


### PR DESCRIPTION
## Details

The Secrets view worker now exposes secret retrieval failures as an accessible inline alert. Add the matching workbench styling so the failure is visually distinct and readable in both dark and light themes.

## Change

- use existing error foreground and validation-border theme variables
- add a subtle themed background and compact banner spacing

Depends on lvce-editor/secrets-view#13.