### PR TITLE
feature: expose file handles command

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -205,6 +205,7 @@ export const commandMap = {
   'FileSystem.stat': lazy('FileSystem.stat'),
   'FileSystem.writeBlob': lazy('FileSystem.writeBlob'),
   'FileSystem.writeFile': lazy('FileSystem.writeFile'),
+  'FileHandles.get': lazy('FileSystemHandle.getFileHandles'),
   'FileSystemHandle.addFileHandle': lazy('FileSystemHandle.addFileHandle'),
   'FileSystemHandle.getFileHandles': lazy('FileSystemHandle.getFileHandles'),
   'FileSystemHandle.getFilePathElectron': lazy('FileSystemHandle.getFilePathElectron'),

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -42,6 +42,10 @@ test('registers the drop data command', () => {
   expect(commandMap['DropData.get']).toBeDefined()
 })
 
+test('registers the file handles command', () => {
+  expect(commandMap['FileHandles.get']).toBeDefined()
+})
+
 test('registers the active text document command', () => {
   expect(commandMap['GetActiveEditor.getTextDocument']).toBeDefined()
 })


### PR DESCRIPTION
Expose the typed FileHandles.get renderer-worker command used by dropId-based clipboard handling. Keep the legacy command alias until consumers have migrated.