### PR TITLE
fix: disable text selection in simple browser new tab input

### DIFF
--- a/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
@@ -110,6 +110,7 @@ const html = `<!doctype html>
         color: inherit;
         font: inherit;
         font-size: 15px;
+        user-select: none;
       }
 
       input::placeholder {

--- a/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
@@ -13,6 +13,7 @@ test('provides a self-contained new tab page', () => {
   expect(getHtml()).toContain('action="https://www.google.com/search"')
   expect(getHtml()).toContain('name="q"')
   expect(getHtml()).toContain('aria-label="Search with Google"')
+  expect(getHtml()).toContain('user-select: none;')
 })
 
 test('hides the internal page URL from the address bar', () => {


### PR DESCRIPTION
Disable text selection for the Simple Browser new-tab search input so its prompt cannot be highlighted.