### PR TITLE
fix: preserve direct dialog test mocks

### DIFF
--- a/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
+++ b/packages/build/src/parts/BundleRendererWorker/BundleRendererWorker.ts
@@ -155,11 +155,13 @@ export const bundleRendererWorker = async ({ cachePath, platform, commitHash, as
         replacement: `../../../static/`,
       })
     }
-    await Replace.replace({
-      path: `${cachePath}/src/parts/HandleSecretsViewMessagePort/HandleSecretsViewMessagePort.ts`,
-      occurrence: `../../../../../static/`,
-      replacement: `../../../static/`,
-    })
+    for (const file of ['HandleMockDialogWorkerMessagePort', 'HandleSecretsViewMessagePort']) {
+      await Replace.replace({
+        path: `${cachePath}/src/parts/${file}/${file}.ts`,
+        occurrence: `../../../../../static/`,
+        replacement: `../../../static/`,
+      })
+    }
     for (const file of ['IpcChildModule']) {
       await Replace.replace({
         path: `${cachePath}/src/parts/${file}/${file}.js`,

--- a/packages/renderer-worker/src/parts/ConfirmPrompt/ConfirmPrompt.js
+++ b/packages/renderer-worker/src/parts/ConfirmPrompt/ConfirmPrompt.js
@@ -16,6 +16,10 @@ export const mock = (mockId) => {
   _mockId = mockId
 }
 
+export const isMocked = () => {
+  return Boolean(_mockId)
+}
+
 export const prompt = async (
   message,
   { platform = Platform.getPlatform(), confirmMessage = ConfirmPromptStrings.ok(), title = '', cancelMessage = ConfirmPromptStrings.cancel() } = {},

--- a/packages/renderer-worker/src/parts/HandleMockDialogWorkerMessagePort/HandleMockDialogWorkerMessagePort.ts
+++ b/packages/renderer-worker/src/parts/HandleMockDialogWorkerMessagePort/HandleMockDialogWorkerMessagePort.ts
@@ -1,0 +1,11 @@
+import { PlainMessagePortRpcParent } from '../../../../../static/js/lvce-editor-rpc.js'
+import * as ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt.js'
+
+export const handleMockDialogWorkerMessagePort = async (port: MessagePort): Promise<void> => {
+  await PlainMessagePortRpcParent.create({
+    commandMap: {
+      'ConfirmPrompt.prompt': ConfirmPrompt.prompt,
+    },
+    messagePort: port,
+  })
+}

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -12,6 +12,7 @@ import * as ChatToolWorker from '../ChatToolWorker/ChatToolWorker.js'
 import * as ChatViewModelWorker from '../ChatViewModelWorker/ChatViewModelWorker.js'
 import * as ChatViewWorker from '../ChatViewWorker/ChatViewWorker.js'
 import * as ClipBoardWorker from '../ClipBoardWorker/ClipBoardWorker.js'
+import * as ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt.js'
 import * as DialogWorker from '../DialogWorker/DialogWorker.js'
 import * as DiffViewWorker from '../DiffViewWorker/DiffViewWorker.js'
 import * as DiffWorker from '../DiffWorker/DiffWorker.js'
@@ -23,6 +24,7 @@ import * as ExtensionManagementWorker from '../ExtensionManagementWorker/Extensi
 import * as ExtensionSearchViewWorker from '../ExtensionSearchViewWorker/ExtensionSearchViewWorker.js'
 import * as FileSearchWorker from '../FileSearchWorker/FileSearchWorker.js'
 import * as FileSystemWorker from '../FileSystemWorker/FileSystemWorker.js'
+import * as HandleMockDialogWorkerMessagePort from '../HandleMockDialogWorkerMessagePort/HandleMockDialogWorkerMessagePort.ts'
 import * as IconThemeWorker from '../IconThemeWorker/IconThemeWorker.js'
 import * as IframeWorker from '../IframeWorker/IframeWorker.js'
 import * as KeyBindingsViewWorker from '../KeyBindingsViewWorker/KeyBindingsViewWorker.js'
@@ -121,6 +123,10 @@ export const sendMessagePortToErrorWorker = async (port, initialCommand, rpcId) 
 export const sendMessagePortToDialogWorker = async (port, initialCommand) => {
   Assert.object(port)
   Assert.string(initialCommand)
+  if (ConfirmPrompt.isMocked()) {
+    await HandleMockDialogWorkerMessagePort.handleMockDialogWorkerMessagePort(port)
+    return
+  }
   await DialogWorker.invokeAndTransfer(initialCommand, port)
 }
 

--- a/packages/renderer-worker/test/ConfirmPrompt.test.ts
+++ b/packages/renderer-worker/test/ConfirmPrompt.test.ts
@@ -71,3 +71,11 @@ test('prompt - preserves test worker mocks', async () => {
   })
   expect(DialogWorker.invoke).not.toHaveBeenCalled()
 })
+
+test('isMocked', () => {
+  expect(ConfirmPrompt.isMocked()).toBe(false)
+
+  ConfirmPrompt.mock(42)
+
+  expect(ConfirmPrompt.isMocked()).toBe(true)
+})

--- a/packages/renderer-worker/test/HandleMockDialogWorkerMessagePort.test.ts
+++ b/packages/renderer-worker/test/HandleMockDialogWorkerMessagePort.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+// @ts-ignore
+import { PlainMessagePortRpc } from '../../../static/js/lvce-editor-rpc.js'
+
+const prompt = jest.fn<(...args: readonly any[]) => Promise<boolean>>()
+
+jest.unstable_mockModule('../src/parts/ConfirmPrompt/ConfirmPrompt.js', () => ({
+  prompt,
+}))
+
+const { handleMockDialogWorkerMessagePort } = await import('../src/parts/HandleMockDialogWorkerMessagePort/HandleMockDialogWorkerMessagePort.ts')
+
+let rpc: any
+
+afterEach(async () => {
+  await rpc?.dispose()
+  rpc = undefined
+  prompt.mockReset()
+})
+
+test('forwards confirm prompts to the renderer worker mock', async () => {
+  const { port1, port2 } = new MessageChannel()
+  rpc = await PlainMessagePortRpc.create({ commandMap: {}, messagePort: port1 })
+  prompt.mockResolvedValue(true)
+  await handleMockDialogWorkerMessagePort(port2)
+  const options = { confirmMessage: 'Replace', title: 'Replace All' }
+
+  await expect(rpc.invoke('ConfirmPrompt.prompt', 'Replace all?', options)).resolves.toBe(true)
+
+  expect(prompt).toHaveBeenCalledWith('Replace all?', options)
+})

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -17,6 +17,18 @@ jest.unstable_mockModule('../src/parts/DialogWorker/DialogWorker.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/ConfirmPrompt/ConfirmPrompt.js', () => {
+  return {
+    isMocked: jest.fn(() => false),
+  }
+})
+
+jest.unstable_mockModule('../src/parts/HandleMockDialogWorkerMessagePort/HandleMockDialogWorkerMessagePort.ts', () => {
+  return {
+    handleMockDialogWorkerMessagePort: jest.fn(),
+  }
+})
+
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => {
   return {
     invokeAndTransfer: jest.fn(),
@@ -53,9 +65,11 @@ jest.unstable_mockModule('../src/parts/WorkspaceConnection/WorkspaceConnection.j
   }
 })
 
+const ConfirmPrompt = await import('../src/parts/ConfirmPrompt/ConfirmPrompt.js')
 const DialogWorker = await import('../src/parts/DialogWorker/DialogWorker.js')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const ExplorerViewWorker = await import('../src/parts/ExplorerViewWorker/ExplorerViewWorker.js')
+const HandleMockDialogWorkerMessagePort = await import('../src/parts/HandleMockDialogWorkerMessagePort/HandleMockDialogWorkerMessagePort.ts')
 const MainAreaWorker = await import('../src/parts/MainAreaWorker/MainAreaWorker.js')
 const SecretsViewWorker = await import('../src/parts/SecretsViewWorker/SecretsViewWorker.ts')
 const SettingsWorker = await import('../src/parts/SettingsWorker/SettingsWorker.js')
@@ -106,6 +120,18 @@ test('sendMessagePortToDialogWorker', async () => {
 
   expect(DialogWorker.invokeAndTransfer).toHaveBeenCalledTimes(1)
   expect(DialogWorker.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', port)
+})
+
+test('sendMessagePortToDialogWorker preserves confirm prompt mocks', async () => {
+  const { port1: port, port2 } = new MessageChannel()
+  jest.mocked(ConfirmPrompt.isMocked).mockReturnValue(true)
+
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToDialogWorker(port, 'HandleMessagePort.handleMessagePort')
+
+  expect(HandleMockDialogWorkerMessagePort.handleMockDialogWorkerMessagePort).toHaveBeenCalledWith(port)
+  expect(DialogWorker.invokeAndTransfer).not.toHaveBeenCalled()
+  port.close()
+  port2.close()
 })
 
 test('sendMessagePortToExtensionHostWorker forwards to extension management worker', async () => {


### PR DESCRIPTION
Direct dialog-worker connections bypassed renderer-worker confirmation mocks, causing view-worker end-to-end tests to wait on a real dialog.

When a confirmation mock is active, terminate newly requested dialog ports in renderer-worker and forward `ConfirmPrompt.prompt` to the existing test-worker mock. Production dialog ports continue to use dialog-worker unchanged. Register the new handler in renderer-worker packaging and cover both routing paths.

Verified with:
- renderer-worker focused suites (16 tests)
- renderer-worker typecheck
- build package typecheck
- `npm run build:server`
- text-search-view `search.replace-all-one-result` against the locally built server