### PR TITLE
fix: align simple browser menu below button

### DIFF
--- a/packages/renderer-worker/src/parts/ContextMenu/ContextMenu.js
+++ b/packages/renderer-worker/src/parts/ContextMenu/ContextMenu.js
@@ -28,3 +28,12 @@ export const show2 = async (uid, menuId, x, y, ...args) => {
   // @ts-ignore
   return module.show2(uid, menuId, x, y, ...args)
 }
+
+export const show2Below = async (uid, menuId, x, y, ...args) => {
+  Assert.number(uid)
+  Assert.number(menuId)
+  Assert.number(x)
+  Assert.number(y)
+  const module = await getModule()
+  return module.show2Below(uid, menuId, x, y, ...args)
+}

--- a/packages/renderer-worker/src/parts/ContextMenu/ContextMenuBrowser.js
+++ b/packages/renderer-worker/src/parts/ContextMenu/ContextMenuBrowser.js
@@ -17,3 +17,8 @@ export const show2 = async (uid, menuId, x, y, ...args) => {
   // TODO maybe only send labels and keybindings to ui (id not needed on ui)
   // TODO what about separators?
 }
+
+export const show2Below = async (uid, menuId, x, y, ...args) => {
+  await Menu.hide()
+  await Menu.show2Below(uid, menuId, x, y, ...args)
+}

--- a/packages/renderer-worker/src/parts/ContextMenu/ContextMenuElectron.js
+++ b/packages/renderer-worker/src/parts/ContextMenu/ContextMenuElectron.js
@@ -7,3 +7,7 @@ export const show = (x, y, id, ...args) => {
 export const show2 = (uid, menuId, x, y, ...args) => {
   return ElectronContextMenu.openContextMenu2(x, y, uid, menuId, ...args)
 }
+
+export const show2Below = (uid, menuId, x, y, ...args) => {
+  return ElectronContextMenu.openContextMenu2(x, y, uid, menuId, ...args)
+}

--- a/packages/renderer-worker/src/parts/Menu/Menu.js
+++ b/packages/renderer-worker/src/parts/Menu/Menu.js
@@ -21,6 +21,16 @@ export const show2 = async (uid, menuId, x, y, ...args) => {
   }
 }
 
+export const show2Below = async (uid, menuId, x, y, ...args) => {
+  await SimpleBrowserOverlay.show('menu')
+  try {
+    await MenuWorker.invoke('Menu.show2Below', uid, menuId, x, y, ...args)
+  } catch (error) {
+    await SimpleBrowserOverlay.hide('menu')
+    throw error
+  }
+}
+
 export const closeSubMenu = async () => {
   await MenuWorker.invoke('Menu.closeSubMenu')
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -50,7 +50,7 @@ export const renderEventListeners = () => {
     },
     {
       name: DomEventListenerFunctions.HandleClickSimpleBrowserMenu,
-      params: ['showMenu', 'event.clientX', 'event.clientY'],
+      params: ['showMenu', 'event.clientX', 'event.currentTarget.offsetTop', 'event.currentTarget.offsetHeight'],
     },
   ]
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserShowMenu.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserShowMenu.js
@@ -1,7 +1,8 @@
 import * as ContextMenu from '../ContextMenu/ContextMenu.js'
 import * as MenuEntryId from '../MenuEntryId/MenuEntryId.js'
 
-export const showMenu = async (state, x, y) => {
-  await ContextMenu.show2(state.uid, MenuEntryId.SimpleBrowserToolbar, x, y)
+export const showMenu = async (state, x, buttonTop, buttonHeight) => {
+  const y = state.y + buttonTop + buttonHeight
+  await ContextMenu.show2Below(state.uid, MenuEntryId.SimpleBrowserToolbar, x, y)
   return state
 }

--- a/packages/renderer-worker/test/Menu.test.ts
+++ b/packages/renderer-worker/test/Menu.test.ts
@@ -31,6 +31,13 @@ test('show2 hides the Simple Browser while a menu is open', async () => {
   expect(MenuWorker.invoke).toHaveBeenCalledWith('Menu.show2', 7, 'EditorContextMenu', 10, 20, 'arg')
 })
 
+test('show2Below hides the Simple Browser while a menu is open', async () => {
+  await Menu.show2Below(7, 'EditorContextMenu', 10, 20, 'arg')
+
+  expect(SimpleBrowserOverlay.show).toHaveBeenCalledWith('menu')
+  expect(MenuWorker.invoke).toHaveBeenCalledWith('Menu.show2Below', 7, 'EditorContextMenu', 10, 20, 'arg')
+})
+
 test('hide restores the Simple Browser even when hiding the menu fails', async () => {
   // @ts-ignore
   MenuWorker.invoke.mockRejectedValue(new Error('failed'))

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -101,9 +101,7 @@ test('synchronizes the native address value when selecting another tab', () => {
 
   expect(ViewletSimpleBrowserRender.render[2].isEqual(oldState, newState)).toBe(false)
   expect(ViewletSimpleBrowserRender.render[2].multiple).toBe(true)
-  expect(ViewletSimpleBrowserRender.render[2].apply(oldState, newState)).toEqual([
-    ['Viewlet.setValueByName', 42, 'simple-browser-address', ''],
-  ])
+  expect(ViewletSimpleBrowserRender.render[2].apply(oldState, newState)).toEqual([['Viewlet.setValueByName', 42, 'simple-browser-address', '']])
 })
 
 test('focuses the address input for a new empty tab', () => {
@@ -112,9 +110,7 @@ test('focuses the address input for a new empty tab', () => {
 
   expect(ViewletSimpleBrowserRender.render[3].isEqual(oldState, newState)).toBe(false)
   expect(ViewletSimpleBrowserRender.render[3].multiple).toBe(true)
-  expect(ViewletSimpleBrowserRender.render[3].apply(oldState, newState)).toEqual([
-    ['Viewlet.focusElementByName', 42, 'simple-browser-address'],
-  ])
+  expect(ViewletSimpleBrowserRender.render[3].apply(oldState, newState)).toEqual([['Viewlet.focusElementByName', 42, 'simple-browser-address']])
 })
 
 test('routes the browser menu button click with its bottom-edge coordinates', () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -117,10 +117,10 @@ test('focuses the address input for a new empty tab', () => {
   ])
 })
 
-test('routes the browser menu button click with pointer coordinates', () => {
+test('routes the browser menu button click with its bottom-edge coordinates', () => {
   expect(ViewletSimpleBrowserRender.renderEventListeners()).toContainEqual({
     name: 'handleClickSimpleBrowserMenu',
-    params: ['showMenu', 'event.clientX', 'event.clientY'],
+    params: ['showMenu', 'event.clientX', 'event.currentTarget.offsetTop', 'event.currentTarget.offsetHeight'],
   })
 })
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowserShowMenu.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserShowMenu.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('../src/parts/ContextMenu/ContextMenu.js', () => ({
-  show2: jest.fn(),
+  show2Below: jest.fn(),
 }))
 
 const ContextMenu = await import('../src/parts/ContextMenu/ContextMenu.js')
@@ -13,8 +13,8 @@ beforeEach(() => {
 })
 
 test('opens the toolbar menu at the menu button', async () => {
-  const state = { uid: 42 }
+  const state = { uid: 42, y: 95 }
 
-  await expect(ViewletSimpleBrowserShowMenu.showMenu(state, 700, 65)).resolves.toBe(state)
-  expect(ContextMenu.show2).toHaveBeenCalledWith(42, MenuEntryId.SimpleBrowserToolbar, 700, 65)
+  await expect(ViewletSimpleBrowserShowMenu.showMenu(state, 700, 35, 30)).resolves.toBe(state)
+  expect(ContextMenu.show2Below).toHaveBeenCalledWith(42, MenuEntryId.SimpleBrowserToolbar, 700, 160)
 })


### PR DESCRIPTION
Positions the Simple Browser toolbar menu below the ellipsis button by anchoring it to the button's bottom edge.