### PR TITLE
fix: focus simple browser address on new tab

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -5,6 +5,7 @@ import * as BrowserSearchSuggestions from '../BrowserSearchSuggestions/BrowserSe
 import * as Command from '../Command/Command.js'
 import * as ElectronWebContentsView from '../ElectronWebContentsView/ElectronWebContentsView.js'
 import * as ElectronWebContentsViewFunctions from '../ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js'
+import * as ElectronWindow from '../ElectronWindow/ElectronWindow.js'
 import * as GetFallThroughKeyBindings from '../GetFallThroughKeyBindings/GetFallThroughKeyBindings.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as IframeSrc from '../IframeSrc/IframeSrc.js'
@@ -290,6 +291,7 @@ export const createNewTab = async (state) => {
     await ElectronWebContentsViewFunctions.hide(currentState.browserViewId)
   }
   await ElectronWebContentsViewFunctions.show(tab.browserViewId)
+  await ElectronWindow.focus()
   const newState = activateTab(currentState, [...currentState.tabs, tab], currentState.tabs.length)
   return { ...newState, focusAddressVersion: newState.focusAddressVersion + 1 }
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -102,13 +102,24 @@ const renderTitle = {
   },
 }
 
+const renderAddressValue = {
+  isEqual(oldState, newState) {
+    return oldState.browserViewId === newState.browserViewId
+  },
+  apply(oldState, newState) {
+    return [['Viewlet.setValueByName', newState.uid, InputName.SimpleBrowserAddress, newState.inputValue]]
+  },
+  multiple: true,
+}
+
 const renderFocusAddress = {
   isEqual(oldState, newState) {
     return oldState.focusAddressVersion === newState.focusAddressVersion
   },
   apply(oldState, newState) {
-    return ['Viewlet.focusElementByName', newState.uid, InputName.SimpleBrowserAddress]
+    return [['Viewlet.focusElementByName', newState.uid, InputName.SimpleBrowserAddress]]
   },
+  multiple: true,
 }
 
-export const render = [renderDom, renderTitle, renderFocusAddress]
+export const render = [renderDom, renderTitle, renderAddressValue, renderFocusAddress]

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -61,6 +61,10 @@ jest.unstable_mockModule('../src/parts/ElectronWebContentsView/ElectronWebConten
   }
 })
 
+jest.unstable_mockModule('../src/parts/ElectronWindow/ElectronWindow.js', () => ({
+  focus: jest.fn(),
+}))
+
 jest.unstable_mockModule('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js', () => {
   return {
     getKeyBindings() {
@@ -83,6 +87,7 @@ const BrowserSearchSuggestions = await import('../src/parts/BrowserSearchSuggest
 const Command = await import('../src/parts/Command/Command.js')
 const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
 const ElectronWebContentsView = await import('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js')
+const ElectronWindow = await import('../src/parts/ElectronWindow/ElectronWindow.js')
 const KeyCode = await import('../src/parts/KeyCode/KeyCode.js')
 const KeyModifier = await import('../src/parts/KeyModifier/KeyModifier.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
@@ -275,6 +280,7 @@ test('creates and selects an empty tab while keeping the original view alive', a
   expect(ElectronWebContentsView.disposeWebContentsView).not.toHaveBeenCalled()
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
+  expect(ElectronWindow.focus).toHaveBeenCalledTimes(1)
 })
 
 test('opens a target blank link in a new selected tab by default', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -69,12 +69,26 @@ test('does not focus the address input after suggestions close', () => {
   expect(commands).toHaveLength(1)
 })
 
+test('synchronizes the native address value when selecting another tab', () => {
+  const oldState = { ...state, browserViewId: 12, inputValue: 'https://example.com' }
+  const newState = { ...state, browserViewId: 13, inputValue: '' }
+
+  expect(ViewletSimpleBrowserRender.render[2].isEqual(oldState, newState)).toBe(false)
+  expect(ViewletSimpleBrowserRender.render[2].multiple).toBe(true)
+  expect(ViewletSimpleBrowserRender.render[2].apply(oldState, newState)).toEqual([
+    ['Viewlet.setValueByName', 42, 'simple-browser-address', ''],
+  ])
+})
+
 test('focuses the address input for a new empty tab', () => {
   const oldState = { ...state, focusAddressVersion: 0 }
   const newState = { ...state, focusAddressVersion: 1 }
 
-  expect(ViewletSimpleBrowserRender.render[2].isEqual(oldState, newState)).toBe(false)
-  expect(ViewletSimpleBrowserRender.render[2].apply(oldState, newState)).toEqual(['Viewlet.focusElementByName', 42, 'simple-browser-address'])
+  expect(ViewletSimpleBrowserRender.render[3].isEqual(oldState, newState)).toBe(false)
+  expect(ViewletSimpleBrowserRender.render[3].multiple).toBe(true)
+  expect(ViewletSimpleBrowserRender.render[3].apply(oldState, newState)).toEqual([
+    ['Viewlet.focusElementByName', 42, 'simple-browser-address'],
+  ])
 })
 
 test('routes tab context-menu events with the tab index and pointer coordinates', () => {


### PR DESCRIPTION
## Details

Opening a new Simple Browser tab left native keyboard focus in the newly shown WebContentsView. The address input also retained the previous tab's live DOM value after its value attribute was removed.

## Change

- transfer native focus back to the parent renderer after showing an empty tab
- synchronize the address input property when the selected WebContentsView changes
- cover both focus transfer and address-value synchronization with regression tests

## Tests

- npm test -- --runInBand ViewletSimpleBrowserRender.test.ts ViewletSimpleBrowser.test.ts
- npm run type-check (packages/renderer-worker)
- npm run lint
- npm run build:electron:deb:x64 -- --product=lvce