### PR TITLE
feature: style secrets view actions

### DIFF
--- a/static/css/parts/MaskIcon.css
+++ b/static/css/parts/MaskIcon.css
@@ -244,6 +244,21 @@
   mask-image: url(/icons/trash.svg);
 }
 
+.MaskIconCopy,
+.IconCopy {
+  mask-image: url(/icons/copy.svg);
+}
+
+.MaskIconEye,
+.IconEye {
+  mask-image: url(/icons/eye.svg);
+}
+
+.MaskIconEyeClosed,
+.IconEyeClosed {
+  mask-image: url(/icons/eye-closed.svg);
+}
+
 .MaskIconSplitHorizontal,
 .IconSplitHorizontal {
   mask-image: url(/icons/split-horizontal.svg);

--- a/static/css/parts/ViewletSecrets.css
+++ b/static/css/parts/ViewletSecrets.css
@@ -11,7 +11,21 @@
 }
 
 .SecretsViewHeader {
+  align-items: flex-start;
   contain: content;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.SecretsViewHeaderContent {
+  min-width: 0;
+}
+
+.SecretsViewHeaderActions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 6px;
 }
 
 .SecretsViewTitle {
@@ -61,8 +75,19 @@
   gap: 6px;
 }
 
-.SecretsViewButton {
+.SecretsViewHeaderActions .SecretsViewButton {
   min-width: 64px;
+}
+
+.SecretsViewActions .SecretsViewButton {
+  align-items: center;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+
+.SecretsViewActions [name^='delete:'] {
+  color: var(--vscode-errorForeground, #f48771);
 }
 
 .SecretsViewEmpty {
@@ -72,6 +97,15 @@
 }
 
 @media (max-width: 720px) {
+  .SecretsViewHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .SecretsViewHeaderActions {
+    justify-content: flex-end;
+  }
+
   .SecretsViewRow {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Details

Complete the Render-style Secrets view introduced by lvce-editor/secrets-view#14 with a responsive header action area and compact row icon controls.

## Change

- align Edit, Save, and Cancel at the top right and stack them safely on narrow layouts
- size reveal, copy, and delete as compact icon buttons
- theme delete as a destructive action
- register copy, eye, eye-closed, and trash masks against the existing icon asset set
- preserve the responsive single-column row layout