### PR TITLE
fix: avoid shared process lookup on web

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchExtensionManagementWorker/LaunchExtensionManagementWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchExtensionManagementWorker/LaunchExtensionManagementWorker.js
@@ -5,11 +5,20 @@ import * as IpcParent from '../IpcParent/IpcParent.js'
 import * as IpcParentType from '../IpcParentType/IpcParentType.js'
 import * as JsonRpc from '../JsonRpc/JsonRpc.js'
 import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+
+const getExtensionDevelopmentConfig = (platform) => {
+  if (platform === PlatformType.Web) {
+    return undefined
+  }
+  return SharedProcess.invoke('ExtensionManagement.getLinkedExtensionDevelopmentConfig')
+}
 
 export const launchExtensionManagementWorker = async () => {
   const name = 'Extension Management Worker'
-  const developmentConfig = await SharedProcess.invoke('ExtensionManagement.getLinkedExtensionDevelopmentConfig')
+  const platform = Platform.getPlatform()
+  const developmentConfig = await getExtensionDevelopmentConfig(platform)
   const ipc = await IpcParent.create({
     method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
     name,
@@ -19,6 +28,6 @@ export const launchExtensionManagementWorker = async () => {
     ),
   })
   HandleIpc.handleIpc(ipc)
-  await JsonRpc.invoke(ipc, 'Extensions.initialize', Platform.getPlatform(), developmentConfig)
+  await JsonRpc.invoke(ipc, 'Extensions.initialize', platform, developmentConfig)
   return ipc
 }

--- a/packages/renderer-worker/test/LaunchExtensionManagementWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchExtensionManagementWorker.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as IpcParentType from '../src/parts/IpcParentType/IpcParentType.js'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+
+jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => ({
+  getConfiguredWorkerUrl: jest.fn(() => 'https://example.com/extension-management-worker.js'),
+}))
+
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => ({
+  handleIpc: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => ({
+  create: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+  invoke: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+
+const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
+const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
+const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const JsonRpc = await import('../src/parts/JsonRpc/JsonRpc.js')
+const LaunchExtensionManagementWorker = await import('../src/parts/LaunchExtensionManagementWorker/LaunchExtensionManagementWorker.js')
+const Platform = await import('../src/parts/Platform/Platform.js')
+const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).mockReturnValue('https://example.com/extension-management-worker.js')
+})
+
+test('launchExtensionManagementWorker - launches web worker without shared process', async () => {
+  const ipc = {}
+  jest.mocked(Platform.getPlatform).mockReturnValue(PlatformType.Web)
+  jest.mocked(IpcParent.create).mockResolvedValue(ipc)
+
+  await expect(LaunchExtensionManagementWorker.launchExtensionManagementWorker()).resolves.toBe(ipc)
+
+  expect(SharedProcess.invoke).not.toHaveBeenCalled()
+  expect(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).toHaveBeenCalledWith(
+    'develop.extensionManagementWorkerPath',
+    '/packages/renderer-worker/node_modules/@lvce-editor/extension-management-worker/dist/extensionManagementWorkerMain.js',
+  )
+  expect(IpcParent.create).toHaveBeenCalledWith({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Extension Management Worker',
+    url: 'https://example.com/extension-management-worker.js',
+  })
+  expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+  expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'Extensions.initialize', PlatformType.Web, undefined)
+})
+
+test('launchExtensionManagementWorker - loads development config for remote worker', async () => {
+  const ipc = {}
+  const developmentConfig = { extensions: [], hotReload: true }
+  jest.mocked(Platform.getPlatform).mockReturnValue(PlatformType.Remote)
+  jest.mocked(SharedProcess.invoke).mockResolvedValue(developmentConfig)
+  jest.mocked(IpcParent.create).mockResolvedValue(ipc)
+
+  await expect(LaunchExtensionManagementWorker.launchExtensionManagementWorker()).resolves.toBe(ipc)
+
+  expect(SharedProcess.invoke).toHaveBeenCalledWith('ExtensionManagement.getLinkedExtensionDevelopmentConfig')
+  expect(JsonRpc.invoke).toHaveBeenCalledWith(ipc, 'Extensions.initialize', PlatformType.Remote, developmentConfig)
+})


### PR DESCRIPTION
Keep the static web startup path from requesting linked-extension development configuration through the unavailable shared process. Initialize the extension management worker with its web defaults and cover both web and remote behavior.