### PR TITLE
fix: restore simple browser tabs lazily

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -141,10 +141,42 @@ export const create = (id, uri, x, y, width, height) => {
 }
 
 export const saveState = (state) => {
-  const { iframeSrc } = state
+  const { iframeSrc, selectedTabIndex, tabs } = state
   return {
     iframeSrc,
+    selectedTabIndex,
+    tabs: tabs.map((tab) => ({
+      favicon: tab.favicon,
+      iframeSrc: tab.iframeSrc,
+      inputValue: tab.inputValue,
+      title: tab.title,
+    })),
   }
+}
+
+const getTabsFromSavedState = (savedState) => {
+  if (!Array.isArray(savedState?.tabs)) {
+    return []
+  }
+  return savedState.tabs
+    .filter((tab) => tab && typeof tab === 'object')
+    .map((tab) => {
+      const iframeSrc = typeof tab.iframeSrc === 'string' ? tab.iframeSrc : ''
+      return createTab({
+        browserViewId: 0,
+        favicon: typeof tab.favicon === 'string' ? tab.favicon : '',
+        iframeSrc,
+        inputValue: typeof tab.inputValue === 'string' ? tab.inputValue : iframeSrc,
+        title: typeof tab.title === 'string' ? tab.title : 'New Tab',
+      })
+    })
+}
+
+const getSavedSelectedTabIndex = (savedState, tabs) => {
+  if (tabs.length === 0 || !Number.isInteger(savedState?.selectedTabIndex)) {
+    return 0
+  }
+  return Math.max(0, Math.min(savedState.selectedTabIndex, tabs.length - 1))
 }
 
 const getUrlFromSavedState = (savedState) => {
@@ -203,7 +235,10 @@ export const loadContent = async (state, savedState) => {
   const { x, y, width, height, uri, uid } = state
   const idPart = uri.slice('simple-browser://'.length)
   const id = getId(idPart)
-  const iframeSrc = getUrlFromSavedState(savedState)
+  const savedTabs = getTabsFromSavedState(savedState)
+  const savedSelectedTabIndex = getSavedSelectedTabIndex(savedState, savedTabs)
+  const savedSelectedTab = savedTabs[savedSelectedTabIndex]
+  const iframeSrc = savedSelectedTab ? savedSelectedTab.iframeSrc : getUrlFromSavedState(savedState)
   // TODO load keybindings in parallel with creating browserview
   const [keyBindings, visitedSites] = await Promise.all([KeyBindingsInitial.getKeyBindings(), BrowserVisitedSites.load()])
   const audioIndicatorEnabled = Preferences.get('simpleBrowser.audioIndicator.enabled') !== false
@@ -217,76 +252,46 @@ export const loadContent = async (state, savedState) => {
   const shortcuts = SimpleBrowserPreferences.getShortCuts()
   const fallThroughKeyBindings = getFallThroughKeyBindings(keyBindings)
 
-  if (id) {
-    const actualId = await ElectronWebContentsView.createWebContentsView(id, uid)
-    await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(actualId, fallThroughKeyBindings)
-    await ElectronWebContentsViewFunctions.resizeWebContentsView(actualId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
-    if (id !== actualId) {
-      await ElectronWebContentsViewFunctions.setIframeSrc(actualId, iframeSrc)
-    }
-    const stats = await ElectronWebContentsViewFunctions.getStats(actualId)
-    const title = stats.title || 'Simple Browser'
-    const tab = createTab({
-      browserViewId: actualId,
-      canGoBack: stats.canGoBack,
-      canGoForward: stats.canGoForward,
-      iframeSrc,
-      inputValue: iframeSrc,
-      muted: Boolean(stats.isAudioMuted),
-      title,
-    })
-    return {
-      ...state,
-      audioIndicatorEnabled,
-      browserViewId: actualId,
-      iframeSrc,
-      inputValue: iframeSrc,
-      canGoBack: stats.canGoBack,
-      canGoForward: stats.canGoForward,
-      headerHeight,
-      selectedTabIndex: 0,
-      suggestionsEnabled,
-      shortcuts,
-      tabs: [tab],
-      tabsEnabled,
-      title,
-      muted: Boolean(stats.isAudioMuted),
-      visitedSites,
-    }
-  }
-
-  const browserViewId = await ElectronWebContentsView.createWebContentsView(/* restoreId */ 0, uid)
+  const browserViewId = await ElectronWebContentsView.createWebContentsView(id, uid)
   await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
   Assert.number(browserViewId)
-  await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
+  if (iframeSrc && (!id || id !== browserViewId)) {
+    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
+  }
   const { title, canGoBack, canGoForward, isAudioMuted } = await ElectronWebContentsViewFunctions.getStats(browserViewId)
+  const restoredTabs =
+    savedTabs.length > 0 ? savedTabs : [createTab({ browserViewId: 0, iframeSrc, inputValue: iframeSrc, title: title || 'Simple Browser' })]
+  const selectedTabIndex = tabsEnabled ? savedSelectedTabIndex : 0
+  const tabsToRestore = tabsEnabled ? restoredTabs : [restoredTabs[savedSelectedTabIndex]]
+  const savedActiveTab = tabsToRestore[selectedTabIndex]
+  const activeTab = createTab({
+    ...savedActiveTab,
+    browserViewId,
+    canGoBack,
+    canGoForward,
+    iframeSrc,
+    inputValue: savedActiveTab.inputValue,
+    muted: Boolean(isAudioMuted),
+    title: title || savedActiveTab.title || 'Simple Browser',
+  })
+  const tabs = tabsToRestore.with(selectedTabIndex, activeTab)
   return {
     ...state,
     audioIndicatorEnabled,
-    iframeSrc,
-    inputValue: iframeSrc,
-    title,
+    iframeSrc: activeTab.iframeSrc,
+    inputValue: activeTab.inputValue,
+    title: activeTab.title,
     browserViewId,
     canGoBack,
     canGoForward,
     muted: Boolean(isAudioMuted),
-    uri: `simple-browser://${browserViewId}`,
+    uri: id ? uri : `simple-browser://${browserViewId}`,
     headerHeight,
-    selectedTabIndex: 0,
+    selectedTabIndex,
     suggestionsEnabled,
     shortcuts,
-    tabs: [
-      createTab({
-        browserViewId,
-        canGoBack,
-        canGoForward,
-        iframeSrc,
-        inputValue: iframeSrc,
-        muted: Boolean(isAudioMuted),
-        title,
-      }),
-    ],
+    tabs,
     tabsEnabled,
     visitedSites,
   }
@@ -298,7 +303,7 @@ export const show = async (state) => {
 }
 
 export const hide = async (state) => {
-  await Promise.all(state.tabs.map((tab) => ElectronWebContentsViewFunctions.hide(tab.browserViewId)))
+  await Promise.all(state.tabs.filter((tab) => tab.browserViewId).map((tab) => ElectronWebContentsViewFunctions.hide(tab.browserViewId)))
 }
 
 const createEmptyTab = async (state) => {
@@ -307,6 +312,18 @@ const createEmptyTab = async (state) => {
   await ElectronWebContentsViewFunctions.hide(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
   return createTab({ browserViewId })
+}
+
+const materializeTab = async (state, tab) => {
+  const createdTab = await createEmptyTab(state)
+  if (tab.iframeSrc) {
+    void ElectronWebContentsViewFunctions.setIframeSrc(createdTab.browserViewId, tab.iframeSrc)
+  }
+  return {
+    ...tab,
+    browserViewId: createdTab.browserViewId,
+    isLoading: Boolean(tab.iframeSrc),
+  }
 }
 
 const switchWebContentsView = async (oldBrowserViewId, newBrowserViewId) => {
@@ -423,10 +440,15 @@ export const selectTab = async (state, index) => {
   if (state.hasSuggestionsOverlay) {
     newState = await closeSuggestions(state)
   }
-  const tab = newState.tabs[selectedTabIndex]
+  let tabs = newState.tabs
+  let tab = tabs[selectedTabIndex]
+  if (!tab.browserViewId) {
+    tab = await materializeTab(newState, tab)
+    tabs = tabs.with(selectedTabIndex, tab)
+  }
   await switchWebContentsView(newState.browserViewId, tab.browserViewId)
   await ElectronWebContentsViewFunctions.focus(tab.browserViewId)
-  return activateTab(newState, newState.tabs, selectedTabIndex)
+  return activateTab(newState, tabs, selectedTabIndex)
 }
 
 export const focusNextTab = (state) => {
@@ -460,7 +482,7 @@ export const closeTab = async (state, index) => {
     const newState = activateTab(currentState, [replacement], 0)
     return { ...newState, focusAddressVersion: newState.focusAddressVersion + 1 }
   }
-  const tabs = currentState.tabs.toSpliced(tabIndex, 1)
+  let tabs = currentState.tabs.toSpliced(tabIndex, 1)
   const wasSelected = tabIndex === currentState.selectedTabIndex
   let selectedTabIndex = currentState.selectedTabIndex
   if (wasSelected) {
@@ -468,11 +490,17 @@ export const closeTab = async (state, index) => {
   } else if (tabIndex < selectedTabIndex) {
     selectedTabIndex--
   }
-  await ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)
+  if (tab.browserViewId) {
+    await ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)
+  }
   if (!wasSelected) {
     return { ...currentState, selectedTabIndex, tabs }
   }
-  const selectedTab = tabs[selectedTabIndex]
+  let selectedTab = tabs[selectedTabIndex]
+  if (!selectedTab.browserViewId) {
+    selectedTab = await materializeTab(currentState, selectedTab)
+    tabs = tabs.with(selectedTabIndex, selectedTab)
+  }
   await ElectronWebContentsViewFunctions.show(selectedTab.browserViewId)
   await ElectronWebContentsViewFunctions.focus(selectedTab.browserViewId)
   return activateTab(currentState, tabs, selectedTabIndex)
@@ -493,8 +521,8 @@ const closeTabsByIndex = async (state, indexes, preferredTabIndex) => {
   const { browserViewId, tabs: currentTabs } = currentState
   const preferredBrowserViewId = currentTabs[preferredTabIndex]?.browserViewId
   const tabsToClose = currentTabs.filter((tab, index) => indexesToClose.has(index))
-  const remainingTabs = currentTabs.filter((tab, index) => !indexesToClose.has(index))
-  await Promise.all(tabsToClose.map((tab) => ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)))
+  let remainingTabs = currentTabs.filter((tab, index) => !indexesToClose.has(index))
+  await Promise.all(tabsToClose.filter((tab) => tab.browserViewId).map((tab) => ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)))
   const retainedSelectedTabIndex = remainingTabs.findIndex((tab) => tab.browserViewId === browserViewId)
   if (retainedSelectedTabIndex !== -1) {
     return {
@@ -507,7 +535,11 @@ const closeTabsByIndex = async (state, indexes, preferredTabIndex) => {
     0,
     remainingTabs.findIndex((tab) => tab.browserViewId === preferredBrowserViewId),
   )
-  const selectedTab = remainingTabs[selectedTabIndex]
+  let selectedTab = remainingTabs[selectedTabIndex]
+  if (!selectedTab.browserViewId) {
+    selectedTab = await materializeTab(currentState, selectedTab)
+    remainingTabs = remainingTabs.with(selectedTabIndex, selectedTab)
+  }
   await ElectronWebContentsViewFunctions.show(selectedTab.browserViewId)
   await ElectronWebContentsViewFunctions.focus(selectedTab.browserViewId)
   return activateTab(currentState, remainingTabs, selectedTabIndex)
@@ -847,7 +879,7 @@ export const handleAudioStateChanged = (state, browserViewId, audible) => {
 
 export const dispose = async (state) => {
   await Promise.all([
-    ...state.tabs.map((tab) => ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)),
+    ...state.tabs.filter((tab) => tab.browserViewId).map((tab) => ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)),
     SimpleBrowserSnapshot.dispose(state.snapshot),
   ])
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserResize.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserResize.js
@@ -12,6 +12,8 @@ export const resize = (state, dimensions) => {
 export const resizeEffect = async (state) => {
   const { headerHeight, tabs, x, y, width, height } = state
   await Promise.all(
-    tabs.map((tab) => ElectronWebContentsViewFunctions.resizeWebContentsView(tab.browserViewId, x, y + headerHeight, width, height - headerHeight)),
+    tabs
+      .filter((tab) => tab.browserViewId)
+      .map((tab) => ElectronWebContentsViewFunctions.resizeWebContentsView(tab.browserViewId, x, y + headerHeight, width, height - headerHeight)),
   )
 }

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -210,6 +210,21 @@ test('create', () => {
   expect(state).toBeDefined()
 })
 
+test('saveState preserves all browser tabs and the selected tab', () => {
+  const state = createTabsState(1)
+
+  expect(ViewletSimpleBrowser.saveState(state)).toEqual({
+    iframeSrc: 'https://two.example',
+    selectedTabIndex: 1,
+    tabs: [
+      { favicon: '', iframeSrc: 'https://one.example', inputValue: 'https://one.example', title: 'One' },
+      { favicon: '', iframeSrc: 'https://two.example', inputValue: 'https://two.example', title: 'Two' },
+      { favicon: '', iframeSrc: 'https://three.example', inputValue: 'https://three.example', title: 'Three' },
+      { favicon: '', iframeSrc: 'https://four.example', inputValue: 'https://four.example', title: 'Four' },
+    ],
+  })
+})
+
 test('uses the URL input focus context for the address field', () => {
   const state = ViewletSimpleBrowser.create(42)
 
@@ -310,6 +325,44 @@ test('loadContent - restore id - browser view does not exist yet', async () => {
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith(2, browserTabKeyBindings)
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(2, 'https://example.com')
+})
+
+test('loadContent restores every tab but creates a web contents view only for the selected tab', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(17)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.getStats.mockResolvedValue({ canGoBack: false, canGoForward: false, title: '' })
+  const state = ViewletSimpleBrowser.create(7, 'simple-browser://12', 10, 20, 300, 200)
+  const savedState = {
+    iframeSrc: 'https://two.example',
+    selectedTabIndex: 1,
+    tabs: [
+      { favicon: 'https://one.example/favicon.ico', iframeSrc: 'https://one.example', inputValue: 'one.example', title: 'One' },
+      { favicon: 'https://two.example/favicon.ico', iframeSrc: 'https://two.example', inputValue: 'two.example', title: 'Two' },
+      { favicon: '', iframeSrc: 'https://three.example', inputValue: 'three.example', title: 'Three' },
+    ],
+  }
+
+  const newState = await ViewletSimpleBrowser.loadContent(state, savedState)
+
+  expect(newState).toMatchObject({
+    browserViewId: 17,
+    iframeSrc: 'https://two.example',
+    inputValue: 'two.example',
+    selectedTabIndex: 1,
+    title: 'Two',
+  })
+  expect(newState.tabs).toMatchObject([
+    { browserViewId: 0, iframeSrc: 'https://one.example', title: 'One' },
+    { browserViewId: 17, iframeSrc: 'https://two.example', title: 'Two' },
+    { browserViewId: 0, iframeSrc: 'https://three.example', title: 'Three' },
+  ])
+  expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledWith(12, 7)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(17, 'https://two.example')
 })
 
 test('handleTitleUpdated', async () => {
@@ -506,6 +559,49 @@ test('switches tabs by showing the selected view before hiding the previous acti
   // @ts-ignore
   const hideCallOrder = ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]
   expect(showCallOrder).toBeLessThan(hideCallOrder)
+})
+
+test('creates a restored background tab web contents view when the tab is selected', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(18)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7, 'simple-browser://17', 10, 20, 300, 200),
+    browserViewId: 17,
+    headerHeight: 65,
+    selectedTabIndex: 1,
+    tabs: [
+      { browserViewId: 0, iframeSrc: 'https://one.example', inputValue: 'one.example', title: 'One' },
+      { browserViewId: 17, iframeSrc: 'https://two.example', inputValue: 'two.example', title: 'Two' },
+    ],
+  }
+
+  const newState = await ViewletSimpleBrowser.selectTab(state, 0)
+
+  expect(newState).toMatchObject({
+    browserViewId: 18,
+    iframeSrc: 'https://one.example',
+    inputValue: 'one.example',
+    selectedTabIndex: 0,
+    title: 'One',
+  })
+  expect(newState.tabs[0]).toMatchObject({ browserViewId: 18, iframeSrc: 'https://one.example', isLoading: true })
+  expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledWith(0, 7)
+  expect(ElectronWebContentsViewFunctions.resizeWebContentsView).toHaveBeenCalledWith(18, 10, 85, 300, 135)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(18, 'https://one.example')
+  expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(18)
+  expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(17)
+  expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(18)
 })
 
 test('Ctrl+Tab from the focused web contents selects the next browser tab', async () => {
@@ -788,7 +884,7 @@ test('hides every retained web contents view when the Simple Browser is hidden',
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
   const state = {
     ...ViewletSimpleBrowser.create(),
-    tabs: [{ browserViewId: 12 }, { browserViewId: 13 }],
+    tabs: [{ browserViewId: 12 }, { browserViewId: 0 }, { browserViewId: 13 }],
   }
 
   await ViewletSimpleBrowser.hide(state)
@@ -803,7 +899,7 @@ test('resizes active and hidden web contents views', async () => {
   ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
   const state = {
     ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
-    tabs: [{ browserViewId: 12 }, { browserViewId: 13 }],
+    tabs: [{ browserViewId: 12 }, { browserViewId: 0 }, { browserViewId: 13 }],
   }
 
   await ViewletSimpleBrowserResize.resizeEffect(state)
@@ -818,7 +914,7 @@ test('disposes every retained web contents view with the Simple Browser', async 
   const state = {
     ...ViewletSimpleBrowser.create(),
     snapshot: 'blob:https://example.com/snapshot',
-    tabs: [{ browserViewId: 12 }, { browserViewId: 13 }],
+    tabs: [{ browserViewId: 12 }, { browserViewId: 0 }, { browserViewId: 13 }],
   }
 
   await ViewletSimpleBrowser.dispose(state)


### PR DESCRIPTION
Restore the complete Simple Browser tab strip across sessions while creating a WebContentsView only for the selected tab. Restored background tabs now create and navigate their view when first selected.