### PR TITLE
fix: seed text search from editor selection

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.search-shortcut-editor-selection.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-shortcut-editor-selection.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-shortcut-editor-selection'
+
+export const test: Test = async ({ Command, Editor, FileSystem, Locator, Main, Workspace, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const fileUri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(fileUri, 'prefix abc suffix')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(fileUri)
+  await Editor.setSelections(new Uint32Array([0, 7, 0, 10]))
+
+  await Command.execute('Layout.openTextSearch')
+
+  const searchInput = Locator('.SideBar textarea[name="SearchValue"]')
+  await expect(searchInput).toBeVisible()
+  await expect(searchInput).toBeFocused()
+  await expect(searchInput).toHaveValue('abc')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.search-shortcut-no-editor.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.search-shortcut-no-editor.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.search-shortcut-no-editor'
+
+export const test: Test = async ({ Command, Locator, expect }) => {
+  await Command.execute('Layout.openTextSearch')
+
+  const searchInput = Locator('.SideBar textarea[name="SearchValue"]')
+  await expect(searchInput).toBeVisible()
+  await expect(searchInput).toBeFocused()
+}

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -610,6 +610,7 @@ export const commandMap = {
   'Layout.openOutput': lazy('Layout.openOutput'),
   'Layout.openProblems': lazy('Layout.openProblems'),
   'Layout.openSideBarViewlet': lazy('Layout.openSideBarViewlet'),
+  'Layout.openTextSearch': lazy('Layout.openTextSearch'),
   'Layout.openSecondarySideBarViewlet': lazy('Layout.openSecondarySideBarViewlet'),
   'Layout.setBadgeCount': lazy('Layout.setBadgeCount'),
   'Layout.setUpdateState': lazy('Layout.setUpdateState'),

--- a/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
+++ b/packages/renderer-worker/src/parts/GetActiveEditor/GetActiveEditor.js
@@ -1,6 +1,9 @@
 import * as Command from '../Command/Command.js'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
+import * as GetSelectionPairs from '../GetSelectionPairs/GetSelectionPairs.js'
+import * as JoinLines from '../JoinLines/JoinLines.js'
 import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
+import * as TextDocument from '../TextDocument/TextDocument.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
@@ -56,6 +59,31 @@ export const getSelectionsWithInvoke = async (invoke) => {
 
 export const getSelections = async () => {
   return getSelectionsWithInvoke(EditorWorker.invoke)
+}
+
+export const getSelectionTextWithInvoke = async (invoke) => {
+  const instance = ViewletStates.getInstance(ViewletModuleId.EditorText)
+  if (!instance) {
+    return ''
+  }
+  const [text, selectionsValue] = await Promise.all([invoke('Editor.getText', instance.state.id), invoke('Editor.getSelections2', instance.state.id)])
+  const selections = Array.from(selectionsValue)
+  if (selections.length < 4) {
+    return ''
+  }
+  const [startRowIndex, startColumnIndex, endRowIndex, endColumnIndex] = GetSelectionPairs.getSelectionPairs(selections, 0)
+  const selectedLines = TextDocument.getSelectionText(
+    { lines: text.split('\n') },
+    {
+      end: { columnIndex: endColumnIndex, rowIndex: endRowIndex },
+      start: { columnIndex: startColumnIndex, rowIndex: startRowIndex },
+    },
+  )
+  return JoinLines.joinLines(selectedLines)
+}
+
+export const getSelectionText = async () => {
+  return getSelectionTextWithInvoke(EditorWorker.invoke)
 }
 
 export const getOpenEditorUrisWithInvoke = async (invoke) => {

--- a/packages/renderer-worker/src/parts/OpenTextSearch/OpenTextSearch.ts
+++ b/packages/renderer-worker/src/parts/OpenTextSearch/OpenTextSearch.ts
@@ -1,0 +1,36 @@
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+
+interface SearchInstance {
+  readonly state: {
+    readonly uid: number
+  }
+}
+
+interface OpenTextSearchResult<State> {
+  readonly commands: readonly any[]
+  readonly newState: State
+}
+
+export interface OpenTextSearchDependencies<State> {
+  readonly executeViewletCommand: (uid: number, command: string, ...args: readonly unknown[]) => Promise<void>
+  readonly getInstance: (moduleId: string) => SearchInstance | undefined
+  readonly getSelectionText: () => Promise<string>
+  readonly openSideBarView: (state: State, moduleId: string) => Promise<OpenTextSearchResult<State>>
+}
+
+export const openTextSearch = async <State>(state: State, dependencies: OpenTextSearchDependencies<State>): Promise<OpenTextSearchResult<State>> => {
+  const { executeViewletCommand, getInstance, getSelectionText, openSideBarView } = dependencies
+  const selectedText = await getSelectionText()
+  const result = await openSideBarView(state, ViewletModuleId.Search)
+  const searchInstance = getInstance(ViewletModuleId.Search)
+  if (!searchInstance) {
+    return result
+  }
+  if (selectedText) {
+    await executeViewletCommand(searchInstance.state.uid, 'handleInput', selectedText)
+  }
+  return {
+    ...result,
+    commands: [...result.commands, ['Viewlet.focusElementByName', searchInstance.state.uid, 'SearchValue']],
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -7,6 +7,7 @@ import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import * as Command from '../Command/Command.js'
 import * as Commit from '../Commit/Commit.js'
 import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as GetActiveEditor from '../GetActiveEditor/GetActiveEditor.js'
 import * as GetActionsVirtualDom from '../GetActionsVirtualDom/GetActionsVirtualDom.js'
 import * as GetAutoUpdateType from '../GetAutoUpdateType/GetAutoUpdateType.js'
 import * as GetDefaultTitleBarHeight from '../GetDefaultTitleBarHeight/GetDefaultTitleBarHeight.js'
@@ -17,6 +18,7 @@ import * as LayoutModules from '../LayoutModules/LayoutModules.ts'
 import * as MenuEntriesState from '../MenuEntriesState/MenuEntriesState.js'
 import * as Location from '../Location/Location.js'
 import * as PanelWorker from '../PanelWorker/PanelWorker.js'
+import * as OpenTextSearch from '../OpenTextSearch/OpenTextSearch.ts'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Preferences from '../Preferences/Preferences.js'
@@ -2825,6 +2827,15 @@ export const openSideBarView = async (state: LayoutState, moduleId, focus = fals
   await ViewletManager.waitForLoadContentLater(moduleId)
   await Viewlet.focus(moduleId)
   return result
+}
+
+export const openTextSearch = async (state: LayoutState): Promise<LayoutStateResult> => {
+  return OpenTextSearch.openTextSearch(state, {
+    executeViewletCommand: Viewlet.executeViewletCommand,
+    getInstance: ViewletStates.getInstance,
+    getSelectionText: GetActiveEditor.getSelectionText,
+    openSideBarView: (currentState, moduleId) => openSideBarView(currentState, moduleId, false, undefined),
+  })
 }
 
 export const openSecondarySideBarView = async (state: LayoutState, moduleId, focus = false, args): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutCommands.js
@@ -83,6 +83,7 @@ export const CommandsWithSideEffects = {
   openOutput: ViewletLayout.openOutput,
   openProblems: ViewletLayout.openProblems,
   openSideBarViewlet: ViewletLayout.openSideBarView,
+  openTextSearch: ViewletLayout.openTextSearch,
   openSecondarySideBarViewlet: ViewletLayout.openSecondarySideBarView,
   openPanelViewlet: ViewletLayout.openPanelView,
   refreshAuthState: ViewletLayout.refreshAuthState,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -73,8 +73,7 @@ export const getKeyBindings = () => {
     },
     {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyF,
-      command: 'Layout.openSideBarViewlet',
-      args: ['Search'],
+      command: 'Layout.openTextSearch',
     },
     {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyY,

--- a/packages/renderer-worker/test/GetActiveEditor.test.ts
+++ b/packages/renderer-worker/test/GetActiveEditor.test.ts
@@ -104,6 +104,93 @@ test('getSelections returns an empty array when there is no active editor', asyn
   expect(invoke).not.toHaveBeenCalled()
 })
 
+test('getSelectionText returns the primary selection text', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.txt',
+    },
+  })
+  const invoke = jest.fn(async (command: string) => {
+    if (command === 'Editor.getText') {
+      return 'prefix abc suffix'
+    }
+    return new Uint32Array([0, 7, 0, 10])
+  })
+
+  await expect(GetActiveEditor.getSelectionTextWithInvoke(invoke)).resolves.toBe('abc')
+})
+
+test('getSelectionText normalizes a reversed selection', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.txt',
+    },
+  })
+  const invoke = jest.fn(async (command: string) => {
+    if (command === 'Editor.getText') {
+      return 'prefix abc suffix'
+    }
+    return new Uint32Array([0, 10, 0, 7])
+  })
+
+  await expect(GetActiveEditor.getSelectionTextWithInvoke(invoke)).resolves.toBe('abc')
+})
+
+test('getSelectionText returns a multiline selection', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.txt',
+    },
+  })
+  const invoke = jest.fn(async (command: string) => {
+    if (command === 'Editor.getText') {
+      return 'one two\nthree four'
+    }
+    return new Uint32Array([0, 4, 1, 5])
+  })
+
+  await expect(GetActiveEditor.getSelectionTextWithInvoke(invoke)).resolves.toBe('two\nthree')
+})
+
+test('getSelectionText returns an empty string without an active editor', async () => {
+  const invoke = jest.fn()
+
+  await expect(GetActiveEditor.getSelectionTextWithInvoke(invoke)).resolves.toBe('')
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('getSelectionText returns an empty string without a complete selection', async () => {
+  ViewletStates.set(1, {
+    factory: {},
+    moduleId: 'EditorText',
+    renderedState: {},
+    state: {
+      id: 42,
+      uri: 'file:///test.txt',
+    },
+  })
+  const invoke = jest.fn(async (command: string) => {
+    if (command === 'Editor.getText') {
+      return 'text'
+    }
+    return new Uint32Array()
+  })
+
+  await expect(GetActiveEditor.getSelectionTextWithInvoke(invoke)).resolves.toBe('')
+})
+
 test('setSelections updates selections for the active editor', async () => {
   ViewletStates.set(1, {
     factory: {},

--- a/packages/renderer-worker/test/OpenTextSearch.test.ts
+++ b/packages/renderer-worker/test/OpenTextSearch.test.ts
@@ -1,0 +1,65 @@
+import { expect, jest, test } from '@jest/globals'
+import { openTextSearch } from '../src/parts/OpenTextSearch/OpenTextSearch.ts'
+
+test('opens Search, applies the editor selection, and focuses the rendered input', async () => {
+  const calls: string[] = []
+  const state = { uid: 1 }
+  const result = { commands: [['render']], newState: state }
+  const openSideBarView = jest.fn<(currentState: typeof state, moduleId: string) => Promise<typeof result>>(async () => {
+    calls.push('open')
+    return result
+  })
+  const executeViewletCommand = jest.fn<(uid: number, command: string, ...args: readonly unknown[]) => Promise<void>>(async (_uid, command) => {
+    calls.push(command)
+  })
+
+  const actual = await openTextSearch(state, {
+    executeViewletCommand,
+    getInstance: () => ({ state: { uid: 42 } }),
+    getSelectionText: async () => 'abc',
+    openSideBarView,
+  })
+
+  expect(openSideBarView).toHaveBeenCalledWith(state, 'Search')
+  expect(executeViewletCommand).toHaveBeenCalledWith(42, 'handleInput', 'abc')
+  expect(calls).toEqual(['open', 'handleInput'])
+  expect(actual).toEqual({
+    commands: [['render'], ['Viewlet.focusElementByName', 42, 'SearchValue']],
+    newState: state,
+  })
+})
+
+test('opens Search normally when no editor text is selected', async () => {
+  const state = { uid: 1 }
+  const result = { commands: [], newState: state }
+  const openSideBarView = jest.fn<(currentState: typeof state, moduleId: string) => Promise<typeof result>>(async () => result)
+  const executeViewletCommand = jest.fn<(uid: number, command: string, ...args: readonly unknown[]) => Promise<void>>(async () => {})
+
+  const actual = await openTextSearch(state, {
+    executeViewletCommand,
+    getInstance: () => ({ state: { uid: 42 } }),
+    getSelectionText: async () => '',
+    openSideBarView,
+  })
+
+  expect(openSideBarView).toHaveBeenCalledWith(state, 'Search')
+  expect(executeViewletCommand).not.toHaveBeenCalled()
+  expect(actual.commands).toEqual([['Viewlet.focusElementByName', 42, 'SearchValue']])
+})
+
+test('does not apply input when Search failed to create an instance', async () => {
+  const state = { uid: 1 }
+  const result = { commands: [], newState: state }
+  const executeViewletCommand = jest.fn<(uid: number, command: string, ...args: readonly unknown[]) => Promise<void>>(async () => {})
+
+  await expect(
+    openTextSearch(state, {
+      executeViewletCommand,
+      getInstance: () => undefined,
+      getSelectionText: async () => 'abc',
+      openSideBarView: async () => result,
+    }),
+  ).resolves.toBe(result)
+
+  expect(executeViewletCommand).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutKeyBindings.test.ts
@@ -36,3 +36,16 @@ test('getKeyBindings - toggle terminal panel', () => {
     ]),
   )
 })
+
+test('getKeyBindings - open text search', () => {
+  const keyBindings = ViewletLayoutKeyBindings.getKeyBindings()
+
+  expect(keyBindings).toEqual(
+    expect.arrayContaining([
+      {
+        command: 'Layout.openTextSearch',
+        key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyF,
+      },
+    ]),
+  )
+})


### PR DESCRIPTION
## Summary

- seed Text Search with the primary active-editor selection when Ctrl+Shift+F opens it
- preserve normal Search opening when no editor or selection exists
- focus the Search input after the view is rendered

## Validation

- root lint
- type-check for all six projects
- 36 focused renderer-worker unit tests
- selection-to-search e2e test, including five-run timing stress pass
- no-editor Search e2e test