### PR TITLE
fix: update focus when activating terminals

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -1,5 +1,6 @@
 import * as Assert from '../Assert/Assert.ts'
 import * as Command from '../Command/Command.js'
+import * as Focus from '../Focus/Focus.js'
 import * as GetTerminalSpawnOptions from '../GetTerminalSpawnOptions/GetTerminalSpawnOptions.js'
 import * as Id from '../Id/Id.js'
 import * as Preferences from '../Preferences/Preferences.js'
@@ -7,6 +8,7 @@ import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import * as WhenExpression from '../WhenExpression/WhenExpression.js'
 
 export const create = (id, uri, x, y, width, height) => {
   Assert.number(id)
@@ -225,6 +227,7 @@ export const handleMouseDown = (state, childUid) => {
   if (!childUids.includes(childUid)) {
     return state
   }
+  Focus.setFocus(WhenExpression.FocusTerminal)
   return {
     ...state,
     activeTerminalUids: activeTerminalUids.with(selectedIndex, childUid),
@@ -376,6 +379,7 @@ export const focus = (state) => {
   if (childUid === -1) {
     return state
   }
+  Focus.setFocus(WhenExpression.FocusTerminal)
   return {
     ...state,
     focusVersion: focusVersion + 1,

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const commandExecute = jest.fn()
+const focusSetFocus = jest.fn()
 const rendererProcessInvoke = jest.fn()
 const viewletDisposeFunctional = jest.fn((uid) => [['Viewlet.dispose', uid]])
 const viewletExecuteViewletCommand = jest.fn()
@@ -34,6 +35,12 @@ jest.unstable_mockModule('../src/parts/Id/Id.js', () => {
     create() {
       return nextId++
     },
+  }
+})
+
+jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => {
+  return {
+    setFocus: focusSetFocus,
   }
 })
 
@@ -81,6 +88,7 @@ const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModule
 const ViewletTerminals = await import('../src/parts/ViewletTerminals/ViewletTerminals.js')
 const ViewletTerminalsRender = await import('../src/parts/ViewletTerminals/ViewletTerminalsRender.js')
 const ViewletTerminalsRenderActions = await import('../src/parts/ViewletTerminals/ViewletTerminalsRenderActions.js')
+const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
 
 const createLoadedState = () => {
   return {
@@ -356,6 +364,7 @@ test('handleMouseDown selects and focuses the terminal the user pressed', () => 
     childUid: 41,
     focusVersion: 1,
   })
+  expect(focusSetFocus).toHaveBeenCalledWith(WhenExpression.FocusTerminal)
   expect(ViewletTerminalsRender.renderFocus.apply(state, newState)).toEqual([['Viewlet.focus', 41]])
 })
 
@@ -369,6 +378,7 @@ test('handleMouseDown focuses an already active terminal', () => {
     childUid: 41,
     focusVersion: 1,
   })
+  expect(focusSetFocus).toHaveBeenCalledWith(WhenExpression.FocusTerminal)
   expect(ViewletTerminalsRender.renderFocus.apply(state, newState)).toEqual([['Viewlet.focus', 41]])
 })
 
@@ -621,6 +631,7 @@ test('focus eventually focuses the active xterm child', () => {
   const newState = ViewletTerminals.focus(state)
 
   expect(newState.focusVersion).toBe(1)
+  expect(focusSetFocus).toHaveBeenCalledWith(WhenExpression.FocusTerminal)
   expect(ViewletTerminalsRender.renderFocus.isEqual(state, newState)).toBe(false)
   expect(ViewletTerminalsRender.renderFocus.apply(state, newState)).toEqual([['Viewlet.focus', 41]])
 })
@@ -629,4 +640,5 @@ test('focus does nothing when there are no terminal instances', () => {
   const state = ViewletTerminals.create(1, '', 10, 20, 800, 400)
 
   expect(ViewletTerminals.focus(state)).toBe(state)
+  expect(focusSetFocus).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
## Problem

Activating the terminal panel or pressing an xterm focuses its DOM input, but the renderer-worker focus context can remain Explorer. Explorer-only keybindings may then run while the user types in the terminal.

## Change

Set `FocusTerminal` whenever the terminals view focuses its active child or handles a valid terminal mousedown.

## Tests

- Added focus-context assertions for terminal focus and mousedown
- 375 renderer-worker suites / 1,727 tests passed
- Renderer-worker type-check passed
- Validated `echo shortcutpass`, `echo mousepass`, and `echo aftersettle` in the real Electron UI with Explorer expanded

Note: the package-local `xo` script reports the repository-wide existing XO/style mismatch (114,255 findings); the changed files pass `git diff --check`.