### PR TITLE
Fix extension security details layout

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -353,6 +353,41 @@ test('bundleCss preserves the extension runtime status layout', async () => {
   }
 }, 30_000)
 
+test('bundleCss preserves the extension security details layout', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
+
+  try {
+    await bundleCss({
+      outDir: dir,
+      assetDir: '',
+    })
+
+    const css = await readFile(join(dir, 'parts', 'ViewletExtensionDetail.css'), 'utf8')
+
+    expect(css).toContain(`.SecurityDefinitionList {
+  align-items: baseline;
+  column-gap: 24px;
+  contain: content;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  margin: 0;
+  max-width: 640px;
+  row-gap: 12px;
+}`)
+    expect(css).toContain(`.SecurityDefinitionList > dt {
+  color: var(--DescriptionForeground, color-mix(in srgb, var(--WorkbenchForeground) 76%, transparent));
+  font-weight: 600;
+}`)
+    expect(css).toContain(`.SecurityDefinitionList > dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}`)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test('bundleCss preserves readable table links and invalid cell squiggles', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 

--- a/packages/extension-host-worker-tests/src/viewlet.extension-detail-security-layout.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.extension-detail-security-layout.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.extension-detail-security-layout'
+
+export const test: Test = async ({ expect, ExtensionDetail, Locator }) => {
+  await ExtensionDetail.open('builtin.theme-atom-one-dark')
+  await ExtensionDetail.selectFeatures()
+
+  await Locator('.FeaturesList .Feature[name="Security"]').click()
+
+  const definitionList = Locator('.SecurityDefinitionList')
+  await expect(definitionList).toHaveCSS('display', 'grid')
+  await expect(definitionList).toHaveCSS('align-items', 'baseline')
+  await expect(definitionList.locator(':scope > dd').first()).toHaveCSS('margin-left', '0px')
+}

--- a/static/css/parts/ViewletExtensionDetail.css
+++ b/static/css/parts/ViewletExtensionDetail.css
@@ -118,6 +118,28 @@
   overflow-wrap: anywhere;
 }
 
+.SecurityDefinitionList {
+  align-items: baseline;
+  column-gap: 24px;
+  contain: content;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  margin: 0;
+  max-width: 640px;
+  row-gap: 12px;
+}
+
+.SecurityDefinitionList > dt {
+  color: var(--DescriptionForeground, color-mix(in srgb, var(--WorkbenchForeground) 76%, transparent));
+  font-weight: 600;
+}
+
+.SecurityDefinitionList > dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .Resource {
   display: flex;
   contain: content;


### PR DESCRIPTION
Display extension Security labels and values in aligned columns on the same row. Add bundled-CSS and end-to-end regression coverage.