### PR TITLE
feature: improve simple browser new tab page

### DIFF
--- a/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
@@ -1,0 +1,165 @@
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; form-action https://www.google.com">
+    <title>New Tab</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #1c2121;
+        color: #f3f5f4;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 100%;
+        min-width: 260px;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        overflow: hidden;
+        background:
+          radial-gradient(circle at 50% 24%, rgba(131, 81, 255, 0.09), transparent 34%),
+          #1c2121;
+      }
+
+      main {
+        display: flex;
+        width: min(680px, calc(100% - 48px));
+        margin: 0 auto;
+        padding-top: clamp(88px, 21vh, 220px);
+        flex-direction: column;
+        align-items: center;
+        gap: 48px;
+      }
+
+      .Brand {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        font-size: 28px;
+        font-weight: 650;
+        letter-spacing: -0.6px;
+      }
+
+      .BrandMark {
+        display: grid;
+        width: 52px;
+        height: 52px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 15px;
+        background: linear-gradient(145deg, #30284a, #252b2b);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
+        place-items: center;
+      }
+
+      .BrandMark svg {
+        width: 34px;
+        height: 34px;
+      }
+
+      form {
+        width: 100%;
+      }
+
+      .SearchBox {
+        display: flex;
+        width: 100%;
+        height: 52px;
+        padding: 0 18px;
+        align-items: center;
+        gap: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.09);
+        border-radius: 15px;
+        background: #272d2d;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+        transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+      }
+
+      .SearchBox:hover {
+        background: #2b3231;
+      }
+
+      .SearchBox:focus-within {
+        border-color: #8b6df0;
+        box-shadow: 0 0 0 3px rgba(139, 109, 240, 0.18), 0 10px 28px rgba(0, 0, 0, 0.24);
+      }
+
+      .SearchIcon {
+        width: 19px;
+        height: 19px;
+        flex: none;
+        color: #aab2af;
+      }
+
+      input {
+        width: 100%;
+        min-width: 0;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        font-size: 15px;
+      }
+
+      input::placeholder {
+        color: #9ca5a2;
+        opacity: 1;
+      }
+
+      input::-webkit-search-cancel-button {
+        filter: invert(1);
+        opacity: 0.65;
+      }
+
+      @media (max-height: 500px) {
+        main {
+          padding-top: 56px;
+          gap: 30px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="Brand" aria-label="LVCE">
+        <span class="BrandMark" aria-hidden="true">
+          <svg viewBox="0 0 48 48" role="img">
+            <defs>
+              <linearGradient id="mark" x1="8" y1="5" x2="38" y2="43" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#b06cff"></stop>
+                <stop offset="1" stop-color="#7b49e8"></stop>
+              </linearGradient>
+            </defs>
+            <path fill="url(#mark)" d="M20 3 30 39 18 46 11 42Z"></path>
+          </svg>
+        </span>
+        <span>LVCE</span>
+      </div>
+      <form role="search" action="https://www.google.com/search" method="get">
+        <label class="SearchBox">
+          <svg class="SearchIcon" viewBox="0 0 24 24" aria-hidden="true">
+            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m20 20-4.2-4.2m1.2-5.3a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0Z"></path>
+          </svg>
+          <input type="search" name="q" aria-label="Search with Google" placeholder="Search with Google" autocomplete="off" spellcheck="false">
+        </label>
+      </form>
+    </main>
+  </body>
+</html>`
+
+export const url = `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+
+export const toDisplayUrl = (value) => {
+  return value === url ? '' : value
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -17,6 +17,7 @@ import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as KeyBindingsInitial from '../KeyBindingsInitial/KeyBindingsInitial.js'
 import * as KeyModifier from '../KeyModifier/KeyModifier.js'
 import * as Preferences from '../Preferences/Preferences.js'
+import * as SimpleBrowserNewTabPage from '../SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js'
 import * as SimpleBrowserPreferences from '../SimpleBrowserPreferences/SimpleBrowserPreferences.js'
 import * as SimpleBrowserSnapshot from '../SimpleBrowserSnapshot/SimpleBrowserSnapshot.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
@@ -306,7 +307,7 @@ export const hide = async (state) => {
   await Promise.all(state.tabs.filter((tab) => tab.browserViewId).map((tab) => ElectronWebContentsViewFunctions.hide(tab.browserViewId)))
 }
 
-const createEmptyTab = async (state) => {
+const createUnloadedTab = async (state) => {
   const { headerHeight, height, uid, width, x, y } = state
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0, uid)
   await ElectronWebContentsViewFunctions.hide(browserViewId)
@@ -314,8 +315,14 @@ const createEmptyTab = async (state) => {
   return createTab({ browserViewId })
 }
 
+const createEmptyTab = async (state) => {
+  const tab = await createUnloadedTab(state)
+  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.url)
+  return tab
+}
+
 const materializeTab = async (state, tab) => {
-  const createdTab = await createEmptyTab(state)
+  const createdTab = tab.iframeSrc ? await createUnloadedTab(state) : await createEmptyTab(state)
   if (tab.iframeSrc) {
     void ElectronWebContentsViewFunctions.setIframeSrc(createdTab.browserViewId, tab.iframeSrc)
   }
@@ -356,7 +363,7 @@ export const duplicateTab = async (state, index) => {
   }
   const currentState = hasSuggestionsOverlay ? await closeSuggestions(state) : state
   const sourceTab = currentState.tabs[tabIndex]
-  const emptyTab = await createEmptyTab(currentState)
+  const emptyTab = sourceTab.iframeSrc ? await createUnloadedTab(currentState) : await createEmptyTab(currentState)
   const tab = {
     ...emptyTab,
     iframeSrc: sourceTab.iframeSrc,
@@ -400,7 +407,7 @@ export const reloadTab = async (state, index) => {
 export const openTab = async (state, url, disposition) => {
   const { hasSuggestionsOverlay } = state
   const currentState = hasSuggestionsOverlay ? await closeSuggestions(state) : state
-  const emptyTab = await createEmptyTab(currentState)
+  const emptyTab = await createUnloadedTab(currentState)
   const tab = {
     ...emptyTab,
     iframeSrc: url,
@@ -793,7 +800,7 @@ export const handleWillNavigate = (state, browserViewId, value) => {
   const [actualBrowserViewId, url] = parseWebContentsEvent(state, browserViewId, value)
   return updateTab(state, actualBrowserViewId, {
     favicon: '',
-    iframeSrc: url,
+    iframeSrc: SimpleBrowserNewTabPage.toDisplayUrl(url),
     isAudioPlaying: false,
     isLoading: true,
   })
@@ -827,12 +834,13 @@ export const handleKeyBinding = async (state, browserViewId, keyBinding) => {
 
 export const handleDidNavigate = async (state, browserViewId, value) => {
   const [actualBrowserViewId, url] = parseWebContentsEvent(state, browserViewId, value)
+  const displayUrl = SimpleBrowserNewTabPage.toDisplayUrl(url)
   const { canGoBack, canGoForward } = await ElectronWebContentsViewFunctions.getStats(actualBrowserViewId)
   return updateTab(state, actualBrowserViewId, {
     canGoBack,
     canGoForward,
-    iframeSrc: url,
-    inputValue: url,
+    iframeSrc: displayUrl,
+    inputValue: displayUrl,
     isLoading: false,
   })
 }

--- a/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jest/globals'
+import * as SimpleBrowserNewTabPage from '../src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js'
+
+const prefix = 'data:text/html;charset=utf-8,'
+
+const getHtml = (): string => decodeURIComponent(SimpleBrowserNewTabPage.url.slice(prefix.length))
+
+test('provides a self-contained new tab page', () => {
+  expect(SimpleBrowserNewTabPage.url.startsWith(prefix)).toBe(true)
+  expect(getHtml()).toContain('<title>New Tab</title>')
+  expect(getHtml()).toContain('<span>LVCE</span>')
+  expect(getHtml()).toContain('role="search"')
+  expect(getHtml()).toContain('action="https://www.google.com/search"')
+  expect(getHtml()).toContain('name="q"')
+  expect(getHtml()).toContain('aria-label="Search with Google"')
+})
+
+test('hides the internal page URL from the address bar', () => {
+  expect(SimpleBrowserNewTabPage.toDisplayUrl(SimpleBrowserNewTabPage.url)).toBe('')
+  expect(SimpleBrowserNewTabPage.toDisplayUrl('https://example.com')).toBe('https://example.com')
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -104,6 +104,7 @@ const InputName = await import('../src/parts/InputName/InputName.js')
 const KeyCode = await import('../src/parts/KeyCode/KeyCode.js')
 const KeyModifier = await import('../src/parts/KeyModifier/KeyModifier.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
+const SimpleBrowserNewTabPage = await import('../src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js')
 const SimpleBrowserSnapshot = await import('../src/parts/SimpleBrowserSnapshot/SimpleBrowserSnapshot.js')
 const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModuleId.js')
 const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
@@ -405,6 +406,7 @@ test('creates and selects an empty tab while keeping the original view alive', a
   expect(ElectronWebContentsView.disposeWebContentsView).not.toHaveBeenCalled()
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, SimpleBrowserNewTabPage.url)
   expect(ElectronWindow.focus).toHaveBeenCalledTimes(1)
 })
 
@@ -980,6 +982,18 @@ test('handleDidNavigate refreshes navigation state', async () => {
     inputValue: 'https://example.com/one',
     isLoading: false,
   })
+})
+
+test('keeps the internal new tab URL out of the address state', async () => {
+  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12 }
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.getStats.mockResolvedValueOnce({ canGoBack: false, canGoForward: false })
+
+  const loadingState = ViewletSimpleBrowser.handleWillNavigate(state, 12, SimpleBrowserNewTabPage.url)
+  const loadedState = await ViewletSimpleBrowser.handleDidNavigate(loadingState, 12, SimpleBrowserNewTabPage.url)
+
+  expect(loadingState).toMatchObject({ iframeSrc: '', isLoading: true })
+  expect(loadedState).toMatchObject({ iframeSrc: '', inputValue: '', isLoading: false })
 })
 
 test('showOverlay captures and hides the WebContentsView', async () => {


### PR DESCRIPTION
Adds a calm, Firefox-inspired LVCE start page to empty Simple Browser tabs with a prominent search field and responsive dark styling. Keeps the internal page URL hidden and avoids adding it to tabs that navigate directly to content.