### PR TITLE
feature: update explorer-view to version 7.30.3

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -31,7 +31,7 @@
         "@lvce-editor/editor-worker": "^19.51.1",
         "@lvce-editor/embeds-worker": "^4.14.0",
         "@lvce-editor/error-worker": "^3.9.0",
-        "@lvce-editor/explorer-view": "^7.30.2",
+        "@lvce-editor/explorer-view": "^7.30.3",
         "@lvce-editor/extension-detail-view": "^7.42.0",
         "@lvce-editor/extension-host-sub-worker": "^3.14.0",
         "@lvce-editor/extension-management-worker": "^4.70.0",
@@ -1044,9 +1044,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/explorer-view": {
-      "version": "7.30.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/explorer-view/-/explorer-view-7.30.2.tgz",
-      "integrity": "sha512-u0FEU3onuBKc4XtK94/fYhvB02hszvqlOPPoz0gG7QP0LwCJKJHP090BniIXq+xn2bOMsBQ/Z0v0BCUXKIsQ5A==",
+      "version": "7.30.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/explorer-view/-/explorer-view-7.30.3.tgz",
+      "integrity": "sha512-llYyEzh7zXOyd3Oa4SL3XmdkgTX+v29MHePiK+mRm/nLSAkoynoA+ZmPm/rGh9KOmb6HsJhIhPfMMsz1dfzDLg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-detail-view": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -63,7 +63,7 @@
     "@lvce-editor/editor-worker": "^19.51.1",
     "@lvce-editor/embeds-worker": "^4.14.0",
     "@lvce-editor/error-worker": "^3.9.0",
-    "@lvce-editor/explorer-view": "^7.30.2",
+    "@lvce-editor/explorer-view": "^7.30.3",
     "@lvce-editor/extension-detail-view": "^7.42.0",
     "@lvce-editor/extension-host-sub-worker": "^3.14.0",
     "@lvce-editor/extension-management-worker": "^4.70.0",


### PR DESCRIPTION
Updates `@lvce-editor/explorer-view` to 7.30.3.

This includes the fix that makes `Ctrl+0` transfer DOM focus to Explorer when its remembered logical target is already the list.