### PR TITLE
fix: forward Search view resize

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -184,6 +184,16 @@
           "name": "TextSearch.render2",
           "parameters": [{ "source": "state", "name": "uid" }, { "source": "result", "name": "diff" }]
         },
+        "resize": {
+          "name": "TextSearch.handleResize",
+          "parameters": [
+            { "source": "state", "name": "uid" },
+            { "source": "argument", "name": "dimensions", "index": "x" },
+            { "source": "argument", "name": "dimensions", "index": "y" },
+            { "source": "argument", "name": "dimensions", "index": "width" },
+            { "source": "argument", "name": "dimensions", "index": "height" }
+          ]
+        },
         "saveState": { "name": "TextSearch.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "terminate": { "name": "TextSearch.terminate", "parameters": [] },
         "getCommandIds": { "name": "TextSearch.getCommandIds", "parameters": [] },

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -266,6 +266,33 @@ test('forwards preview bounds changes to the preview worker', async () => {
   expect(result).toMatchObject(dimensions)
 })
 
+test('forwards search bounds changes to the text search worker', async () => {
+  const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
+    if (method === 'TextSearch.diff2' || method === 'TextSearch.render2') {
+      return []
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: getWorkerViewletConfig('textSearchView'),
+    context: { assetDir: 'test://assets', platform: 2, workspacePath: '/test' },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const state = viewlet.create(7, 'test://search', 182, 64, 170, 698)
+  const dimensions = { height: 698, width: 252, x: 100, y: 64 }
+
+  const result = await viewlet.resize!(state, dimensions)
+
+  expect(invoke.mock.calls).toEqual([
+    ['TextSearch.handleResize', 7, 100, 64, 252, 698],
+    ['TextSearch.diff2', 7],
+    ['TextSearch.render2', 7, []],
+    ['TextSearch.renderActions', 7],
+  ])
+  expect(result).toMatchObject(dimensions)
+})
+
 test('preserves command short-circuit and phase-specific diff parameters', async () => {
   const config: any = createConfig({ commandSkipRenderWhenDiffEmpty: true })
   config.methods.commandDiff = {


### PR DESCRIPTION
## Summary
- forward Search view bounds changes to `TextSearch.handleResize`
- spread the current x/y/width/height through the worker-viewlet lifecycle descriptor
- add a focused lifecycle regression test

## Why
Official Debian acceptance showed that the dynamic Search message height is correct at initial width but stays stale after dragging the sidebar sash. The Search worker already recomputes message height in `handleResize`; its worker-viewlet metadata used state-only resizing and never invoked that method.

## Validation
- `CreateWorkerViewlet.test.ts`: 20 passed
- renderer-worker type-check
- root lint
- dependency install from lockfile