### PR TITLE
feature: wrap simple browser snapshot image

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -62,6 +62,28 @@ test('bundleCss lets the simple browser fill the preview area height', async () 
   }
 }, 30_000)
 
+test('bundleCss strictly contains the simple browser snapshot wrapper', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletSimpleBrowser.css'), 'utf8')
+
+    expect(css).toContain(`.SimpleBrowserSnapshotWrapper {
+  contain: strict;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss keeps the preview sash transparent', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -164,13 +164,20 @@ export const getSimpleBrowserVirtualDom = (
     },
   )
   if (snapshot) {
-    dom.push({
-      type: VirtualDomElements.Img,
-      className: suggestions.length > 0 ? 'SimpleBrowserSnapshot SimpleBrowserSnapshotSearchSuggestions' : 'SimpleBrowserSnapshot',
-      src: snapshot,
-      draggable: false,
-      childCount: 0,
-    })
+    dom.push(
+      {
+        type: VirtualDomElements.Div,
+        className: 'SimpleBrowserSnapshotWrapper',
+        childCount: 1,
+      },
+      {
+        type: VirtualDomElements.Img,
+        className: suggestions.length > 0 ? 'SimpleBrowserSnapshot SimpleBrowserSnapshotSearchSuggestions' : 'SimpleBrowserSnapshot',
+        src: snapshot,
+        draggable: false,
+        childCount: 0,
+      },
+    )
   }
   if (suggestions.length > 0) {
     dom.push({

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -6,13 +6,20 @@ test('renders a snapshot below the browser header', () => {
   const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(true, true, false, 'https://example.com', 'data:image/png;base64,c25hcHNob3Q=')
 
   expect(dom[0].childCount).toBe(3)
-  expect(dom.at(-1)).toEqual({
-    type: VirtualDomElements.Img,
-    className: 'SimpleBrowserSnapshot',
-    src: 'data:image/png;base64,c25hcHNob3Q=',
-    draggable: false,
-    childCount: 0,
-  })
+  expect(dom.slice(-2)).toEqual([
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserSnapshotWrapper',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Img,
+      className: 'SimpleBrowserSnapshot',
+      src: 'data:image/png;base64,c25hcHNob3Q=',
+      draggable: false,
+      childCount: 0,
+    },
+  ])
 })
 
 test('names the address input so focus can be restored after rendering', () => {

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -104,11 +104,17 @@
   contain: strict;
 }
 
-.SimpleBrowserSnapshot {
+.SimpleBrowserSnapshotWrapper {
   contain: strict;
   flex: 1;
-  filter: brightness(0.8);
   min-height: 0;
+  width: 100%;
+}
+
+.SimpleBrowserSnapshot {
+  display: block;
+  filter: brightness(0.8);
+  height: 100%;
   object-fit: fill;
   pointer-events: none;
   width: 100%;


### PR DESCRIPTION
Wrap the simple browser snapshot image in a strictly contained, flex-sized element while preserving the snapshot's rendering and suggestion-state appearance. Add focused DOM and bundled-CSS regression coverage.