### PR TITLE
fix: update simple browser navigation state

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -767,9 +767,12 @@ export const handleKeyBinding = async (state, browserViewId, keyBinding) => {
   return state
 }
 
-export const handleDidNavigate = (state, browserViewId, value) => {
+export const handleDidNavigate = async (state, browserViewId, value) => {
   const [actualBrowserViewId, url] = parseWebContentsEvent(state, browserViewId, value)
+  const { canGoBack, canGoForward } = await ElectronWebContentsViewFunctions.getStats(actualBrowserViewId)
   return updateTab(state, actualBrowserViewId, {
+    canGoBack,
+    canGoForward,
     iframeSrc: url,
     inputValue: url,
     isLoading: false,

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -42,14 +42,7 @@ jest.unstable_mockModule('../src/parts/ElectronWebContentsViewFunctions/Electron
     show: jest.fn(() => {
       throw new Error('not implemented')
     }),
-    getStats() {
-      return {
-        title: 'test',
-        url: '',
-        canGoBack: true,
-        canGoForward: true,
-      }
-    },
+    getStats: jest.fn(),
   }
 })
 jest.unstable_mockModule('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js', () => {
@@ -106,6 +99,16 @@ const Preferences = await import('../src/parts/Preferences/Preferences.js')
 const SimpleBrowserSnapshot = await import('../src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js')
 const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
 const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
+
+beforeEach(() => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.getStats.mockResolvedValue({
+    title: 'test',
+    url: '',
+    canGoBack: true,
+    canGoForward: true,
+  })
+})
 
 const browserTabKeyBindings = [
   KeyModifier.CtrlCmd | KeyCode.KeyW,
@@ -820,7 +823,7 @@ test('setUrl applies the loading state before navigation completes', async () =>
     inputValue: 'https://example.com',
     isLoading: true,
   })
-  expect(ViewletSimpleBrowser.handleDidNavigate(loadingState, 'https://example.com')).toMatchObject({
+  await expect(ViewletSimpleBrowser.handleDidNavigate(loadingState, 'https://example.com')).resolves.toMatchObject({
     isLoading: false,
   })
 })
@@ -835,19 +838,20 @@ test('setUrl opens cookie import urls as a main-area view', async () => {
   expect(newState).toMatchObject({ inputValue: 'cookie-import-view:///firefox/default' })
 })
 
-test('handleDidNavigate', () => {
-  const state = { ...ViewletSimpleBrowser.create(), isLoading: true }
+test('handleDidNavigate refreshes navigation state', async () => {
+  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, isLoading: true }
   // @ts-ignore
-  const newState = ViewletSimpleBrowser.handleDidNavigate(state, 'https://example.com/one', false, false)
+  ElectronWebContentsViewFunctions.getStats.mockResolvedValueOnce({ canGoBack: true, canGoForward: false })
+
+  const newState = await ViewletSimpleBrowser.handleDidNavigate(state, 12, 'https://example.com/one')
+
+  expect(ElectronWebContentsViewFunctions.getStats).toHaveBeenCalledWith(12)
   expect(newState).toMatchObject({
+    canGoBack: true,
+    canGoForward: false,
     iframeSrc: 'https://example.com/one',
     inputValue: 'https://example.com/one',
     isLoading: false,
-  })
-  // @ts-ignore
-  expect(ViewletSimpleBrowser.handleDidNavigate(newState, 'https://example.com/two', false, false)).toMatchObject({
-    iframeSrc: 'https://example.com/two',
-    inputValue: 'https://example.com/two',
   })
 })
 


### PR DESCRIPTION
Refreshes Back and Forward availability from the active WebContentsView whenever navigation completes. This corrects the stale disabled state found while accepting the official v0.111.7 Debian package after an A-to-B link navigation.