### PR TITLE
feature: show favicons in browser suggestions

### DIFF
--- a/packages/renderer-worker/src/parts/BrowserVisitedSites/BrowserVisitedSites.js
+++ b/packages/renderer-worker/src/parts/BrowserVisitedSites/BrowserVisitedSites.js
@@ -1,0 +1,97 @@
+import * as LocalStorage from '../LocalStorage/LocalStorage.js'
+
+const storageKey = 'simple-browser-visited-sites'
+const maximumVisitedSites = 100
+const maximumFaviconLength = 4096
+
+const getOrigin = (value) => {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return undefined
+    }
+    return url.origin
+  } catch {
+    return undefined
+  }
+}
+
+const isValidFavicon = (favicon) => {
+  if (typeof favicon !== 'string' || favicon.length === 0 || favicon.length > maximumFaviconLength) {
+    return false
+  }
+  if (favicon.startsWith('data:image/')) {
+    return true
+  }
+  return Boolean(getOrigin(favicon))
+}
+
+const normalizeSite = (site) => {
+  if (!site || typeof site !== 'object') {
+    return undefined
+  }
+  const origin = getOrigin(site.origin)
+  if (!origin || !isValidFavicon(site.favicon)) {
+    return undefined
+  }
+  return {
+    favicon: site.favicon,
+    origin,
+  }
+}
+
+export const normalize = (value) => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const sites = []
+  const origins = new Set()
+  for (const item of value) {
+    const site = normalizeSite(item)
+    if (!site || origins.has(site.origin)) {
+      continue
+    }
+    origins.add(site.origin)
+    sites.push(site)
+    if (sites.length === maximumVisitedSites) {
+      break
+    }
+  }
+  return sites
+}
+
+export const load = async () => {
+  try {
+    return normalize(await LocalStorage.getJson(storageKey))
+  } catch {
+    return []
+  }
+}
+
+export const save = async (sites) => {
+  try {
+    await LocalStorage.setJson(storageKey, sites)
+  } catch {
+    // Browsing should continue when local storage is unavailable or full.
+  }
+}
+
+export const add = (sites, url, favicon) => {
+  const origin = getOrigin(url)
+  if (!origin || !isValidFavicon(favicon)) {
+    return sites
+  }
+  const newSite = { favicon, origin }
+  return [newSite, ...sites.filter((site) => site.origin !== origin)].slice(0, maximumVisitedSites)
+}
+
+export const getSuggestions = (sites, query) => {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (normalizedQuery.length < 2) {
+    return []
+  }
+  return sites
+    .filter((site) => site.origin.toLowerCase().includes(normalizedQuery))
+    .slice(0, 4)
+    .map((site) => ({ favicon: site.favicon, type: 'url', value: site.origin }))
+}

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -231,6 +231,8 @@ export const getSimpleBrowserVirtualDom = (
     })
     for (let index = 0; index < suggestions.length; index++) {
       const suggestion = suggestions[index]
+      const favicon = typeof suggestion === 'string' ? '' : suggestion.favicon
+      const value = typeof suggestion === 'string' ? suggestion : suggestion.value
       const selected = index === selectedSuggestionIndex
       dom.push(
         {
@@ -238,16 +240,25 @@ export const getSimpleBrowserVirtualDom = (
           className: selected ? 'SimpleBrowserSuggestion SimpleBrowserSuggestionSelected' : 'SimpleBrowserSuggestion',
           role: AriaRoles.Option,
           ariaSelected: selected,
-          'data-value': suggestion,
+          'data-value': value,
           onClick: DomEventListenerFunctions.HandleClickSuggestion,
           childCount: 2,
         },
-        {
-          type: VirtualDomElements.Div,
-          className: 'MaskIcon MaskIconSearch SimpleBrowserSuggestionIcon',
-          childCount: 0,
-        },
-        text(suggestion),
+        favicon
+          ? {
+              type: VirtualDomElements.Img,
+              className: 'SimpleBrowserSuggestionFavicon',
+              crossOrigin: 'anonymous',
+              src: favicon,
+              draggable: false,
+              childCount: 0,
+            }
+          : {
+              type: VirtualDomElements.Div,
+              className: 'MaskIcon MaskIconSearch SimpleBrowserSuggestionIcon',
+              childCount: 0,
+            },
+        text(value),
       )
     }
   }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -2,6 +2,7 @@
 
 import * as Assert from '../Assert/Assert.ts'
 import * as BrowserSearchSuggestions from '../BrowserSearchSuggestions/BrowserSearchSuggestions.js'
+import * as BrowserVisitedSites from '../BrowserVisitedSites/BrowserVisitedSites.js'
 import * as Command from '../Command/Command.js'
 import * as ElectronWebContentsView from '../ElectronWebContentsView/ElectronWebContentsView.js'
 import * as ElectronWebContentsViewFunctions from '../ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js'
@@ -135,6 +136,7 @@ export const create = (id, uri, x, y, width, height) => {
     tabsEnabled: true,
     selectedTabIndex: 0,
     zoomLevel: 0,
+    visitedSites: [],
   }
 }
 
@@ -163,7 +165,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   const headerHeight = getHeaderHeight(tabsEnabled)
   // TODO since browser view is not visible at this point
   // it is not necessary to load keybindings for it
-  const keyBindings = await KeyBindingsInitial.getKeyBindings()
+  const [keyBindings, visitedSites] = await Promise.all([KeyBindingsInitial.getKeyBindings(), BrowserVisitedSites.load()])
   const fallThroughKeyBindings = getFallThroughKeyBindings(keyBindings)
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0)
   await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
@@ -181,6 +183,7 @@ export const backgroundLoadContent = async (state, savedState) => {
     tabsEnabled,
     title,
     zoomLevel: 0,
+    visitedSites,
     uri: `simple-browser://${browserViewId}`,
     iframeSrc,
     inputValue: iframeSrc,
@@ -202,7 +205,7 @@ export const loadContent = async (state, savedState) => {
   const id = getId(idPart)
   const iframeSrc = getUrlFromSavedState(savedState)
   // TODO load keybindings in parallel with creating browserview
-  const keyBindings = await KeyBindingsInitial.getKeyBindings()
+  const [keyBindings, visitedSites] = await Promise.all([KeyBindingsInitial.getKeyBindings(), BrowserVisitedSites.load()])
   const audioIndicatorEnabled = Preferences.get('simpleBrowser.audioIndicator.enabled') !== false
   const suggestionsEnabled = Preferences.get('simpleBrowser.suggestions')
   const tabsEnabled = Preferences.get('simpleBrowser.tabs.enabled') !== false
@@ -248,6 +251,7 @@ export const loadContent = async (state, savedState) => {
       tabsEnabled,
       title,
       muted: Boolean(stats.isAudioMuted),
+      visitedSites,
     }
   }
 
@@ -284,6 +288,7 @@ export const loadContent = async (state, savedState) => {
       }),
     ],
     tabsEnabled,
+    visitedSites,
   }
 }
 
@@ -598,13 +603,13 @@ export const handleInput = async (state, value) => {
     ...updateTab(state, state.browserViewId, { inputValue: value }),
     selectedSuggestionIndex: -1,
   }
-  if (!state.suggestionsEnabled || !shouldRequestSuggestions(value)) {
+  if (!state.suggestionsEnabled || value.trim().length < 2) {
     if (state.hasSuggestionsOverlay) {
       void Command.execute('SimpleBrowser.closeSuggestions')
     }
     return newState
   }
-  void requestSuggestions(state.uid, value)
+  void requestSuggestions(state.uid, value, shouldRequestSuggestions(value))
   return newState
 }
 
@@ -615,27 +620,48 @@ const shouldRequestSuggestions = (value) => {
   if (query.length < 2) {
     return false
   }
-  return !/^(?:[a-z][a-z\d+.-]*:\/\/|localhost(?::\d+)?(?:\/|$)|\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:\/|$))/i.test(query)
+  return !/^(?:[a-z][a-z\d+.-]*:\/\/|localhost(?::\d+)?(?:\/|$)|\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:\/|$)|(?:[\w-]+\.)+[a-z]{2,}(?::\d+)?(?:\/|$))/i.test(
+    query,
+  )
 }
 
-const requestSuggestions = async (uid, query) => {
+const requestSuggestions = async (uid, query, requestProviderSuggestions) => {
   let suggestions = []
-  try {
-    suggestions = await BrowserSearchSuggestions.get(query)
-  } catch {
-    // Provider failures should leave normal address-bar navigation available.
+  if (requestProviderSuggestions) {
+    try {
+      suggestions = await BrowserSearchSuggestions.get(query)
+    } catch {
+      // Provider failures should leave normal address-bar navigation available.
+    }
   }
   await Command.execute('SimpleBrowser.applySuggestions', uid, query, suggestions)
+}
+
+const createSearchSuggestion = (value) => {
+  return { favicon: '', type: 'search', value }
+}
+
+const getSuggestionValue = (suggestion) => {
+  return typeof suggestion === 'string' ? suggestion : suggestion?.value
 }
 
 export const applySuggestions = async (state, uid, query, suggestions) => {
   if (state.uid !== uid || state.inputValue !== query || !state.suggestionsEnabled) {
     return state
   }
-  if (!Array.isArray(suggestions) || suggestions.length === 0) {
+  const visitedSiteSuggestions = BrowserVisitedSites.getSuggestions(state.visitedSites, query)
+  const providerSuggestions = Array.isArray(suggestions) ? suggestions : []
+  const allSuggestions = [
+    ...visitedSiteSuggestions,
+    ...(providerSuggestions.length > 0 ? [createSearchSuggestion(query)] : []),
+    ...providerSuggestions.map(createSearchSuggestion),
+  ]
+  const uniqueSuggestions = allSuggestions
+    .filter((suggestion, index) => allSuggestions.findIndex((other) => other.value === suggestion.value) === index)
+    .slice(0, 8)
+  if (uniqueSuggestions.length === 0) {
     return closeSuggestions(state)
   }
-  const uniqueSuggestions = [query, ...suggestions.filter((suggestion) => suggestion !== query)].slice(0, 8)
   const overlayState = await showOverlay(state, suggestionsOverlayId)
   if (!overlayState.overlayIds.includes(suggestionsOverlayId)) {
     return state
@@ -701,7 +727,7 @@ const navigate = (state, value) => {
 }
 
 export const acceptSuggestion = async (state, value) => {
-  const suggestion = typeof value === 'string' ? value : state.suggestions[state.selectedSuggestionIndex]
+  const suggestion = typeof value === 'string' ? value : getSuggestionValue(state.suggestions[state.selectedSuggestionIndex])
   if (typeof suggestion !== 'string') {
     return state
   }
@@ -798,7 +824,20 @@ export const handleTitleUpdated = async (state, browserViewId, value) => {
 export const handlePageFaviconUpdated = (state, browserViewId, favicons) => {
   const [actualBrowserViewId, actualFavicons] = parseWebContentsEvent(state, browserViewId, favicons)
   const favicon = Array.isArray(actualFavicons) ? actualFavicons[0] || '' : ''
-  return updateTab(state, actualBrowserViewId, { favicon })
+  const tab = state.tabs.find((tab) => tab.browserViewId === actualBrowserViewId)
+  const newState = updateTab(state, actualBrowserViewId, { favicon })
+  if (!tab) {
+    return newState
+  }
+  const visitedSites = BrowserVisitedSites.add(state.visitedSites, tab.iframeSrc, favicon)
+  if (visitedSites === state.visitedSites) {
+    return newState
+  }
+  void BrowserVisitedSites.save(visitedSites)
+  return {
+    ...newState,
+    visitedSites,
+  }
 }
 
 export const handleAudioStateChanged = (state, browserViewId, audible) => {

--- a/packages/renderer-worker/test/BrowserVisitedSites.test.ts
+++ b/packages/renderer-worker/test/BrowserVisitedSites.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/LocalStorage/LocalStorage.js', () => ({
+  getJson: jest.fn(),
+  setJson: jest.fn(),
+}))
+
+const BrowserVisitedSites = await import('../src/parts/BrowserVisitedSites/BrowserVisitedSites.js')
+const LocalStorage = await import('../src/parts/LocalStorage/LocalStorage.js')
+
+test('loads normalized visited sites', async () => {
+  // @ts-ignore
+  LocalStorage.getJson.mockResolvedValue([
+    { favicon: 'https://soundcloud.com/favicon.ico', origin: 'https://soundcloud.com/discover' },
+    { favicon: 'https://duplicate.example/favicon.ico', origin: 'https://soundcloud.com' },
+    { favicon: 'javascript:alert(1)', origin: 'https://invalid.example' },
+  ])
+
+  await expect(BrowserVisitedSites.load()).resolves.toEqual([{ favicon: 'https://soundcloud.com/favicon.ico', origin: 'https://soundcloud.com' }])
+  expect(LocalStorage.getJson).toHaveBeenCalledWith('simple-browser-visited-sites')
+})
+
+test('returns an empty list when storage cannot be read', async () => {
+  // @ts-ignore
+  LocalStorage.getJson.mockRejectedValue(new Error('storage unavailable'))
+
+  await expect(BrowserVisitedSites.load()).resolves.toEqual([])
+})
+
+test('adds the latest favicon once per origin', () => {
+  const sites = [
+    { favicon: 'https://old.example/favicon.ico', origin: 'https://soundcloud.com' },
+    { favicon: 'https://example.com/favicon.ico', origin: 'https://example.com' },
+  ]
+
+  expect(BrowserVisitedSites.add(sites, 'https://soundcloud.com/discover', 'https://soundcloud.com/new-favicon.ico')).toEqual([
+    { favicon: 'https://soundcloud.com/new-favicon.ico', origin: 'https://soundcloud.com' },
+    { favicon: 'https://example.com/favicon.ico', origin: 'https://example.com' },
+  ])
+})
+
+test('ignores non-http pages and unusable favicons', () => {
+  const sites = [{ favicon: 'https://example.com/favicon.ico', origin: 'https://example.com' }]
+
+  expect(BrowserVisitedSites.add(sites, 'file:///tmp/index.html', 'https://example.com/favicon.ico')).toBe(sites)
+  expect(BrowserVisitedSites.add(sites, 'https://example.com', 'blob:https://example.com/icon')).toBe(sites)
+})
+
+test('finds matching origins and includes their favicon', () => {
+  const sites = [
+    { favicon: 'https://soundcloud.com/favicon.ico', origin: 'https://soundcloud.com' },
+    { favicon: 'https://example.com/favicon.ico', origin: 'https://example.com' },
+  ]
+
+  expect(BrowserVisitedSites.getSuggestions(sites, 'sound')).toEqual([
+    {
+      favicon: 'https://soundcloud.com/favicon.ico',
+      type: 'url',
+      value: 'https://soundcloud.com',
+    },
+  ])
+})
+
+test('saves visited sites without surfacing storage failures', async () => {
+  const sites = [{ favicon: 'https://soundcloud.com/favicon.ico', origin: 'https://soundcloud.com' }]
+  // @ts-ignore
+  LocalStorage.setJson.mockRejectedValue(new Error('storage full'))
+
+  await expect(BrowserVisitedSites.save(sites)).resolves.toBeUndefined()
+  expect(LocalStorage.setJson).toHaveBeenCalledWith('simple-browser-visited-sites', sites)
+})

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -82,6 +82,26 @@ test('renders accessible search suggestions above an undimmed snapshot', () => {
   )
 })
 
+test('renders the stored favicon for a URL suggestion', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, 'soundcloud', '', [
+    {
+      favicon: 'https://soundcloud.com/favicon.ico',
+      type: 'url',
+      value: 'https://soundcloud.com',
+    },
+  ])
+
+  expect(dom).toContainEqual(
+    expect.objectContaining({
+      className: 'SimpleBrowserSuggestionFavicon',
+      crossOrigin: 'anonymous',
+      src: 'https://soundcloud.com/favicon.ico',
+      type: VirtualDomElements.Img,
+    }),
+  )
+  expect(dom).toContainEqual(expect.objectContaining({ 'data-value': 'https://soundcloud.com' }))
+})
+
 test('renders selectable tabs with favicon, title, close, and new tab controls', () => {
   const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, '', '', [], -1, [
     { favicon: 'https://example.com/favicon.png', isAudioPlaying: true, title: 'Example' },

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -74,6 +74,13 @@ jest.unstable_mockModule('../src/parts/BrowserSearchSuggestions/BrowserSearchSug
   get: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/BrowserVisitedSites/BrowserVisitedSites.js', () => ({
+  add: jest.fn(),
+  getSuggestions: jest.fn(),
+  load: jest.fn(),
+  save: jest.fn(),
+}))
+
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
   execute: jest.fn(),
 }))
@@ -87,6 +94,7 @@ const ViewletSimpleBrowser = await import('../src/parts/ViewletSimpleBrowser/Vie
 const ViewletSimpleBrowserOpenBackgroundTab = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserOpenBackgroundTab.js')
 const ViewletSimpleBrowserResize = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserResize.js')
 const BrowserSearchSuggestions = await import('../src/parts/BrowserSearchSuggestions/BrowserSearchSuggestions.js')
+const BrowserVisitedSites = await import('../src/parts/BrowserVisitedSites/BrowserVisitedSites.js')
 const Command = await import('../src/parts/Command/Command.js')
 const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
 const ElectronWebContentsView = await import('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js')
@@ -101,6 +109,12 @@ const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModule
 const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
 
 beforeEach(() => {
+  // @ts-ignore
+  BrowserVisitedSites.add.mockImplementation((sites) => sites)
+  // @ts-ignore
+  BrowserVisitedSites.getSuggestions.mockReturnValue([])
+  // @ts-ignore
+  BrowserVisitedSites.load.mockResolvedValue([])
   // @ts-ignore
   ElectronWebContentsViewFunctions.getStats.mockResolvedValue({
     title: 'test',
@@ -588,6 +602,23 @@ test('updates the matching background tab from web contents events', async () =>
   expect(withAudio.tabs[1]).toMatchObject({ favicon: 'https://two.example/favicon.png', isAudioPlaying: true, title: 'Updated Two' })
 })
 
+test('remembers the origin when a page favicon is received', () => {
+  const visitedSites = [{ favicon: 'https://soundcloud.com/favicon.ico', origin: 'https://soundcloud.com' }]
+  // @ts-ignore
+  BrowserVisitedSites.add.mockReturnValue(visitedSites)
+  const state = {
+    ...ViewletSimpleBrowser.create(),
+    browserViewId: 12,
+    tabs: [{ browserViewId: 12, favicon: '', iframeSrc: 'https://soundcloud.com/discover', title: 'SoundCloud' }],
+  }
+
+  const newState = ViewletSimpleBrowser.handlePageFaviconUpdated(state, 12, ['https://soundcloud.com/favicon.ico'])
+
+  expect(BrowserVisitedSites.add).toHaveBeenCalledWith([], 'https://soundcloud.com/discover', 'https://soundcloud.com/favicon.ico')
+  expect(BrowserVisitedSites.save).toHaveBeenCalledWith(visitedSites)
+  expect(newState).toMatchObject({ favicon: 'https://soundcloud.com/favicon.ico', visitedSites })
+})
+
 test('updates audio state for the selected tab', () => {
   const state = {
     ...ViewletSimpleBrowser.create(),
@@ -970,11 +1001,15 @@ test('handleInput requests suggestions when enabled', async () => {
 })
 
 test('handleInput does not disclose URL-like values to the suggestions provider', async () => {
+  // @ts-ignore
+  Command.execute.mockResolvedValue(undefined)
   const state = { ...ViewletSimpleBrowser.create(7), suggestionsEnabled: true }
 
-  await ViewletSimpleBrowser.handleInput(state, 'https://example.com/private')
+  await ViewletSimpleBrowser.handleInput(state, 'soundcloud.com')
+  await new Promise((resolve) => setTimeout(resolve, 0))
 
   expect(BrowserSearchSuggestions.get).not.toHaveBeenCalled()
+  expect(Command.execute).toHaveBeenCalledWith('SimpleBrowser.applySuggestions', 7, 'soundcloud.com', [])
 })
 
 test('applySuggestions ignores stale results', async () => {
@@ -1013,7 +1048,11 @@ test('applySuggestions captures the page and shows provider results', async () =
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: 0,
     snapshot: 'blob:https://example.com/snapshot',
-    suggestions: ['what is', 'what is my ip', 'what is love'],
+    suggestions: [
+      { favicon: '', type: 'search', value: 'what is' },
+      { favicon: '', type: 'search', value: 'what is my ip' },
+      { favicon: '', type: 'search', value: 'what is love' },
+    ],
   })
 })
 
@@ -1034,7 +1073,10 @@ test('applySuggestions does not capture a page for an empty new tab', async () =
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: 0,
     snapshot: '',
-    suggestions: ['what is', 'what is my ip'],
+    suggestions: [
+      { favicon: '', type: 'search', value: 'what is' },
+      { favicon: '', type: 'search', value: 'what is my ip' },
+    ],
   })
   expect(ElectronWebContentsViewFunctions.capturePage).not.toHaveBeenCalled()
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
@@ -1085,6 +1127,32 @@ test('suggestion selection stays within the available results', () => {
   expect(first.selectedSuggestionIndex).toBe(0)
 })
 
+test('applySuggestions places matching visited sites before provider results', async () => {
+  const localSuggestion = {
+    favicon: 'https://soundcloud.com/favicon.ico',
+    type: 'url',
+    value: 'https://soundcloud.com',
+  }
+  // @ts-ignore
+  BrowserVisitedSites.getSuggestions.mockReturnValue([localSuggestion])
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: 'soundcloud',
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.applySuggestions(state, 7, 'soundcloud', ['soundcloud music'])
+
+  expect(newState.suggestions).toEqual([
+    localSuggestion,
+    { favicon: '', type: 'search', value: 'soundcloud' },
+    { favicon: '', type: 'search', value: 'soundcloud music' },
+  ])
+})
+
 test('acceptSuggestion restores the page and navigates', async () => {
   // @ts-ignore
   ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
@@ -1095,7 +1163,10 @@ test('acceptSuggestion restores the page and navigates', async () => {
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: 1,
     snapshot: 'blob:https://example.com/snapshot',
-    suggestions: ['what is', 'what is my ip'],
+    suggestions: [
+      { favicon: '', type: 'search', value: 'what is' },
+      { favicon: '', type: 'search', value: 'what is my ip' },
+    ],
     suggestionsEnabled: true,
   }
 
@@ -1112,4 +1183,29 @@ test('acceptSuggestion restores the page and navigates', async () => {
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(12)
   expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, 'https://www.google.com/search?q=what+is+my+ip')
+})
+
+test('acceptSuggestion navigates directly to a visited URL suggestion', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    hasSuggestionsOverlay: true,
+    overlayIds: ['search-suggestions'],
+    selectedSuggestionIndex: 0,
+    suggestions: [
+      {
+        favicon: 'https://soundcloud.com/favicon.ico',
+        type: 'url',
+        value: 'https://soundcloud.com',
+      },
+    ],
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.acceptSuggestion(state)
+
+  expect(newState).toMatchObject({ iframeSrc: 'https://soundcloud.com', inputValue: 'https://soundcloud.com', isLoading: true })
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, 'https://soundcloud.com')
 })

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -195,3 +195,11 @@
   pointer-events: none;
   width: 18px;
 }
+
+.SimpleBrowserSuggestionFavicon {
+  flex: 0 0 18px;
+  height: 18px;
+  object-fit: contain;
+  pointer-events: none;
+  width: 18px;
+}


### PR DESCRIPTION
Store a bounded list of visited browser origins and their reported favicons, then show matching URL suggestions ahead of search-provider results. URL-like input stays local and storage failures do not interrupt browsing.