### PR TITLE
fix: load asynchronous renderer commands

### DIFF
--- a/packages/renderer-worker/src/parts/Command/Command.js
+++ b/packages/renderer-worker/src/parts/Command/Command.js
@@ -10,9 +10,10 @@ export const state = {
   },
 }
 
-const initializeModule = (module) => {
+const initializeModule = async (module) => {
   if (module.Commands) {
-    for (const [key, value] of Object.entries(module.Commands)) {
+    const commands = module.getCommands && Object.keys(module.Commands).length === 0 ? await module.getCommands() : module.Commands
+    for (const [key, value] of Object.entries(commands)) {
       if (module.name) {
         const actualKey = key.includes('.') ? key : `${module.name}.${key}`
         register(actualKey, value)
@@ -28,7 +29,7 @@ const initializeModule = (module) => {
 const loadModule = async (moduleId) => {
   try {
     const module = await state.load(moduleId)
-    initializeModule(module)
+    await initializeModule(module)
   } catch (error) {
     throw new VError(error, `failed to load module ${moduleId}`)
   }

--- a/packages/renderer-worker/src/parts/Command/Command.js
+++ b/packages/renderer-worker/src/parts/Command/Command.js
@@ -5,6 +5,7 @@ import { VError } from '../VError/VError.js'
 export const state = {
   commands: Object.create(null),
   pendingModules: Object.create(null),
+  /** @type {(moduleId: any) => Promise<any>} */
   async load(moduleId) {
     throw new Error('not implemented')
   },

--- a/packages/renderer-worker/test/Command.test.ts
+++ b/packages/renderer-worker/test/Command.test.ts
@@ -13,7 +13,7 @@ test('execute - error - failed to load module', async () => {
 })
 
 test('execute - loads commands provided asynchronously', async () => {
-  const execute = jest.fn(() => 'done')
+  const execute = jest.fn((_argument: string) => 'done')
   Command.state.load = async () => {
     return {
       Commands: {},

--- a/packages/renderer-worker/test/Command.test.ts
+++ b/packages/renderer-worker/test/Command.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import * as Command from '../src/parts/Command/Command.js'
 
 test('execute - error - failed to load module', async () => {
@@ -10,4 +10,18 @@ test('execute - error - failed to load module', async () => {
       'failed to load module 41: TypeError: Failed to fetch dynamically imported module: http://localhost:3000/packages/renderer-worker/src/parts/Test/Test.ipc.js',
     ),
   )
+})
+
+test('execute - loads commands provided asynchronously', async () => {
+  const execute = jest.fn(() => 'done')
+  Command.state.load = async () => {
+    return {
+      Commands: {},
+      getCommands: async () => ({ execute }),
+      name: 'About',
+    }
+  }
+
+  await expect(Command.execute('About.execute', 'argument')).resolves.toBe('done')
+  expect(execute).toHaveBeenCalledWith('argument')
 })


### PR DESCRIPTION
## Summary

Load command maps returned by asynchronous renderer modules before registering their commands. This moves the behavior out of downstream renderer-bundle patches and adds regression coverage.