### PR TITLE
fix: make keybindings palette commands executable

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -197,11 +197,11 @@ export const getQuickPickMenuEntries = () => {
       label: 'Focus: Extensions',
     },
     {
-      id: 'Preferences.openUserKeyBindings',
+      id: 'Preferences.openKeyBindingsJson',
       label: 'Preferences: Open User Key Bindings',
     },
     {
-      id: 'Preferences.openDefaultKeyBindings',
+      id: 'Main.openKeyBindings',
       label: 'Preferences: Open Default Key Bindings',
       aliases: ['Set Key Bindings', 'Key Map', 'Key Mapping'],
     },

--- a/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutMenuEntries.test.ts
@@ -40,6 +40,24 @@ test('getQuickPickMenuEntries includes reset view locations command', () => {
   })
 })
 
+test('getQuickPickMenuEntries includes executable keybindings commands', () => {
+  const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
+
+  expect(entries).toEqual(
+    expect.arrayContaining([
+      {
+        id: 'Preferences.openKeyBindingsJson',
+        label: 'Preferences: Open User Key Bindings',
+      },
+      {
+        id: 'Main.openKeyBindings',
+        label: 'Preferences: Open Default Key Bindings',
+        aliases: ['Set Key Bindings', 'Key Map', 'Key Mapping'],
+      },
+    ]),
+  )
+})
+
 test('getQuickPickMenuEntries includes preview orientation command', () => {
   const entries = ViewletLayoutMenuEntries.getQuickPickMenuEntries()
 


### PR DESCRIPTION
Fixes the Keyboard Shortcuts command-palette entries so the visual keybindings view and user keybindings JSON invoke their existing executable commands. Adds focused regression coverage for both entries.