### PR TITLE
fix: preserve provider blobs for binary reads

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
@@ -42,7 +42,7 @@ const executeProvider = async ({ isolatedMethod, isolatedParams, legacyMethod, l
   })
 }
 
-export const readFile = (uri) => {
+const readProviderFile = (uri) => {
   const { protocol, path, uri: providerUri } = getProviderProtocolPathAndUri(uri)
   return executeProvider({
     isolatedMethod: 'Extensions.executeFileSystemProviderReadFile',
@@ -53,8 +53,13 @@ export const readFile = (uri) => {
   })
 }
 
+export const readFile = async (uri) => {
+  const content = await readProviderFile(uri)
+  return content instanceof Blob ? content.text() : content
+}
+
 export const getBlob = async (uri, type = '') => {
-  const content = await readFile(uri)
+  const content = await readProviderFile(uri)
   if (content instanceof Blob) {
     return content
   }

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -41,6 +41,12 @@ test('readFile', async () => {
   expect(await ExtensionHostFileSystem.readFile('memfs:///test.txt')).toBe('test content')
 })
 
+test('readFile converts binary provider content to text', async () => {
+  invoke.mockResolvedValue({ found: true, result: new Blob(['test content']) })
+
+  await expect(ExtensionHostFileSystem.readFile('remote-ssh:///workspace/test.txt')).resolves.toBe('test content')
+})
+
 test('readFile - wrapped extension host uri', async () => {
   // @ts-ignore
   ExtensionHostShared.executeProvider.mockImplementation(async () => {


### PR DESCRIPTION
Keep provider blobs intact for binary consumers while converting them to text for normal file reads.