### PR TITLE
feature: fade long simple browser tab labels

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -84,6 +84,29 @@ test('bundleCss strictly contains the simple browser snapshot wrapper', async ()
   }
 }, 30_000)
 
+test('bundleCss fades overflowing simple browser tab titles', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletSimpleBrowser.css'), 'utf8')
+
+    expect(css).toContain(`.SimpleBrowserTabTitle {
+  flex: 1;
+  mask-image: linear-gradient(to right, black calc(100% - 12px), transparent);
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss keeps the preview sash transparent', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -72,9 +72,9 @@
 
 .SimpleBrowserTabTitle {
   flex: 1;
+  mask-image: linear-gradient(to right, black calc(100% - 12px), transparent);
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Fade overflowing Simple Browser tab labels at the right edge instead of showing an ellipsis. Short labels remain fully visible.