### PR TITLE
feature: enable persistent file hash cache

### DIFF
--- a/packages/shared-process/src/parts/LaunchFileSystemProcess/LaunchFileSystemProcess.ts
+++ b/packages/shared-process/src/parts/LaunchFileSystemProcess/LaunchFileSystemProcess.ts
@@ -4,6 +4,7 @@ import * as IpcId from '../IpcId/IpcId.ts'
 import * as IsElectron from '../IsElectron/IsElectron.ts'
 import * as JsonRpc from '../JsonRpc/JsonRpc.ts'
 import * as LaunchProcess from '../LaunchProcess/LaunchProcess.ts'
+import * as PlatformPaths from '../PlatformPaths/PlatformPaths.ts'
 
 export const launchFileSystemProcess = async (): Promise<any> => {
   const ipc = await LaunchProcess.launchProcess({
@@ -17,6 +18,6 @@ export const launchFileSystemProcess = async (): Promise<any> => {
   set(IpcId.FileSystemProcess, ipc)
   // TODO call initialize function, but file system process should create connection to main process
   // TODO maybe call initialize function as part of rpc setup?
-  await JsonRpc.invoke(ipc, 'Initialize.initialize')
+  await JsonRpc.invoke(ipc, 'Initialize.initialize', PlatformPaths.getCacheDir())
   return ipc
 }

--- a/packages/shared-process/test/LaunchFileSystemProcess.test.ts
+++ b/packages/shared-process/test/LaunchFileSystemProcess.test.ts
@@ -1,0 +1,76 @@
+import { expect, jest, test } from '@jest/globals'
+
+const setup = async (): Promise<any> => {
+  jest.resetModules()
+
+  const ipc = {
+    send: jest.fn(),
+  }
+  const invoke = jest.fn()
+  const launchProcess = jest.fn(async (_options: any) => ipc)
+  const set = jest.fn()
+
+  jest.unstable_mockModule('@lvce-editor/rpc-registry', () => ({
+    RpcId: {
+      AuthWorker: 1,
+      ClipBoardProcess: 2,
+      EmbedsProcess: 3,
+      EmbedsWorker: 4,
+      ExtensionHostWorker: 5,
+      FileSystemProcess: 6,
+      MainProcess: 7,
+      SearchProcess: 8,
+      SharedProcess: 9,
+    },
+    set,
+  }))
+
+  jest.unstable_mockModule('../src/parts/FileSystemProcessPath/FileSystemProcessPath.js', () => ({
+    fileSystemProcessPath: '/test/fileSystemProcessMain.js',
+  }))
+
+  jest.unstable_mockModule('../src/parts/IsElectron/IsElectron.js', () => ({
+    isElectron: false,
+  }))
+
+  jest.unstable_mockModule('../src/parts/JsonRpc/JsonRpc.js', () => ({
+    invoke,
+  }))
+
+  jest.unstable_mockModule('../src/parts/LaunchProcess/LaunchProcess.js', () => ({
+    launchProcess,
+  }))
+
+  jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
+    getCacheDir: (): string => '/test/cache/lvce-editor',
+  }))
+
+  const IpcId = await import('../src/parts/IpcId/IpcId.js')
+  const LaunchFileSystemProcess = await import('../src/parts/LaunchFileSystemProcess/LaunchFileSystemProcess.js')
+
+  return {
+    invoke,
+    ipc,
+    IpcId,
+    LaunchFileSystemProcess,
+    launchProcess,
+    set,
+  }
+}
+
+test('launchFileSystemProcess - initializes with product cache directory', async () => {
+  const { invoke, ipc, IpcId, LaunchFileSystemProcess, launchProcess, set } = await setup()
+
+  const result = await LaunchFileSystemProcess.launchFileSystemProcess()
+
+  expect(result).toBe(ipc)
+  expect(launchProcess).toHaveBeenCalledWith({
+    defaultPath: '/test/fileSystemProcessMain.js',
+    isElectron: false,
+    name: 'File System Process',
+    settingName: 'develop.fileSystemProcessPath',
+    targetRpcId: IpcId.FileSystemProcess,
+  })
+  expect(set).toHaveBeenCalledWith(IpcId.FileSystemProcess, ipc)
+  expect(invoke).toHaveBeenCalledWith(ipc, 'Initialize.initialize', '/test/cache/lvce-editor')
+})


### PR DESCRIPTION
## Summary

- initialize the file-system process with the LVCE product cache directory
- add shared-process coverage for the initialization argument
- rely on the automated `@lvce-editor/file-system-process` 5.16.0 dependency update

## Validation

- 410 shared-process tests passed
- shared-process type-check passed
- repository lint and knip passed
- formatting and diff checks passed