### PR TITLE
fix: apply user keybindings at runtime

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemAppKeyBindings.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemAppKeyBindings.js
@@ -7,8 +7,10 @@ export const readFile = () => {
   return FileSystemAppShared.readFileInternal(PlatformPaths.getUserKeyBindingsPath, defaultContent)
 }
 
-export const writeFile = (content) => {
-  return FileSystemAppShared.writeFileInternal(PlatformPaths.getUserKeyBindingsPath, content)
+export const writeFile = async (content) => {
+  await FileSystemAppShared.writeFileInternal(PlatformPaths.getUserKeyBindingsPath, content)
+  const KeyBindings = await import('../KeyBindings/KeyBindings.js')
+  await KeyBindings.reloadUserKeyBindings()
 }
 
 export const readJson = () => {}

--- a/packages/renderer-worker/src/parts/KeyBindings/KeyBindings.js
+++ b/packages/renderer-worker/src/parts/KeyBindings/KeyBindings.js
@@ -2,6 +2,7 @@ import * as Command from '../Command/Command.js'
 import * as Assert from '../Assert/Assert.ts'
 import * as ExtensionKeyBindings from '../ExtensionKeyBindings/ExtensionKeyBindings.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
+import * as UserKeyBindings from '../UserKeyBindings/UserKeyBindings.js'
 
 // TODO where to store keybindings? need them here and in renderer process
 // how to avoid duplicate loading / where to store them and keep them in sync?
@@ -37,6 +38,15 @@ export const handleKeyBinding = async (identifier) => {
 }
 
 export const hydrate = async () => {
-  const keyBindings = await ExtensionKeyBindings.getKeyBindings()
-  KeyBindingsState.setKeyBindings('extensions', keyBindings)
+  const [extensionKeyBindings, userKeyBindings] = await Promise.all([
+    ExtensionKeyBindings.getKeyBindings(),
+    UserKeyBindings.getKeyBindings(),
+  ])
+  KeyBindingsState.setKeyBindings('extensions', extensionKeyBindings)
+  KeyBindingsState.setKeyBindings('user', userKeyBindings)
+}
+
+export const reloadUserKeyBindings = async () => {
+  const keyBindings = await UserKeyBindings.getKeyBindings()
+  KeyBindingsState.setKeyBindings('user', keyBindings)
 }

--- a/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
@@ -39,7 +39,12 @@ const matchesContext = (keyBinding) => {
 }
 
 const getMatchingKeyBindings = (keyBindingSets) => {
-  return Object.values(keyBindingSets).reverse().flat(1).filter(matchesContext)
+  const userKeyBindings = keyBindingSets.user || []
+  const defaultKeyBindings = Object.entries(keyBindingSets)
+    .filter(([id]) => id !== 'user')
+    .map(([, keyBindings]) => keyBindings)
+    .reverse()
+  return [userKeyBindings, ...defaultKeyBindings].flat(1).filter(matchesContext)
 }
 
 const getAvailableKeyBindings = (keyBindings) => {

--- a/packages/renderer-worker/src/parts/PreferencesFileWatcher/PreferencesFileWatcher.js
+++ b/packages/renderer-worker/src/parts/PreferencesFileWatcher/PreferencesFileWatcher.js
@@ -1,5 +1,6 @@
 import * as FileWatcher from '../FileWatcher/FileWatcher.js'
 import * as GetPathDirName from '../GetPathDirName/GetPathDirName.js'
+import * as KeyBindings from '../KeyBindings/KeyBindings.js'
 import * as PathToFileUri from '../PathToFileUri/PathToFileUri.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformPaths from '../PlatformPaths/PlatformPaths.js'
@@ -9,6 +10,8 @@ import * as Preferences from '../Preferences/Preferences.js'
 const ReloadDelay = 100
 
 let reloadTimeout
+let keyBindingsReloadTimeout
+let keyBindingsUri = ''
 let settingsUri = ''
 let watcher
 
@@ -22,17 +25,32 @@ const scheduleReload = () => {
   }, ReloadDelay)
 }
 
-const handleEvent = (event) => {
-  if (event.detail.uri !== settingsUri) {
-    return
+const scheduleKeyBindingsReload = () => {
+  if (keyBindingsReloadTimeout !== undefined) {
+    clearTimeout(keyBindingsReloadTimeout)
   }
-  scheduleReload()
+  keyBindingsReloadTimeout = setTimeout(async () => {
+    keyBindingsReloadTimeout = undefined
+    await KeyBindings.reloadUserKeyBindings()
+  }, ReloadDelay)
+}
+
+const handleEvent = (event) => {
+  if (event.detail.uri === settingsUri) {
+    scheduleReload()
+  } else if (event.detail.uri === keyBindingsUri) {
+    scheduleKeyBindingsReload()
+  }
 }
 
 export const dispose = async () => {
   if (reloadTimeout !== undefined) {
     clearTimeout(reloadTimeout)
     reloadTimeout = undefined
+  }
+  if (keyBindingsReloadTimeout !== undefined) {
+    clearTimeout(keyBindingsReloadTimeout)
+    keyBindingsReloadTimeout = undefined
   }
   if (!watcher) {
     return
@@ -49,9 +67,13 @@ export const hydrate = async () => {
     return
   }
   try {
-    const settingsPath = await PlatformPaths.getUserSettingsPath()
+    const [settingsPath, keyBindingsPath] = await Promise.all([
+      PlatformPaths.getUserSettingsPath(),
+      PlatformPaths.getUserKeyBindingsPath(),
+    ])
     const settingsDirectory = GetPathDirName.getPathDirName(settingsPath)
     settingsUri = PathToFileUri.pathToFileUri(settingsPath)
+    keyBindingsUri = PathToFileUri.pathToFileUri(keyBindingsPath)
     watcher = await FileWatcher.watch({
       exclude: [],
       roots: [PathToFileUri.pathToFileUri(settingsDirectory)],

--- a/packages/renderer-worker/src/parts/UserKeyBindings/UserKeyBindings.js
+++ b/packages/renderer-worker/src/parts/UserKeyBindings/UserKeyBindings.js
@@ -1,0 +1,27 @@
+import * as FileSystem from '../FileSystem/FileSystem.js'
+
+const isValidUserKeyBinding = (keyBinding) => {
+  return (
+    keyBinding &&
+    keyBinding.source === 'User' &&
+    typeof keyBinding.command === 'string' &&
+    keyBinding.command.length > 0 &&
+    Number.isInteger(keyBinding.key)
+  )
+}
+
+export const getKeyBindings = async () => {
+  try {
+    const content = await FileSystem.readFile('app://keybindings.json')
+    if (typeof content !== 'string') {
+      return []
+    }
+    const parsed = JSON.parse(content)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+    return parsed.filter(isValidUserKeyBinding)
+  } catch {
+    return []
+  }
+}

--- a/packages/renderer-worker/test/FileSystemApp.test.ts
+++ b/packages/renderer-worker/test/FileSystemApp.test.ts
@@ -47,11 +47,18 @@ jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => {
 
 jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => {
   return {
+    getUserKeyBindingsPath: jest.fn(() => {
+      throw new Error('not implemented')
+    }),
     getUserSettingsPath: jest.fn(() => {
       throw new Error('not implemented')
     }),
   }
 })
+
+jest.unstable_mockModule('../src/parts/KeyBindings/KeyBindings.js', () => ({
+  reloadUserKeyBindings: jest.fn(),
+}))
 
 jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => {
   return {
@@ -62,6 +69,7 @@ jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => {
 })
 
 const FileSystemApp = await import('../src/parts/FileSystem/FileSystemApp.js')
+const KeyBindings = await import('../src/parts/KeyBindings/KeyBindings.js')
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
 const FileSystem = await import('../src/parts/FileSystem/FileSystem.js')
 
@@ -75,6 +83,16 @@ test('readFile - settings', async () => {
     return '{}'
   })
   expect(await FileSystemApp.readFile('settings.json')).toBe('{}')
+})
+
+test('writeFile - keybindings reloads runtime keybindings after persisting', async () => {
+  jest.mocked(PlatformPaths.getUserKeyBindingsPath).mockResolvedValue('~/.config/app/keybindings.json')
+  jest.mocked(FileSystem.writeFile).mockResolvedValue()
+
+  await FileSystemApp.writeFile('keybindings.json', '[]')
+
+  expect(FileSystem.writeFile).toHaveBeenCalledWith('~/.config/app/keybindings.json', '[]')
+  expect(KeyBindings.reloadUserKeyBindings).toHaveBeenCalledTimes(1)
 })
 
 test('readFile - settings - error', async () => {

--- a/packages/renderer-worker/test/KeyBindings.test.ts
+++ b/packages/renderer-worker/test/KeyBindings.test.ts
@@ -18,14 +18,23 @@ jest.unstable_mockModule('../src/parts/ExtensionKeyBindings/ExtensionKeyBindings
   }
 })
 
+jest.unstable_mockModule('../src/parts/UserKeyBindings/UserKeyBindings.js', () => {
+  return {
+    getKeyBindings: jest.fn(() => []),
+  }
+})
+
 const ExtensionKeyBindings = await import('../src/parts/ExtensionKeyBindings/ExtensionKeyBindings.js')
 const KeyBindings = await import('../src/parts/KeyBindings/KeyBindings.js')
 const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
 const Logger = await import('../src/parts/Logger/Logger.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const UserKeyBindings = await import('../src/parts/UserKeyBindings/UserKeyBindings.js')
 
 beforeEach(() => {
   jest.resetAllMocks()
+  jest.mocked(ExtensionKeyBindings.getKeyBindings).mockResolvedValue([])
+  jest.mocked(UserKeyBindings.getKeyBindings).mockResolvedValue([])
   KeyBindingsState.state.keyBindings = []
   KeyBindingsState.state.keyBindingSets = Object.create(null)
   KeyBindingsState.state.keyBindingSetCounts = Object.create(null)
@@ -156,4 +165,40 @@ test('hydrate registers extension keybindings', async () => {
   await KeyBindings.hydrate()
 
   expect(KeyBindingsState.state.keyBindingSets.extensions).toBe(keyBindings)
+})
+
+test('hydrate registers user keybindings', async () => {
+  const keyBindings = [
+    {
+      command: 'Explorer.focusNext',
+      key: 29,
+      when: 13,
+      source: 'User',
+    },
+  ]
+  jest.mocked(UserKeyBindings.getKeyBindings).mockResolvedValue(keyBindings)
+
+  await KeyBindings.hydrate()
+
+  expect(KeyBindingsState.state.keyBindingSets.user).toBe(keyBindings)
+})
+
+test('reloadUserKeyBindings replaces user keybindings', async () => {
+  const keyBindings = [{ command: 'Explorer.focusNext', key: 29, when: 13, source: 'User' }]
+  jest.mocked(UserKeyBindings.getKeyBindings).mockResolvedValue(keyBindings)
+
+  await KeyBindings.reloadUserKeyBindings()
+
+  expect(KeyBindingsState.state.keyBindingSets.user).toBe(keyBindings)
+  expect(ExtensionKeyBindings.getKeyBindings).not.toHaveBeenCalled()
+})
+
+test('user keybindings take precedence when a component loads afterwards', () => {
+  const userKeyBinding = { command: 'test.user', key: 29, source: 'User' }
+  const componentKeyBinding = { command: 'test.component', key: 29 }
+
+  KeyBindingsState.setKeyBindings('user', [userKeyBinding])
+  KeyBindingsState.setKeyBindings('Editor', [componentKeyBinding])
+
+  expect(KeyBindingsState.getKeyBinding(29)).toBe(userKeyBinding)
 })

--- a/packages/renderer-worker/test/PreferencesFileWatcher.test.ts
+++ b/packages/renderer-worker/test/PreferencesFileWatcher.test.ts
@@ -19,7 +19,12 @@ jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
 }))
 
 jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
+  getUserKeyBindingsPath: jest.fn(() => '/home/test/.config/lvce/keybindings.json'),
   getUserSettingsPath: jest.fn(() => '/home/test/.config/lvce/settings.json'),
+}))
+
+jest.unstable_mockModule('../src/parts/KeyBindings/KeyBindings.js', () => ({
+  reloadUserKeyBindings: jest.fn(),
 }))
 
 jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
@@ -27,6 +32,7 @@ jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({
 }))
 
 const FileWatcher = await import('../src/parts/FileWatcher/FileWatcher.js')
+const KeyBindings = await import('../src/parts/KeyBindings/KeyBindings.js')
 const Platform = await import('../src/parts/Platform/Platform.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 const PreferencesFileWatcher = await import('../src/parts/PreferencesFileWatcher/PreferencesFileWatcher.js')
@@ -104,7 +110,7 @@ test('settings file changes are debounced', async () => {
   expect(Preferences.reload).toHaveBeenCalledTimes(1)
 })
 
-test('changes to other files are ignored', async () => {
+test('keybindings file changes reload user keybindings after a debounce', async () => {
   await PreferencesFileWatcher.hydrate()
   const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
 
@@ -114,8 +120,21 @@ test('changes to other files are ignored', async () => {
       uri: 'file:///home/test/.config/lvce/keybindings.json',
     },
   })
+  expect(KeyBindings.reloadUserKeyBindings).not.toHaveBeenCalled()
   await jest.runAllTimersAsync()
 
+  expect(KeyBindings.reloadUserKeyBindings).toHaveBeenCalledTimes(1)
+  expect(Preferences.reload).not.toHaveBeenCalled()
+})
+
+test('changes to other files are ignored', async () => {
+  await PreferencesFileWatcher.hydrate()
+  const handleEvent = addEventListener.mock.calls[0][1] as (event: any) => void
+
+  handleEvent({ detail: { eventName: 'change', uri: 'file:///home/test/.config/lvce/other.json' } })
+  await jest.runAllTimersAsync()
+
+  expect(KeyBindings.reloadUserKeyBindings).not.toHaveBeenCalled()
   expect(Preferences.reload).not.toHaveBeenCalled()
 })
 
@@ -129,5 +148,6 @@ test('dispose stops watching and cancels a pending reload', async () => {
 
   expect(removeEventListener).toHaveBeenCalledWith('watcher-event', expect.any(Function))
   expect(FileWatcher.dispose).toHaveBeenCalledWith(watcher)
+  expect(KeyBindings.reloadUserKeyBindings).not.toHaveBeenCalled()
   expect(Preferences.reload).not.toHaveBeenCalled()
 })

--- a/packages/renderer-worker/test/UserKeyBindings.test.ts
+++ b/packages/renderer-worker/test/UserKeyBindings.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  readFile: jest.fn(),
+}))
+
+const FileSystem = await import('../src/parts/FileSystem/FileSystem.js')
+const UserKeyBindings = await import('../src/parts/UserKeyBindings/UserKeyBindings.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('getKeyBindings loads valid user entries from persisted keybindings', async () => {
+  const userKeyBinding = { command: 'Explorer.focusNext', key: 29, when: 13, source: 'User' }
+  jest.mocked(FileSystem.readFile).mockResolvedValue(
+    JSON.stringify([
+      { command: 'Explorer.focusNext', key: 16, when: 13, source: 'System' },
+      userKeyBinding,
+      { command: '', key: 30, source: 'User' },
+    ]),
+  )
+
+  await expect(UserKeyBindings.getKeyBindings()).resolves.toEqual([userKeyBinding])
+  expect(FileSystem.readFile).toHaveBeenCalledWith('app://keybindings.json')
+})
+
+test.each(['{}', 'invalid json'])('getKeyBindings ignores invalid persisted content: %s', async (content) => {
+  jest.mocked(FileSystem.readFile).mockResolvedValue(content)
+
+  await expect(UserKeyBindings.getKeyBindings()).resolves.toEqual([])
+})
+
+test('getKeyBindings ignores read errors', async () => {
+  jest.mocked(FileSystem.readFile).mockRejectedValue(new Error('EACCES'))
+
+  await expect(UserKeyBindings.getKeyBindings()).resolves.toEqual([])
+})


### PR DESCRIPTION
## Summary

- load persisted user keybindings during runtime hydration
- give user bindings stable priority over component and extension defaults
- reload bindings after UI writes and external file changes
- ignore malformed or non-user persisted entries safely

## Validation

- renderer-worker focused tests: 45 passed
- renderer-worker full suite: 1,799 passed
- workspace type-check: passed
- lint: passed
- static production build: passed
- real Electron source build: `a` moves Explorer focus after live config update and after restart; `ArrowDown` remains functional