### PR TITLE
fix: render simple browser incrementally

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -75,7 +75,8 @@
         "@lvce-editor/text-search-view": "^1.13.0",
         "@lvce-editor/text-search-worker": "^7.16.0",
         "@lvce-editor/title-bar-worker": "^4.20.3",
-        "@lvce-editor/update-worker": "^2.14.0"
+        "@lvce-editor/update-worker": "^2.14.0",
+        "@lvce-editor/virtual-dom-worker": "^11.16.2"
       },
       "devDependencies": {
         "@jest/globals": "^30.4.1",
@@ -1333,6 +1334,15 @@
       "resolved": "https://registry.npmjs.org/@lvce-editor/update-worker/-/update-worker-2.14.0.tgz",
       "integrity": "sha512-0xoLLhqJT0duPMikdcdZnPXM9SxuZhq1HDDn0UcLnAX9JZVara47Xng36WEM6FhupsQRbH0cQGUyylB7VAvwiw==",
       "license": "MIT"
+    },
+    "node_modules/@lvce-editor/virtual-dom-worker": {
+      "version": "11.16.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.16.2.tgz",
+      "integrity": "sha512-lL4a3f/0MUlMzqqFEJ5Physpa70gpyww8HEwDMKgthUe4bG9rTjWa9nAXzvLZ4tQxjKbbHSBQNJJmS/+NWRb/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/constants": "^5.29.0"
+      }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.6.0",

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -107,7 +107,8 @@
     "@lvce-editor/text-search-view": "^1.13.0",
     "@lvce-editor/text-search-worker": "^7.16.0",
     "@lvce-editor/title-bar-worker": "^4.20.3",
-    "@lvce-editor/update-worker": "^2.14.0"
+    "@lvce-editor/update-worker": "^2.14.0",
+    "@lvce-editor/virtual-dom-worker": "^11.16.2"
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -1,3 +1,4 @@
+import { diffTree } from '@lvce-editor/virtual-dom-worker'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
 import * as GetSimpleBrowserVirtualDom from '../GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js'
 import * as InputName from '../InputName/InputName.js'
@@ -38,6 +39,21 @@ const areTabsEqual = (oldTabs, newTabs) => {
   })
 }
 
+const getDom = (state) => {
+  return GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(
+    state.canGoBack,
+    state.canGoForward,
+    state.isLoading,
+    state.inputValue,
+    state.snapshot,
+    state.suggestions,
+    state.selectedSuggestionIndex,
+    state.tabs,
+    state.selectedTabIndex,
+    state.tabsEnabled,
+  )
+}
+
 const renderDom = {
   isEqual(oldState, newState) {
     return (
@@ -54,19 +70,11 @@ const renderDom = {
     )
   },
   apply(oldState, newState) {
-    const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(
-      newState.canGoBack,
-      newState.canGoForward,
-      newState.isLoading,
-      newState.inputValue,
-      newState.snapshot,
-      newState.suggestions,
-      newState.selectedSuggestionIndex,
-      newState.tabs,
-      newState.selectedTabIndex,
-      newState.tabsEnabled,
-    )
-    const commands = [['Viewlet.setDom2', newState.uid, dom]]
+    const newDom = getDom(newState)
+    const commands =
+      oldState.browserViewId === 0
+        ? [['Viewlet.setDom2', newState.uid, newDom]]
+        : [['Viewlet.setPatches', newState.uid, diffTree(getDom(oldState), newDom)]]
     if (newState.suggestions.length > 0) {
       commands.push(['Viewlet.focusElementByName', newState.uid, InputName.SimpleBrowserAddress])
     }

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@jest/globals'
 import * as ViewletSimpleBrowserRender from '../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js'
 
 const state = {
+  browserViewId: 12,
   canGoBack: false,
   canGoForward: false,
   iframeSrc: 'https://example.com',
@@ -31,7 +32,7 @@ test('rerenders when suggestions change', () => {
   expect(ViewletSimpleBrowserRender.render[0].isEqual(state, newState)).toBe(false)
 })
 
-test('restores address input focus while suggestions are visible', () => {
+test('renders suggestions incrementally and restores address input focus', () => {
   const newState = {
     ...state,
     suggestions: ['what is'],
@@ -39,8 +40,21 @@ test('restores address input focus while suggestions are visible', () => {
 
   const commands = ViewletSimpleBrowserRender.render[0].apply(state, newState)
 
-  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setDom2', 42])
+  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setPatches', 42])
+  expect(commands[0][2]).not.toHaveLength(0)
   expect(commands.at(-1)).toEqual(['Viewlet.focusElementByName', 42, 'simple-browser-address'])
+})
+
+test('renders the initial dom in full', () => {
+  const oldState = {
+    ...state,
+    browserViewId: 0,
+  }
+
+  const commands = ViewletSimpleBrowserRender.render[0].apply(oldState, state)
+
+  expect(commands).toHaveLength(1)
+  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setDom2', 42])
 })
 
 test('does not focus the address input after suggestions close', () => {


### PR DESCRIPTION
Render Simple Browser DOM updates as virtual-DOM patches after the initial render so typing and suggestion updates preserve the existing input and surrounding UI. Add focused renderer coverage for incremental updates and the initial full render.