### PR TITLE
feature: add simple browser audio indicator setting

### DIFF
--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -141,6 +141,14 @@
   },
   {
     "category": "features",
+    "description": "Controls whether tabs playing audio show an audio indicator in the simple browser",
+    "heading": "Simple Browser Audio Indicator",
+    "id": "simpleBrowser.audioIndicator.enabled",
+    "type": 3,
+    "value": true
+  },
+  {
+    "category": "features",
     "description": "Shows search suggestions in the simple browser",
     "heading": "Simple Browser Suggestions",
     "id": "simpleBrowser.suggestions",

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -17,6 +17,7 @@ export const getSimpleBrowserVirtualDom = (
   tabs = [],
   selectedTabIndex = 0,
   tabsEnabled = true,
+  audioIndicatorEnabled = true,
 ) => {
   /** @type {any[]} */
   const dom = [
@@ -47,7 +48,7 @@ export const getSimpleBrowserVirtualDom = (
         onClick: DomEventListenerFunctions.HandleClickSimpleBrowserTab,
         onContextMenu: DomEventListenerFunctions.HandleContextMenuSimpleBrowserTab,
         title: tab.title || 'New Tab',
-        childCount: 2 + (tab.favicon ? 1 : 0) + (tab.isAudioPlaying ? 1 : 0),
+        childCount: 2 + (tab.favicon ? 1 : 0) + (audioIndicatorEnabled && tab.isAudioPlaying ? 1 : 0),
       })
       if (tab.favicon) {
         dom.push({
@@ -67,7 +68,7 @@ export const getSimpleBrowserVirtualDom = (
         },
         text(tab.title || 'New Tab'),
       )
-      if (tab.isAudioPlaying) {
+      if (audioIndicatorEnabled && tab.isAudioPlaying) {
         dom.push(
           {
             type: VirtualDomElements.Span,

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -119,6 +119,7 @@ export const create = (id, uri, x, y, width, height) => {
     suggestionsEnabled: false,
     shortcuts: [],
     tabs: [],
+    audioIndicatorEnabled: true,
     tabsEnabled: true,
     selectedTabIndex: 0,
     zoomLevel: 0,
@@ -144,6 +145,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   const { x, y, width, height } = state
   const iframeSrc = getUrlFromSavedState(savedState)
   const shortcuts = SimpleBrowserPreferences.getShortCuts()
+  const audioIndicatorEnabled = Preferences.get('simpleBrowser.audioIndicator.enabled') !== false
   const suggestionsEnabled = Preferences.get('simpleBrowser.suggestions')
   const tabsEnabled = Preferences.get('simpleBrowser.tabs.enabled') !== false
   const headerHeight = getHeaderHeight(tabsEnabled)
@@ -160,6 +162,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   const tabs = [createTab({ browserViewId, iframeSrc, inputValue: iframeSrc, title })]
   return {
     browserViewId,
+    audioIndicatorEnabled,
     headerHeight,
     selectedTabIndex: 0,
     tabs,
@@ -188,6 +191,7 @@ export const loadContent = async (state, savedState) => {
   const iframeSrc = getUrlFromSavedState(savedState)
   // TODO load keybindings in parallel with creating browserview
   const keyBindings = await KeyBindingsInitial.getKeyBindings()
+  const audioIndicatorEnabled = Preferences.get('simpleBrowser.audioIndicator.enabled') !== false
   const suggestionsEnabled = Preferences.get('simpleBrowser.suggestions')
   const tabsEnabled = Preferences.get('simpleBrowser.tabs.enabled') !== false
   const headerHeight = getHeaderHeight(tabsEnabled)
@@ -218,6 +222,7 @@ export const loadContent = async (state, savedState) => {
     })
     return {
       ...state,
+      audioIndicatorEnabled,
       browserViewId: actualId,
       iframeSrc,
       inputValue: iframeSrc,
@@ -242,6 +247,7 @@ export const loadContent = async (state, savedState) => {
   const { title, canGoBack, canGoForward, isAudioMuted } = await ElectronWebContentsViewFunctions.getStats(browserViewId)
   return {
     ...state,
+    audioIndicatorEnabled,
     iframeSrc,
     inputValue: iframeSrc,
     title,

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -64,6 +64,7 @@ const getDom = (state) => {
     state.tabs,
     state.selectedTabIndex,
     state.tabsEnabled,
+    state.audioIndicatorEnabled,
   )
 }
 
@@ -79,6 +80,7 @@ const renderDom = {
       oldState.selectedSuggestionIndex === newState.selectedSuggestionIndex &&
       oldState.selectedTabIndex === newState.selectedTabIndex &&
       oldState.tabsEnabled === newState.tabsEnabled &&
+      oldState.audioIndicatorEnabled === newState.audioIndicatorEnabled &&
       areTabsEqual(oldState.tabs, newState.tabs)
     )
   },

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -95,6 +95,24 @@ test('omits the audio icon for a silent tab', () => {
   expect(dom).not.toContainEqual(expect.objectContaining({ className: 'SimpleBrowserTabAudio' }))
 })
 
+test('omits the audio icon when the audio indicator is disabled', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(
+    false,
+    false,
+    false,
+    '',
+    '',
+    [],
+    -1,
+    [{ favicon: '', isAudioPlaying: true, title: 'Example' }],
+    0,
+    true,
+    false,
+  )
+
+  expect(dom).not.toContainEqual(expect.objectContaining({ className: 'SimpleBrowserTabAudio' }))
+})
+
 test('omits the tab strip when tabs are disabled', () => {
   const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, '', '', [], -1, [], 0, false)
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -183,10 +183,25 @@ test('loadContent', async () => {
   ElectronWebContentsViewFunctions.setIframeSrc.mockImplementation(() => {})
   const state = ViewletSimpleBrowser.create(0, 'simple-browser://', 0, 0, 0, 0)
   expect(await ViewletSimpleBrowser.loadContent(state)).toMatchObject({
+    audioIndicatorEnabled: true,
     headerHeight: 65,
     iframeSrc: 'https://example.com',
     tabsEnabled: true,
   })
+})
+
+test('loadContent disables the audio indicator through simpleBrowser.audioIndicator.enabled', async () => {
+  Preferences.state['simpleBrowser.audioIndicator.enabled'] = false
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(1)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = ViewletSimpleBrowser.create(0, 'simple-browser://', 0, 0, 300, 200)
+
+  const newState = await ViewletSimpleBrowser.loadContent(state)
+
+  expect(newState).toMatchObject({ audioIndicatorEnabled: false })
+  delete Preferences.state['simpleBrowser.audioIndicator.enabled']
 })
 
 test('loadContent disables the tab strip through simpleBrowser.tabs.enabled', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -33,6 +33,19 @@ test('rerenders when suggestions change', () => {
   expect(ViewletSimpleBrowserRender.render[0].isEqual(state, newState)).toBe(false)
 })
 
+test('rerenders when the audio indicator setting changes', () => {
+  const oldState = {
+    ...state,
+    audioIndicatorEnabled: true,
+  }
+  const newState = {
+    ...state,
+    audioIndicatorEnabled: false,
+  }
+
+  expect(ViewletSimpleBrowserRender.render[0].isEqual(oldState, newState)).toBe(false)
+})
+
 test('renders suggestions incrementally and restores address input focus', () => {
   const newState = {
     ...state,

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -51,6 +51,7 @@
 
   "sessionReplay.enabled": false,
 
+  "simpleBrowser.audioIndicator.enabled": true,
   "simpleBrowser.suggestions": false,
   "simpleBrowser.shortcuts": [],
   "simpleBrowser.tabs.enabled": true,


### PR DESCRIPTION
Adds `simpleBrowser.audioIndicator.enabled` to control whether audible tabs show the audio indicator.

The setting defaults to enabled and only gates rendering; audible tab state continues to be tracked.