### PR TITLE
fix: clear problems summary on workspace change

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2656,7 +2656,7 @@ export const refreshProblemsSummary = async (state: LayoutState): Promise<Layout
   }
 }
 
-const clearProblemsSummary = (state: LayoutState): Promise<LayoutStateResult> => {
+export const clearProblemsSummary = (state: LayoutState): Promise<LayoutStateResult> => {
   return callGlobalEvent(state, 'handleProblemsSummaryChange', {
     errorCount: 0,
     hasEditor: false,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -25,6 +25,7 @@ export const Commands = {
 
 export const CommandsWithSideEffects = {
   attachViewlet: ViewletLayout.attachViewlet,
+  clearProblemsSummary: ViewletLayout.clearProblemsSummary,
   handleActiveEditorChange: ViewletLayout.handleActiveEditorChange,
   handleBadgeCountChange: ViewletLayout.handleBadgeCountChange,
   handleColorThemeChanged: ViewletLayout.handleColorThemeChanged,

--- a/packages/renderer-worker/src/parts/WrapProblemsCommand/WrapProblemsCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapProblemsCommand/WrapProblemsCommand.ts
@@ -1,9 +1,11 @@
+import * as Command from '../Command/Command.js'
 import * as NameAnonymousFunction from '../NameAnonymousFunction/NameAnonymousFunction.js'
 import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
 interface ProblemsCommandDependencies {
+  readonly clearProblemsSummary?: () => Promise<unknown>
   readonly getState: () => ProblemsViewState
   readonly invoke: (command: string, ...args: readonly unknown[]) => Promise<unknown>
 }
@@ -17,6 +19,7 @@ interface ProblemsViewState {
 type ProblemsCommand = (state: ProblemsViewState, ...args: readonly unknown[]) => Promise<ProblemsViewState>
 
 const defaultDependencies: ProblemsCommandDependencies = {
+  clearProblemsSummary: () => Command.execute('Layout.clearProblemsSummary'),
   getState: () => ViewletStates.getState(ViewletModuleId.Problems) as ProblemsViewState,
   invoke: ProblemsWorker.invoke,
 }
@@ -26,10 +29,13 @@ const areActionsEqual = (oldActionsDom: readonly unknown[] | undefined, newActio
 }
 
 export const wrapProblemsCommandWithDependencies = (key: string, dependencies: ProblemsCommandDependencies): ProblemsCommand => {
-  const { getState, invoke } = dependencies
+  const { clearProblemsSummary = async () => {}, getState, invoke } = dependencies
   const fn: ProblemsCommand = async (state, ...args) => {
     const { actionsDom: oldActionsDom, uid } = state
     await invoke(`Problems.${key}`, uid, ...args)
+    if (key === 'handleWorkspaceChange') {
+      await clearProblemsSummary()
+    }
     const diffResult = (await invoke('Problems.diff2', uid)) as readonly unknown[]
     const actionsDom = (await invoke('Problems.renderActions', uid)) as readonly unknown[]
     const actionsChanged = !areActionsEqual(oldActionsDom, actionsDom)

--- a/packages/renderer-worker/test/WrapProblemsCommand.test.ts
+++ b/packages/renderer-worker/test/WrapProblemsCommand.test.ts
@@ -72,3 +72,27 @@ test('preserves state when neither body nor actions changed', async () => {
 
   expect(result).toBe(state)
 })
+
+test('clears the problems summary when the workspace changes', async () => {
+  const actionsDom = [{ title: 'View as Table' }]
+  const state = { actionsDom, uid: 7 }
+  const clearProblemsSummary = jest.fn(async () => {})
+  const invoke = jest.fn(async (command: string, ..._args: readonly unknown[]): Promise<unknown> => {
+    if (command === 'Problems.diff2') {
+      return []
+    }
+    if (command === 'Problems.renderActions') {
+      return actionsDom
+    }
+    return undefined
+  })
+  const command = wrapProblemsCommandWithDependencies('handleWorkspaceChange', {
+    clearProblemsSummary,
+    getState: () => state,
+    invoke,
+  })
+
+  await command(state, '/new-workspace')
+
+  expect(clearProblemsSummary).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Clears the Problems panel badge and status-bar summary when the Problems view handles a workspace change.