### PR TITLE
fix: support linked Simple Browser worker

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1560,6 +1560,15 @@
     "contentSecurityPolicy": ["default-src 'none'", "connect-src 'self'"]
   },
   {
+    "id": "simpleBrowser",
+    "fileName": "simpleBrowserViewWorkerMain.js",
+    "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/simple-browser-view/dist/simpleBrowserViewWorkerMain.js",
+    "productionPath": "/packages/simple-browser-view/dist/simpleBrowserViewWorkerMain.js",
+    "settingName": "develop.simpleBrowserWorkerPath",
+    "hotReloadCommand": "",
+    "contentSecurityPolicy": ["default-src 'none'"]
+  },
+  {
     "id": "sourceActionWorker",
     "fileName": "sourceActionWorkerMain.js",
     "contentSecurityPolicy": ["default-src 'none'"],

--- a/packages/shared-process/test/LinkedWorkerPreferences.test.ts
+++ b/packages/shared-process/test/LinkedWorkerPreferences.test.ts
@@ -29,6 +29,18 @@ test('getLinkedWorkerPreferences - resolves a linked worker package', async () =
   })
 })
 
+test('getLinkedWorkerPreferences - resolves the simple browser worker package', async () => {
+  const root = await createPackage({
+    main: 'dist/simpleBrowserViewWorkerMain.js',
+    name: '@lvce-editor/simple-browser-view',
+  })
+  process.argv = [...originalArgv, '--link', root]
+
+  await expect(LinkedWorkerPreferences.getLinkedWorkerPreferences()).resolves.toEqual({
+    'develop.simpleBrowserWorkerPath': join(root, 'dist', 'simpleBrowserViewWorkerMain.js'),
+  })
+})
+
 test('getLinkedWorkerPreferences - ignores extension and unknown packages', async () => {
   const extensionRoot = await mkdtemp(join(tmpdir(), 'linked-extension-'))
   const unknownRoot = await createPackage({


### PR DESCRIPTION
## Summary

- register `@lvce-editor/simple-browser-view` in the worker manifest
- map transient `--link` packages to `develop.simpleBrowserWorkerPath`
- include the worker in packaged asset copying and path replacement

## Validation

- shared-process: 410 passed
- renderer-worker: 1,784 passed
- build: 120 passed
- static-server: 24 passed
- relevant type checks and lint passed
- isolated packaged Electron validation rendered the workbench and opened Simple Browser through the linked local package