### PR TITLE
feature: add simple browser history view

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.simple-browser-history.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.simple-browser-history.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.simple-browser-history'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  await Command.execute('Main.openUri', 'simple-browser-history://')
+
+  const historyView = Locator('.SimpleBrowserHistory')
+  await expect(historyView).toBeVisible()
+  await expect(historyView.locator('h1')).toHaveText('History')
+  await expect(historyView.locator('input')).toHaveAttribute('placeholder', 'Search history')
+  await expect(historyView.locator('button')).toHaveText('Clear history')
+}

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserHistoryVirtualDom/GetSimpleBrowserHistoryVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserHistoryVirtualDom/GetSimpleBrowserHistoryVirtualDom.js
@@ -1,0 +1,46 @@
+import * as HtmlInputType from '../HtmlInputType/HtmlInputType.js'
+import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.js'
+import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
+
+export const getSimpleBrowserHistoryVirtualDom = (searchValue) => {
+  return [
+    {
+      type: VirtualDomElements.Div,
+      className: 'Viewlet SimpleBrowserHistory',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserHistoryContent',
+      childCount: 2,
+    },
+    {
+      type: VirtualDomElements.H1,
+      className: 'SimpleBrowserHistoryHeading',
+      childCount: 1,
+    },
+    text('History'),
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserHistoryControls',
+      childCount: 2,
+    },
+    {
+      type: VirtualDomElements.Input,
+      className: 'InputBox SimpleBrowserHistorySearchInput',
+      inputType: HtmlInputType.Search,
+      placeholder: 'Search history',
+      ariaLabel: 'Search history',
+      onInput: 'handleInput',
+      value: searchValue,
+      childCount: 0,
+    },
+    {
+      type: VirtualDomElements.Button,
+      className: 'Button ButtonSecondary',
+      onClick: 'clearHistory',
+      childCount: 1,
+    },
+    text('Clear history'),
+  ]
+}

--- a/packages/renderer-worker/src/parts/MenuEntriesSimpleBrowserToolbar/MenuEntriesSimpleBrowserToolbar.js
+++ b/packages/renderer-worker/src/parts/MenuEntriesSimpleBrowserToolbar/MenuEntriesSimpleBrowserToolbar.js
@@ -17,6 +17,7 @@ export const getMenuEntries = () => {
     entry('reload', 'Reload', 'SimpleBrowser.reload'),
     entry('open-external', 'Open in Default Browser', 'SimpleBrowser.openExternal'),
     MenuEntrySeparator.menuEntrySeparator,
+    entry('history', 'History', 'SimpleBrowser.openHistory'),
     entry('downloads', 'Downloads', 'SimpleBrowser.openDownloads'),
     MenuEntrySeparator.menuEntrySeparator,
     entry('zoom-in', 'Zoom In', 'SimpleBrowser.zoomIn'),

--- a/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
+++ b/packages/renderer-worker/src/parts/PathDisplay/PathDisplay.js
@@ -44,6 +44,9 @@ export const getLabel = (uri) => {
   if (uri.startsWith('simple-browser://')) {
     return 'Simple Browser'
   }
+  if (uri.startsWith('simple-browser-history://')) {
+    return 'History'
+  }
   if (uri.startsWith('language-models://')) {
     return 'Language Models'
   }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -469,6 +469,12 @@ export const getQuickPickMenuEntries = () => {
       args: ['simple-browser://'],
     },
     {
+      id: 'Main.openUri',
+      label: 'Simple Browser: Open History',
+      args: ['simple-browser-history://'],
+      aliases: ['Open Browser History'],
+    },
+    {
       id: 'SimpleBrowser.openDevtools',
       label: 'Simple Browser: Open Dev Devtools',
     },

--- a/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
+++ b/packages/renderer-worker/src/parts/ViewletMap/ViewletMap.js
@@ -65,6 +65,9 @@ export const getModuleId = async (uri, opener) => {
   if (uri.startsWith('simple-browser://')) {
     return ViewletModuleId.SimpleBrowser
   }
+  if (uri.startsWith('simple-browser-history://')) {
+    return ViewletModuleId.SimpleBrowserHistory
+  }
   if (uri.startsWith('storage-overview://')) {
     return ViewletModuleId.Storage
   }

--- a/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
@@ -94,6 +94,8 @@ export const SecondaryPreview = 'SecondaryPreview'
 
 export const SimpleBrowser = 'SimpleBrowser'
 
+export const SimpleBrowserHistory = 'SimpleBrowserHistory'
+
 export const SourceControl = 'Source Control'
 
 export const StatusBar = 'StatusBar'

--- a/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
@@ -54,6 +54,7 @@ export const map = {
   [ViewletModuleId.SideBar]: () => import('../ViewletSideBar/ViewletSideBar.ipc.js'),
   [ViewletModuleId.SecondarySideBar]: () => import('../ViewletSecondarySideBar/ViewletSecondarySideBar.ipc.js'),
   [ViewletModuleId.SimpleBrowser]: () => import('../ViewletSimpleBrowser/ViewletSimpleBrowser.ipc.js'),
+  [ViewletModuleId.SimpleBrowserHistory]: () => import('../ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistory.ipc.js'),
   [ViewletModuleId.SourceControl]: () => import('../ViewletSourceControl/ViewletSourceControl.ipc.js'),
   [ViewletModuleId.StatusBar]: () => import('../ViewletStatusBar/ViewletStatusBar.ipc.js'),
   [ViewletModuleId.Storage]: () => import('../ViewletStorage/ViewletStorage.ipc.js'),

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -42,6 +42,7 @@ export const Commands = {
 
 export const LazyCommands = {
   openExternal: () => import('./ViewletSimpleBrowserOpenExternal.js'),
+  openHistory: () => import('./ViewletSimpleBrowserOpenHistory.js'),
   openDownloads: () => import('./ViewletSimpleBrowserOpenDownloads.js'),
   openBackgroundTab: () => import('./ViewletSimpleBrowserOpenBackgroundTab.js'),
   handleContextMenu: () => import('./ViewletSimpleBrowserHandleContextMenu.js'),

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserOpenHistory.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserOpenHistory.js
@@ -1,0 +1,6 @@
+import * as Command from '../Command/Command.js'
+
+export const openHistory = async (state) => {
+  await Command.execute('Main.openUri', 'simple-browser-history://')
+  return state
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistory.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistory.ipc.js
@@ -1,0 +1,4 @@
+export * from './ViewletSimpleBrowserHistory.js'
+export * from './ViewletSimpleBrowserHistoryCommands.js'
+export * from './ViewletSimpleBrowserHistoryCss.js'
+export * from './ViewletSimpleBrowserHistoryRender.js'

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistory.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistory.js
@@ -1,0 +1,26 @@
+export const create = (id, uri) => {
+  return {
+    uid: id,
+    uri,
+    loaded: false,
+    searchValue: '',
+  }
+}
+
+export const loadContent = (state) => {
+  return {
+    ...state,
+    loaded: true,
+  }
+}
+
+export const handleInput = (state, value) => {
+  return {
+    ...state,
+    searchValue: value,
+  }
+}
+
+export const clearHistory = (state) => {
+  return state
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistoryCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistoryCommands.js
@@ -1,0 +1,6 @@
+import * as ViewletSimpleBrowserHistory from './ViewletSimpleBrowserHistory.js'
+
+export const Commands = {
+  clearHistory: ViewletSimpleBrowserHistory.clearHistory,
+  handleInput: ViewletSimpleBrowserHistory.handleInput,
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistoryCss.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistoryCss.js
@@ -1,0 +1,1 @@
+export const Css = ['/css/parts/Button.css', '/css/parts/InputBox.css', '/css/parts/ViewletSimpleBrowserHistory.css']

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistoryRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistoryRender.js
@@ -1,0 +1,17 @@
+import * as GetSimpleBrowserHistoryVirtualDom from '../GetSimpleBrowserHistoryVirtualDom/GetSimpleBrowserHistoryVirtualDom.js'
+
+export const hasFunctionalRender = true
+
+export const hasFunctionalRootRender = true
+
+const renderDom = {
+  isEqual(oldState, newState) {
+    return oldState.loaded === newState.loaded
+  },
+  apply(oldState, newState) {
+    const dom = GetSimpleBrowserHistoryVirtualDom.getSimpleBrowserHistoryVirtualDom(newState.searchValue)
+    return ['Viewlet.setDom2', dom]
+  },
+}
+
+export const render = [renderDom]

--- a/packages/renderer-worker/test/GetSimpleBrowserHistoryVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserHistoryVirtualDom.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@jest/globals'
+import * as GetSimpleBrowserHistoryVirtualDom from '../src/parts/GetSimpleBrowserHistoryVirtualDom/GetSimpleBrowserHistoryVirtualDom.js'
+import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
+
+test('renders history placeholder controls', () => {
+  expect(GetSimpleBrowserHistoryVirtualDom.getSimpleBrowserHistoryVirtualDom('example')).toEqual([
+    {
+      type: VirtualDomElements.Div,
+      className: 'Viewlet SimpleBrowserHistory',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserHistoryContent',
+      childCount: 2,
+    },
+    {
+      type: VirtualDomElements.H1,
+      className: 'SimpleBrowserHistoryHeading',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Text,
+      text: 'History',
+      childCount: 0,
+    },
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserHistoryControls',
+      childCount: 2,
+    },
+    {
+      type: VirtualDomElements.Input,
+      className: 'InputBox SimpleBrowserHistorySearchInput',
+      inputType: 'search',
+      placeholder: 'Search history',
+      ariaLabel: 'Search history',
+      onInput: 'handleInput',
+      value: 'example',
+      childCount: 0,
+    },
+    {
+      type: VirtualDomElements.Button,
+      className: 'Button ButtonSecondary',
+      onClick: 'clearHistory',
+      childCount: 1,
+    },
+    {
+      type: VirtualDomElements.Text,
+      text: 'Clear history',
+      childCount: 0,
+    },
+  ])
+})

--- a/packages/renderer-worker/test/MenuEntriesSimpleBrowserToolbar.test.ts
+++ b/packages/renderer-worker/test/MenuEntriesSimpleBrowserToolbar.test.ts
@@ -9,6 +9,7 @@ test('exposes useful Simple Browser actions in the toolbar menu', () => {
     { command: 'SimpleBrowser.reload', flags: MenuItemFlags.None, id: 'reload', label: 'Reload' },
     { command: 'SimpleBrowser.openExternal', flags: MenuItemFlags.None, id: 'open-external', label: 'Open in Default Browser' },
     MenuEntrySeparator.menuEntrySeparator,
+    { command: 'SimpleBrowser.openHistory', flags: MenuItemFlags.None, id: 'history', label: 'History' },
     { command: 'SimpleBrowser.openDownloads', flags: MenuItemFlags.None, id: 'downloads', label: 'Downloads' },
     MenuEntrySeparator.menuEntrySeparator,
     { command: 'SimpleBrowser.zoomIn', flags: MenuItemFlags.None, id: 'zoom-in', label: 'Zoom In' },

--- a/packages/renderer-worker/test/PathDisplay.test.ts
+++ b/packages/renderer-worker/test/PathDisplay.test.ts
@@ -38,6 +38,10 @@ test('getLabel - secrets', () => {
   expect(PathDisplay.getLabel('secrets://')).toBe('Secrets')
 })
 
+test('getLabel - simple browser history', () => {
+  expect(PathDisplay.getLabel('simple-browser-history://')).toBe('History')
+})
+
 test('getFileIcon - secrets', () => {
   expect(PathDisplay.getFileIcon('secrets://')).toBe('MaskIconRecordKey')
 })

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -99,6 +99,17 @@ test('getQuickPickMenuEntries includes simple browser preview command', () => {
   })
 })
 
+test('getQuickPickMenuEntries includes simple browser history command', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toContainEqual({
+    id: 'Main.openUri',
+    label: 'Simple Browser: Open History',
+    args: ['simple-browser-history://'],
+    aliases: ['Open Browser History'],
+  })
+})
+
 test('getQuickPickMenuEntries includes Firefox cookie import command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 

--- a/packages/renderer-worker/test/ViewletMap.test.ts
+++ b/packages/renderer-worker/test/ViewletMap.test.ts
@@ -56,6 +56,10 @@ test('search editor', async () => {
   expect(await ViewletMap.getModuleId('search-editor://1/Search')).toBe(ViewletModuleId.Search)
 })
 
+test('simple browser history', async () => {
+  expect(await ViewletMap.getModuleId('simple-browser-history://')).toBe(ViewletModuleId.SimpleBrowserHistory)
+})
+
 test('inline diff uses the external diff editor', async () => {
   expect(await ViewletMap.getModuleId('inline-diff://data://before<->/test/file.ts')).toBe(ViewletModuleId.DiffEditor)
 })

--- a/packages/renderer-worker/test/ViewletModuleMap.test.ts
+++ b/packages/renderer-worker/test/ViewletModuleMap.test.ts
@@ -39,6 +39,17 @@ test('running extensions uses worker-backed module', async () => {
   expect(typeof module.getCommands).toBe('function')
 })
 
+test('simple browser history exposes the placeholder view', async () => {
+  const module = await ViewletModuleMap.map[ViewletModuleId.SimpleBrowserHistory]()
+
+  expect(module.hasFunctionalRender).toBe(true)
+  expect(module.hasFunctionalRootRender).toBe(true)
+  expect(typeof module.create).toBe('function')
+  expect(typeof module.loadContent).toBe('function')
+  expect(typeof module.Commands.handleInput).toBe('function')
+  expect(typeof module.Commands.clearHistory).toBe('function')
+})
+
 const genericWorkerViewlets = [
   ViewletModuleId.About,
   ViewletModuleId.ActivityBar,

--- a/packages/renderer-worker/test/ViewletSimpleBrowserHistory.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserHistory.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@jest/globals'
+import * as ViewletSimpleBrowserHistory from '../src/parts/ViewletSimpleBrowserHistory/ViewletSimpleBrowserHistory.js'
+
+test('create', () => {
+  expect(ViewletSimpleBrowserHistory.create(12, 'simple-browser-history://')).toEqual({
+    uid: 12,
+    uri: 'simple-browser-history://',
+    loaded: false,
+    searchValue: '',
+  })
+})
+
+test('loadContent', () => {
+  const state = ViewletSimpleBrowserHistory.create(12, 'simple-browser-history://')
+
+  expect(ViewletSimpleBrowserHistory.loadContent(state)).toEqual({
+    ...state,
+    loaded: true,
+  })
+})
+
+test('handleInput', () => {
+  const state = ViewletSimpleBrowserHistory.create(12, 'simple-browser-history://')
+
+  expect(ViewletSimpleBrowserHistory.handleInput(state, 'example')).toEqual({
+    ...state,
+    searchValue: 'example',
+  })
+})
+
+test('clearHistory is a placeholder', () => {
+  const state = ViewletSimpleBrowserHistory.create(12, 'simple-browser-history://')
+
+  expect(ViewletSimpleBrowserHistory.clearHistory(state)).toBe(state)
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowserOpenHistory.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserOpenHistory.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
+}))
+
+const Command = await import('../src/parts/Command/Command.js')
+const ViewletSimpleBrowserOpenHistory = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserOpenHistory.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('opens history in the main area', async () => {
+  const state = { uid: 12 }
+
+  await expect(ViewletSimpleBrowserOpenHistory.openHistory(state)).resolves.toBe(state)
+  expect(Command.execute).toHaveBeenCalledWith('Main.openUri', 'simple-browser-history://')
+})

--- a/static/css/parts/ViewletSimpleBrowserHistory.css
+++ b/static/css/parts/ViewletSimpleBrowserHistory.css
@@ -1,0 +1,25 @@
+.SimpleBrowserHistory {
+  overflow: auto;
+}
+
+.SimpleBrowserHistoryContent {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px;
+}
+
+.SimpleBrowserHistoryHeading {
+  margin: 0 0 24px;
+  font-size: 26px;
+  font-weight: 400;
+}
+
+.SimpleBrowserHistoryControls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.SimpleBrowserHistorySearchInput {
+  min-width: 160px;
+}


### PR DESCRIPTION
Adds a placeholder Simple Browser history view at `simple-browser-history://` with a history heading, search field, and clear button. The view can open in the main or preview area and is available from the Simple Browser toolbar menu and command palette.