### PR TITLE
feature: add process explorer header width class

### DIFF
--- a/static/css/parts/ViewletProcessExplorer.css
+++ b/static/css/parts/ViewletProcessExplorer.css
@@ -33,6 +33,10 @@
   font-weight: 600;
 }
 
+.ProcessExplorerNameHeaderCellWide {
+  width: 40%;
+}
+
 .ProcessExplorerRowFocused {
   background: var(--ListActiveSelectionBackground);
   color: var(--ListActiveSelectionForeground, white);


### PR DESCRIPTION
Add the static Process Explorer name-column width rule so the worker can select it with a class instead of inline CSS.