### PR TITLE
fix: use readable simple browser setting type

### DIFF
--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -159,7 +159,7 @@
     "description": "Controls whether hovering over a simple browser tab shows its full title and memory usage",
     "heading": "Simple Browser Tab Hover",
     "id": "simpleBrowser.tabHover.enabled",
-    "type": 3,
+    "type": "boolean",
     "value": false
   },
   {


### PR DESCRIPTION
## Summary

- use the readable `boolean` type for the Simple Browser tab-hover setting added during the multi-repository rollout

## Tests

- `jq -e 'all(.[]; (.type|type)=="string")' packages/renderer-worker/settings.json`\n- `npm run type-check` (packages/build)\n- `npm test -- BundleBuiltinSettings.test.ts` (packages/build)\n- Prettier check