### PR TITLE
fix: fill cookie import editor

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.cookie-import-view-open.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.cookie-import-view-open.ts
@@ -9,6 +9,7 @@ export const test: Test = async ({ Command, expect, Locator }) => {
 
   const root = Locator('.CookieImportView')
   await expect(root).toBeVisible()
+  await expect(root).toHaveCSS('flex-grow', '1')
   await expect(root.locator('h1')).toHaveText('Import Firefox Cookies')
   await expect(root.locator('#CookieImportBrowser')).toHaveValue('Firefox')
   await expect(root.locator('#CookieImportProfile')).toHaveValue('Default profile')

--- a/static/css/parts/ViewletCookieImport.css
+++ b/static/css/parts/ViewletCookieImport.css
@@ -2,6 +2,7 @@
   align-items: center;
   box-sizing: border-box;
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 24px;
   overflow: auto;


### PR DESCRIPTION
## Summary

- let the cookie importer consume the full editor container
- cover its flex layout with an end-to-end computed-style assertion

## Tests

- `npm run type-check`
- `npm run lint`
- `PATH_PREFIX=/lvce-editor npm run build:static:ignore-icon-theme`
- `PLAYWRIGHT_BROWSERS_PATH=0 node src/_all.js --headless --test-name-prefix=viewlet.cookie-import-view-open`
- `npx lerna run test --since origin/main`