### PR TITLE
feature: handle remote cli workspace requests

### DIFF
--- a/packages/renderer-worker/src/parts/ReconnectingWebSocket/ReconnectingWebSocket.js
+++ b/packages/renderer-worker/src/parts/ReconnectingWebSocket/ReconnectingWebSocket.js
@@ -1,14 +1,26 @@
 const createContext = (webSocket, createWebSocket) => {
   const listeners = new Map()
+  let closed = false
+  let reconnectTimer
 
   const scheduleReconnect = () => {
-    setTimeout(() => void reconnect(), 2000)
+    if (!closed) {
+      reconnectTimer = setTimeout(() => void reconnect(), 2000)
+    }
   }
 
   const reconnect = async () => {
+    if (closed) {
+      return
+    }
     try {
       const originalOnMessage = context.webSocket.onmessage
-      context.webSocket = await createWebSocket()
+      const nextWebSocket = await createWebSocket()
+      if (closed) {
+        nextWebSocket.close()
+        return
+      }
+      context.webSocket = nextWebSocket
       context.webSocket.onmessage = originalOnMessage
       context.webSocket.onclose = handleClose
       for (const [type, typeListeners] of listeners) {
@@ -35,6 +47,12 @@ const createContext = (webSocket, createWebSocket) => {
     },
     send(message) {
       this.webSocket.send(message)
+    },
+    close() {
+      closed = true
+      clearTimeout(reconnectTimer)
+      this.webSocket.onclose = null
+      this.webSocket.close()
     },
     addEventListener(type, listener) {
       let typeListeners = listeners.get(type)

--- a/packages/renderer-worker/src/parts/RemoteCli/RemoteCli.js
+++ b/packages/renderer-worker/src/parts/RemoteCli/RemoteCli.js
@@ -1,0 +1,100 @@
+import * as HandleIpc from '../HandleIpc/HandleIpc.js'
+import * as IpcParentWithWebSocket from '../IpcParentWithWebSocket/IpcParentWithWebSocket.js'
+import * as JsonRpc from '../JsonRpc/JsonRpc.js'
+
+/** @type {{ connectionKey: string, ipc: any, token: symbol | undefined }} */
+const state = {
+  connectionKey: '',
+  ipc: undefined,
+  token: undefined,
+}
+
+const parseOpenRequest = (value) => {
+  if (
+    !value ||
+    (value.kind !== 'file' && value.kind !== 'folder') ||
+    typeof value.path !== 'string' ||
+    !value.path.startsWith('/') ||
+    value.path.includes('\0')
+  ) {
+    throw new TypeError('Remote CLI returned an invalid open request')
+  }
+  return value
+}
+
+const createRpc = async (url) => {
+  const webSocket = await IpcParentWithWebSocket.create({
+    type: 'shared-process',
+    url,
+  })
+  const ipc = IpcParentWithWebSocket.wrap(webSocket)
+  HandleIpc.handleIpc(ipc)
+  return ipc
+}
+
+const run = async (token, ipc, handleOpenRequest) => {
+  while (state.token === token) {
+    const value = await JsonRpc.invoke(ipc, 'RemoteCli.waitForOpenRequest')
+    if (state.token !== token) {
+      return
+    }
+    if (value) {
+      await handleOpenRequest(parseOpenRequest(value))
+    }
+  }
+}
+
+export const stop = () => {
+  state.connectionKey = ''
+  state.token = undefined
+  if (state.ipc) {
+    HandleIpc.unhandleIpc(state.ipc)
+    state.ipc.webSocket.close()
+    state.ipc = undefined
+  }
+}
+
+export const start = async (connectionKey, remoteCliUrl, handleOpenRequest, create = createRpc) => {
+  if (state.connectionKey === connectionKey && state.ipc) {
+    return
+  }
+  stop()
+  const token = Symbol(connectionKey)
+  state.connectionKey = connectionKey
+  state.token = token
+  const ipc = await create(remoteCliUrl)
+  if (state.token !== token) {
+    ipc.webSocket.close()
+    return
+  }
+  state.ipc = ipc
+  void run(token, ipc, handleOpenRequest).catch(() => {
+    if (state.token === token) {
+      stop()
+    }
+  })
+}
+
+const replacePath = (workspaceUri, path) => {
+  const url = new URL(workspaceUri)
+  url.pathname = path
+  url.search = ''
+  url.hash = ''
+  return url.href
+}
+
+export const resolveOpenRequest = (workspaceUri, request) => {
+  const parsed = parseOpenRequest(request)
+  const workspacePath =
+    parsed.kind === 'folder'
+      ? parsed.path
+      : parsed.path.slice(0, parsed.path.lastIndexOf('/')) || '/'
+  return {
+    fileUri:
+      parsed.kind === 'file' ? replacePath(workspaceUri, parsed.path) : '',
+    workspacePath,
+    workspaceUri: replacePath(workspaceUri, workspacePath),
+  }
+}
+
+export const _reset = stop

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -12,6 +12,7 @@ import * as Notification from '../Notification/Notification.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
+import * as RemoteCli from '../RemoteCli/RemoteCli.js'
 import * as StatusBarWorker from '../StatusBarWorker/StatusBarWorker.js'
 import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
 import * as WindowTitle from '../WindowTitle/WindowTitle.js'
@@ -47,6 +48,7 @@ export const setPath = async (path) => {
   state.workspaceUri = path
   state.pathSeparator = pathSeparator
   WorkspaceConnection.reset()
+  RemoteCli.stop()
   await FileSystemWorker.dispose()
   await TextSearchWorker.dispose()
   await onWorkspaceChange()
@@ -70,13 +72,37 @@ export const setUri = async (uri, providedPathSeparator, connection) => {
   state.workspaceUri = uri
   state.pathSeparator = pathSeparator
   if (connection) {
-    WorkspaceConnection.set(uri, connection.command)
+    WorkspaceConnection.set(uri, connection.command, connection.remoteCliUrl)
+    if (connection.remoteCliUrl) {
+      void RemoteCli.start(connection.remoteCliUrl, connection.remoteCliUrl, handleRemoteCliOpenRequest).catch(() => {})
+    } else {
+      RemoteCli.stop()
+    }
   } else {
     WorkspaceConnection.reset()
+    RemoteCli.stop()
   }
   await FileSystemWorker.dispose()
   await TextSearchWorker.dispose()
   await onWorkspaceChange()
+}
+
+const handleRemoteCliOpenRequest = async (request) => {
+  const currentUri = state.workspaceUri
+  const command = WorkspaceConnection.getCommand()
+  const remoteCliUrl = WorkspaceConnection.getRemoteCliUrl()
+  if (!currentUri || !command) {
+    throw new Error('Remote workspace connection is not available')
+  }
+  const resolved = RemoteCli.resolveOpenRequest(currentUri, request)
+  await setUri(resolved.workspaceUri, state.pathSeparator || '/', {
+    command,
+    remoteCliUrl,
+    workspacePath: resolved.workspacePath,
+  })
+  if (resolved.fileUri) {
+    await Command.execute('Main.openUri', resolved.fileUri)
+  }
 }
 
 export const getPath = () => {

--- a/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
+++ b/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
@@ -5,23 +5,49 @@ import * as WorkspaceState from '../WorkspaceState/WorkspaceState.js'
 
 const state = {
   command: '',
+  remoteCliUrl: '',
   workspaceUri: '',
 }
 
-export const set = (workspaceUri, command) => {
+export const set = (workspaceUri, command, remoteCliUrl = '') => {
   if (typeof workspaceUri !== 'string' || typeof command !== 'string' || !command) {
     throw new TypeError('Invalid workspace connection')
   }
+  if (typeof remoteCliUrl !== 'string') {
+    throw new TypeError('Invalid remote CLI URL')
+  }
+  if (remoteCliUrl) {
+    const url = new URL(remoteCliUrl)
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      throw new TypeError('Remote CLI URL must use WebSocket')
+    }
+  }
   state.workspaceUri = workspaceUri
   state.command = command
+  state.remoteCliUrl = remoteCliUrl
 }
 
 export const reset = () => {
   state.workspaceUri = ''
   state.command = ''
+  state.remoteCliUrl = ''
 }
 
 export const isActive = () => Boolean(state.command && WorkspaceState.state.workspaceUri === state.workspaceUri)
+
+export const getCommand = () => {
+  if (!isActive()) {
+    return ''
+  }
+  return state.command
+}
+
+export const getRemoteCliUrl = () => {
+  if (!isActive()) {
+    return ''
+  }
+  return state.remoteCliUrl
+}
 
 export const getWebSocketUrl = async (type) => {
   if (!isActive()) {

--- a/packages/renderer-worker/test/ReconnectingWebSocket.test.ts
+++ b/packages/renderer-worker/test/ReconnectingWebSocket.test.ts
@@ -27,6 +27,8 @@ class MockWebSocket extends EventTarget {
   }
 
   send(): void {}
+
+  close(): void {}
 }
 
 beforeEach(() => {
@@ -121,4 +123,14 @@ test('waits for the existing websocket to reconnect during startup', async () =>
   const webSocket = await ipcPromise
   expect(MockWebSocket.instances).toHaveLength(2)
   expect(webSocket.webSocket).toBe(MockWebSocket.instances[1])
+})
+
+test('does not reconnect after being closed', async () => {
+  const webSocket = ReconnectingWebSocket.create('ws://localhost:3000')
+
+  webSocket.close()
+  MockWebSocket.instances[0].emitClose()
+  await jest.advanceTimersByTimeAsync(2000)
+
+  expect(MockWebSocket.instances).toHaveLength(1)
 })

--- a/packages/renderer-worker/test/RemoteCli.test.ts
+++ b/packages/renderer-worker/test/RemoteCli.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, test } from '@jest/globals'
+import * as RemoteCli from '../src/parts/RemoteCli/RemoteCli.js'
+
+afterEach(() => {
+  RemoteCli._reset()
+})
+
+test('resolves a remote folder request', () => {
+  expect(
+    RemoteCli.resolveOpenRequest('remote-ssh://test@example.com/home/test/old', {
+      kind: 'folder',
+      path: '/home/test/my folder/#project?',
+    }),
+  ).toEqual({
+    fileUri: '',
+    workspacePath: '/home/test/my folder/#project?',
+    workspaceUri:
+      'remote-ssh://test@example.com/home/test/my%20folder/%23project%3F',
+  })
+})
+
+test('resolves a remote file request to its containing workspace', () => {
+  expect(
+    RemoteCli.resolveOpenRequest('remote-ssh://test@example.com/home/test/old', {
+      kind: 'file',
+      path: '/home/test/project/read me.md',
+    }),
+  ).toEqual({
+    fileUri: 'remote-ssh://test@example.com/home/test/project/read%20me.md',
+    workspacePath: '/home/test/project',
+    workspaceUri: 'remote-ssh://test@example.com/home/test/project',
+  })
+})
+
+test('rejects invalid remote paths', () => {
+  expect(() =>
+    RemoteCli.resolveOpenRequest('remote-ssh://test@example.com/home/test', {
+      kind: 'folder',
+      path: 'relative',
+    }),
+  ).toThrow('Remote CLI returned an invalid open request')
+})

--- a/packages/renderer-worker/test/RemoteCliWatch.test.ts
+++ b/packages/renderer-worker/test/RemoteCliWatch.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn<(ipc: unknown, method: string) => Promise<unknown>>()
+const handleIpc = jest.fn()
+const unhandleIpc = jest.fn()
+
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({ invoke }))
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => ({
+  handleIpc,
+  unhandleIpc,
+}))
+
+const RemoteCli = await import('../src/parts/RemoteCli/RemoteCli.js')
+
+afterEach(() => {
+  RemoteCli._reset()
+  invoke.mockReset()
+  handleIpc.mockReset()
+  unhandleIpc.mockReset()
+})
+
+test('waits for remote requests on the provided authenticated socket', async () => {
+  const request = { kind: 'folder', path: '/home/test/project' }
+  invoke.mockResolvedValueOnce(request).mockImplementation(
+    async () =>
+      new Promise(() => {
+        // Keep the next long poll active until the watcher is disposed.
+      }),
+  )
+  const close = jest.fn()
+  const ipc = {
+    listener: undefined,
+    onmessage: undefined,
+    send: jest.fn(),
+    webSocket: { close },
+  }
+  const create = jest.fn(async (_url: string) => ipc)
+  const handleOpenRequest = jest.fn(async (_request: unknown) => {})
+
+  await RemoteCli.start(
+    'connection',
+    'wss://workspace.example.com/shared-process?token=secret',
+    handleOpenRequest,
+    create,
+  )
+  for (let index = 0; index < 4; index++) {
+    await Promise.resolve()
+  }
+
+  expect(create).toHaveBeenCalledWith(
+    'wss://workspace.example.com/shared-process?token=secret',
+  )
+  expect(invoke).toHaveBeenCalledWith(ipc, 'RemoteCli.waitForOpenRequest')
+  expect(handleOpenRequest).toHaveBeenCalledWith(request)
+
+  RemoteCli.stop()
+  expect(unhandleIpc).toHaveBeenCalledWith(ipc)
+  expect(close).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-worker/test/WorkspaceConnection.test.ts
+++ b/packages/renderer-worker/test/WorkspaceConnection.test.ts
@@ -25,12 +25,18 @@ beforeEach(() => {
 
 test('gets a process WebSocket URL through the extension command', async () => {
   workspaceState.workspaceUri = 'workspace-provider://host/work'
-  WorkspaceConnection.set('workspace-provider://host/work', 'workspace-provider.getWebSocketUrl')
+  WorkspaceConnection.set(
+    'workspace-provider://host/work',
+    'workspace-provider.getWebSocketUrl',
+    'wss://workspace.example.com/remote-cli',
+  )
   executeCommand.mockResolvedValue('wss://workspace.example.com/process')
 
   await expect(WorkspaceConnection.getWebSocketUrl('terminal-process')).resolves.toBe('wss://workspace.example.com/process')
   expect(executeCommand).toHaveBeenCalledWith('workspace-provider.getWebSocketUrl', 'terminal-process')
   expect(WorkspaceConnection.isActive()).toBe(true)
+  expect(WorkspaceConnection.getCommand()).toBe('workspace-provider.getWebSocketUrl')
+  expect(WorkspaceConnection.getRemoteCliUrl()).toBe('wss://workspace.example.com/remote-cli')
 })
 
 test('does not invoke the extension command for a different workspace', async () => {
@@ -40,6 +46,8 @@ test('does not invoke the extension command for a different workspace', async ()
   await expect(WorkspaceConnection.getWebSocketUrl('terminal-process')).resolves.toBe('')
   expect(executeCommand).not.toHaveBeenCalled()
   expect(WorkspaceConnection.isActive()).toBe(false)
+  expect(WorkspaceConnection.getCommand()).toBe('')
+  expect(WorkspaceConnection.getRemoteCliUrl()).toBe('')
 })
 
 test('rejects a non-WebSocket URL returned by the extension command', async () => {
@@ -48,6 +56,16 @@ test('rejects a non-WebSocket URL returned by the extension command', async () =
   executeCommand.mockResolvedValue('https://workspace.example.com/process')
 
   await expect(WorkspaceConnection.getWebSocketUrl('terminal-process')).rejects.toThrow(/WebSocket URL/)
+})
+
+test('rejects a non-WebSocket remote CLI URL', () => {
+  expect(() =>
+    WorkspaceConnection.set(
+      'workspace-provider://host/work',
+      'workspace-provider.getWebSocketUrl',
+      'https://workspace.example.com/remote-cli',
+    ),
+  ).toThrow('Remote CLI URL must use WebSocket')
 })
 
 test('bridges a message port to the workspace connection', async () => {

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -10,6 +10,14 @@ const disposeFileSystemWorker = jest.fn<() => Promise<void>>(async () => {})
 const isTest = jest.fn<() => boolean>(() => false)
 const getPlatform = jest.fn(() => PlatformType.Test)
 const setWorkspaceUri = jest.fn(async (_uri: string) => {})
+const startRemoteCli = jest.fn<
+  (
+    connectionKey: string,
+    remoteCliUrl: string,
+    handleOpenRequest: (request: unknown) => Promise<void>,
+  ) => Promise<void>
+>(async () => {})
+const stopRemoteCli = jest.fn()
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
   exists,
@@ -52,6 +60,12 @@ jest.unstable_mockModule('../src/parts/Location/Location.js', () => ({
   setWorkspaceUri,
 }))
 
+jest.unstable_mockModule('../src/parts/RemoteCli/RemoteCli.js', () => ({
+  resolveOpenRequest: jest.fn(),
+  start: startRemoteCli,
+  stop: stopRemoteCli,
+}))
+
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
@@ -68,6 +82,8 @@ beforeEach(() => {
   getPlatform.mockClear()
   getPlatform.mockReturnValue(PlatformType.Test)
   setWorkspaceUri.mockClear()
+  startRemoteCli.mockClear()
+  stopRemoteCli.mockClear()
   GlobalEventBus.state.listenerMap = Object.create(null)
   Workspace.state.pathSeparator = '/'
   Workspace.state.workspacePath = ''
@@ -165,6 +181,7 @@ test('setUri uses a provided provider path separator', async () => {
 test('setUri uses the workspace connection path', async () => {
   await Workspace.setUri('workspace-provider://host/work', '/', {
     command: 'workspace-provider.getWebSocketUrl',
+    remoteCliUrl: 'wss://workspace.example.com/websocket/shared-process',
     workspacePath: '/work',
   })
 
@@ -172,6 +189,11 @@ test('setUri uses the workspace connection path', async () => {
   expect(Workspace.getWorkspaceUri()).toBe('workspace-provider://host/work')
   expect(Workspace.state.pathSeparator).toBe('/')
   expect(getPathSeparator).not.toHaveBeenCalled()
+  expect(startRemoteCli).toHaveBeenCalledWith(
+    'wss://workspace.example.com/websocket/shared-process',
+    'wss://workspace.example.com/websocket/shared-process',
+    expect.any(Function),
+  )
 })
 
 test('setUri persists the workspace uri in an Electron window', async () => {
@@ -179,6 +201,7 @@ test('setUri persists the workspace uri in an Electron window', async () => {
 
   await Workspace.setUri('workspace-provider://host/work', '/', {
     command: 'workspace-provider.getWebSocketUrl',
+    remoteCliUrl: 'wss://workspace.example.com/websocket/shared-process',
     workspacePath: '/work',
   })
 

--- a/packages/shared-process/src/parts/Module/Module.ts
+++ b/packages/shared-process/src/parts/Module/Module.ts
@@ -140,6 +140,8 @@ export const load = (moduleId: any): any => {
       return import('../RebuildNodePty/RebuildNodePty.ipc.ts')
     case ModuleId.RecentlyOpened:
       return import('../RecentlyOpened/RecentlyOpened.ipc.ts')
+    case ModuleId.RemoteCli:
+      return import('../RemoteCli/RemoteCli.ipc.ts')
     case ModuleId.Screen:
       return import('../Screen/Screen.ipc.ts')
     case ModuleId.SendMessagePortToMainProcess:

--- a/packages/shared-process/src/parts/ModuleId/ModuleId.ts
+++ b/packages/shared-process/src/parts/ModuleId/ModuleId.ts
@@ -80,3 +80,4 @@ export const IpcTrace = 92
 export const HandleMessagePortForExtensionNodeProcess = 93
 export const FileWatcherExplorer = 94
 export const HandleMessagePortForFileWatcherExplorer = 95
+export const RemoteCli = 96

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -283,6 +283,9 @@ export const getModuleId = (commandId: any): any => {
       return ModuleId.RebuildNodePty
     case 'RecentlyOpened.addPath':
       return ModuleId.RecentlyOpened
+    case 'RemoteCli.open':
+    case 'RemoteCli.waitForOpenRequest':
+      return ModuleId.RemoteCli
     case 'Screen.getBounds':
     case 'Screen.getHeight':
     case 'Screen.getWidth':

--- a/packages/shared-process/src/parts/RemoteCli/RemoteCli.ipc.ts
+++ b/packages/shared-process/src/parts/RemoteCli/RemoteCli.ipc.ts
@@ -1,0 +1,14 @@
+import type { OpenRequest } from './RemoteCli.ts'
+import * as RemoteCli from './RemoteCli.ts'
+
+export const name = 'RemoteCli'
+
+export const Commands: {
+  readonly open: (request: unknown) => boolean
+  readonly waitForOpenRequest: (
+    timeoutMs?: number,
+  ) => Promise<OpenRequest | undefined>
+} = {
+  open: RemoteCli.open,
+  waitForOpenRequest: RemoteCli.waitForOpenRequest,
+}

--- a/packages/shared-process/src/parts/RemoteCli/RemoteCli.ts
+++ b/packages/shared-process/src/parts/RemoteCli/RemoteCli.ts
@@ -1,0 +1,62 @@
+export interface OpenRequest {
+  readonly kind: 'file' | 'folder'
+  readonly path: string
+}
+
+interface Waiter {
+  readonly resolve: (request: OpenRequest | undefined) => void
+  readonly timeout: NodeJS.Timeout
+}
+
+const waiters: Waiter[] = []
+
+const isOpenRequest = (value: unknown): value is OpenRequest => {
+  const request = value as Partial<OpenRequest> | undefined
+  return Boolean(
+    request &&
+      (request.kind === 'file' || request.kind === 'folder') &&
+      typeof request.path === 'string' &&
+      request.path.startsWith('/') &&
+      !request.path.includes('\0'),
+  )
+}
+
+export const open = (request: unknown): boolean => {
+  if (!isOpenRequest(request)) {
+    throw new TypeError('Invalid remote CLI open request')
+  }
+  const waiter = waiters.pop()
+  if (!waiter) {
+    return false
+  }
+  clearTimeout(waiter.timeout)
+  waiter.resolve(request)
+  return true
+}
+
+export const waitForOpenRequest = (
+  timeoutMs = 30_000,
+): Promise<OpenRequest | undefined> => {
+  return new Promise((resolve) => {
+    const waiter: Waiter = {
+      resolve,
+      timeout: setTimeout(() => {
+        const index = waiters.indexOf(waiter)
+        if (index !== -1) {
+          waiters.splice(index, 1)
+        }
+        resolve(undefined)
+      }, timeoutMs),
+    }
+    waiter.timeout.unref()
+    waiters.push(waiter)
+  })
+}
+
+export const _reset = (): void => {
+  for (const waiter of waiters) {
+    clearTimeout(waiter.timeout)
+    waiter.resolve(undefined)
+  }
+  waiters.length = 0
+}

--- a/packages/shared-process/test/RemoteCli.test.ts
+++ b/packages/shared-process/test/RemoteCli.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import * as RemoteCli from '../src/parts/RemoteCli/RemoteCli.ts'
+
+afterEach(() => {
+  RemoteCli._reset()
+  jest.useRealTimers()
+})
+
+test('delivers an open request to the most recently connected window', async () => {
+  const first = RemoteCli.waitForOpenRequest()
+  const second = RemoteCli.waitForOpenRequest()
+  const request = { kind: 'folder' as const, path: '/home/test/project' }
+
+  expect(RemoteCli.open(request)).toBe(true)
+  await expect(second).resolves.toEqual(request)
+
+  RemoteCli._reset()
+  await expect(first).resolves.toBeUndefined()
+})
+
+test('reports when no connected window is waiting', () => {
+  expect(RemoteCli.open({ kind: 'folder', path: '/home/test/project' })).toBe(
+    false,
+  )
+})
+
+test('rejects invalid requests', () => {
+  expect(() => RemoteCli.open({ kind: 'folder', path: 'relative' })).toThrow(
+    'Invalid remote CLI open request',
+  )
+})
+
+test('expires disconnected window waiters', async () => {
+  jest.useFakeTimers()
+  const request = RemoteCli.waitForOpenRequest(1000)
+
+  await jest.advanceTimersByTimeAsync(1000)
+
+  await expect(request).resolves.toBeUndefined()
+  expect(RemoteCli.open({ kind: 'folder', path: '/home/test/project' })).toBe(
+    false,
+  )
+})


### PR DESCRIPTION
Adds a shared-process broker for remote CLI open requests and a renderer-owned listener for authenticated remote workspace connections. Folder requests switch the current window in place, while file requests switch to the parent workspace and open the file. The listener is lifecycle-safe and covered by shared-process and renderer tests.