### PR TITLE
fix: reveal files when sidebar is hidden

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -352,6 +352,7 @@ export const commandMap = {
   'RecentlyOpened.getRecentlyOpened': lazy('RecentlyOpened.getRecentlyOpened'),
   'RecentlyOpened.hydrate': lazy('RecentlyOpened.hydrate'),
   'Reload.reload': lazy('Reload.reload'),
+  'RevealInExplorer.reveal': lazy('RevealInExplorer.reveal'),
   'SaveFileAs.saveFileAs': lazy('SaveFileAs.saveFileAs'),
   'SaveState.handleVisibilityChange': lazy('SaveState.handleVisibilityChange'),
   'SaveState.hydrate': lazy('SaveState.hydrate'),

--- a/packages/renderer-worker/src/parts/MenuEntriesTab/MenuEntriesTab.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesTab/MenuEntriesTab.js
@@ -45,7 +45,7 @@ export const getMenuEntries = () => {
       id: 'revealInExplorer',
       label: ViewletMainStrings.revealInExplorer(),
       flags: MenuItemFlags.None,
-      command: 'Explorer.revealItem',
+      command: 'RevealInExplorer.reveal',
       args: [uri],
     },
     MenuEntrySeparator.menuEntrySeparator,

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -229,6 +229,8 @@ export const load = (moduleId) => {
       return import('../WebSocketCapability/WebSocketCapability.ipc.js')
     case ModuleId.ExtensionHotReload:
       return import('../ExtensionHotReload/ExtensionHotReload.ipc.js')
+    case ModuleId.RevealInExplorer:
+      return import('../RevealInExplorer/RevealInExplorer.ipc.ts')
     default:
       throw new Error(`module ${moduleId} not found`)
   }

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -116,3 +116,4 @@ export const SendMessagePortToMainProcess = 151
 export const FileSystemMemory = 152
 export const WebSocketCapability = 153
 export const ExtensionHotReload = 154
+export const RevealInExplorer = 155

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -150,6 +150,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.RebuildNodePty
     case 'RecentlyOpened':
       return ModuleId.RecentlyOpened
+    case 'RevealInExplorer':
+      return ModuleId.RevealInExplorer
     case 'Reload':
       return ModuleId.Reload
     case 'SaveFileAs':

--- a/packages/renderer-worker/src/parts/RevealInExplorer/RevealInExplorer.ipc.ts
+++ b/packages/renderer-worker/src/parts/RevealInExplorer/RevealInExplorer.ipc.ts
@@ -1,0 +1,7 @@
+import * as RevealInExplorer from './RevealInExplorer.ts'
+
+export const name = 'RevealInExplorer'
+
+export const Commands = {
+  reveal: RevealInExplorer.revealInExplorer,
+}

--- a/packages/renderer-worker/src/parts/RevealInExplorer/RevealInExplorer.ts
+++ b/packages/renderer-worker/src/parts/RevealInExplorer/RevealInExplorer.ts
@@ -1,0 +1,40 @@
+import * as Command from '../Command/Command.js'
+import * as Viewlet from '../Viewlet/Viewlet.js'
+
+interface ViewletState {
+  readonly currentViewletId?: string
+  readonly parentUid?: number
+  readonly uid: number
+}
+
+interface RevealInExplorerDependencies {
+  readonly executeCommand: (command: string, ...args: readonly unknown[]) => Promise<unknown>
+  readonly executeViewletCommand: (uid: number, command: string, ...args: readonly unknown[]) => Promise<void>
+  readonly getAllStates: () => Record<string, ViewletState>
+}
+
+const defaultDependencies: RevealInExplorerDependencies = {
+  executeCommand: Command.execute,
+  executeViewletCommand: Viewlet.executeViewletCommand,
+  getAllStates: Viewlet.getAllStates,
+}
+
+export const revealInExplorerWithDependencies = async (uri: string, dependencies: RevealInExplorerDependencies): Promise<void> => {
+  const { executeCommand, executeViewletCommand, getAllStates } = dependencies
+  await executeCommand('Layout.showSideBar', 'Explorer')
+  const states = Object.values(getAllStates())
+  const sideBar = states.find((state) => state.currentViewletId === 'Explorer')
+  if (!sideBar) {
+    throw new Error('Explorer sidebar not found')
+  }
+  const explorerUids = states.filter((state) => state.parentUid === sideBar.uid).map((state) => state.uid)
+  if (explorerUids.length === 0) {
+    throw new Error('Explorer view not found')
+  }
+  const explorerUid = Math.max(...explorerUids)
+  await executeViewletCommand(explorerUid, 'revealItem', uri)
+}
+
+export const revealInExplorer = async (uri: string): Promise<void> => {
+  await revealInExplorerWithDependencies(uri, defaultDependencies)
+}

--- a/packages/renderer-worker/test/ModuleMap.test.ts
+++ b/packages/renderer-worker/test/ModuleMap.test.ts
@@ -15,7 +15,18 @@ test('getModule', () => {
   expect(ModuleMap.getModuleId('ExtensionHostSourceControl.getChangedFiles')).toBe(ModuleId.ExtensionManagement)
   expect(ModuleMap.getModuleId('ExtensionHostTextDocument.syncFull')).toBe(ModuleId.ExtensionHostCode)
   expect(ModuleMap.getModuleId('License.openLicense')).toBe(ModuleId.License)
+  expect(ModuleMap.getModuleId('RevealInExplorer.reveal')).toBe(ModuleId.RevealInExplorer)
   expect(ModuleMap.getModuleId('SendMessagePortToMainProcess.sendMessagePortToMainProcess')).toBe(ModuleId.SendMessagePortToMainProcess)
+})
+
+test('getModule - reveal in explorer', async () => {
+  const loadedModule = (await Module.load(ModuleMap.getModuleId('RevealInExplorer.reveal'))) as {
+    readonly Commands: Readonly<Record<string, unknown>>
+    readonly name: string
+  }
+
+  expect(loadedModule.name).toBe('RevealInExplorer')
+  expect(loadedModule.Commands.reveal).toBeDefined()
 })
 
 test('legacy text document synchronization commands are isolated-host compatibility no-ops', async () => {
@@ -42,8 +53,7 @@ test('getModule - layout runtime context', async () => {
 test('getModule - public user data directory command', async () => {
   const moduleId = ModuleMap.getModuleId('Platform.getUserDataDir')
   const loadedModule = await Module.load(moduleId)
-  const commands = (loadedModule as { Commands: Record<string, unknown> })
-    .Commands
+  const commands = (loadedModule as { Commands: Record<string, unknown> }).Commands
 
   expect(moduleId).toBe(ModuleId.PlatformPaths)
   expect(commands['Platform.getUserDataDir']).toBeDefined()

--- a/packages/renderer-worker/test/RevealInExplorer.test.ts
+++ b/packages/renderer-worker/test/RevealInExplorer.test.ts
@@ -1,0 +1,49 @@
+import { expect, jest, test } from '@jest/globals'
+import { revealInExplorerWithDependencies } from '../src/parts/RevealInExplorer/RevealInExplorer.ts'
+
+test('shows the Explorer sidebar before revealing the uri in the newest Explorer view', async () => {
+  const invocations: unknown[][] = []
+  const dependencies = {
+    executeCommand: jest.fn(async (...args: unknown[]): Promise<void> => {
+      invocations.push(args)
+    }),
+    executeViewletCommand: jest.fn(async (...args: unknown[]): Promise<void> => {
+      invocations.push(args)
+    }),
+    getAllStates: jest.fn(() => ({
+      explorerNew: { parentUid: 4, uid: 12 },
+      explorerOld: { parentUid: 4, uid: 8 },
+      layout: { uid: 2 },
+      sideBar: { currentViewletId: 'Explorer', uid: 4 },
+    })),
+  }
+
+  await revealInExplorerWithDependencies('/workspace/src/file.ts', dependencies)
+
+  expect(invocations).toEqual([
+    ['Layout.showSideBar', 'Explorer'],
+    [12, 'revealItem', '/workspace/src/file.ts'],
+  ])
+})
+
+test('throws when the Explorer sidebar cannot be found', async () => {
+  const dependencies = {
+    executeCommand: jest.fn(async (): Promise<void> => {}),
+    executeViewletCommand: jest.fn(async (): Promise<void> => {}),
+    getAllStates: jest.fn(() => ({})),
+  }
+
+  await expect(revealInExplorerWithDependencies('/workspace/src/file.ts', dependencies)).rejects.toThrow('Explorer sidebar not found')
+})
+
+test('throws when the Explorer view cannot be found', async () => {
+  const dependencies = {
+    executeCommand: jest.fn(async (): Promise<void> => {}),
+    executeViewletCommand: jest.fn(async (): Promise<void> => {}),
+    getAllStates: jest.fn(() => ({
+      sideBar: { currentViewletId: 'Explorer', uid: 4 },
+    })),
+  }
+
+  await expect(revealInExplorerWithDependencies('/workspace/src/file.ts', dependencies)).rejects.toThrow('Explorer view not found')
+})


### PR DESCRIPTION
Updates the editor tab action to open Explorer before revealing the selected file, so it also works while the sidebar is hidden.