### PR TITLE
fix: preserve highlighted error view root

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.view-error-syntax-highlighting/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.view-error-syntax-highlighting/extension.json
@@ -1,0 +1,17 @@
+{
+  "id": "sample.view-error-syntax-highlighting",
+  "name": "Error Syntax Highlighting",
+  "description": "Throws while creating a virtual DOM view",
+  "version": "1.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onView:sample.view-error-syntax-highlighting"],
+  "views": [
+    {
+      "id": "sample.view-error-syntax-highlighting",
+      "title": "Error Syntax Highlighting",
+      "icon": "symbol-keyword",
+      "kind": "virtualDom"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.view-error-syntax-highlighting/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.view-error-syntax-highlighting/main.js
@@ -1,4 +1,7 @@
-const { WebWorkerRpcClient } = await import('/static/js/lvce-editor-rpc.js')
+const currentUrl = new URL(import.meta.url)
+const packagesIndex = currentUrl.pathname.indexOf('/packages/')
+const assetDir = currentUrl.pathname.startsWith('/remote/') ? '/static' : currentUrl.pathname.slice(0, packagesIndex)
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
 
 const view = {
   icon: 'symbol-keyword',

--- a/packages/extension-host-worker-tests/fixtures/sample.view-error-syntax-highlighting/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.view-error-syntax-highlighting/main.js
@@ -1,0 +1,30 @@
+const { WebWorkerRpcClient } = await import('/static/js/lvce-editor-rpc.js')
+
+const view = {
+  icon: 'symbol-keyword',
+  id: 'sample.view-error-syntax-highlighting',
+  kind: 'virtualDom',
+  title: 'Error Syntax Highlighting',
+}
+
+const commandMap = {
+  'ExtensionApi.createViewInstance'() {
+    throw new Error('Synthetic view creation failure')
+  },
+  'ExtensionApi.getStatusBarItems'() {
+    return []
+  },
+  'ExtensionApi.getViewActions'() {
+    return []
+  },
+  'ExtensionApi.getViewMenuEntries'() {
+    return []
+  },
+  'ExtensionApi.getViewRegistrySnapshot'() {
+    return {
+      views: [view],
+    }
+  },
+}
+
+await WebWorkerRpcClient.create({ commandMap })

--- a/packages/extension-host-worker-tests/src/viewlet.error-syntax-highlighting.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.error-syntax-highlighting.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.error-syntax-highlighting'
+
+export const test: Test = async ({ ActivityBar, expect, Extension, Locator }) => {
+  await Extension.addWebExtension(new URL('../fixtures/sample.view-error-syntax-highlighting/', import.meta.url).href)
+  await ActivityBar.handleExtensionsChanged()
+
+  const activityBarItem = Locator('.ActivityBarItem[title="Error Syntax Highlighting"]')
+  await expect(activityBarItem).toBeVisible()
+  await activityBarItem.click()
+
+  await expect(Locator('.Viewlet.Error')).toBeVisible()
+  const codeFrame = Locator('.Viewlet.Error .SyntaxHighlightedCodeFrame')
+  await expect(codeFrame).toBeVisible()
+  await expect(codeFrame).toContainText("throw new Error('Synthetic view creation failure')")
+  await expect(codeFrame.locator('.Token').first()).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js
@@ -1,4 +1,5 @@
 import * as GetViewletErrorMessage from '../GetViewletErrorMessage/GetViewletErrorMessage.js'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.js'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
 
@@ -20,5 +21,13 @@ export const getViewletErrorVirtualDom = (error) => {
   const messageDom = getTextSectionDom(GetViewletErrorMessage.getViewletErrorTitle(error), 'ViewletErrorMessage')
   const codeFrameDom = Array.isArray(error?.syntaxHighlightedCodeFrame) ? error.syntaxHighlightedCodeFrame : []
   const stackDom = getTextSectionDom(error?.stack, 'ViewletErrorStack', VirtualDomElements.Pre)
-  return [...messageDom, ...codeFrameDom, ...stackDom]
+  const sections = [messageDom, codeFrameDom, stackDom].filter((section) => section.length > 0)
+  return [
+    {
+      childCount: sections.length,
+      className: MergeClassNames.mergeClassNames('Viewlet', 'Error'),
+      type: VirtualDomElements.Div,
+    },
+    ...sections.flat(),
+  ]
 }

--- a/packages/renderer-worker/test/GetViewletErrorVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetViewletErrorVirtualDom.test.ts
@@ -25,6 +25,11 @@ test('getViewletErrorVirtualDom', () => {
     }),
   ).toEqual([
     {
+      childCount: 3,
+      className: 'Viewlet Error',
+      type: VirtualDomElements.Div,
+    },
+    {
       childCount: 1,
       className: 'ViewletErrorMessage',
       type: VirtualDomElements.Div,

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -994,6 +994,11 @@ test('load - renders a syntax highlighted generic error', async () => {
       42,
       [
         {
+          childCount: 3,
+          className: 'Viewlet Error',
+          type: VirtualDomElements.Div,
+        },
+        {
           childCount: 1,
           className: 'ViewletErrorMessage',
           type: VirtualDomElements.Div,


### PR DESCRIPTION
Keep the standard error view root when replacing its contents with syntax-highlighted virtual DOM. Add a browser fixture that throws during view creation and verifies the rendered source line and token nodes.