### PR TITLE
fix: enable simple browser navigation buttons

### DIFF
--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -135,6 +135,7 @@ export const getSimpleBrowserVirtualDom = (
       className: ClassNames.IconButton,
       childCount: 1,
       title: 'Back',
+      disabled: !canGoBack,
       onClick: DomEventListenerFunctions.HandleClickBackward,
     },
     {
@@ -147,6 +148,7 @@ export const getSimpleBrowserVirtualDom = (
       className: ClassNames.IconButton,
       childCount: 1,
       title: 'Forward',
+      disabled: !canGoForward,
       onClick: DomEventListenerFunctions.HandleClickForward,
     },
     {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -11,6 +11,18 @@ export const hasFunctionalRootRender = true
 export const renderEventListeners = () => {
   return [
     {
+      name: DomEventListenerFunctions.HandleClickBackward,
+      params: ['backward'],
+    },
+    {
+      name: DomEventListenerFunctions.HandleClickForward,
+      params: ['forward'],
+    },
+    {
+      name: DomEventListenerFunctions.HandleClickReload,
+      params: ['reload'],
+    },
+    {
       name: DomEventListenerFunctions.HandleFocusInSimpleBrowser,
       params: ['handleFocusIn', 'event.target.name'],
     },

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -39,6 +39,13 @@ test('names the address input so focus can be restored after rendering', () => {
   )
 })
 
+test('disables unavailable navigation buttons', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, true, false, 'https://example.com')
+
+  expect(dom.find((node) => node.title === 'Back')).toMatchObject({ disabled: true })
+  expect(dom.find((node) => node.title === 'Forward')).toMatchObject({ disabled: false })
+})
+
 test('tracks focus anywhere in the simple browser chrome', () => {
   const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, '')
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -124,6 +124,17 @@ test('routes the browser menu button click with pointer coordinates', () => {
   })
 })
 
+test.each([
+  [DomEventListenerFunctions.HandleClickBackward, 'backward'],
+  [DomEventListenerFunctions.HandleClickForward, 'forward'],
+  [DomEventListenerFunctions.HandleClickReload, 'reload'],
+])('routes %s to the %s command', (name, command) => {
+  expect(ViewletSimpleBrowserRender.renderEventListeners()).toContainEqual({
+    name,
+    params: [command],
+  })
+})
+
 test('routes browser chrome focus with the focused element name', () => {
   expect(ViewletSimpleBrowserRender.renderEventListeners()).toContainEqual({
     name: DomEventListenerFunctions.HandleFocusInSimpleBrowser,


### PR DESCRIPTION
Registers Back, Forward, and Reload in the Simple Browser functional event map so the toolbar continues to dispatch commands after incremental renders. Also reflects navigation availability through the Back and Forward buttons' disabled state and adds focused regression coverage.