### PR TITLE
fix: avoid loading viewlet workers for simple browser shortcuts

### DIFF
--- a/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
+++ b/packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js
@@ -99,5 +99,5 @@ export const removeKeyBindings = (id) => {
 }
 
 export const getKeyBindings = () => {
-  return state.keyBindings
+  return state.matchingKeyBindings
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -14,7 +14,7 @@ import * as IframeSrc from '../IframeSrc/IframeSrc.js'
 import * as InputName from '../InputName/InputName.js'
 import * as KeyCode from '../KeyCode/KeyCode.js'
 import * as KeyBindings from '../KeyBindings/KeyBindings.js'
-import * as KeyBindingsInitial from '../KeyBindingsInitial/KeyBindingsInitial.js'
+import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
 import * as KeyModifier from '../KeyModifier/KeyModifier.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as PrettyBytes from '../PrettyBytes/PrettyBytes.js'
@@ -35,7 +35,8 @@ const focusPreviousTabKeyBinding = KeyModifier.CtrlCmd | KeyModifier.Shift | Key
 const browserTabKeyBindings = [closeTabKeyBinding, createNewTabKeyBinding, focusNextTabKeyBinding, focusPreviousTabKeyBinding]
 const visibleBrowserUids = new Set()
 
-const getFallThroughKeyBindings = (keyBindings) => {
+const getFallThroughKeyBindings = () => {
+  const keyBindings = KeyBindingsState.getKeyBindings()
   return [...new Set([...GetFallThroughKeyBindings.getFallThroughKeyBindings(keyBindings), ...browserTabKeyBindings])]
 }
 
@@ -207,12 +208,8 @@ export const backgroundLoadContent = async (state, savedState) => {
   const tabHoverEnabled = Preferences.get('simpleBrowser.tabHover.enabled') === true
   const unloadTabs = Preferences.get('simpleBrowser.unloadTabs') === true
   const headerHeight = getHeaderHeight(tabsEnabled)
-  // TODO since browser view is not visible at this point
-  // it is not necessary to load keybindings for it
-  const [keyBindings, visitedSites] = await Promise.all([KeyBindingsInitial.getKeyBindings(), BrowserVisitedSites.load()])
-  const fallThroughKeyBindings = getFallThroughKeyBindings(keyBindings)
+  const visitedSites = await BrowserVisitedSites.load()
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0)
-  await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
   const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
@@ -253,8 +250,7 @@ export const loadContent = async (state, savedState) => {
   const savedSelectedTabIndex = getSavedSelectedTabIndex(savedState, savedTabs)
   const savedSelectedTab = savedTabs[savedSelectedTabIndex]
   const iframeSrc = savedSelectedTab ? savedSelectedTab.iframeSrc : getUrlFromSavedState(savedState)
-  // TODO load keybindings in parallel with creating browserview
-  const [keyBindings, visitedSites] = await Promise.all([KeyBindingsInitial.getKeyBindings(), BrowserVisitedSites.load()])
+  const visitedSites = await BrowserVisitedSites.load()
   const audioIndicatorEnabled = Preferences.get('simpleBrowser.audioIndicator.enabled') !== false
   const suggestionsEnabled = Preferences.get('simpleBrowser.suggestions')
   const tabsEnabled = Preferences.get('simpleBrowser.tabs.enabled') !== false
@@ -266,7 +262,7 @@ export const loadContent = async (state, savedState) => {
   const browserViewWidth = width
   const browserViewHeight = height - headerHeight
   const shortcuts = SimpleBrowserPreferences.getShortCuts()
-  const fallThroughKeyBindings = getFallThroughKeyBindings(keyBindings)
+  const fallThroughKeyBindings = getFallThroughKeyBindings()
 
   const browserViewId = await ElectronWebContentsView.createWebContentsView(id, uid)
   await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)

--- a/packages/renderer-worker/test/KeyBindings.test.ts
+++ b/packages/renderer-worker/test/KeyBindings.test.ts
@@ -69,6 +69,7 @@ test('update refreshes matching keybindings without sending equal identifiers', 
   expect(KeyBindingsState.state.keyBindingIdentifiers).toEqual(new Uint32Array([1]))
   expect(KeyBindingsState.state.matchingKeyBindings).toEqual([currentKeyBinding])
   expect(KeyBindingsState.getKeyBinding(1)).toBe(currentKeyBinding)
+  expect(KeyBindingsState.getKeyBindings()).toEqual([currentKeyBinding])
 })
 
 test.each([

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -67,9 +67,7 @@ jest.unstable_mockModule('../src/parts/Focus/Focus.js', () => ({
 
 jest.unstable_mockModule('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js', () => {
   return {
-    getKeyBindings() {
-      return []
-    },
+    getKeyBindings: jest.fn(() => []),
   }
 })
 
@@ -109,6 +107,8 @@ const ElectronWindow = await import('../src/parts/ElectronWindow/ElectronWindow.
 const Focus = await import('../src/parts/Focus/Focus.js')
 const InputName = await import('../src/parts/InputName/InputName.js')
 const KeyCode = await import('../src/parts/KeyCode/KeyCode.js')
+const KeyBindingsInitial = await import('../src/parts/KeyBindingsInitial/KeyBindingsInitial.js')
+const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
 const KeyModifier = await import('../src/parts/KeyModifier/KeyModifier.js')
 const Preferences = await import('../src/parts/Preferences/Preferences.js')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
@@ -124,6 +124,7 @@ beforeEach(() => {
   BrowserVisitedSites.getSuggestions.mockReturnValue([])
   // @ts-ignore
   BrowserVisitedSites.load.mockResolvedValue([])
+  KeyBindingsState.state.matchingKeyBindings = []
   // @ts-ignore
   ElectronWebContentsViewFunctions.getStats.mockResolvedValue({
     title: 'test',
@@ -270,6 +271,41 @@ test('loadContent', async () => {
     tabsEnabled: true,
     unloadTabs: false,
   })
+})
+
+test('loadContent uses registered keybindings without loading every viewlet', async () => {
+  const registeredKeyBinding = {
+    command: 'test.registered',
+    key: KeyModifier.CtrlCmd | KeyCode.KeyB,
+  }
+  KeyBindingsState.state.matchingKeyBindings = [registeredKeyBinding]
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(1)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setFallthroughKeyBindings.mockResolvedValue(undefined)
+  const state = ViewletSimpleBrowser.create(0, 'simple-browser://1', 0, 0, 300, 200)
+
+  await ViewletSimpleBrowser.loadContent(state)
+
+  expect(KeyBindingsInitial.getKeyBindings).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith(1, [registeredKeyBinding.key, ...browserTabKeyBindings])
+})
+
+test('backgroundLoadContent does not load or configure keybindings for an invisible browser view', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(1)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue({ newTitle: '' })
+  const state = ViewletSimpleBrowser.create(0, 'simple-browser://', 0, 0, 300, 200)
+
+  await ViewletSimpleBrowser.backgroundLoadContent(state)
+
+  expect(KeyBindingsInitial.getKeyBindings).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).not.toHaveBeenCalled()
 })
 
 test('loadContent enables tab hovers through simpleBrowser.tabHover.enabled', async () => {


### PR DESCRIPTION
## Summary
- read Simple Browser fall-through shortcuts from the active keybinding registry
- avoid configuring keybindings while a browser view is preloaded invisibly
- cover foreground and background loading with regression tests

## Root cause
Simple Browser called `KeyBindingsInitial.getKeyBindings()` during both foreground loading and background restoration. That helper enumerates every viewlet and invokes each `getKeyBindings` implementation, which starts worker-backed views such as Text Search, Quick Pick, Process Explorer, Language Models, Diff, Dialog, and About.

## Validation
- `npm test -- --runInBand test/ViewletSimpleBrowser.test.ts test/KeyBindings.test.ts`
- `npm run type-check`
- `npm test -- --runInBand` (392 suites, 1,839 tests passed; 21 suites skipped)
- `git diff --check`

Package-wide `npm run lint` currently reports 118,585 pre-existing repository style errors, including the existing PascalCase directory convention.