### PR TITLE
feature: syntax highlight error code frames

### DIFF
--- a/packages/renderer-worker/src/parts/GetTokenizePath/GetTokenizePath.js
+++ b/packages/renderer-worker/src/parts/GetTokenizePath/GetTokenizePath.js
@@ -1,6 +1,6 @@
-import * as Languages from '../Languages/Languages.js'
+import * as LanguagesState from '../LanguagesState/LanguagesState.js'
 
 export const getTokenizePath = (languageId) => {
-  const tokenizePath = Languages.getTokenizeFunctionPath(languageId)
+  const tokenizePath = LanguagesState.getTokenizeFunctionPath(languageId)
   return tokenizePath
 }

--- a/packages/renderer-worker/src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js
+++ b/packages/renderer-worker/src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js
@@ -4,7 +4,7 @@ const isNonEmptyString = (value) => {
   return typeof value === 'string' && value.length > 0
 }
 
-const getMessage = (error) => {
+export const getViewletErrorTitle = (error) => {
   if (error?.type && error?.message) {
     const prefix = `${error.type}: `
     return error.message.startsWith(prefix) ? error.message : `${prefix}${error.message}`
@@ -13,6 +13,6 @@ const getMessage = (error) => {
 }
 
 export const getViewletErrorMessage = (error) => {
-  const message = getMessage(error)
+  const message = getViewletErrorTitle(error)
   return [message, error?.codeFrame, error?.stack].filter(isNonEmptyString).join('\n\n')
 }

--- a/packages/renderer-worker/src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js
@@ -1,0 +1,24 @@
+import * as GetViewletErrorMessage from '../GetViewletErrorMessage/GetViewletErrorMessage.js'
+import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
+import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
+
+const getTextSectionDom = (value, className, type = VirtualDomElements.Div) => {
+  if (typeof value !== 'string' || !value) {
+    return []
+  }
+  return [
+    {
+      childCount: 1,
+      className,
+      type,
+    },
+    text(value),
+  ]
+}
+
+export const getViewletErrorVirtualDom = (error) => {
+  const messageDom = getTextSectionDom(GetViewletErrorMessage.getViewletErrorTitle(error), 'ViewletErrorMessage')
+  const codeFrameDom = Array.isArray(error?.syntaxHighlightedCodeFrame) ? error.syntaxHighlightedCodeFrame : []
+  const stackDom = getTextSectionDom(error?.stack, 'ViewletErrorStack', VirtualDomElements.Pre)
+  return [...messageDom, ...codeFrameDom, ...stackDom]
+}

--- a/packages/renderer-worker/src/parts/LanguagesState/LanguagesState.js
+++ b/packages/renderer-worker/src/parts/LanguagesState/LanguagesState.js
@@ -1,20 +1,3 @@
-// TODO merge all of this with extension host languages module
-
-// @ts-ignore
-import * as Assert from '../Assert/Assert.ts'
-// @ts-ignore
-import * as CodeFrameColumns from '../CodeFrameColumns/CodeFrameColumns.js'
-// @ts-ignore
-import * as ExtensionHostLanguages from '../ExtensionHost/ExtensionHostLanguages.js'
-// @ts-ignore
-import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
-// @ts-ignore
-import * as Logger from '../Logger/Logger.js'
-// @ts-ignore
-import * as Preferences from '../Preferences/Preferences.js'
-// @ts-ignore
-import * as SplitLines from '../SplitLines/SplitLines.js'
-
 export const state = {
   loadState: false,
   isHydrating: false,

--- a/packages/renderer-worker/src/parts/PrettyError/PrettyError.js
+++ b/packages/renderer-worker/src/parts/PrettyError/PrettyError.js
@@ -1,4 +1,5 @@
 import * as ErrorWorker from '../ErrorWorker/ErrorWorker.ts'
+import * as GetTokenizePath from '../GetTokenizePath/GetTokenizePath.js'
 
 const serializeError = (error) => {
   if (!error) {
@@ -19,7 +20,8 @@ const serializeError = (error) => {
 export const prepare = async (error) => {
   try {
     const serialized = serializeError(error)
-    const prepared = await ErrorWorker.invoke('Errors.prepare', serialized)
+    const tokenizerPath = GetTokenizePath.getTokenizePath('javascript')
+    const prepared = await ErrorWorker.invoke('Errors.prepare', serialized, { tokenizerPath })
     return prepared
   } catch {
     return error

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -5,6 +5,7 @@ import * as ErrorHandling from '../ErrorHandling/ErrorHandling.js'
 import { CancelationError } from '../Errors/CancelationError.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as GetViewletErrorMessage from '../GetViewletErrorMessage/GetViewletErrorMessage.js'
+import * as GetViewletErrorVirtualDom from '../GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js'
 import * as Id from '../Id/Id.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 import * as LayoutWidgets from '../LayoutWidgets/LayoutWidgets.ts'
@@ -845,7 +846,12 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
         // TODO
         // const errorCommands=
       } else {
-        commands.push(['Viewlet.send', /* id */ viewletUid, 'setMessage', message])
+        if (Array.isArray(prettyError?.syntaxHighlightedCodeFrame) && prettyError.syntaxHighlightedCodeFrame.length > 0) {
+          const dom = GetViewletErrorVirtualDom.getViewletErrorVirtualDom(prettyError)
+          commands.push(['Viewlet.setDom2', viewletUid, dom])
+        } else {
+          commands.push(['Viewlet.send', /* id */ viewletUid, 'setMessage', message])
+        }
         // @ts-ignore
         if (viewlet.append) {
           commands.push([kAppend, parentUid, viewletUid])

--- a/packages/renderer-worker/test/GetViewletErrorVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetViewletErrorVirtualDom.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@jest/globals'
+import { getViewletErrorVirtualDom } from '../src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
+
+test('getViewletErrorVirtualDom', () => {
+  const syntaxHighlightedCodeFrame = [
+    {
+      childCount: 1,
+      className: 'SyntaxHighlightedCodeFrame',
+      type: VirtualDomElements.Pre,
+    },
+    {
+      childCount: 0,
+      text: 'const value = 1',
+      type: VirtualDomElements.Text,
+    },
+  ]
+
+  expect(
+    getViewletErrorVirtualDom({
+      message: 'Oops',
+      stack: '    at test.js:1:1',
+      syntaxHighlightedCodeFrame,
+      type: 'TypeError',
+    }),
+  ).toEqual([
+    {
+      childCount: 1,
+      className: 'ViewletErrorMessage',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 0,
+      text: 'TypeError: Oops',
+      type: VirtualDomElements.Text,
+    },
+    ...syntaxHighlightedCodeFrame,
+    {
+      childCount: 1,
+      className: 'ViewletErrorStack',
+      type: VirtualDomElements.Pre,
+    },
+    {
+      childCount: 0,
+      text: '    at test.js:1:1',
+      type: VirtualDomElements.Text,
+    },
+  ])
+})

--- a/packages/renderer-worker/test/PrettyError.test.ts
+++ b/packages/renderer-worker/test/PrettyError.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable jest/no-restricted-jest-methods -- Error preparation tests use ESM module mocks for worker dependencies. */
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
+const getTokenizePath = jest.fn<(languageId: string) => string>(() => '/tokenize-javascript.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  getTokenizePath.mockReturnValue('/tokenize-javascript.js')
+})
+
+jest.unstable_mockModule('../src/parts/ErrorWorker/ErrorWorker.ts', () => ({
+  invoke,
+}))
+
+jest.unstable_mockModule('../src/parts/GetTokenizePath/GetTokenizePath.js', () => ({
+  getTokenizePath,
+}))
+
+const PrettyError = await import('../src/parts/PrettyError/PrettyError.js')
+
+test('prepare passes the javascript tokenizer path to the error worker', async () => {
+  const error = new TypeError('Oops')
+  const prepared = {
+    message: 'TypeError: Oops',
+    syntaxHighlightedCodeFrame: [],
+  }
+  invoke.mockResolvedValue(prepared)
+
+  expect(await PrettyError.prepare(error)).toBe(prepared)
+  expect(getTokenizePath).toHaveBeenCalledWith('javascript')
+  expect(invoke).toHaveBeenCalledWith(
+    'Errors.prepare',
+    {
+      code: undefined,
+      codeFrame: undefined,
+      constructor: {
+        name: 'TypeError',
+      },
+      message: 'Oops',
+      name: 'TypeError',
+      stack: error.stack,
+    },
+    {
+      tokenizerPath: '/tokenize-javascript.js',
+    },
+  )
+})
+
+test('prepare returns the original error when preparation fails', async () => {
+  const error = new Error('Oops')
+  invoke.mockRejectedValue(new Error('Worker failed'))
+
+  expect(await PrettyError.prepare(error)).toBe(error)
+})

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { CancelationError } from '../src/parts/Errors/CancelationError.js'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
 import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
 
 beforeEach(() => {
@@ -35,6 +36,7 @@ jest.unstable_mockModule('../src/parts/PrettyError/PrettyError.js', () => {
       codeFrame: error.codeFrame || '',
       message: error.message,
       stack: '    at treeToArray (editorWorkerMain.js:10:8)',
+      syntaxHighlightedCodeFrame: error.syntaxHighlightedCodeFrame,
       type: error.name,
     }),
     getMessage: (error: any) => `${error.type}: ${error.message}`,
@@ -941,6 +943,79 @@ test('load - custom error renderer preserves the original error and does not app
     ['Viewlet.create', 'Error', 42],
     ['Viewlet.create', 'EditorTextError', 42],
     ['Viewlet.setDom2', 42, errorDom],
+  ])
+})
+
+test('load - renders a syntax highlighted generic error', async () => {
+  // @ts-ignore
+  RendererProcess.invoke.mockResolvedValue(undefined)
+  const syntaxHighlightedCodeFrame = [
+    {
+      childCount: 1,
+      className: 'SyntaxHighlightedCodeFrame',
+      type: VirtualDomElements.Pre,
+    },
+    {
+      childCount: 0,
+      text: 'throw error',
+      type: VirtualDomElements.Text,
+    },
+  ]
+  const error = new TypeError('Oops')
+  // @ts-ignore
+  error.syntaxHighlightedCodeFrame = syntaxHighlightedCodeFrame
+  const getModule = async () => ({
+    create() {
+      return { uid: 42 }
+    },
+    loadContent() {
+      throw error
+    },
+  })
+  const viewlet = {
+    append: false,
+    disposed: false,
+    getModule,
+    id: 'VideoPreview',
+    parentUid: -1,
+    setBounds: false,
+    show: false,
+    type: 0,
+    uid: 42,
+    uri: 'test://video.mp4',
+  }
+
+  const commands = await ViewletManager.load(viewlet)
+
+  expect(commands).toEqual([
+    ['Viewlet.create', 'Error', 42],
+    [
+      'Viewlet.setDom2',
+      42,
+      [
+        {
+          childCount: 1,
+          className: 'ViewletErrorMessage',
+          type: VirtualDomElements.Div,
+        },
+        {
+          childCount: 0,
+          text: 'TypeError: Oops',
+          type: VirtualDomElements.Text,
+        },
+        ...syntaxHighlightedCodeFrame,
+        {
+          childCount: 1,
+          className: 'ViewletErrorStack',
+          type: VirtualDomElements.Pre,
+        },
+        {
+          childCount: 0,
+          text: '    at treeToArray (editorWorkerMain.js:10:8)',
+          type: VirtualDomElements.Text,
+        },
+      ],
+    ],
   ])
 })
 

--- a/static/css/parts/Viewlet.css
+++ b/static/css/parts/Viewlet.css
@@ -15,3 +15,14 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+.ViewletErrorMessage,
+.ViewletErrorStack,
+.SyntaxHighlightedCodeFrame {
+  margin: 0;
+}
+
+.SyntaxHighlightedCodeFrame {
+  margin-block: 1rem;
+  white-space: pre;
+}


### PR DESCRIPTION
Render source-mapped error code frames as syntax-highlighted virtual DOM using the existing JavaScript tokenizer worker. Preserve plain-text error rendering as a best-effort fallback when preparation or tokenization fails.