### PR TITLE
fix: connect remote workspace without extension cycle

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -72,7 +72,7 @@ export const setUri = async (uri, providedPathSeparator, connection) => {
   state.workspaceUri = uri
   state.pathSeparator = pathSeparator
   if (connection) {
-    WorkspaceConnection.set(uri, connection.command, connection.remoteCliUrl)
+    WorkspaceConnection.set(uri, connection.command, connection.remoteCliUrl, connection.webSocketUrl)
     if (connection.remoteCliUrl) {
       void RemoteCli.start(connection.remoteCliUrl, connection.remoteCliUrl, handleRemoteCliOpenRequest).catch(() => {})
     } else {
@@ -91,6 +91,7 @@ const handleRemoteCliOpenRequest = async (request) => {
   const currentUri = state.workspaceUri
   const command = WorkspaceConnection.getCommand()
   const remoteCliUrl = WorkspaceConnection.getRemoteCliUrl()
+  const webSocketUrl = WorkspaceConnection.getWebSocketUrlTemplate()
   if (!currentUri || !command) {
     throw new Error('Remote workspace connection is not available')
   }
@@ -98,6 +99,7 @@ const handleRemoteCliOpenRequest = async (request) => {
   await setUri(resolved.workspaceUri, state.pathSeparator || '/', {
     command,
     remoteCliUrl,
+    webSocketUrl,
     workspacePath: resolved.workspacePath,
   })
   if (resolved.fileUri) {

--- a/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
+++ b/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
@@ -6,31 +6,39 @@ import * as WorkspaceState from '../WorkspaceState/WorkspaceState.js'
 const state = {
   command: '',
   remoteCliUrl: '',
+  webSocketUrl: '',
   workspaceUri: '',
 }
 
-export const set = (workspaceUri, command, remoteCliUrl = '') => {
+const validateWebSocketUrl = (value, name) => {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Invalid ${name}`)
+  }
+  if (value) {
+    const url = new URL(value)
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      throw new TypeError(`${name} must use WebSocket`)
+    }
+  }
+}
+
+export const set = (workspaceUri, command, remoteCliUrl = '', webSocketUrl = '') => {
   if (typeof workspaceUri !== 'string' || typeof command !== 'string' || !command) {
     throw new TypeError('Invalid workspace connection')
   }
-  if (typeof remoteCliUrl !== 'string') {
-    throw new TypeError('Invalid remote CLI URL')
-  }
-  if (remoteCliUrl) {
-    const url = new URL(remoteCliUrl)
-    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
-      throw new TypeError('Remote CLI URL must use WebSocket')
-    }
-  }
+  validateWebSocketUrl(remoteCliUrl, 'Remote CLI URL')
+  validateWebSocketUrl(webSocketUrl, 'Workspace WebSocket URL')
   state.workspaceUri = workspaceUri
   state.command = command
   state.remoteCliUrl = remoteCliUrl
+  state.webSocketUrl = webSocketUrl
 }
 
 export const reset = () => {
   state.workspaceUri = ''
   state.command = ''
   state.remoteCliUrl = ''
+  state.webSocketUrl = ''
 }
 
 export const isActive = () => Boolean(state.command && WorkspaceState.state.workspaceUri === state.workspaceUri)
@@ -49,9 +57,21 @@ export const getRemoteCliUrl = () => {
   return state.remoteCliUrl
 }
 
+export const getWebSocketUrlTemplate = () => {
+  if (!isActive()) {
+    return ''
+  }
+  return state.webSocketUrl
+}
+
 export const getWebSocketUrl = async (type) => {
   if (!isActive()) {
     return ''
+  }
+  if (state.webSocketUrl) {
+    const url = new URL(state.webSocketUrl)
+    url.pathname = `/websocket/${encodeURIComponent(type)}`
+    return url.href
   }
   const value = await ExtensionHostCommands.executeCommand(state.command, type)
   if (typeof value !== 'string') {

--- a/packages/renderer-worker/test/WorkspaceConnection.test.ts
+++ b/packages/renderer-worker/test/WorkspaceConnection.test.ts
@@ -39,6 +39,24 @@ test('gets a process WebSocket URL through the extension command', async () => {
   expect(WorkspaceConnection.getRemoteCliUrl()).toBe('wss://workspace.example.com/remote-cli')
 })
 
+test('derives a process WebSocket URL from the workspace connection', async () => {
+  workspaceState.workspaceUri = 'workspace-provider://host/work'
+  WorkspaceConnection.set(
+    'workspace-provider://host/work',
+    'workspace-provider.getWebSocketUrl',
+    'wss://workspace.example.com/websocket/shared-process?token=secret',
+    'wss://workspace.example.com/websocket/file-system-process?token=secret',
+  )
+
+  await expect(WorkspaceConnection.getWebSocketUrl('terminal-process')).resolves.toBe(
+    'wss://workspace.example.com/websocket/terminal-process?token=secret',
+  )
+  expect(executeCommand).not.toHaveBeenCalled()
+  expect(WorkspaceConnection.getWebSocketUrlTemplate()).toBe(
+    'wss://workspace.example.com/websocket/file-system-process?token=secret',
+  )
+})
+
 test('does not invoke the extension command for a different workspace', async () => {
   workspaceState.workspaceUri = 'file:///tmp/work'
   WorkspaceConnection.set('workspace-provider://host/work', 'workspace-provider.getWebSocketUrl')
@@ -48,6 +66,7 @@ test('does not invoke the extension command for a different workspace', async ()
   expect(WorkspaceConnection.isActive()).toBe(false)
   expect(WorkspaceConnection.getCommand()).toBe('')
   expect(WorkspaceConnection.getRemoteCliUrl()).toBe('')
+  expect(WorkspaceConnection.getWebSocketUrlTemplate()).toBe('')
 })
 
 test('rejects a non-WebSocket URL returned by the extension command', async () => {
@@ -66,6 +85,17 @@ test('rejects a non-WebSocket remote CLI URL', () => {
       'https://workspace.example.com/remote-cli',
     ),
   ).toThrow('Remote CLI URL must use WebSocket')
+})
+
+test('rejects a non-WebSocket workspace URL', () => {
+  expect(() =>
+    WorkspaceConnection.set(
+      'workspace-provider://host/work',
+      'workspace-provider.getWebSocketUrl',
+      '',
+      'https://workspace.example.com/process',
+    ),
+  ).toThrow('Workspace WebSocket URL must use WebSocket')
 })
 
 test('bridges a message port to the workspace connection', async () => {


### PR DESCRIPTION
## Details

Remote workspace activation can request process WebSocket URLs from a fresh extension instance before that instance restores its backend. Restore itself needs the extension node process, creating a circular wait and leaving the explorer empty.

## Change

Allow authenticated workspace connections to provide a direct WebSocket template. Core derives process URLs from it and retains the extension command as a compatibility fallback. Preserve the template when a remote CLI request switches folders.

## Tests

- lint
- type-check
- renderer-worker: 364 suites and 1674 tests passed
- focused workspace connection and remote CLI workspace-switch tests