### PR TITLE
fix: keep terminal startup from blocking panel rendering

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -32,17 +32,20 @@ export const create = (id, cwd = '') => {
 }
 
 export const loadContent = async (state, _savedState?: any, configuredSpawnOptions?: any) => {
-  const { cwd, uid } = state
   const { command, args } = configuredSpawnOptions || (await GetTerminalSpawnOptions.getTerminalSpawnOptions())
-  await TerminalWorker.invoke('Terminal.create', uid, cwd || Workspace.state.workspacePath, command, args, {
-    backend: getBackend(),
-  })
   return {
     ...state,
     command,
     args,
     xtermMounted: true,
   }
+}
+
+export const loadContentLater = async (state) => {
+  const { args, command, cwd, uid } = state
+  await TerminalWorker.invoke('Terminal.create', uid, cwd || Workspace.state.workspacePath, command, args, {
+    backend: getBackend(),
+  })
 }
 
 export const handleInput = async (state, data) => {

--- a/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2Commands.ts
+++ b/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2Commands.ts
@@ -7,5 +7,6 @@ export const Commands = {
   handleInput: ViewletTerminal.handleInput,
   handleKeyDown: ViewletTerminal.handleKeyDown,
   handleMouseDown: ViewletTerminal.handleMouseDown,
+  loadContentLater: ViewletTerminal.loadContentLater,
   resize: ViewletTerminal.resize,
 }

--- a/packages/renderer-worker/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminal2.test.ts
@@ -67,6 +67,7 @@ jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => {
 })
 
 const ViewletTerminal2 = await import('../src/parts/ViewletTerminal2/ViewletTerminal2.ts')
+const ViewletTerminal2Commands = await import('../src/parts/ViewletTerminal2/ViewletTerminal2Commands.ts')
 
 test('create initializes xterm dimensions', () => {
   expect(ViewletTerminal2.create(1)).toMatchObject({
@@ -78,13 +79,11 @@ test('create initializes xterm dimensions', () => {
   })
 })
 
-test('loadContent starts the terminal transport', async () => {
+test('loadContent mounts xterm before starting the terminal transport', async () => {
   const state = ViewletTerminal2.create(2)
   const newState = await ViewletTerminal2.loadContent(state, undefined, undefined)
 
-  expect(terminalWorkerInvoke).toHaveBeenCalledWith('Terminal.create', 2, '/workspace', 'bash', ['-i'], {
-    backend: 'mock',
-  })
+  expect(terminalWorkerInvoke).not.toHaveBeenCalled()
   expect(newState).toMatchObject({
     args: ['-i'],
     command: 'bash',
@@ -101,19 +100,38 @@ test('loadContent uses spawn options supplied by the terminal tabs parent', asyn
 
   const newState = await ViewletTerminal2.loadContent(state, undefined, spawnOptions)
 
-  expect(terminalWorkerInvoke).toHaveBeenCalledWith('Terminal.create', 9, '/workspace', 'zsh', ['-l'], {
-    backend: 'mock',
-  })
+  expect(terminalWorkerInvoke).not.toHaveBeenCalled()
   expect(newState).toMatchObject(spawnOptions)
 })
 
-test('loadContent starts the terminal transport in the requested cwd', async () => {
-  const state = ViewletTerminal2.create(2, 'file:///workspace/folder')
-  await ViewletTerminal2.loadContent(state, undefined, undefined)
+test('loadContentLater starts the terminal transport in the requested cwd', async () => {
+  const state = {
+    ...ViewletTerminal2.create(2, 'file:///workspace/folder'),
+    args: ['-i'],
+    command: 'bash',
+  }
+  await ViewletTerminal2.loadContentLater(state)
 
   expect(terminalWorkerInvoke).toHaveBeenCalledWith('Terminal.create', 2, 'file:///workspace/folder', 'bash', ['-i'], {
     backend: 'mock',
   })
+})
+
+test('loadContentLater falls back to the workspace cwd', async () => {
+  const state = {
+    ...ViewletTerminal2.create(3),
+    args: ['-l'],
+    command: 'zsh',
+  }
+  await ViewletTerminal2.loadContentLater(state)
+
+  expect(terminalWorkerInvoke).toHaveBeenCalledWith('Terminal.create', 3, '/workspace', 'zsh', ['-l'], {
+    backend: 'mock',
+  })
+})
+
+test('commands expose deferred terminal startup', () => {
+  expect(ViewletTerminal2Commands.Commands.loadContentLater).toBe(ViewletTerminal2.loadContentLater)
 })
 
 test('handleInput forwards xterm input to the terminal worker', async () => {


### PR DESCRIPTION
## Summary

- render and commit the terminal view before starting the terminal transport
- start `Terminal.create` through the existing deferred `loadContentLater` lifecycle hook
- cover deferred startup, configured spawn options, and workspace/current-directory behavior

## Why

The View > Terminal command awaited `Terminal.create` as part of the initial viewlet load. If terminal-process startup remained pending, the panel creation RPC and title-bar menu command remained pending too, leaving the View menu open with no terminal panel committed.

## Validation

- renderer-worker focused regression suite: 69 passed, 8 skipped
- renderer-worker full suite: 385 suites / 1,786 tests passed
- renderer-worker typecheck: passed
- development Electron UI: View > Terminal closes the menu, opens/focuses the terminal, and executes `printf TERMINAL_FIX_OK`

## Lint baseline

`packages/renderer-worker` XO currently reports repository-wide pre-existing convention errors (including every PascalCase source directory and existing no-semicolon files), so it is not a meaningful changed-file gate for this patch.