### PR TITLE
fix: preserve local process explorer connection

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -537,6 +537,7 @@ export const commandMap = {
   'Workspace.setUri': lazy('Workspace.setUri'),
   'Workspace.supportsConnectionCommand': lazy('Workspace.supportsConnectionCommand'),
   'WebSocketCapability.create': lazy('WebSocketCapability.create'),
+  'WebSocketCapability.isActive': lazy('WebSocketCapability.isActive'),
   'Layout.getAllQuickPickMenuEntries': lazy('Layout.getAllQuickPickMenuEntries'),
   'Layout.attachViewlet': lazy('Layout.attachViewlet'),
   'Layout.createPanelViewlet': lazy('Layout.createPanelViewlet'),

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -92,9 +92,6 @@ export const sendMessagePortToSharedProcess = async (port, initialCommand, rpcId
 
 export const sendMessagePortToProcessExplorer = async (port) => {
   Assert.object(port)
-  if (await WorkspaceConnection.connectMessagePort('process-explorer', port)) {
-    return
-  }
   await SharedProcess.invokeAndTransfer('HandleMessagePortForProcessExplorer.handleMessagePortForProcessExplorer', port)
 }
 

--- a/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletProcessExplorer/ViewletProcessExplorer.ipc.js
@@ -3,7 +3,13 @@ import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
 
-const getPlatform = () => (WorkspaceConnection.isActive() ? PlatformType.Remote : Platform.getPlatform())
+const getPlatform = () => {
+  const platform = Platform.getPlatform()
+  if (platform === PlatformType.Electron) {
+    return platform
+  }
+  return WorkspaceConnection.isActive() ? PlatformType.Remote : platform
+}
 
 export const {
   Commands,

--- a/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.ipc.js
+++ b/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.ipc.js
@@ -4,4 +4,5 @@ export const name = 'WebSocketCapability'
 
 export const Commands = {
   create: WebSocketCapability.create,
+  isActive: WebSocketCapability.isActive,
 }

--- a/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.js
+++ b/packages/renderer-worker/src/parts/WebSocketCapability/WebSocketCapability.js
@@ -2,6 +2,8 @@ import * as GetWebSocketUrl from '../GetWebSocketUrl/GetWebSocketUrl.js'
 import * as Location from '../Location/Location.js'
 import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
 
+export const isActive = WorkspaceConnection.isActive
+
 export const create = async (type) => {
   const remoteUrl = await WorkspaceConnection.getWebSocketUrl(type)
   return {

--- a/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
+++ b/packages/renderer-worker/test/LoadProcessExplorerViewletModule.test.ts
@@ -1,4 +1,11 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Module boundary tests require ESM dependency mocks. */
 import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const getPlatform = jest.fn<() => number>(() => 3)
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform,
+}))
 
 jest.unstable_mockModule('../src/parts/WorkspaceConnection/WorkspaceConnection.js', () => ({
   isActive: jest.fn(() => false),
@@ -9,6 +16,7 @@ const PlatformType = await import('../src/parts/PlatformType/PlatformType.js')
 const WorkspaceConnection = await import('../src/parts/WorkspaceConnection/WorkspaceConnection.js')
 
 beforeEach(() => {
+  getPlatform.mockReturnValue(PlatformType.Remote)
   jest.mocked(WorkspaceConnection.isActive).mockReturnValue(false)
 })
 
@@ -30,9 +38,21 @@ test('loads worker-backed viewlet on web with an active workspace connection', a
   const module = await LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule(PlatformType.Web)
 
   const state = module.create(7, 'process-explorer://', 1, 2, 3, 4)
-  expect(state.platform).toBe(PlatformType.Remote)
+  const { platform } = state
+  expect(platform).toBe(PlatformType.Remote)
   expect(typeof module.getCommands).toBe('function')
   expect(typeof module.getKeyBindings).toBe('function')
+})
+
+test('keeps electron platform with an active workspace connection', async () => {
+  getPlatform.mockReturnValue(PlatformType.Electron)
+  jest.mocked(WorkspaceConnection.isActive).mockReturnValue(true)
+
+  const module = await LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule(PlatformType.Electron)
+
+  const state = module.create(7, 'process-explorer://', 1, 2, 3, 4)
+  const { platform } = state
+  expect(platform).toBe(PlatformType.Electron)
 })
 
 test.each([PlatformType.Electron, PlatformType.Remote])('loads worker-backed viewlet on platform %s', async (platform) => {

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -70,6 +70,7 @@ test('sendMessagePortToProcessExplorer', async () => {
 
   expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
   expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePortForProcessExplorer.handleMessagePortForProcessExplorer', port)
+  expect(WorkspaceConnection.connectMessagePort).not.toHaveBeenCalled()
 })
 
 test('sendMessagePortToFileWatcherExplorer', async () => {

--- a/packages/renderer-worker/test/WebSocketCapability.test.ts
+++ b/packages/renderer-worker/test/WebSocketCapability.test.ts
@@ -1,0 +1,25 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Module boundary tests require ESM dependency mocks. */
+import { expect, jest, test } from '@jest/globals'
+
+const getWebSocketUrl = jest.fn<(_type: string) => Promise<string>>(async () => 'ws://remote.example/process')
+const isActive = jest.fn(() => true)
+
+jest.unstable_mockModule('../src/parts/WorkspaceConnection/WorkspaceConnection.js', () => ({
+  getWebSocketUrl,
+  isActive,
+}))
+
+const WebSocketCapability = await import('../src/parts/WebSocketCapability/WebSocketCapability.js')
+
+test('isActive returns workspace connection state', () => {
+  expect(WebSocketCapability.isActive()).toBe(true)
+  expect(isActive).toHaveBeenCalledTimes(1)
+})
+
+test('create returns remote websocket capability', async () => {
+  await expect(WebSocketCapability.create('process-explorer')).resolves.toEqual({
+    protocols: [],
+    url: 'ws://remote.example/process',
+  })
+  expect(getWebSocketUrl).toHaveBeenCalledWith('process-explorer')
+})


### PR DESCRIPTION
Keep the process explorer connected to the local shared process in remote Electron workspaces and expose the active remote WebSocket capability so it can load both machines.