### PR TITLE
fix: bundle renderer worker dependencies

### DIFF
--- a/packages/build/src/parts/BundleJsRollup/BundleJsRollup.ts
+++ b/packages/build/src/parts/BundleJsRollup/BundleJsRollup.ts
@@ -14,6 +14,7 @@ type BundleOptions = {
   readonly external?: Array<string | RegExp>
   readonly from: string
   readonly minify?: boolean
+  readonly modulePaths?: string[]
   readonly platform: 'node' | 'webworker' | 'web' | 'node/cjs'
   readonly sourceMap?: boolean
   readonly typescript?: boolean
@@ -52,20 +53,25 @@ export const bundleJs = async ({
   allowCyclicDependencies = false,
   babelExternal = false,
   external = [],
+  modulePaths = [],
   typescript = from.endsWith('.ts'),
   sourceMap = true,
 }: BundleOptions) => {
   try {
     const allExternal = getExternal(babelExternal, external)
     const plugins: rollup.Plugin[] = [jsonPlugin]
-    if (platform === 'node/cjs' || platform === 'node') {
-      const { default: commonjs } = await import('@rollup/plugin-commonjs')
+    if (platform === 'node/cjs' || platform === 'node' || modulePaths.length > 0) {
       const { nodeResolve } = await import('@rollup/plugin-node-resolve')
-      plugins.push(
+      if (platform === 'node/cjs' || platform === 'node') {
+        const { default: commonjs } = await import('@rollup/plugin-commonjs')
         // @ts-ignore
-        commonjs(),
+        plugins.push(commonjs())
+      }
+      plugins.push(
         nodeResolve({
-          preferBuiltins: true,
+          browser: platform === 'web' || platform === 'webworker',
+          modulePaths,
+          preferBuiltins: platform === 'node/cjs' || platform === 'node',
         }),
       )
     }

--- a/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
+++ b/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
@@ -270,6 +270,7 @@ export const bundleRendererWorker = async ({ cachePath, platform, commitHash, as
     await BundleJs.bundleJs({
       cwd: cachePath,
       from: `./src/rendererWorkerMain.ts`,
+      modulePaths: [Path.absolute('packages/renderer-worker/node_modules')],
       platform: 'webworker',
       sourceMap: false,
     })

--- a/packages/build/test/BundleRendererWorker.test.ts
+++ b/packages/build/test/BundleRendererWorker.test.ts
@@ -1,0 +1,31 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@jest/globals'
+import { bundleRendererWorker } from '../src/parts/BundleRendererWorker/BundleRendererWorker.ts'
+
+test('bundles npm dependencies into the renderer worker', async () => {
+  const cachePath = await mkdtemp(join(tmpdir(), 'lvce-renderer-worker-bundle-'))
+  try {
+    await bundleRendererWorker({
+      assetDir: '/test-asset-dir',
+      cachePath,
+      commitHash: 'test-commit',
+      date: '2026-08-28T00:00:00.000Z',
+      iconThemeEtag: '',
+      platform: 'electron',
+      product: {
+        applicationName: 'lvce-test',
+        nameLong: 'LVCE Test',
+      },
+      version: '0.0.0-test',
+    })
+
+    const bundle = await readFile(join(cachePath, 'dist', 'rendererWorkerMain.js'), 'utf8')
+
+    expect(bundle).not.toMatch(/from ['"]@lvce-editor\//)
+    expect(bundle).not.toMatch(/import ['"]@lvce-editor\//)
+  } finally {
+    await rm(cachePath, { force: true, recursive: true })
+  }
+}, 60_000)


### PR DESCRIPTION
## Details

The renderer worker production bundle left npm imports unresolved. In Electron v0.110.19, this emitted a top-level `@lvce-editor/virtual-dom-worker` import that the module worker could not resolve, preventing the workbench from starting.

## Change

- resolve renderer-worker npm dependencies from its package-local `node_modules` during Rollup bundling
- use browser resolution for web and web-worker targets
- add an integration test that rejects bare LVCE imports in the generated renderer worker entry

## Validation

- `npm test -- --runInBand --silent` in `packages/build` (33 suites, 117 tests)
- `npm run type-check`
- `npm run lint`
- `npm run build:static:ignore-icon-theme`
- verified generated `rendererWorkerMain.js` starts with bundled code and has no static `@lvce-editor` import