### PR TITLE
Increase Simple Browser favicon spacing

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -84,6 +84,29 @@ test('bundleCss strictly contains the simple browser snapshot wrapper', async ()
   }
 }, 30_000)
 
+test('bundleCss keeps extra space between the simple browser favicon and tab title', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletSimpleBrowser.css'), 'utf8')
+
+    expect(css).toContain(`.SimpleBrowserTabFavicon {
+  flex: 0 0 16px;
+  height: 16px;
+  margin-inline-end: 2px;
+  object-fit: contain;
+  width: 16px;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss keeps the preview sash transparent', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -60,6 +60,7 @@
 .SimpleBrowserTabFavicon {
   flex: 0 0 16px;
   height: 16px;
+  margin-inline-end: 2px;
   object-fit: contain;
   width: 16px;
 }


### PR DESCRIPTION
Increase the spacing between each Simple Browser tab favicon and its label without changing the spacing of the other tab controls. Add CSS bundle coverage for the favicon spacing rule.