### PR TITLE
Add Simple Browser tab keyboard shortcuts

### DIFF
--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
@@ -4,6 +4,7 @@ export const name = 'ElectronBrowserView'
 
 export const Commands = {
   handleDidNavigate: ElectronBrowserView.handleDidNavigate,
+  handleKeyBinding: ElectronBrowserView.handleKeyBinding,
   handlePageFaviconUpdated: ElectronBrowserView.handlePageFaviconUpdated,
   handleTitleUpdated: ElectronBrowserView.handleTitleUpdated,
   handleWillNavigate: ElectronBrowserView.handleWillNavigate,

--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.js
@@ -7,6 +7,8 @@ const dispatch =
   }
 export const handleDidNavigate = dispatch('browser-view-did-navigate')
 
+export const handleKeyBinding = dispatch('browser-view-key-binding')
+
 export const handlePageFaviconUpdated = dispatch('browser-view-page-favicon-updated')
 
 export const handleTitleUpdated = dispatch('browser-view-title-updated')

--- a/packages/renderer-worker/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js
+++ b/packages/renderer-worker/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js
@@ -58,8 +58,8 @@ export const copyImageAt = (id, x, y) => {
   return EmbedsWorker.invoke('ElectronWebContentsView.copyImageAt', id, x, y)
 }
 
-export const setFallthroughKeyBindings = (fallthroughKeyBindings) => {
-  return EmbedsWorker.invoke('ElectronWebContentsView.setFallthroughKeyBindings', fallthroughKeyBindings)
+export const setFallthroughKeyBindings = (id, fallthroughKeyBindings) => {
+  return EmbedsWorker.invoke('ElectronWebContentsView.setFallthroughKeyBindings', id, fallthroughKeyBindings)
 }
 
 export const getStats = (id) => {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -8,13 +8,17 @@ import * as ElectronWebContentsViewFunctions from '../ElectronWebContentsViewFun
 import * as GetFallThroughKeyBindings from '../GetFallThroughKeyBindings/GetFallThroughKeyBindings.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as IframeSrc from '../IframeSrc/IframeSrc.js'
+import * as KeyCode from '../KeyCode/KeyCode.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as KeyBindingsInitial from '../KeyBindingsInitial/KeyBindingsInitial.js'
+import * as KeyModifier from '../KeyModifier/KeyModifier.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as SimpleBrowserPreferences from '../SimpleBrowserPreferences/SimpleBrowserPreferences.js'
 
 const navigationHeaderHeight = 30
 const tabsHeaderHeight = 35
+const focusNextTabKeyBinding = KeyModifier.CtrlCmd | KeyCode.Tab
+const focusPreviousTabKeyBinding = KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.Tab
 
 const getHeaderHeight = (tabsEnabled) => navigationHeaderHeight + (tabsEnabled ? tabsHeaderHeight : 0)
 
@@ -135,7 +139,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   const keyBindings = await KeyBindingsInitial.getKeyBindings()
   const fallThroughKeyBindings = GetFallThroughKeyBindings.getFallThroughKeyBindings(keyBindings)
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0)
-  await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(fallThroughKeyBindings)
+  await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
   const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
@@ -178,10 +182,11 @@ export const loadContent = async (state, savedState) => {
   const browserViewWidth = width
   const browserViewHeight = height - headerHeight
   const shortcuts = SimpleBrowserPreferences.getShortCuts()
+  const fallThroughKeyBindings = GetFallThroughKeyBindings.getFallThroughKeyBindings(keyBindings)
 
   if (id) {
     const actualId = await ElectronWebContentsView.createWebContentsView(id, uid)
-    await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(keyBindings)
+    await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(actualId, fallThroughKeyBindings)
     await ElectronWebContentsViewFunctions.resizeWebContentsView(actualId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
     if (id !== actualId) {
       await ElectronWebContentsViewFunctions.setIframeSrc(actualId, iframeSrc)
@@ -213,9 +218,8 @@ export const loadContent = async (state, savedState) => {
     }
   }
 
-  const fallThroughKeyBindings = GetFallThroughKeyBindings.getFallThroughKeyBindings(keyBindings)
   const browserViewId = await ElectronWebContentsView.createWebContentsView(/* restoreId */ 0, uid)
-  await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(fallThroughKeyBindings)
+  await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
@@ -542,7 +546,16 @@ export const handleWillNavigate = (state, browserViewId, value) => {
   })
 }
 
-export const handleKeyBinding = async (state, keyBinding) => {
+export const handleKeyBinding = async (state, browserViewId, keyBinding) => {
+  if (Number(browserViewId) !== state.browserViewId) {
+    return state
+  }
+  if (keyBinding === focusNextTabKeyBinding && state.tabs.length > 0) {
+    return selectTab(state, (state.selectedTabIndex + 1) % state.tabs.length)
+  }
+  if (keyBinding === focusPreviousTabKeyBinding && state.tabs.length > 0) {
+    return selectTab(state, (state.selectedTabIndex - 1 + state.tabs.length) % state.tabs.length)
+  }
   await KeyBindings.handleKeyBinding(keyBinding)
   return state
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -44,6 +44,7 @@ export const LazyCommands = {
 
 export const Events = {
   'browser-view-did-navigate': SimpleBrowser.handleDidNavigate,
+  'browser-view-key-binding': SimpleBrowser.handleKeyBinding,
   'browser-view-page-favicon-updated': SimpleBrowser.handlePageFaviconUpdated,
   'browser-view-title-updated': SimpleBrowser.handleTitleUpdated,
   'browser-view-will-navigate': SimpleBrowser.handleWillNavigate,

--- a/packages/renderer-worker/test/ElectronBrowserView.test.ts
+++ b/packages/renderer-worker/test/ElectronBrowserView.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 beforeEach(() => {
   jest.resetAllMocks()
+  GlobalEventBus.state.listenerMap = Object.create(null)
 })
 
 jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
@@ -14,6 +15,16 @@ jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
 
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const ElectronBrowserView = await import('../src/parts/ElectronBrowserView/ElectronBrowserView.js')
+const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+
+test('forwards web contents keybindings through the global event bus', async () => {
+  const listener = jest.fn()
+  GlobalEventBus.addListener('browser-view-key-binding', listener)
+
+  await ElectronBrowserView.handleKeyBinding(12, 2050)
+
+  expect(listener).toHaveBeenCalledWith(12, 2050)
+})
 
 test.skip('createBrowserView - error', async () => {
   // @ts-ignore

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -80,7 +80,36 @@ const BrowserSearchSuggestions = await import('../src/parts/BrowserSearchSuggest
 const Command = await import('../src/parts/Command/Command.js')
 const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
 const ElectronWebContentsView = await import('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js')
+const KeyCode = await import('../src/parts/KeyCode/KeyCode.js')
+const KeyModifier = await import('../src/parts/KeyModifier/KeyModifier.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
+
+const createTwoTabState = () => ({
+  ...ViewletSimpleBrowser.create(),
+  browserViewId: 12,
+  tabs: [
+    {
+      browserViewId: 12,
+      canGoBack: false,
+      canGoForward: false,
+      favicon: '',
+      iframeSrc: 'https://one.example',
+      inputValue: 'https://one.example',
+      isLoading: false,
+      title: 'One',
+    },
+    {
+      browserViewId: 13,
+      canGoBack: true,
+      canGoForward: false,
+      favicon: '',
+      iframeSrc: 'https://two.example',
+      inputValue: 'https://two.example',
+      isLoading: false,
+      title: 'Two',
+    },
+  ],
+})
 
 test('create', () => {
   const state = ViewletSimpleBrowser.create()
@@ -133,7 +162,7 @@ test('loadContent - restore id - same browser view', async () => {
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledWith(1, 0)
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledTimes(1)
-  expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith([])
+  expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith(1, [])
   expect(ElectronWebContentsViewFunctions.setIframeSrc).not.toHaveBeenCalled()
 })
 
@@ -151,7 +180,7 @@ test('loadContent - restore id - browser view does not exist yet', async () => {
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledWith(1, 0)
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledTimes(1)
-  expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith([])
+  expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith(2, [])
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(2, 'https://example.com')
 })
@@ -313,6 +342,45 @@ test('switches tabs by hiding only the previous active view', async () => {
   expect(newState).toMatchObject({ browserViewId: 13, canGoBack: true, inputValue: 'https://two.example', selectedTabIndex: 1, title: 'Two' })
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
+})
+
+test('Ctrl+Tab from the focused web contents selects the next browser tab', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  const state = createTwoTabState()
+
+  const newState = await ViewletSimpleBrowser.handleKeyBinding(state, 12, KeyModifier.CtrlCmd | KeyCode.Tab)
+
+  expect(newState).toMatchObject({ browserViewId: 13, selectedTabIndex: 1, title: 'Two' })
+  expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(13)
+})
+
+test('Ctrl+Shift+Tab from the focused web contents wraps to the previous browser tab', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  const state = createTwoTabState()
+
+  const newState = await ViewletSimpleBrowser.handleKeyBinding(state, 12, KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.Tab)
+
+  expect(newState).toMatchObject({ browserViewId: 13, selectedTabIndex: 1, title: 'Two' })
+  expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(13)
+})
+
+test('ignores keybindings from another simple browser instance', async () => {
+  const state = createTwoTabState()
+
+  const newState = await ViewletSimpleBrowser.handleKeyBinding(state, 99, KeyModifier.CtrlCmd | KeyCode.Tab)
+
+  expect(newState).toBe(state)
+  expect(ElectronWebContentsViewFunctions.hide).not.toHaveBeenCalled()
 })
 
 test('updates the matching background tab from web contents events', async () => {


### PR DESCRIPTION
Make Ctrl+Tab and Ctrl+Shift+Tab cycle forward and backward through Simple Browser tabs even while the embedded page is focused.