### PR TITLE
refactor: extract macOS signing scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,34 +122,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        run: |
-          for secret in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID CSC_LINK CSC_KEY_PASSWORD; do
-            if [ -z "${!secret}" ]; then
-              echo "macOS signing is disabled because one or more signing secrets are unavailable."
-              echo "enabled=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          certificate_path="$RUNNER_TEMP/developer-id-application.p12"
-          keychain_path="$RUNNER_TEMP/lvce-signing.keychain-db"
-          keychain_password="$(uuidgen)"
-          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
-          printf '%s' "$CSC_LINK" | base64 -D > "$certificate_path"
-          test -s "$api_key_path"
-          test -s "$certificate_path"
-          chmod 600 "$api_key_path"
-          security create-keychain -p "$keychain_password" "$keychain_path"
-          security set-keychain-settings -lut 21600 "$keychain_path"
-          security unlock-keychain -p "$keychain_password" "$keychain_path"
-          security list-keychains -d user -s "$keychain_path"
-          security import "$certificate_path" -k "$keychain_path" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
-          security find-identity -v -p codesigning "$keychain_path" | grep 'Developer ID Application'
-          rm "$certificate_path"
-          echo "APPLE_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
-          echo "CSC_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"
-          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        run: bash packages/build/scripts/github-actions/prepare-macos-signing.sh optional
       - name: Build Electron App (Macos dmg, arm64, unsigned)
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled != 'true'
         run: npm run build:electron:mac:arm64
@@ -171,28 +144,11 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
-          xcrun notarytool submit "$dmg_path" --key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" --wait
-          xcrun stapler staple "$dmg_path"
+        run: bash packages/build/scripts/github-actions/notarize-macos-dmg.sh
       - name: Verify signed and notarized macOS installer
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         shell: bash
-        run: |
-          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
-          test -f "$dmg_path"
-          mount_point="$(mktemp -d "${RUNNER_TEMP}/lvce-dmg.XXXXXX")"
-          cleanup() {
-            hdiutil detach "$mount_point" >/dev/null 2>&1 || true
-            rmdir "$mount_point" >/dev/null 2>&1 || true
-          }
-          trap cleanup EXIT
-          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
-          app_path="$(find "$mount_point" -maxdepth 2 -name '*.app' -print -quit)"
-          test -n "$app_path"
-          codesign --verify --deep --strict --verbose=2 "$app_path"
-          spctl --assess --type execute --verbose "$app_path"
-          xcrun stapler validate "$dmg_path"
+        run: bash packages/build/scripts/github-actions/verify-macos-dmg.sh
       - name: Upload signed macOS installer
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/macos-signing-smoke.yml
+++ b/.github/workflows/macos-signing-smoke.yml
@@ -71,32 +71,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        run: |
-          for secret in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID CSC_LINK CSC_KEY_PASSWORD; do
-            if [ -z "${!secret}" ]; then
-              echo "Missing required macOS signing secret: $secret" >&2
-              exit 1
-            fi
-          done
-          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          certificate_path="$RUNNER_TEMP/developer-id-application.p12"
-          keychain_path="$RUNNER_TEMP/lvce-signing.keychain-db"
-          keychain_password="$(uuidgen)"
-          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
-          printf '%s' "$CSC_LINK" | base64 -D > "$certificate_path"
-          test -s "$api_key_path"
-          test -s "$certificate_path"
-          chmod 600 "$api_key_path"
-          security create-keychain -p "$keychain_password" "$keychain_path"
-          security set-keychain-settings -lut 21600 "$keychain_path"
-          security unlock-keychain -p "$keychain_password" "$keychain_path"
-          security list-keychains -d user -s "$keychain_path"
-          security import "$certificate_path" -k "$keychain_path" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
-          security find-identity -v -p codesigning "$keychain_path" | grep 'Developer ID Application'
-          rm "$certificate_path"
-          echo "APPLE_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
-          echo "CSC_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"
+        run: bash packages/build/scripts/github-actions/prepare-macos-signing.sh required
       - name: Build signed macOS DMG
         run: npm run build:electron:mac:arm64 -- --product=lvce
         env:
@@ -111,24 +86,7 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
-          xcrun notarytool submit "$dmg_path" --key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" --wait
-          xcrun stapler staple "$dmg_path"
+        run: bash packages/build/scripts/github-actions/notarize-macos-dmg.sh
       - name: Verify signing and notarization
         shell: bash
-        run: |
-          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
-          test -f "$dmg_path"
-          mount_point="$(mktemp -d "${RUNNER_TEMP}/lvce-dmg.XXXXXX")"
-          cleanup() {
-            hdiutil detach "$mount_point" >/dev/null 2>&1 || true
-            rmdir "$mount_point" >/dev/null 2>&1 || true
-          }
-          trap cleanup EXIT
-          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
-          app_path="$(find "$mount_point" -maxdepth 2 -name '*.app' -print -quit)"
-          test -n "$app_path"
-          codesign --verify --deep --strict --verbose=2 "$app_path"
-          spctl --assess --type execute --verbose "$app_path"
-          xcrun stapler validate "$dmg_path"
+        run: bash packages/build/scripts/github-actions/verify-macos-dmg.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,32 +222,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        run: |
-          for secret in APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID CSC_LINK CSC_KEY_PASSWORD; do
-            if [ -z "${!secret}" ]; then
-              echo "Missing required macOS signing secret: $secret" >&2
-              exit 1
-            fi
-          done
-          api_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
-          certificate_path="$RUNNER_TEMP/developer-id-application.p12"
-          keychain_path="$RUNNER_TEMP/lvce-signing.keychain-db"
-          keychain_password="$(uuidgen)"
-          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
-          printf '%s' "$CSC_LINK" | base64 -D > "$certificate_path"
-          test -s "$api_key_path"
-          test -s "$certificate_path"
-          chmod 600 "$api_key_path"
-          security create-keychain -p "$keychain_password" "$keychain_path"
-          security set-keychain-settings -lut 21600 "$keychain_path"
-          security unlock-keychain -p "$keychain_password" "$keychain_path"
-          security list-keychains -d user -s "$keychain_path"
-          security import "$certificate_path" -k "$keychain_path" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
-          security find-identity -v -p codesigning "$keychain_path" | grep 'Developer ID Application'
-          rm "$certificate_path"
-          echo "APPLE_API_KEY_PATH=$api_key_path" >> "$GITHUB_ENV"
-          echo "CSC_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"
+        run: bash packages/build/scripts/github-actions/prepare-macos-signing.sh required
       - name: Build signed Electron App (Macos dmg, arm64)
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
         run: npm run build:electron:mac:arm64 -- --product=lvce
@@ -264,28 +239,11 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: |
-          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
-          xcrun notarytool submit "$dmg_path" --key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" --wait
-          xcrun stapler staple "$dmg_path"
+        run: bash packages/build/scripts/github-actions/notarize-macos-dmg.sh
       - name: Verify signed and notarized macOS installer
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
         shell: bash
-        run: |
-          dmg_path="packages/build/.tmp/releases/lvce-arm64.dmg"
-          test -f "$dmg_path"
-          mount_point="$(mktemp -d "${RUNNER_TEMP}/lvce-dmg.XXXXXX")"
-          cleanup() {
-            hdiutil detach "$mount_point" >/dev/null 2>&1 || true
-            rmdir "$mount_point" >/dev/null 2>&1 || true
-          }
-          trap cleanup EXIT
-          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
-          app_path="$(find "$mount_point" -maxdepth 2 -name '*.app' -print -quit)"
-          test -n "$app_path"
-          codesign --verify --deep --strict --verbose=2 "$app_path"
-          spctl --assess --type execute --verbose "$app_path"
-          xcrun stapler validate "$dmg_path"
+        run: bash packages/build/scripts/github-actions/verify-macos-dmg.sh
       - name: Rename Electron App (Macos dmg, arm64)
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'
         shell: bash

--- a/packages/build/Build-Macos.md
+++ b/packages/build/Build-Macos.md
@@ -38,6 +38,12 @@ Required secrets:
 
 The workflows decode `APPLE_API_KEY_BASE64` into a temporary `.p8` file and import `CSC_LINK` into a temporary keychain. The build signs the prepackaged app before electron-builder creates and signs the DMG; the workflow then notarizes and staples the finished DMG. Keep these as repository secrets, never repository variables.
 
+The GitHub Actions shell logic is shared by the scripts in `scripts/github-actions`:
+
+- `prepare-macos-signing.sh` validates the secrets and creates the temporary signing keychain.
+- `notarize-macos-dmg.sh` submits the DMG to Apple and staples the accepted ticket.
+- `verify-macos-dmg.sh` mounts the DMG and verifies its app signature, Gatekeeper assessment, and stapled ticket.
+
 ### Bundle identifiers
 
 - `lvce`: `com.lvceeditor.lvce`
@@ -50,6 +56,5 @@ Run the `macos-signing-smoke` workflow manually from GitHub Actions after adding
 ```sh
 codesign --verify --deep --strict --verbose=2 path/to/Lvce.app
 spctl --assess --type execute --verbose path/to/Lvce.app
-xcrun stapler validate path/to/Lvce.app
 xcrun stapler validate path/to/lvce-arm64.dmg
 ```

--- a/packages/build/scripts/github-actions/notarize-macos-dmg.sh
+++ b/packages/build/scripts/github-actions/notarize-macos-dmg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly dmg_path="${1:-packages/build/.tmp/releases/lvce-arm64.dmg}"
+
+: "${APPLE_API_KEY:?APPLE_API_KEY is required}"
+: "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID is required}"
+: "${APPLE_API_ISSUER:?APPLE_API_ISSUER is required}"
+
+test -f "$dmg_path"
+xcrun notarytool submit "$dmg_path" \
+  --key "$APPLE_API_KEY" \
+  --key-id "$APPLE_API_KEY_ID" \
+  --issuer "$APPLE_API_ISSUER" \
+  --wait
+xcrun stapler staple "$dmg_path"

--- a/packages/build/scripts/github-actions/prepare-macos-signing.sh
+++ b/packages/build/scripts/github-actions/prepare-macos-signing.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly mode="${1:-required}"
+readonly signing_secrets=(
+  APPLE_API_KEY_BASE64
+  APPLE_API_KEY_ID
+  APPLE_API_ISSUER
+  APPLE_TEAM_ID
+  CSC_LINK
+  CSC_KEY_PASSWORD
+)
+
+if [[ "$mode" != "required" && "$mode" != "optional" ]]; then
+  echo "Usage: $0 [required|optional]" >&2
+  exit 2
+fi
+
+for secret in "${signing_secrets[@]}"; do
+  if [[ -z "${!secret:-}" ]]; then
+    if [[ "$mode" == "optional" ]]; then
+      echo "macOS signing is disabled because one or more signing secrets are unavailable."
+      echo "enabled=false" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+      exit 0
+    fi
+    echo "Missing required macOS signing secret: $secret" >&2
+    exit 1
+  fi
+done
+
+readonly api_key_path="${RUNNER_TEMP:?RUNNER_TEMP is required}/AuthKey_${APPLE_API_KEY_ID}.p8"
+readonly certificate_path="$RUNNER_TEMP/developer-id-application.p12"
+readonly keychain_path="$RUNNER_TEMP/lvce-signing.keychain-db"
+readonly keychain_password="$(uuidgen)"
+
+printf '%s' "$APPLE_API_KEY_BASE64" | base64 -D > "$api_key_path"
+printf '%s' "$CSC_LINK" | base64 -D > "$certificate_path"
+test -s "$api_key_path"
+test -s "$certificate_path"
+chmod 600 "$api_key_path"
+
+security create-keychain -p "$keychain_password" "$keychain_path"
+security set-keychain-settings -lut 21600 "$keychain_path"
+security unlock-keychain -p "$keychain_password" "$keychain_path"
+security list-keychains -d user -s "$keychain_path"
+security import "$certificate_path" -k "$keychain_path" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain_path"
+security find-identity -v -p codesigning "$keychain_path" | grep 'Developer ID Application'
+
+rm "$certificate_path"
+{
+  echo "APPLE_API_KEY_PATH=$api_key_path"
+  echo "CSC_KEYCHAIN_PATH=$keychain_path"
+} >> "${GITHUB_ENV:?GITHUB_ENV is required}"
+
+if [[ "$mode" == "optional" ]]; then
+  echo "enabled=true" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+fi

--- a/packages/build/scripts/github-actions/verify-macos-dmg.sh
+++ b/packages/build/scripts/github-actions/verify-macos-dmg.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly dmg_path="${1:-packages/build/.tmp/releases/lvce-arm64.dmg}"
+
+test -f "$dmg_path"
+mount_point="$(mktemp -d "${RUNNER_TEMP:?RUNNER_TEMP is required}/lvce-dmg.XXXXXX")"
+readonly mount_point
+
+cleanup() {
+  hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+  rmdir "$mount_point" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
+app_path="$(find "$mount_point" -maxdepth 2 -name '*.app' -print -quit)"
+readonly app_path
+test -n "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+spctl --assess --type execute --verbose "$app_path"
+xcrun stapler validate "$dmg_path"


### PR DESCRIPTION
## Summary

- move Apple credential preparation into a shared Bash script
- share DMG notarization and verification scripts across CI, release, and smoke workflows
- keep the remaining short workflow commands inline

## Validation

- `bash -n packages/build/scripts/github-actions/*.sh`
- optional/required signing credential mode checks
- Prettier workflow parsing and formatting check
- build package typecheck
- build package tests: 30 suites, 103 tests passed