### PR TITLE
fix: register simple browser audio event

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -97,6 +97,7 @@ export const commandMap = {
   'Download.downloadToDownloadsFolder': lazy('Download.downloadToDownloadsFolder'),
   'EditorDiagnostics.hydrate': lazy('EditorDiagnostics.hydrate'),
   'EditorError.3900': lazy('EditorError.3900'),
+  'ElectronBrowserView.handleAudioStateChanged': lazy('ElectronBrowserView.handleAudioStateChanged'),
   'ElectronBrowserView.handleContextMenu': lazy('ElectronBrowserView.handleContextMenu'),
   'ElectronBrowserView.handleDidNavigate': lazy('ElectronBrowserView.handleDidNavigate'),
   'ElectronBrowserView.handlePageFaviconUpdated': lazy('ElectronBrowserView.handlePageFaviconUpdated'),

--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
@@ -3,6 +3,7 @@ import * as ElectronBrowserView from './ElectronBrowserView.js'
 export const name = 'ElectronBrowserView'
 
 export const Commands = {
+  handleAudioStateChanged: ElectronBrowserView.handleAudioStateChanged,
   handleContextMenu: ElectronBrowserView.handleContextMenu,
   handleDidNavigate: ElectronBrowserView.handleDidNavigate,
   handleKeyBinding: ElectronBrowserView.handleKeyBinding,

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -22,7 +22,8 @@ test('registers the simple browser suggestion event bridge commands', () => {
   expect(commandMap['SimpleBrowser.closeSuggestions']).toBeDefined()
 })
 
-test('registers the simple browser favicon event bridge command', () => {
+test('registers the simple browser event bridge commands', () => {
+  expect(commandMap['ElectronBrowserView.handleAudioStateChanged']).toBeDefined()
   expect(commandMap['ElectronBrowserView.handleContextMenu']).toBeDefined()
   expect(commandMap['ElectronBrowserView.handlePageFaviconUpdated']).toBeDefined()
   expect(commandMap['ElectronBrowserView.handleWindowOpen']).toBeDefined()

--- a/packages/renderer-worker/test/ElectronBrowserView.test.ts
+++ b/packages/renderer-worker/test/ElectronBrowserView.test.ts
@@ -15,7 +15,21 @@ jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
 
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const ElectronBrowserView = await import('../src/parts/ElectronBrowserView/ElectronBrowserView.js')
+const ElectronBrowserViewIpc = await import('../src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js')
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+
+test('registers the audio state handler with the IPC module', () => {
+  expect(ElectronBrowserViewIpc.Commands.handleAudioStateChanged).toBe(ElectronBrowserView.handleAudioStateChanged)
+})
+
+test('forwards web contents audio state changes through the global event bus', () => {
+  const listener = jest.fn()
+  GlobalEventBus.addListener('browser-view-audio-state-changed', listener)
+
+  ElectronBrowserView.handleAudioStateChanged(12, true)
+
+  expect(listener).toHaveBeenCalledWith(12, true)
+})
 
 test('forwards web contents keybindings through the global event bus', async () => {
   const listener = jest.fn()


### PR DESCRIPTION
## Summary
- register the Simple Browser audio-state event in the renderer command map
- expose the handler from the Electron browser view IPC module
- cover both registrations and the global-event relay with unit tests

## Tests
- `npm test -- --runInBand test/CommandMap.test.ts test/ElectronBrowserView.test.ts`
- `npm run type-check`
- targeted ESLint for changed source files