### PR TITLE
fix: avoid detached macos resource signatures

### DIFF
--- a/packages/build/Build-Macos.md
+++ b/packages/build/Build-Macos.md
@@ -38,6 +38,8 @@ Required secrets:
 
 The workflows decode `APPLE_API_KEY_BASE64` into a temporary `.p8` file and import `CSC_LINK` into a temporary keychain. The build signs the prepackaged app before electron-builder creates and signs the DMG; the workflow then notarizes and staples the finished DMG. Keep these as repository secrets, never repository variables.
 
+Only Mach-O files and nested app/framework bundles are signed. Signing binary-looking resource files creates detached `com.apple.cs.*` extended attributes that Finder cannot reliably copy from a DMG. The verification step rejects installers containing those attributes before upload.
+
 The GitHub Actions shell logic is shared by the scripts in `scripts/github-actions`:
 
 - `prepare-macos-signing.sh` validates the secrets and creates the temporary signing keychain.

--- a/packages/build/scripts/github-actions/verify-macos-dmg.sh
+++ b/packages/build/scripts/github-actions/verify-macos-dmg.sh
@@ -22,6 +22,21 @@ hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
 app_path="$(find "$mount_point" -maxdepth 2 -name '*.app' -print -quit)"
 readonly app_path
 test -n "$app_path"
+
+signed_resources="$(find "$app_path" -type f -exec sh -c '
+  for resource_path do
+    if xattr -p com.apple.cs.CodeSignature "$resource_path" >/dev/null 2>&1; then
+      printf "%s\n" "$resource_path"
+    fi
+  done
+' sh {} +)"
+readonly signed_resources
+if [[ -n "$signed_resources" ]]; then
+  echo "The app contains detached signatures on ordinary resource files:" >&2
+  echo "$signed_resources" >&2
+  exit 1
+fi
+
 codesign --verify --deep --strict --verbose=2 "$app_path"
 spctl --assess --type execute --verbose "$app_path"
 xcrun stapler validate "$dmg_path"

--- a/packages/build/src/parts/SignMacApp/SignMacApp.ts
+++ b/packages/build/src/parts/SignMacApp/SignMacApp.ts
@@ -1,4 +1,40 @@
 import { signAsync } from '@electron/osx-sign'
+import { closeSync, openSync, readSync } from 'node:fs'
+
+const MachOMagic = new Set([
+  'cafebabe',
+  'cafebabf',
+  'cefaedfe',
+  'cffaedfe',
+  'feedface',
+  'feedfacf',
+  'bebafeca',
+  'bfbafeca',
+])
+
+export const isMachOHeader = (header: Uint8Array) => {
+  if (header.length < 4) {
+    return false
+  }
+  return MachOMagic.has(Buffer.from(header.subarray(0, 4)).toString('hex'))
+}
+
+const isMachOFile = (filePath: string) => {
+  const fileDescriptor = openSync(filePath, 'r')
+  try {
+    const header = Buffer.alloc(4)
+    return readSync(fileDescriptor, header, 0, header.length, 0) === header.length && isMachOHeader(header)
+  } finally {
+    closeSync(fileDescriptor)
+  }
+}
+
+export const shouldIgnoreMacCodeSignPath = (filePath: string) => {
+  if (filePath.endsWith('.app') || filePath.endsWith('.framework')) {
+    return false
+  }
+  return !isMachOFile(filePath)
+}
 
 export const getSigningKeychain = (environment: Readonly<Record<string, string | undefined>>) => {
   return environment.CSC_KEYCHAIN || undefined
@@ -11,6 +47,7 @@ export const signMacApp = async ({ appPath, entitlementsPath, entitlementsInheri
   }
   await signAsync({
     app: appPath,
+    ignore: shouldIgnoreMacCodeSignPath,
     keychain,
     platform: 'darwin',
     strictVerify: true,

--- a/packages/build/test/SignMacApp.test.ts
+++ b/packages/build/test/SignMacApp.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@jest/globals'
-import { getSigningKeychain } from '../src/parts/SignMacApp/SignMacApp.ts'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getSigningKeychain, isMachOHeader, shouldIgnoreMacCodeSignPath } from '../src/parts/SignMacApp/SignMacApp.ts'
 
 test('macOS signing remains disabled without a signing keychain', () => {
   expect(getSigningKeychain({})).toBeUndefined()
@@ -7,4 +10,39 @@ test('macOS signing remains disabled without a signing keychain', () => {
 
 test('macOS signing uses the configured keychain', () => {
   expect(getSigningKeychain({ CSC_KEYCHAIN: '/tmp/signing.keychain-db' })).toBe('/tmp/signing.keychain-db')
+})
+
+test.each([
+  [0xfe, 0xed, 0xfa, 0xce],
+  [0xce, 0xfa, 0xed, 0xfe],
+  [0xfe, 0xed, 0xfa, 0xcf],
+  [0xcf, 0xfa, 0xed, 0xfe],
+  [0xca, 0xfe, 0xba, 0xbe],
+  [0xbe, 0xba, 0xfe, 0xca],
+  [0xca, 0xfe, 0xba, 0xbf],
+  [0xbf, 0xba, 0xfe, 0xca],
+])('recognizes Mach-O header %p', (...header) => {
+  expect(isMachOHeader(Uint8Array.from(header))).toBe(true)
+})
+
+test('does not recognize non-Mach-O resources as code', () => {
+  expect(isMachOHeader(Uint8Array.from([0x89, 0x50, 0x4e, 0x47]))).toBe(false)
+  expect(isMachOHeader(Uint8Array.from([0x7f, 0x45, 0x4c, 0x46]))).toBe(false)
+  expect(isMachOHeader(Uint8Array.from([0x50, 0x4b, 0x03, 0x04]))).toBe(false)
+})
+
+test('signs Mach-O files but ignores binary resource files', () => {
+  const fixturePath = mkdtempSync(join(tmpdir(), 'lvce-macos-signing-'))
+  try {
+    const machOPath = join(fixturePath, 'native.node')
+    const resourcePath = join(fixturePath, 'resource.pak')
+    writeFileSync(machOPath, Uint8Array.from([0xcf, 0xfa, 0xed, 0xfe]))
+    writeFileSync(resourcePath, Uint8Array.from([0x50, 0x4b, 0x03, 0x04]))
+
+    expect(shouldIgnoreMacCodeSignPath(machOPath)).toBe(false)
+    expect(shouldIgnoreMacCodeSignPath(resourcePath)).toBe(true)
+    expect(shouldIgnoreMacCodeSignPath(join(fixturePath, 'Nested.app'))).toBe(false)
+  } finally {
+    rmSync(fixturePath, { recursive: true })
+  }
 })

--- a/packages/build/test/VerifyMacOsDmgScript.test.ts
+++ b/packages/build/test/VerifyMacOsDmgScript.test.ts
@@ -1,0 +1,10 @@
+import { readFile } from 'node:fs/promises'
+import { expect, test } from '@jest/globals'
+
+test('macOS DMG verification rejects detached resource signatures', async () => {
+  const scriptUrl = new URL('../scripts/github-actions/verify-macos-dmg.sh', import.meta.url)
+  const script = await readFile(scriptUrl, 'utf8')
+
+  expect(script).toContain('com.apple.cs.CodeSignature')
+  expect(script).toContain('The app contains detached signatures on ordinary resource files')
+})


### PR DESCRIPTION
Fix macOS release signing so only Mach-O code and nested app/framework bundles are signed.

Reject detached resource signatures during DMG verification to prevent broken artifacts that Finder cannot install.