### PR TITLE
fix: notarize macOS CI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,17 +144,17 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-        run: bash packages/build/scripts/github-actions/notarize-macos-dmg.sh
+        run: bash packages/build/scripts/github-actions/notarize-macos-dmg.sh packages/build/.tmp/releases/lvce-oss-arm64.dmg
       - name: Verify signed and notarized macOS installer
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         shell: bash
-        run: bash packages/build/scripts/github-actions/verify-macos-dmg.sh
+        run: bash packages/build/scripts/github-actions/verify-macos-dmg.sh packages/build/.tmp/releases/lvce-oss-arm64.dmg
       - name: Upload signed macOS installer
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64' && steps.macos-signing.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: lvce-macos-arm64
-          path: packages/build/.tmp/releases/lvce-arm64.dmg
+          path: packages/build/.tmp/releases/lvce-oss-arm64.dmg
           if-no-files-found: error
       - name: Cache Electron Builder Dependencies (Windows)
         uses: actions/cache@v6

--- a/packages/build/scripts/github-actions/notarize-macos-dmg.sh
+++ b/packages/build/scripts/github-actions/notarize-macos-dmg.sh
@@ -8,7 +8,10 @@ readonly dmg_path="${1:-packages/build/.tmp/releases/lvce-arm64.dmg}"
 : "${APPLE_API_KEY_ID:?APPLE_API_KEY_ID is required}"
 : "${APPLE_API_ISSUER:?APPLE_API_ISSUER is required}"
 
-test -f "$dmg_path"
+if [[ ! -f "$dmg_path" ]]; then
+  echo "macOS DMG not found: $dmg_path" >&2
+  exit 1
+fi
 xcrun notarytool submit "$dmg_path" \
   --key "$APPLE_API_KEY" \
   --key-id "$APPLE_API_KEY_ID" \

--- a/packages/build/scripts/github-actions/verify-macos-dmg.sh
+++ b/packages/build/scripts/github-actions/verify-macos-dmg.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 readonly dmg_path="${1:-packages/build/.tmp/releases/lvce-arm64.dmg}"
 
-test -f "$dmg_path"
+if [[ ! -f "$dmg_path" ]]; then
+  echo "macOS DMG not found: $dmg_path" >&2
+  exit 1
+fi
 mount_point="$(mktemp -d "${RUNNER_TEMP:?RUNNER_TEMP is required}/lvce-dmg.XXXXXX")"
 readonly mount_point
 

--- a/packages/build/test/CiWorkflow.test.ts
+++ b/packages/build/test/CiWorkflow.test.ts
@@ -1,0 +1,12 @@
+import { readFile } from 'node:fs/promises'
+import { expect, test } from '@jest/globals'
+
+test('macOS signing steps use the lvce-oss CI artifact', async () => {
+  const ciWorkflowUrl = new URL('../../../.github/workflows/ci.yml', import.meta.url)
+  const ciWorkflow = await readFile(ciWorkflowUrl, 'utf8')
+  const dmgPath = 'packages/build/.tmp/releases/lvce-oss-arm64.dmg'
+
+  expect(ciWorkflow).toContain(`notarize-macos-dmg.sh ${dmgPath}`)
+  expect(ciWorkflow).toContain(`verify-macos-dmg.sh ${dmgPath}`)
+  expect(ciWorkflow).toContain(`path: ${dmgPath}`)
+})


### PR DESCRIPTION
## Root cause

The trusted `main` CI build uses the default `lvce-oss` product and emits `lvce-oss-arm64.dmg`, but its newly extracted notarization and verification calls used the release workflow default, `lvce-arm64.dmg`. The signed build succeeded and the notarization script then failed its file check before contacting Apple.

## Fix

- pass the `lvce-oss-arm64.dmg` path explicitly through CI notarization and verification
- upload that same signed artifact
- report the expected path when a DMG is missing
- add a workflow regression test covering all three path consumers

## Validation

- regression test failed before the workflow change and passes after it
- build package typecheck
- build package tests: 31 suites, 104 tests passed
- Bash syntax and missing-DMG diagnostics
- Prettier workflow/test check