### PR TITLE
fix: avoid simple browser tab flicker

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -303,16 +303,20 @@ const createEmptyTab = async (state) => {
   return createTab({ browserViewId })
 }
 
+const switchWebContentsView = async (oldBrowserViewId, newBrowserViewId) => {
+  await ElectronWebContentsViewFunctions.show(newBrowserViewId)
+  if (oldBrowserViewId) {
+    await ElectronWebContentsViewFunctions.hide(oldBrowserViewId)
+  }
+}
+
 export const createNewTab = async (state) => {
   if (!state.tabsEnabled) {
     return state
   }
   const currentState = state.hasSuggestionsOverlay ? await closeSuggestions(state) : state
   const tab = await createEmptyTab(currentState)
-  if (currentState.browserViewId) {
-    await ElectronWebContentsViewFunctions.hide(currentState.browserViewId)
-  }
-  await ElectronWebContentsViewFunctions.show(tab.browserViewId)
+  await switchWebContentsView(currentState.browserViewId, tab.browserViewId)
   await ElectronWindow.focus()
   const newState = activateTab(currentState, [...currentState.tabs, tab], currentState.tabs.length)
   return { ...newState, focusAddressVersion: newState.focusAddressVersion + 1 }
@@ -340,10 +344,7 @@ export const duplicateTab = async (state, index) => {
   if (tab.iframeSrc) {
     void ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, tab.iframeSrc)
   }
-  if (browserViewId) {
-    await ElectronWebContentsViewFunctions.hide(browserViewId)
-  }
-  await ElectronWebContentsViewFunctions.show(tab.browserViewId)
+  await switchWebContentsView(browserViewId, tab.browserViewId)
   await ElectronWebContentsViewFunctions.focus(tab.browserViewId)
   const tabs = currentState.tabs.toSpliced(tabIndex + 1, 0, tab)
   const newState = activateTab(currentState, tabs, tabIndex + 1)
@@ -388,10 +389,7 @@ export const openTab = async (state, url, disposition) => {
   if (disposition === 'background-tab') {
     return { ...currentState, tabs }
   }
-  if (currentState.browserViewId) {
-    await ElectronWebContentsViewFunctions.hide(currentState.browserViewId)
-  }
-  await ElectronWebContentsViewFunctions.show(tab.browserViewId)
+  await switchWebContentsView(currentState.browserViewId, tab.browserViewId)
   await ElectronWebContentsViewFunctions.focus(tab.browserViewId)
   return activateTab(currentState, tabs, currentState.tabs.length)
 }
@@ -420,8 +418,7 @@ export const selectTab = async (state, index) => {
     newState = await closeSuggestions(state)
   }
   const tab = newState.tabs[selectedTabIndex]
-  await ElectronWebContentsViewFunctions.hide(newState.browserViewId)
-  await ElectronWebContentsViewFunctions.show(tab.browserViewId)
+  await switchWebContentsView(newState.browserViewId, tab.browserViewId)
   await ElectronWebContentsViewFunctions.focus(tab.browserViewId)
   return activateTab(newState, newState.tabs, selectedTabIndex)
 }

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -430,7 +430,7 @@ test('ignores a target blank event from another simple browser instance', async 
   expect(Command.execute).not.toHaveBeenCalled()
 })
 
-test('switches tabs by hiding only the previous active view', async () => {
+test('switches tabs by showing the selected view before hiding the previous active view', async () => {
   // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
   // @ts-ignore
@@ -478,6 +478,10 @@ test('switches tabs by hiding only the previous active view', async () => {
   })
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
+  // @ts-ignore
+  expect(ElectronWebContentsViewFunctions.show.mock.invocationCallOrder[0]).toBeLessThan(
+    ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0],
+  )
 })
 
 test('Ctrl+Tab from the focused web contents selects the next browser tab', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -479,9 +479,10 @@ test('switches tabs by showing the selected view before hiding the previous acti
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
   // @ts-ignore
-  expect(ElectronWebContentsViewFunctions.show.mock.invocationCallOrder[0]).toBeLessThan(
-    ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0],
-  )
+  const showCallOrder = ElectronWebContentsViewFunctions.show.mock.invocationCallOrder[0]
+  // @ts-ignore
+  const hideCallOrder = ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]
+  expect(showCallOrder).toBeLessThan(hideCallOrder)
 })
 
 test('Ctrl+Tab from the focused web contents selects the next browser tab', async () => {


### PR DESCRIPTION
Show the incoming Simple Browser WebContentsView before hiding the previous active view. Reuse the same handoff for selecting, creating, duplicating, and opening foreground tabs.