### PR TITLE
fix: keep cookie importer tab title

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.cookie-import-view-command.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.cookie-import-view-command.ts
@@ -8,5 +8,7 @@ export const test: Test = async ({ expect, Locator, QuickPick }) => {
   await QuickPick.selectItem('Simple Browser: Import Cookies from Firefox')
 
   await expect(Locator('.CookieImportView')).toBeVisible()
-  await expect(Locator('.MainTab[title="Import Firefox Cookies"]')).toBeVisible()
+  const tab = Locator('.MainTab[title="cookie-import-view:///"]')
+  await expect(tab).toBeVisible()
+  await expect(tab.locator('.TabTitle')).toHaveText('Import Firefox Cookies')
 }

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -38,7 +38,6 @@
     "hotReloadCommand": "",
     "viewlet": {
       "name": "CookieImportView",
-      "title": "Cookie Import",
       "css": ["/css/parts/Button.css", "/css/parts/InputBox.css", "/css/parts/ViewletCookieImport.css"],
       "state": { "idKey": "uid", "fields": ["uri", "x", "y", "width", "height"] },
       "commandPrefix": "CookieImportView",

--- a/packages/renderer-worker/test/Workers.test.ts
+++ b/packages/renderer-worker/test/Workers.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@jest/globals'
+import * as Workers from '../src/parts/Workers/Workers.js'
+
+test('cookie import view should let the main area own its tab title', () => {
+  const worker = Workers.getWorkers().find(({ id }) => id === 'cookieImportView')
+
+  expect(worker).toBeDefined()
+  expect(worker?.viewlet?.title).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

- let main-area URI metadata own the cookie importer tab title
- assert the worker configuration does not overwrite that title
- make the command-palette e2e verify the rendered tab text

## Validation

- renderer-worker tests passed
- all TypeScript projects passed
- lint passed

Part of the cookie importer test-and-fix pass.