### PR TITLE
feature: add inline search history suggestions

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.simple-browser-inline-suggestion.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.simple-browser-inline-suggestion.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.simple-browser-inline-suggestion'
+
+// The standard e2e runner is browser-only; this view requires Electron WebContentsView.
+export const skip = process.env.RUN_SIMPLE_BROWSER_SUGGESTIONS_E2E === '1' ? 0 : 1
+
+export const test: Test = async ({ Command, expect, Locator, Settings }) => {
+  await Settings.update({ 'simpleBrowser.suggestions': true })
+  await Command.execute('LocalStorage.setJson', 'simple-browser-search-history', ['cheeseburger'])
+  await Command.execute('Layout.showPreview', 'simple-browser://')
+
+  const input = Locator('.SimpleBrowserHeader input.InputBox')
+  await Command.execute('SimpleBrowser.handleInput', 'cheese')
+
+  await expect(input).toHaveValue('cheese')
+  await expect(Locator('.SimpleBrowserInlineSuggestion')).toHaveAttribute('data-value', 'cheeseburger')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.simple-browser-search-history-suggestion.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.simple-browser-search-history-suggestion.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.simple-browser-search-history-suggestion'
+
+// The standard e2e runner is browser-only; this view requires Electron WebContentsView.
+export const skip = process.env.RUN_SIMPLE_BROWSER_SUGGESTIONS_E2E === '1' ? 0 : 1
+
+export const test: Test = async ({ Command, expect, Locator, Settings }) => {
+  await Settings.update({ 'simpleBrowser.suggestions': true })
+  await Command.execute('Layout.showPreview', 'simple-browser://')
+  const input = Locator('.SimpleBrowserHeader input.InputBox')
+
+  await Command.execute('SimpleBrowser.handleInput', 'cheeseburger')
+  await Command.execute('SimpleBrowser.go')
+  await Command.execute('SimpleBrowser.handleInput', 'cheese')
+
+  const historySuggestion = Locator('.SimpleBrowserSuggestion[data-value="cheeseburger"]')
+  await expect(historySuggestion).toBeVisible()
+  await historySuggestion.click()
+  await expect(input).toHaveValue('cheeseburger')
+}

--- a/packages/renderer-worker/src/parts/BrowserSearchHistory/BrowserSearchHistory.js
+++ b/packages/renderer-worker/src/parts/BrowserSearchHistory/BrowserSearchHistory.js
@@ -1,0 +1,76 @@
+import * as LocalStorage from '../LocalStorage/LocalStorage.js'
+
+const storageKey = 'simple-browser-search-history'
+const maximumSearches = 100
+const maximumSearchLength = 2048
+
+const normalizeSearch = (value) => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const search = value.trim()
+  if (search.length === 0 || search.length > maximumSearchLength) {
+    return undefined
+  }
+  return search
+}
+
+export const normalize = (value) => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const searches = []
+  const normalizedSearches = new Set()
+  for (const item of value) {
+    const search = normalizeSearch(item)
+    const normalizedSearch = search?.toLowerCase()
+    if (!search || normalizedSearches.has(normalizedSearch)) {
+      continue
+    }
+    normalizedSearches.add(normalizedSearch)
+    searches.push(search)
+    if (searches.length === maximumSearches) {
+      break
+    }
+  }
+  return searches
+}
+
+export const load = async () => {
+  try {
+    return normalize(await LocalStorage.getJson(storageKey))
+  } catch {
+    return []
+  }
+}
+
+export const save = async (searches) => {
+  try {
+    await LocalStorage.setJson(storageKey, searches)
+  } catch {
+    // Searching should continue when local storage is unavailable or full.
+  }
+}
+
+export const add = (searches, value) => {
+  const search = normalizeSearch(value)
+  if (!search) {
+    return searches
+  }
+  const normalizedSearch = search.toLowerCase()
+  if (searches[0]?.toLowerCase() === normalizedSearch) {
+    return searches
+  }
+  return [search, ...searches.filter((item) => item.toLowerCase() !== normalizedSearch)].slice(0, maximumSearches)
+}
+
+export const getSuggestions = (searches, query) => {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (normalizedQuery.length < 2) {
+    return []
+  }
+  return searches
+    .filter((search) => search.toLowerCase().startsWith(normalizedQuery) && search.toLowerCase() !== normalizedQuery)
+    .slice(0, 4)
+    .map((value) => ({ favicon: '', type: 'history', value }))
+}

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -6,6 +6,21 @@ import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEven
 import * as InputName from '../InputName/InputName.js'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.js'
 
+const getSuggestionValue = (suggestion) => {
+  return typeof suggestion === 'string' ? suggestion : suggestion?.value
+}
+
+const getInlineSuggestion = (value, suggestions) => {
+  const normalizedValue = value.toLowerCase()
+  for (const suggestion of suggestions) {
+    const suggestionValue = getSuggestionValue(suggestion)
+    if (typeof suggestionValue === 'string' && suggestionValue.length > value.length && suggestionValue.toLowerCase().startsWith(normalizedValue)) {
+      return suggestionValue
+    }
+  }
+  return ''
+}
+
 export const getSimpleBrowserVirtualDom = (
   canGoBack,
   canGoForward,
@@ -21,6 +36,7 @@ export const getSimpleBrowserVirtualDom = (
   pageSnapshotDom = [],
   tabHover,
 ) => {
+  const inlineSuggestion = getInlineSuggestion(value, suggestions)
   /** @type {any[]} */
   const dom = [
     {
@@ -28,12 +44,7 @@ export const getSimpleBrowserVirtualDom = (
       className: tabsEnabled ? 'Viewlet SimpleBrowser SimpleBrowserTabsEnabled' : 'Viewlet SimpleBrowser',
       onFocusIn: DomEventListenerFunctions.HandleFocusInSimpleBrowser,
       childCount:
-        1 +
-        (tabsEnabled ? 1 : 0) +
-        (snapshot ? 1 : 0) +
-        (pageSnapshotDom.length > 0 ? 1 : 0) +
-        (suggestions.length > 0 ? 1 : 0) +
-        (tabHover ? 1 : 0),
+        1 + (tabsEnabled ? 1 : 0) + (snapshot ? 1 : 0) + (pageSnapshotDom.length > 0 ? 1 : 0) + (suggestions.length > 0 ? 1 : 0) + (tabHover ? 1 : 0),
     },
   ]
   if (tabsEnabled) {
@@ -180,6 +191,36 @@ export const getSimpleBrowserVirtualDom = (
       className: isLoading ? 'MaskIcon MaskIconClose' : 'MaskIcon MaskIconRefresh',
       childCount: 0,
     },
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserAddressBar',
+      childCount: inlineSuggestion ? 2 : 1,
+    },
+  )
+  if (inlineSuggestion) {
+    dom.push(
+      {
+        type: VirtualDomElements.Div,
+        className: 'SimpleBrowserInlineSuggestion',
+        ariaHidden: true,
+        'data-value': inlineSuggestion,
+        childCount: 2,
+      },
+      {
+        type: VirtualDomElements.Span,
+        className: 'SimpleBrowserInlineSuggestionPrefix',
+        childCount: 1,
+      },
+      text(value),
+      {
+        type: VirtualDomElements.Span,
+        className: 'SimpleBrowserInlineSuggestionSuffix',
+        childCount: 1,
+      },
+      text(inlineSuggestion.slice(value.length)),
+    )
+  }
+  dom.push(
     {
       type: VirtualDomElements.Input,
       className: ClassNames.InputBox,

--- a/packages/renderer-worker/src/parts/IframeSrc/IframeSrc.js
+++ b/packages/renderer-worker/src/parts/IframeSrc/IframeSrc.js
@@ -41,6 +41,22 @@ const isLocalHostUrlWithOutHttp = (input) => {
   return input.startsWith('localhost:')
 }
 
+export const isSearchInput = (input, shortcuts = []) => {
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    return false
+  }
+  for (const shortcut of shortcuts) {
+    if (shortcut && shortcut.prefix === input && typeof shortcut.url === 'string') {
+      return false
+    }
+  }
+  if (isValidHttpUrl(input) || isValidFileUrl(input) || isLocalHostUrlWithOutHttp(input) || isValidFilePath(input)) {
+    return false
+  }
+  const dotIndex = input.indexOf(Character.Dot)
+  return dotIndex === -1 || dotIndex === input.length - 1
+}
+
 export const toIframeSrc = (input, shortcuts = []) => {
   for (const shortcut of shortcuts) {
     if (shortcut && shortcut.prefix === input && typeof shortcut.url === 'string') {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -1,6 +1,7 @@
 // based on vscode's simple browser by Microsoft (https://github.com/microsoft/vscode/blob/e8fe2d07d31f30698b9262dd5e1fcc59a85c6bb1/extensions/simple-browser/src/extension.ts, License MIT)
 
 import * as Assert from '../Assert/Assert.ts'
+import * as BrowserSearchHistory from '../BrowserSearchHistory/BrowserSearchHistory.js'
 import * as BrowserSearchSuggestions from '../BrowserSearchSuggestions/BrowserSearchSuggestions.js'
 import * as BrowserHistory from '../BrowserHistory/BrowserHistory.js'
 import * as BrowserVisitedSites from '../BrowserVisitedSites/BrowserVisitedSites.js'
@@ -140,6 +141,7 @@ export const create = (id, uri, x, y, width, height) => {
     overlayIds: [],
     snapshot: '',
     suggestionsEnabled: false,
+    searchHistory: [],
     shortcuts: [],
     tabs: [],
     audioIndicatorEnabled: true,
@@ -210,7 +212,10 @@ export const backgroundLoadContent = async (state, savedState) => {
   const tabHoverEnabled = Preferences.get('simpleBrowser.tabHover.enabled') === true
   const unloadTabs = Preferences.get('simpleBrowser.unloadTabs') === true
   const headerHeight = getHeaderHeight(tabsEnabled)
-  const visitedSites = await BrowserVisitedSites.load()
+  const [searchHistory, visitedSites] = await Promise.all([
+    BrowserSearchHistory.load(),
+    BrowserVisitedSites.load(),
+  ])
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
@@ -222,6 +227,7 @@ export const backgroundLoadContent = async (state, savedState) => {
     audioIndicatorEnabled,
     headerHeight,
     selectedTabIndex: 0,
+    searchHistory,
     tabs,
     tabsEnabled,
     tabHoverEnabled,
@@ -252,7 +258,10 @@ export const loadContent = async (state, savedState) => {
   const savedSelectedTabIndex = getSavedSelectedTabIndex(savedState, savedTabs)
   const savedSelectedTab = savedTabs[savedSelectedTabIndex]
   const iframeSrc = savedSelectedTab ? savedSelectedTab.iframeSrc : getUrlFromSavedState(savedState)
-  const visitedSites = await BrowserVisitedSites.load()
+  const [searchHistory, visitedSites] = await Promise.all([
+    BrowserSearchHistory.load(),
+    BrowserVisitedSites.load(),
+  ])
   const audioIndicatorEnabled = Preferences.get('simpleBrowser.audioIndicator.enabled') !== false
   const suggestionsEnabled = Preferences.get('simpleBrowser.suggestions')
   const tabsEnabled = Preferences.get('simpleBrowser.tabs.enabled') !== false
@@ -303,6 +312,7 @@ export const loadContent = async (state, savedState) => {
     uri: id ? uri : `simple-browser://${browserViewId}`,
     headerHeight,
     selectedTabIndex,
+    searchHistory,
     suggestionsEnabled,
     shortcuts,
     tabs,
@@ -801,8 +811,10 @@ export const handleInput = async (state, value) => {
   if (!shouldRequestSuggestions(value)) {
     return applySuggestions(newState, state.uid, value, [])
   }
+  const localSuggestions = getLocalSuggestions(newState, value)
+  const stateWithLocalSuggestions = localSuggestions.length > 0 ? await applySuggestions(newState, state.uid, value, [], localSuggestions) : newState
   void requestSuggestions(state.uid, value)
-  return newState
+  return stateWithLocalSuggestions
 }
 
 const suggestionsOverlayId = 'search-suggestions'
@@ -835,14 +847,18 @@ const getSuggestionValue = (suggestion) => {
   return typeof suggestion === 'string' ? suggestion : suggestion?.value
 }
 
-export const applySuggestions = async (state, uid, query, suggestions) => {
+const getLocalSuggestions = (state, query) => {
+  return [...BrowserSearchHistory.getSuggestions(state.searchHistory, query), ...BrowserVisitedSites.getSuggestions(state.visitedSites, query)]
+}
+
+export const applySuggestions = async (state, uid, query, suggestions, precomputedLocalSuggestions) => {
   if (state.uid !== uid || state.inputValue !== query || !state.suggestionsEnabled) {
     return state
   }
-  const visitedSiteSuggestions = BrowserVisitedSites.getSuggestions(state.visitedSites, query)
+  const localSuggestions = precomputedLocalSuggestions || getLocalSuggestions(state, query)
   const providerSuggestions = Array.isArray(suggestions) ? suggestions : []
   const allSuggestions = [
-    ...visitedSiteSuggestions,
+    ...localSuggestions,
     ...(providerSuggestions.length > 0 ? [createSearchSuggestion(query)] : []),
     ...providerSuggestions.map(createSearchSuggestion),
   ]
@@ -902,6 +918,21 @@ const openCookieImportView = (value) => {
   return true
 }
 
+const addToSearchHistory = (state, value) => {
+  if (!IframeSrc.isSearchInput(value, state.shortcuts)) {
+    return state
+  }
+  const searchHistory = BrowserSearchHistory.add(state.searchHistory, value)
+  if (searchHistory === state.searchHistory) {
+    return state
+  }
+  void BrowserSearchHistory.save(searchHistory)
+  return {
+    ...state,
+    searchHistory,
+  }
+}
+
 const navigate = (state, value) => {
   if (openCookieImportView(value)) {
     return state
@@ -909,7 +940,8 @@ const navigate = (state, value) => {
   const iframeSrc = IframeSrc.toIframeSrc(value, state.shortcuts)
   void ElectronWebContentsViewFunctions.setIframeSrc(state.browserViewId, iframeSrc)
   void ElectronWebContentsViewFunctions.focus(state.browserViewId)
-  return updateTab(state, state.browserViewId, {
+  const stateWithSearchHistory = addToSearchHistory(state, value)
+  return updateTab(stateWithSearchHistory, state.browserViewId, {
     iframeSrc,
     inputValue: value,
     isLoading: true,
@@ -933,8 +965,9 @@ export const setUrl = async (state, value) => {
   }
   const iframeSrc = IframeSrc.toIframeSrc(inputValue, shortcuts)
   void ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
+  const stateWithSearchHistory = addToSearchHistory(newState1, inputValue)
 
-  return updateTab(newState1, browserViewId, {
+  return updateTab(stateWithSearchHistory, browserViewId, {
     iframeSrc,
     isLoading: true,
   })

--- a/packages/renderer-worker/test/BrowserSearchHistory.test.ts
+++ b/packages/renderer-worker/test/BrowserSearchHistory.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+jest.unstable_mockModule('../src/parts/LocalStorage/LocalStorage.js', () => ({
+  getJson: jest.fn(),
+  setJson: jest.fn(),
+}))
+
+const BrowserSearchHistory = await import('../src/parts/BrowserSearchHistory/BrowserSearchHistory.js')
+const LocalStorage = await import('../src/parts/LocalStorage/LocalStorage.js')
+
+test('loads normalized recent searches', async () => {
+  // @ts-ignore
+  LocalStorage.getJson.mockResolvedValue([' cheeseburger ', 'CHEESEBURGER', '', 42, 'cheese cake'])
+
+  await expect(BrowserSearchHistory.load()).resolves.toEqual(['cheeseburger', 'cheese cake'])
+  expect(LocalStorage.getJson).toHaveBeenCalledWith('simple-browser-search-history')
+})
+
+test('returns an empty list when storage cannot be read', async () => {
+  // @ts-ignore
+  LocalStorage.getJson.mockRejectedValue(new Error('storage unavailable'))
+
+  await expect(BrowserSearchHistory.load()).resolves.toEqual([])
+})
+
+test('moves a repeated search to the front', () => {
+  expect(BrowserSearchHistory.add(['cheese cake', 'Cheeseburger'], 'cheeseburger')).toEqual(['cheeseburger', 'cheese cake'])
+})
+
+test('suggests recent searches by prefix in recency order', () => {
+  expect(BrowserSearchHistory.getSuggestions(['cheeseburger recipe', 'cheese cake', 'best cheese'], 'cheese')).toEqual([
+    { favicon: '', type: 'history', value: 'cheeseburger recipe' },
+    { favicon: '', type: 'history', value: 'cheese cake' },
+  ])
+})
+
+test('saves searches without surfacing storage failures', async () => {
+  const searches = ['cheeseburger']
+  // @ts-ignore
+  LocalStorage.setJson.mockRejectedValue(new Error('storage full'))
+
+  await expect(BrowserSearchHistory.save(searches)).resolves.toBeUndefined()
+  expect(LocalStorage.setJson).toHaveBeenCalledWith('simple-browser-search-history', searches)
+})

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -114,6 +114,31 @@ test('renders accessible search suggestions above an undimmed snapshot', () => {
   )
 })
 
+test('renders the first matching suggestion inline without changing the input value', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, 'cheese', '', [
+    { favicon: '', type: 'history', value: 'cheeseburger' },
+  ])
+
+  expect(dom).toContainEqual(
+    expect.objectContaining({
+      ariaHidden: true,
+      className: 'SimpleBrowserInlineSuggestion',
+      'data-value': 'cheeseburger',
+    }),
+  )
+  expect(dom).toContainEqual(expect.objectContaining({ className: 'SimpleBrowserInlineSuggestionSuffix' }))
+  expect(dom).toContainEqual(expect.objectContaining({ name: 'simple-browser-address', value: 'cheese' }))
+  expect(dom).toContainEqual(expect.objectContaining({ text: 'burger' }))
+})
+
+test('does not render an inline suggestion for an exact match', () => {
+  const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, 'cheese', '', [
+    { favicon: '', type: 'search', value: 'cheese' },
+  ])
+
+  expect(dom).not.toContainEqual(expect.objectContaining({ className: 'SimpleBrowserInlineSuggestion' }))
+})
+
 test('renders the stored favicon for a URL suggestion', () => {
   const dom = GetSimpleBrowserVirtualDom.getSimpleBrowserVirtualDom(false, false, false, 'soundcloud', '', [
     {

--- a/packages/renderer-worker/test/IframeSrc.test.ts
+++ b/packages/renderer-worker/test/IframeSrc.test.ts
@@ -21,6 +21,13 @@ test('search term', () => {
   expect(IframeSrc.toIframeSrc('example')).toBe('https://www.google.com/search?q=example')
 })
 
+test('identifies search terms for history', () => {
+  expect(IframeSrc.isSearchInput('cheeseburger')).toBe(true)
+  expect(IframeSrc.isSearchInput('example.com')).toBe(false)
+  expect(IframeSrc.isSearchInput('https://example.com')).toBe(false)
+  expect(IframeSrc.isSearchInput('g', [{ prefix: 'g', url: 'https://google.com' }])).toBe(false)
+})
+
 test('not a url', () => {
   expect(IframeSrc.toIframeSrc('https://example')).toBe('https://example')
 })

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -79,6 +79,13 @@ jest.unstable_mockModule('../src/parts/BrowserHistory/BrowserHistory.js', () => 
   record: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/BrowserSearchHistory/BrowserSearchHistory.js', () => ({
+  add: jest.fn(),
+  getSuggestions: jest.fn(),
+  load: jest.fn(),
+  save: jest.fn(),
+}))
+
 jest.unstable_mockModule('../src/parts/BrowserVisitedSites/BrowserVisitedSites.js', () => ({
   add: jest.fn(),
   getSuggestions: jest.fn(),
@@ -104,6 +111,7 @@ const ViewletSimpleBrowserOpenBackgroundTab = await import('../src/parts/Viewlet
 const ViewletSimpleBrowserResize = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserResize.js')
 const BrowserHistory = await import('../src/parts/BrowserHistory/BrowserHistory.js')
 const BrowserSearchSuggestions = await import('../src/parts/BrowserSearchSuggestions/BrowserSearchSuggestions.js')
+const BrowserSearchHistory = await import('../src/parts/BrowserSearchHistory/BrowserSearchHistory.js')
 const BrowserVisitedSites = await import('../src/parts/BrowserVisitedSites/BrowserVisitedSites.js')
 const Command = await import('../src/parts/Command/Command.js')
 const ColorTheme = await import('../src/parts/ColorTheme/ColorTheme.js')
@@ -125,6 +133,12 @@ const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.
 
 beforeEach(() => {
   ColorTheme.state.colorThemeCss = ''
+  // @ts-ignore
+  BrowserSearchHistory.add.mockImplementation((searches) => searches)
+  // @ts-ignore
+  BrowserSearchHistory.getSuggestions.mockReturnValue([])
+  // @ts-ignore
+  BrowserSearchHistory.load.mockResolvedValue([])
   // @ts-ignore
   BrowserVisitedSites.add.mockImplementation((sites) => sites)
   // @ts-ignore
@@ -263,6 +277,8 @@ test('uses the browser focus context for tabs and toolbar controls', () => {
 
 test('loadContent', async () => {
   // @ts-ignore
+  BrowserSearchHistory.load.mockResolvedValue(['cheeseburger'])
+  // @ts-ignore
   ElectronWebContentsView.createWebContentsView.mockImplementation(() => {
     return 1
   })
@@ -275,6 +291,7 @@ test('loadContent', async () => {
     audioIndicatorEnabled: true,
     headerHeight: 65,
     iframeSrc: 'https://example.com',
+    searchHistory: ['cheeseburger'],
     tabHoverEnabled: false,
     tabsEnabled: true,
     unloadTabs: false,
@@ -1680,6 +1697,94 @@ test('applySuggestions places matching visited sites before provider results', a
     { favicon: '', type: 'search', value: 'soundcloud' },
     { favicon: '', type: 'search', value: 'soundcloud music' },
   ])
+})
+
+test('applySuggestions places matching recent searches first', async () => {
+  const historySuggestion = { favicon: '', type: 'history', value: 'cheeseburger' }
+  const visitedSuggestion = { favicon: 'https://cheese.example/favicon.ico', type: 'url', value: 'https://cheese.example' }
+  // @ts-ignore
+  BrowserSearchHistory.getSuggestions.mockReturnValue([historySuggestion])
+  // @ts-ignore
+  BrowserVisitedSites.getSuggestions.mockReturnValue([visitedSuggestion])
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: 'cheese',
+    searchHistory: ['cheeseburger'],
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.applySuggestions(state, 7, 'cheese', ['cheese recipes'])
+
+  expect(newState.suggestions).toEqual([
+    historySuggestion,
+    visitedSuggestion,
+    { favicon: '', type: 'search', value: 'cheese' },
+    { favicon: '', type: 'search', value: 'cheese recipes' },
+  ])
+})
+
+test('handleInput shows matching search history before the provider responds', async () => {
+  const historySuggestion = { favicon: '', type: 'history', value: 'cheeseburger' }
+  // @ts-ignore
+  BrowserSearchHistory.getSuggestions.mockReturnValue([historySuggestion])
+  // @ts-ignore
+  BrowserSearchSuggestions.get.mockReturnValue(new Promise(() => {}))
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: '',
+    searchHistory: ['cheeseburger'],
+    suggestionsEnabled: true,
+  }
+
+  const newState = await ViewletSimpleBrowser.handleInput(state, 'cheese')
+
+  expect(BrowserSearchHistory.getSuggestions).toHaveBeenCalledWith(['cheeseburger'], 'cheese')
+  expect(newState).toMatchObject({ hasSuggestionsOverlay: true, selectedSuggestionIndex: 0, suggestions: [historySuggestion] })
+})
+
+test('go saves a submitted search in recent history', async () => {
+  // @ts-ignore
+  BrowserSearchHistory.add.mockReturnValue(['cheeseburger'])
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: 'cheeseburger',
+    searchHistory: [],
+  }
+
+  const newState = await ViewletSimpleBrowser.go(state)
+
+  expect(BrowserSearchHistory.add).toHaveBeenCalledWith([], 'cheeseburger')
+  expect(BrowserSearchHistory.save).toHaveBeenCalledWith(['cheeseburger'])
+  expect(newState.searchHistory).toEqual(['cheeseburger'])
+})
+
+test('go does not save a submitted URL in search history', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(7),
+    browserViewId: 12,
+    inputValue: 'example.com',
+    searchHistory: ['cheeseburger'],
+  }
+
+  await ViewletSimpleBrowser.go(state)
+
+  expect(BrowserSearchHistory.add).not.toHaveBeenCalled()
+  expect(BrowserSearchHistory.save).not.toHaveBeenCalled()
 })
 
 test('acceptSuggestion restores the page and navigates', async () => {

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -18,9 +18,36 @@
   display: flex;
 }
 
-.SimpleBrowserHeader .InputBox {
-  color: var(--InputBoxForeground, var(--WorkbenchForeground));
+.SimpleBrowserAddressBar {
+  background: var(--InputBoxBackground, var(--MainBackground, var(--EditorBackground)));
   flex: 1;
+  height: 24px;
+  position: relative;
+}
+
+.SimpleBrowserHeader .InputBox {
+  background: transparent;
+  box-sizing: border-box;
+  color: var(--InputBoxForeground, var(--WorkbenchForeground));
+  position: relative;
+  z-index: 1;
+}
+
+.SimpleBrowserInlineSuggestion {
+  box-sizing: border-box;
+  color: var(--InputBoxPlaceholderForeground, rgb(255 255 255 / 40%));
+  font-size: 13px;
+  height: 24px;
+  inset: 0;
+  overflow: hidden;
+  padding: 5px 7px;
+  pointer-events: none;
+  position: absolute;
+  white-space: pre;
+}
+
+.SimpleBrowserInlineSuggestionPrefix {
+  visibility: hidden;
 }
 
 .SimpleBrowserTabs {


### PR DESCRIPTION
Adds ghosted inline completion to the Simple Browser address bar without changing the typed input value. Stores completed searches locally and ranks matching recent searches ahead of visited-site and provider suggestions, with focused unit and Electron e2e regression coverage.