### PR TITLE
feature: remove legacy file handles command

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -207,7 +207,6 @@ export const commandMap = {
   'FileSystem.writeFile': lazy('FileSystem.writeFile'),
   'FileHandles.get': lazy('FileSystemHandle.getFileHandles'),
   'FileSystemHandle.addFileHandle': lazy('FileSystemHandle.addFileHandle'),
-  'FileSystemHandle.getFileHandles': lazy('FileSystemHandle.getFileHandles'),
   'FileSystemHandle.getFilePathElectron': lazy('FileSystemHandle.getFilePathElectron'),
   'FileWatcher.handleEvent': lazy('FileWatcher.handleEvent'),
   'FileWatcher.watchFile': lazy('FileWatcher.watchFile'),


### PR DESCRIPTION
## Summary

- remove the legacy external FileSystemHandle.getFileHandles command
- keep FileHandles.get as the single public file-handle bridge
- preserve the internal FileSystemHandle implementation and Electron path command

## Validation

- renderer-worker CommandMap test: 12 passed
- renderer-worker type-check