### PR TITLE
fix: use object url for simple browser snapshot

### DIFF
--- a/packages/renderer-worker/src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js
@@ -1,0 +1,13 @@
+import * as MimeType from '../MimeType/MimeType.js'
+import * as Url from '../Url/Url.js'
+
+export const create = (bytes) => {
+  const blob = new Blob([bytes], { type: MimeType.ImagePng })
+  return Url.createObjectUrl(blob)
+}
+
+export const dispose = (snapshot) => {
+  if (snapshot) {
+    Url.revokeObjectUrl(snapshot)
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -17,6 +17,7 @@ import * as KeyBindingsInitial from '../KeyBindingsInitial/KeyBindingsInitial.js
 import * as KeyModifier from '../KeyModifier/KeyModifier.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as SimpleBrowserPreferences from '../SimpleBrowserPreferences/SimpleBrowserPreferences.js'
+import * as SimpleBrowserSnapshot from '../SimpleBrowserSnapshot/SimpleBrowserSnapshot.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as WhenExpression from '../WhenExpression/WhenExpression.js'
 
@@ -548,8 +549,12 @@ export const showOverlay = async (state, overlayId) => {
       overlayIds,
     }
   }
+  let snapshot = ''
   try {
-    const snapshot = state.iframeSrc ? await ElectronWebContentsViewFunctions.capturePage(state.browserViewId) : ''
+    if (state.iframeSrc) {
+      const bytes = await ElectronWebContentsViewFunctions.capturePage(state.browserViewId)
+      snapshot = SimpleBrowserSnapshot.create(bytes)
+    }
     await ElectronWebContentsViewFunctions.hide(state.browserViewId)
     return {
       ...state,
@@ -557,6 +562,7 @@ export const showOverlay = async (state, overlayId) => {
       snapshot,
     }
   } catch (error) {
+    SimpleBrowserSnapshot.dispose(snapshot)
     console.error('[renderer-worker] Failed to capture Simple Browser page', error)
     return state
   }
@@ -577,6 +583,8 @@ export const hideOverlay = async (state, overlayId) => {
     await ElectronWebContentsViewFunctions.show(state.browserViewId)
   } catch (error) {
     console.error('[renderer-worker] Failed to restore Simple Browser page', error)
+  } finally {
+    SimpleBrowserSnapshot.dispose(state.snapshot)
   }
   return {
     ...state,
@@ -796,5 +804,8 @@ export const handleAudioStateChanged = (state, browserViewId, audible) => {
 }
 
 export const dispose = async (state) => {
-  await Promise.all(state.tabs.map((tab) => ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)))
+  await Promise.all([
+    ...state.tabs.map((tab) => ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)),
+    SimpleBrowserSnapshot.dispose(state.snapshot),
+  ])
 }

--- a/packages/renderer-worker/test/ElectronWebContentsViewFunctions.test.ts
+++ b/packages/renderer-worker/test/ElectronWebContentsViewFunctions.test.ts
@@ -8,10 +8,11 @@ const EmbedsWorker = await import('../src/parts/EmbedsWorker/EmbedsWorker.js')
 const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
 
 test('capturePage forwards to the embeds worker', async () => {
+  const png = new Uint8Array([137, 80, 78, 71])
   // @ts-ignore
-  EmbedsWorker.invoke.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  EmbedsWorker.invoke.mockResolvedValue(png)
 
-  await expect(ElectronWebContentsViewFunctions.capturePage(12)).resolves.toBe('data:image/png;base64,c25hcHNob3Q=')
+  await expect(ElectronWebContentsViewFunctions.capturePage(12)).resolves.toBe(png)
   expect(EmbedsWorker.invoke).toHaveBeenCalledWith('ElectronWebContentsView.capturePage', 12)
 })
 

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -3,7 +3,13 @@ import * as GetSimpleBrowserVirtualDom from '../src/parts/GetSimpleBrowserVirtua
 import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.js'
 
 test('renders a snapshot below the browser header', () => {
-  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(true, true, false, 'https://example.com', 'data:image/png;base64,c25hcHNob3Q=')
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(
+    true,
+    true,
+    false,
+    'https://example.com',
+    'blob:https://example.com/snapshot',
+  )
 
   expect(dom[0].childCount).toBe(3)
   expect(dom.slice(-2)).toEqual([
@@ -15,7 +21,7 @@ test('renders a snapshot below the browser header', () => {
     {
       type: VirtualDomElements.Img,
       className: 'SimpleBrowserSnapshot',
-      src: 'data:image/png;base64,c25hcHNob3Q=',
+      src: 'blob:https://example.com/snapshot',
       draggable: false,
       childCount: 0,
     },
@@ -45,7 +51,7 @@ test('renders accessible search suggestions above an undimmed snapshot', () => {
     true,
     false,
     'what is',
-    'data:image/png;base64,c25hcHNob3Q=',
+    'blob:https://example.com/snapshot',
     ['what is', 'what is my ip'],
     1,
   )
@@ -54,7 +60,7 @@ test('renders accessible search suggestions above an undimmed snapshot', () => {
   expect(dom).toContainEqual({
     type: VirtualDomElements.Img,
     className: 'SimpleBrowserSnapshot SimpleBrowserSnapshotSearchSuggestions',
-    src: 'data:image/png;base64,c25hcHNob3Q=',
+    src: 'blob:https://example.com/snapshot',
     draggable: false,
     childCount: 0,
   })

--- a/packages/renderer-worker/test/SimpleBrowserSnapshot.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserSnapshot.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const createObjectUrl = jest.fn<(blob: Blob) => string>()
+const revokeObjectUrl = jest.fn<(url: string) => void>()
+
+jest.unstable_mockModule('../src/parts/Url/Url.js', () => ({
+  createObjectUrl,
+  revokeObjectUrl,
+}))
+
+const SimpleBrowserSnapshot = await import('../src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('creates a png object url from captured bytes', async () => {
+  const bytes = new Uint8Array([137, 80, 78, 71])
+  createObjectUrl.mockReturnValue('blob:https://example.com/snapshot')
+
+  expect(SimpleBrowserSnapshot.create(bytes)).toBe('blob:https://example.com/snapshot')
+  expect(createObjectUrl).toHaveBeenCalledTimes(1)
+  const blob = createObjectUrl.mock.calls[0][0]
+  expect(blob.type).toBe('image/png')
+  await expect(blob.arrayBuffer()).resolves.toEqual(bytes.buffer)
+})
+
+test('revokes a snapshot object url', () => {
+  SimpleBrowserSnapshot.dispose('blob:https://example.com/snapshot')
+
+  expect(revokeObjectUrl).toHaveBeenCalledWith('blob:https://example.com/snapshot')
+})
+
+test('does not revoke an empty snapshot', () => {
+  SimpleBrowserSnapshot.dispose('')
+
+  expect(revokeObjectUrl).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -85,6 +85,11 @@ jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
   execute: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js', () => ({
+  create: jest.fn(),
+  dispose: jest.fn(),
+}))
+
 const ViewletSimpleBrowser = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js')
 const ViewletSimpleBrowserOpenBackgroundTab = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserOpenBackgroundTab.js')
 const ViewletSimpleBrowserResize = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserResize.js')
@@ -98,6 +103,7 @@ const InputName = await import('../src/parts/InputName/InputName.js')
 const KeyCode = await import('../src/parts/KeyCode/KeyCode.js')
 const KeyModifier = await import('../src/parts/KeyModifier/KeyModifier.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
+const SimpleBrowserSnapshot = await import('../src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js')
 const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
 const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
 
@@ -777,6 +783,7 @@ test('disposes every retained web contents view with the Simple Browser', async 
   ElectronWebContentsView.disposeWebContentsView.mockResolvedValue(undefined)
   const state = {
     ...ViewletSimpleBrowser.create(),
+    snapshot: 'blob:https://example.com/snapshot',
     tabs: [{ browserViewId: 12 }, { browserViewId: 13 }],
   }
 
@@ -785,6 +792,7 @@ test('disposes every retained web contents view with the Simple Browser', async 
   expect(ElectronWebContentsView.disposeWebContentsView).toHaveBeenCalledTimes(2)
   expect(ElectronWebContentsView.disposeWebContentsView).toHaveBeenNthCalledWith(1, 12)
   expect(ElectronWebContentsView.disposeWebContentsView).toHaveBeenNthCalledWith(2, 13)
+  expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
 })
 
 test('handleWillNavigate', () => {
@@ -844,29 +852,35 @@ test('handleDidNavigate', () => {
 })
 
 test('showOverlay captures and hides the WebContentsView', async () => {
+  const png = new Uint8Array([137, 80, 78, 71])
   // @ts-ignore
-  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(png)
   // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/snapshot')
   const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
 
   const newState = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
 
   expect(newState).toMatchObject({
     overlayIds: ['quick-pick'],
-    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    snapshot: 'blob:https://example.com/snapshot',
   })
   expect(ElectronWebContentsViewFunctions.capturePage).toHaveBeenCalledWith(12)
+  expect(SimpleBrowserSnapshot.create).toHaveBeenCalledWith(png)
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
 })
 
 test('overlays share one snapshot and restore after the last overlay closes', async () => {
   // @ts-ignore
-  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(new Uint8Array([137, 80, 78, 71]))
   // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
   // @ts-ignore
   ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  // @ts-ignore
+  SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/snapshot')
   const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
 
   const withQuickPick = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
@@ -875,12 +889,56 @@ test('overlays share one snapshot and restore after the last overlay closes', as
   const restored = await ViewletSimpleBrowser.hideOverlay(withMenu, 'menu')
 
   expect(ElectronWebContentsViewFunctions.capturePage).toHaveBeenCalledTimes(1)
+  expect(SimpleBrowserSnapshot.create).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledTimes(1)
+  expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledTimes(1)
+  expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
   expect(restored).toMatchObject({
     overlayIds: [],
     snapshot: '',
   })
+})
+
+test('showOverlay revokes a new snapshot when hiding the WebContentsView fails', async () => {
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    // @ts-ignore
+    ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(new Uint8Array([137, 80, 78, 71]))
+    // @ts-ignore
+    ElectronWebContentsViewFunctions.hide.mockRejectedValue(new Error('Failed to hide'))
+    // @ts-ignore
+    SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/snapshot')
+    const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
+
+    const newState = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
+
+    expect(newState).toBe(state)
+    expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
+  } finally {
+    consoleError.mockRestore()
+  }
+})
+
+test('hideOverlay revokes the snapshot when restoring the WebContentsView fails', async () => {
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  try {
+    // @ts-ignore
+    ElectronWebContentsViewFunctions.show.mockRejectedValue(new Error('Failed to show'))
+    const state = {
+      ...ViewletSimpleBrowser.create(),
+      browserViewId: 12,
+      overlayIds: ['quick-pick'],
+      snapshot: 'blob:https://example.com/snapshot',
+    }
+
+    const newState = await ViewletSimpleBrowser.hideOverlay(state, 'quick-pick')
+
+    expect(newState).toMatchObject({ overlayIds: [], snapshot: '' })
+    expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
+  } finally {
+    consoleError.mockRestore()
+  }
 })
 
 test('handleInput does not request suggestions when disabled', async () => {
@@ -931,9 +989,11 @@ test('applySuggestions ignores stale results', async () => {
 
 test('applySuggestions captures the page and shows provider results', async () => {
   // @ts-ignore
-  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue('data:image/png;base64,c25hcHNob3Q=')
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(new Uint8Array([137, 80, 78, 71]))
   // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/snapshot')
   const state = {
     ...ViewletSimpleBrowser.create(7),
     browserViewId: 12,
@@ -948,7 +1008,7 @@ test('applySuggestions captures the page and shows provider results', async () =
     hasSuggestionsOverlay: true,
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: 0,
-    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    snapshot: 'blob:https://example.com/snapshot',
     suggestions: ['what is', 'what is my ip', 'what is love'],
   })
 })
@@ -986,7 +1046,7 @@ test('applySuggestions closes an existing popup after a provider failure', async
     inputValue: 'what is',
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: 0,
-    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    snapshot: 'blob:https://example.com/snapshot',
     suggestions: ['what is'],
     suggestionsEnabled: true,
   }
@@ -1001,6 +1061,7 @@ test('applySuggestions closes an existing popup after a provider failure', async
     suggestions: [],
   })
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(12)
+  expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
 })
 
 test('suggestion selection stays within the available results', () => {
@@ -1029,7 +1090,7 @@ test('acceptSuggestion restores the page and navigates', async () => {
     hasSuggestionsOverlay: true,
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: 1,
-    snapshot: 'data:image/png;base64,c25hcHNob3Q=',
+    snapshot: 'blob:https://example.com/snapshot',
     suggestions: ['what is', 'what is my ip'],
     suggestionsEnabled: true,
   }
@@ -1045,5 +1106,6 @@ test('acceptSuggestion restores the page and navigates', async () => {
     suggestions: [],
   })
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(12)
+  expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, 'https://www.google.com/search?q=what+is+my+ip')
 })


### PR DESCRIPTION
Render Simple Browser overlay snapshots from PNG blobs through short-lived object URLs. Revoke each URL when the final overlay closes, capture setup fails, or the Simple Browser is disposed.