### PR TITLE
fix: refine simple browser tab hover

### DIFF
--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -304,10 +304,10 @@ export const getSimpleBrowserVirtualDom = (
       text(tabHover.title),
       {
         type: VirtualDomElements.Div,
-        className: 'SimpleBrowserTabHoverMemory',
+        className: 'SimpleBrowserTabHoverStatus',
         childCount: 1,
       },
-      text(tabHover.memoryLabel),
+      text(tabHover.statusLabel),
     )
   }
   return dom

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -715,14 +715,14 @@ export const showTabHover = async (state, index, tabOffsetLeft, tabWidth, tabsSc
   if (!overlayState.overlayIds.includes(tabHoverOverlayId)) {
     return state
   }
-  let memoryLabel = 'Memory usage unavailable'
+  let statusLabel = tab.browserViewId ? 'Memory usage unavailable' : 'Tab is unloaded'
   let title = tab.title || 'New Tab'
   if (tab.browserViewId) {
     try {
       const stats = await ElectronWebContentsViewFunctions.getStats(tab.browserViewId, true)
       title = stats.title || title
       if (Number.isFinite(stats.memory)) {
-        memoryLabel = `Memory usage: ${PrettyBytes.formatBytes(stats.memory)}`
+        statusLabel = `Memory usage: ${PrettyBytes.formatBytes(stats.memory)}`
       }
     } catch (error) {
       console.error('[renderer-worker] Failed to get Simple Browser tab memory usage', error)
@@ -736,7 +736,7 @@ export const showTabHover = async (state, index, tabOffsetLeft, tabWidth, tabsSc
     tabHover: {
       index: tabIndex,
       left,
-      memoryLabel,
+      statusLabel,
       tabLeft: Number(tabLeft),
       tabWidth: Number(tabWidth),
       title,

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -240,7 +240,7 @@ test('renders the rich tab hover with the full title and memory usage', () => {
   const tabHover = {
     index: 0,
     left: 24,
-    memoryLabel: 'Memory usage: 42 MB',
+    statusLabel: 'Memory usage: 42 MB',
     title: 'A complete page title',
   }
   const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(
@@ -277,6 +277,7 @@ test('renders the rich tab hover with the full title and memory usage', () => {
     }),
   )
   expect(dom).toContainEqual(expect.objectContaining({ text: 'A complete page title' }))
+  expect(dom).toContainEqual(expect.objectContaining({ className: 'SimpleBrowserTabHoverStatus' }))
   expect(dom).toContainEqual(expect.objectContaining({ text: 'Memory usage: 42 MB' }))
 })
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -1306,7 +1306,7 @@ test('showTabHover captures the page and shows the full title and memory usage',
     tabHover: {
       index: 0,
       left: 25,
-      memoryLabel: 'Memory usage: 42 MB',
+      statusLabel: 'Memory usage: 42 MB',
       tabLeft: 25,
       tabWidth: 180,
       title: 'A complete page title',
@@ -1350,7 +1350,7 @@ test('showTabHover shows the saved title for an unloaded tab without requesting 
   expect(ElectronWebContentsViewFunctions.getStats).not.toHaveBeenCalled()
   expect(newState.tabHover).toMatchObject({
     index: 1,
-    memoryLabel: 'Memory usage unavailable',
+    statusLabel: 'Tab is unloaded',
     title: 'Unloaded complete title',
   })
 })
@@ -1361,7 +1361,7 @@ test('hideTabHover ignores pointer transitions inside the hovered tab', async ()
     browserViewId: 12,
     overlayIds: ['tab-hover'],
     snapshot: 'blob:https://example.com/snapshot',
-    tabHover: { index: 0, left: 25, memoryLabel: 'Memory usage: 42 MB', tabLeft: 25, tabWidth: 180, title: 'Example' },
+    tabHover: { index: 0, left: 25, statusLabel: 'Memory usage: 42 MB', tabLeft: 25, tabWidth: 180, title: 'Example' },
   }
 
   await expect(ViewletSimpleBrowser.hideTabHover(state, 0, 50, 30)).resolves.toBe(state)
@@ -1376,7 +1376,7 @@ test('hideTabHover restores the page after the pointer leaves the tab', async ()
     browserViewId: 12,
     overlayIds: ['tab-hover'],
     snapshot: 'blob:https://example.com/snapshot',
-    tabHover: { index: 0, left: 25, memoryLabel: 'Memory usage: 42 MB', tabLeft: 25, tabWidth: 180, title: 'Example' },
+    tabHover: { index: 0, left: 25, statusLabel: 'Memory usage: 42 MB', tabLeft: 25, tabWidth: 180, title: 'Example' },
   }
 
   const newState = await ViewletSimpleBrowser.hideTabHover(state, 0, 50, 80)

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -107,14 +107,15 @@
 }
 
 .SimpleBrowserTabHover {
-  background: var(--MenuBackground, var(--EditorBackground));
-  border: 1px solid var(--WidgetBorder, var(--PanelBorder, transparent));
+  background: var(--QuickPickBackground, rgb(40 46 47));
+  border: 1px solid color-mix(in srgb, var(--WorkbenchForeground, rgb(156 162 160)) 18%, transparent);
   border-radius: 8px;
-  box-shadow: rgb(0 0 0 / 36%) 0 6px 18px;
+  box-shadow: rgb(0 0 0 / 28%) 0 6px 18px;
   box-sizing: border-box;
-  color: var(--MenuForeground, var(--WorkbenchForeground));
+  color: var(--WorkbenchForeground, rgb(156 162 160));
   max-width: calc(100% - 16px);
-  padding: 12px 14px;
+  overflow: hidden;
+  padding: 11px 13px 0;
   pointer-events: none;
   position: absolute;
   top: 34px;
@@ -128,10 +129,14 @@
   overflow-wrap: anywhere;
 }
 
-.SimpleBrowserTabHoverMemory {
-  color: var(--DescriptionForeground, currentColor);
-  line-height: 20px;
-  margin-top: 8px;
+.SimpleBrowserTabHoverStatus {
+  background: color-mix(in srgb, var(--WorkbenchForeground, rgb(156 162 160)) 4%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--WorkbenchForeground, rgb(156 162 160)) 10%, transparent);
+  color: var(--DescriptionForeground, color-mix(in srgb, var(--WorkbenchForeground, rgb(156 162 160)) 72%, transparent));
+  font-size: 12px;
+  line-height: 18px;
+  margin: 10px -13px 0;
+  padding: 8px 13px 9px;
 }
 
 .SimpleBrowserTabClose:hover,


### PR DESCRIPTION
Refine the Simple Browser tab hover with an opaque themed surface, a softer outline, and a separated low-contrast status section. Unloaded tabs now say that the tab is unloaded instead of reporting memory as unavailable.