### PR TITLE
fix: use theme colors in simple browser

### DIFF
--- a/packages/build/test/BundleCss.test.ts
+++ b/packages/build/test/BundleCss.test.ts
@@ -38,7 +38,7 @@ test('bundleCss does not add filename comment to App.css', async () => {
   }
 }, 30_000)
 
-test('bundleCss lets the simple browser fill the preview area height', async () => {
+test('bundleCss lets the simple browser fill the preview area height and use workbench theme colors', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'lvce-bundle-css-'))
 
   try {
@@ -49,14 +49,11 @@ test('bundleCss lets the simple browser fill the preview area height', async () 
 
     const css = await readFile(join(dir, 'parts', 'ViewletSimpleBrowser.css'), 'utf8')
 
-    expect(css).toContain(`.SimpleBrowser {
-  contain: strict;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  position: relative;
-}`)
+    expect(css).toContain('background: var(--EditorBackground, var(--MainBackground));')
+    expect(css).toContain('color: var(--WorkbenchForeground);')
+    expect(css).toContain('flex: 1;')
+    expect(css).toContain('min-height: 0;')
+    expect(css).toContain('background: var(--TabsBackground, var(--MainBackground, var(--EditorBackground)));')
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
@@ -49,7 +49,8 @@ const applyColorTheme = async (colorThemeId) => {
 }
 
 export const getColorThemeCss = () => {
-  return state.colorThemeCss
+  const { colorThemeCss } = state
+  return colorThemeCss
 }
 
 export const setColorTheme = async (colorThemeId) => {

--- a/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
+++ b/packages/renderer-worker/src/parts/ColorTheme/ColorTheme.js
@@ -16,6 +16,7 @@ import { VError } from '../VError/VError.js'
 // actual color theme can be computed after workbench has loaded (most times will be the same and doesn't need to be computed)
 
 export const state = {
+  colorThemeCss: '',
   watchedTheme: '',
 }
 
@@ -32,6 +33,7 @@ const applyColorTheme = async (colorThemeId) => {
     if (!colorThemeCss) {
       return new Error(`Color theme is empty`)
     }
+    state.colorThemeCss = colorThemeCss
     await Css.addCssStyleSheet('ContributedColorTheme', colorThemeCss)
     if (Platform.getPlatform() === PlatformType.Web) {
       const themeColor = GetMetaThemeColor.getMetaThemeColor(colorThemeId) || ''
@@ -44,6 +46,10 @@ const applyColorTheme = async (colorThemeId) => {
   } catch (error) {
     return new VError(error, `Failed to apply color theme "${colorThemeId}"`)
   }
+}
+
+export const getColorThemeCss = () => {
+  return state.colorThemeCss
 }
 
 export const setColorTheme = async (colorThemeId) => {

--- a/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
@@ -1,4 +1,55 @@
-const html = `<!doctype html>
+import * as ColorTheme from '../ColorTheme/ColorTheme.js'
+
+const dataUrlPrefix = 'data:text/html;charset=utf-8,'
+const marker = '<!--lvce-simple-browser-new-tab-->'
+const urlPrefix = `${dataUrlPrefix}${encodeURIComponent(marker)}`
+
+const getCssVariable = (css, name) => {
+  const prefix = `--${name}:`
+  const start = css.indexOf(prefix)
+  if (start === -1) {
+    return ''
+  }
+  const valueStart = start + prefix.length
+  const end = css.indexOf(';', valueStart)
+  return css.slice(valueStart, end === -1 ? undefined : end).trim()
+}
+
+const getColor = (css, names, fallback) => {
+  for (const name of names) {
+    const value = getCssVariable(css, name)
+    if (value) {
+      return value
+    }
+  }
+  return fallback
+}
+
+const escapeHtml = (value) => {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}
+
+const getThemeVariables = (css) => {
+  const editorBackground = getColor(css, ['EditorBackground', 'EditorBackGround', 'MainBackground'], '#1c2121')
+  const workbenchForeground = getColor(css, ['WorkbenchForeground'], '#f3f5f4')
+  const inputBoxBackground = getColor(css, ['InputBoxBackground', 'WidgetBackground'], '#272d2d')
+  const inputBoxForeground = getColor(css, ['InputBoxForeground', 'WorkbenchForeground'], workbenchForeground)
+  const inputBoxPlaceholderForeground = getColor(css, ['InputBoxPlaceholderForeground', 'DescriptionForeground'], '#9ca5a2')
+  const inputBoxBorder = getColor(css, ['InputBoxBorder', 'ContrastBorder'], 'color-mix(in srgb, currentColor 9%, transparent)')
+  const focusOutline = getColor(css, ['FocusOutline', 'FocusBorder', 'SplitButtonBackground', 'LinkForeground'], '#8b6df0')
+  const widgetBackground = getColor(css, ['WidgetBackground', 'InputBoxBackground'], inputBoxBackground)
+  return `
+        --EditorBackground: ${escapeHtml(editorBackground)};
+        --WorkbenchForeground: ${escapeHtml(workbenchForeground)};
+        --InputBoxBackground: ${escapeHtml(inputBoxBackground)};
+        --InputBoxForeground: ${escapeHtml(inputBoxForeground)};
+        --InputBoxPlaceholderForeground: ${escapeHtml(inputBoxPlaceholderForeground)};
+        --InputBoxBorder: ${escapeHtml(inputBoxBorder)};
+        --FocusOutline: ${escapeHtml(focusOutline)};
+        --WidgetBackground: ${escapeHtml(widgetBackground)};`
+}
+
+const getHtml = (colorThemeCss) => `${marker}<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">
@@ -9,8 +60,8 @@ const html = `<!doctype html>
       :root {
         color-scheme: dark;
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background: #1c2121;
-        color: #f3f5f4;
+        background: var(--EditorBackground);
+        color: var(--WorkbenchForeground);${getThemeVariables(colorThemeCss)}
       }
 
       * {
@@ -28,8 +79,8 @@ const html = `<!doctype html>
       body {
         overflow: hidden;
         background:
-          radial-gradient(circle at 50% 24%, rgba(131, 81, 255, 0.09), transparent 34%),
-          #1c2121;
+          radial-gradient(circle at 50% 24%, color-mix(in srgb, var(--FocusOutline) 9%, transparent), transparent 34%),
+          var(--EditorBackground);
       }
 
       main {
@@ -55,9 +106,9 @@ const html = `<!doctype html>
         display: grid;
         width: 52px;
         height: 52px;
-        border: 1px solid rgba(255, 255, 255, 0.08);
+        border: 1px solid color-mix(in srgb, var(--WorkbenchForeground) 8%, transparent);
         border-radius: 15px;
-        background: linear-gradient(145deg, #30284a, #252b2b);
+        background: linear-gradient(145deg, color-mix(in srgb, var(--FocusOutline) 30%, var(--WidgetBackground)), var(--WidgetBackground));
         box-shadow: 0 10px 30px rgba(0, 0, 0, 0.24);
         place-items: center;
       }
@@ -78,27 +129,28 @@ const html = `<!doctype html>
         padding: 0 18px;
         align-items: center;
         gap: 12px;
-        border: 1px solid rgba(255, 255, 255, 0.09);
+        border: 1px solid var(--InputBoxBorder);
         border-radius: 15px;
-        background: #272d2d;
+        background: var(--InputBoxBackground);
+        color: var(--InputBoxForeground);
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
         transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
       }
 
       .SearchBox:hover {
-        background: #2b3231;
+        background: color-mix(in srgb, var(--InputBoxBackground) 92%, var(--WorkbenchForeground));
       }
 
       .SearchBox:focus-within {
-        border-color: #8b6df0;
-        box-shadow: 0 0 0 3px rgba(139, 109, 240, 0.18), 0 10px 28px rgba(0, 0, 0, 0.24);
+        border-color: var(--FocusOutline);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--FocusOutline) 18%, transparent), 0 10px 28px rgba(0, 0, 0, 0.24);
       }
 
       .SearchIcon {
         width: 19px;
         height: 19px;
         flex: none;
-        color: #aab2af;
+        color: var(--InputBoxPlaceholderForeground);
       }
 
       input {
@@ -114,12 +166,11 @@ const html = `<!doctype html>
       }
 
       input::placeholder {
-        color: #9ca5a2;
+        color: var(--InputBoxPlaceholderForeground);
         opacity: 1;
       }
 
       input::-webkit-search-cancel-button {
-        filter: invert(1);
         opacity: 0.65;
       }
 
@@ -138,8 +189,8 @@ const html = `<!doctype html>
           <svg viewBox="0 0 48 48" role="img">
             <defs>
               <linearGradient id="mark" x1="8" y1="5" x2="38" y2="43" gradientUnits="userSpaceOnUse">
-                <stop stop-color="#b06cff"></stop>
-                <stop offset="1" stop-color="#7b49e8"></stop>
+                <stop stop-color="var(--FocusOutline)"></stop>
+                <stop offset="1" stop-color="var(--FocusOutline)"></stop>
               </linearGradient>
             </defs>
             <path fill="url(#mark)" d="M20 3 30 39 18 46 11 42Z"></path>
@@ -159,8 +210,12 @@ const html = `<!doctype html>
   </body>
 </html>`
 
-export const url = `data:text/html;charset=utf-8,${encodeURIComponent(html)}`
+export const getUrl = (colorThemeCss = ColorTheme.getColorThemeCss()) => {
+  return `${dataUrlPrefix}${encodeURIComponent(getHtml(colorThemeCss))}`
+}
+
+export const url = getUrl()
 
 export const toDisplayUrl = (value) => {
-  return value === url ? '' : value
+  return value.startsWith(urlPrefix) ? '' : value
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -215,7 +215,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
-  const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
+  const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl())
   const title = newTitle || 'Simple Browser'
   const tabs = [createTab({ browserViewId, iframeSrc, inputValue: iframeSrc, title })]
   return {
@@ -272,8 +272,8 @@ export const loadContent = async (state, savedState) => {
   await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
   Assert.number(browserViewId)
-  if (iframeSrc && (!id || id !== browserViewId)) {
-    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
+  if (!iframeSrc || !id || id !== browserViewId) {
+    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl())
   }
   const { title, canGoBack, canGoForward, isAudioMuted } = await ElectronWebContentsViewFunctions.getStats(browserViewId)
   const restoredTabs =
@@ -339,8 +339,18 @@ const createUnloadedTab = async (state) => {
 
 const createEmptyTab = async (state) => {
   const tab = await createUnloadedTab(state)
-  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.url)
+  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.getUrl())
   return tab
+}
+
+export const handleColorThemeChanged = async (state) => {
+  const newTabUrl = SimpleBrowserNewTabPage.getUrl()
+  await Promise.all(
+    state.tabs
+      .filter((tab) => !tab.iframeSrc && tab.browserViewId)
+      .map((tab) => ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, newTabUrl)),
+  )
+  return state
 }
 
 const materializeTab = async (state, tab) => {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -344,11 +344,10 @@ const createEmptyTab = async (state) => {
 }
 
 export const handleColorThemeChanged = async (state) => {
+  const { tabs } = state
   const newTabUrl = SimpleBrowserNewTabPage.getUrl()
   await Promise.all(
-    state.tabs
-      .filter((tab) => !tab.iframeSrc && tab.browserViewId)
-      .map((tab) => ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, newTabUrl)),
+    tabs.filter((tab) => !tab.iframeSrc && tab.browserViewId).map((tab) => ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, newTabUrl)),
   )
   return state
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -20,6 +20,7 @@ export const Commands = {
   getDomTree: ViewletSimpleBrowserGetDomTree.getDomTree,
   go: SimpleBrowser.go,
   handleAudioStateChanged: SimpleBrowser.handleAudioStateChanged,
+  handleColorThemeChanged: SimpleBrowser.handleColorThemeChanged,
   handleDidNavigate: SimpleBrowser.handleDidNavigate,
   handleDidNavigationCancel: SimpleBrowser.handleDidNavigationCancel,
   handleFocusIn: SimpleBrowser.handleFocusIn,

--- a/packages/renderer-worker/test/ColorTheme.test.ts
+++ b/packages/renderer-worker/test/ColorTheme.test.ts
@@ -6,6 +6,7 @@ beforeEach(() => {
   for (const key in Preferences.state) {
     delete Preferences.state[key]
   }
+  ColorTheme.state.colorThemeCss = ''
   ColorTheme.state.watchedTheme = ''
 })
 
@@ -49,6 +50,7 @@ test('reload applies slime when no color theme is selected', async () => {
   expect(GetColorThemeNames.getColorThemeNames).not.toHaveBeenCalled()
   expect(GetColorThemeCss.getColorThemeCss).toHaveBeenCalledWith('slime')
   expect(Css.addCssStyleSheet).toHaveBeenCalledWith('ContributedColorTheme', ':root { --theme-id: "slime"; }')
+  expect(ColorTheme.getColorThemeCss()).toBe(':root { --theme-id: "slime"; }')
 })
 
 test('reload switches to slime when the selected color theme is no longer contributed', async () => {

--- a/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
@@ -3,7 +3,7 @@ import * as SimpleBrowserNewTabPage from '../src/parts/SimpleBrowserNewTabPage/S
 
 const prefix = 'data:text/html;charset=utf-8,'
 
-const getHtml = (): string => decodeURIComponent(SimpleBrowserNewTabPage.url.slice(prefix.length))
+const getHtml = (url: string = SimpleBrowserNewTabPage.url): string => decodeURIComponent(url.slice(prefix.length))
 
 test('provides a self-contained new tab page', () => {
   expect(SimpleBrowserNewTabPage.url.startsWith(prefix)).toBe(true)
@@ -16,7 +16,37 @@ test('provides a self-contained new tab page', () => {
   expect(getHtml()).toContain('user-select: none;')
 })
 
+test('uses workbench theme colors', () => {
+  const url = SimpleBrowserNewTabPage.getUrl(`:root {
+    --EditorBackground: #193549;
+    --WorkbenchForeground: #c5c5c5;
+    --InputBoxBackground: #15232d;
+    --InputBoxForeground: #ffc600;
+    --InputBoxPlaceholderForeground: #aaaaaa;
+    --InputBoxBorder: #0d3a58;
+    --FocusOutline: #0088ff;
+    --WidgetBackground: #122738;
+  }`)
+  const html = getHtml(url)
+
+  expect(html).toContain('--EditorBackground: #193549;')
+  expect(html).toContain('--InputBoxBackground: #15232d;')
+  expect(html).toContain('--InputBoxForeground: #ffc600;')
+  expect(html).toContain('--FocusOutline: #0088ff;')
+  expect(html).toContain('background: var(--EditorBackground);')
+})
+
+test('falls back from the legacy empty EditorBackGround color to MainBackground', () => {
+  const url = SimpleBrowserNewTabPage.getUrl(`:root {
+    --EditorBackGround: ;
+    --MainBackground: #193549;
+  }`)
+
+  expect(getHtml(url)).toContain('--EditorBackground: #193549;')
+})
+
 test('hides the internal page URL from the address bar', () => {
   expect(SimpleBrowserNewTabPage.toDisplayUrl(SimpleBrowserNewTabPage.url)).toBe('')
+  expect(SimpleBrowserNewTabPage.toDisplayUrl(SimpleBrowserNewTabPage.getUrl(':root { --EditorBackground: #193549; }'))).toBe('')
   expect(SimpleBrowserNewTabPage.toDisplayUrl('https://example.com')).toBe('https://example.com')
 })

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -103,6 +103,7 @@ const ViewletSimpleBrowserResize = await import('../src/parts/ViewletSimpleBrows
 const BrowserSearchSuggestions = await import('../src/parts/BrowserSearchSuggestions/BrowserSearchSuggestions.js')
 const BrowserVisitedSites = await import('../src/parts/BrowserVisitedSites/BrowserVisitedSites.js')
 const Command = await import('../src/parts/Command/Command.js')
+const ColorTheme = await import('../src/parts/ColorTheme/ColorTheme.js')
 const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.js')
 const ElectronWebContentsView = await import('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js')
 const ElectronWindow = await import('../src/parts/ElectronWindow/ElectronWindow.js')
@@ -118,6 +119,7 @@ const ViewletModuleId = await import('../src/parts/ViewletModuleId/ViewletModule
 const WhenExpression = await import('../src/parts/WhenExpression/WhenExpression.js')
 
 beforeEach(() => {
+  ColorTheme.state.colorThemeCss = ''
   // @ts-ignore
   BrowserVisitedSites.add.mockImplementation((sites) => sites)
   // @ts-ignore
@@ -444,8 +446,22 @@ test('creates and selects an empty tab while keeping the original view alive', a
   expect(ElectronWebContentsView.disposeWebContentsView).not.toHaveBeenCalled()
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
-  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, SimpleBrowserNewTabPage.url)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, SimpleBrowserNewTabPage.getUrl())
   expect(ElectronWindow.focus).toHaveBeenCalledTimes(1)
+})
+
+test('updates open new tab pages when the color theme changes', async () => {
+  ColorTheme.state.colorThemeCss = ':root { --EditorBackground: #193549; --InputBoxBackground: #15232d; }'
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = createTwoTabState()
+  state.tabs[0].iframeSrc = ''
+
+  const newState = await ViewletSimpleBrowser.handleColorThemeChanged(state)
+
+  expect(newState).toBe(state)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, SimpleBrowserNewTabPage.getUrl())
 })
 
 test('opens a target blank link in a new selected tab by default', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -455,7 +455,8 @@ test('updates open new tab pages when the color theme changes', async () => {
   // @ts-ignore
   ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
   const state = createTwoTabState()
-  state.tabs[0].iframeSrc = ''
+  const { tabs } = state
+  tabs[0].iframeSrc = ''
 
   const newState = await ViewletSimpleBrowser.handleColorThemeChanged(state)
 

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -1,4 +1,6 @@
 .SimpleBrowser {
+  background: var(--EditorBackground, var(--MainBackground));
+  color: var(--WorkbenchForeground);
   contain: strict;
   flex: 1;
   display: flex;
@@ -8,6 +10,7 @@
 }
 
 .SimpleBrowserHeader {
+  background: var(--MainBackground, var(--EditorBackground));
   box-sizing: border-box;
   height: 30px;
   width: 100%;
@@ -16,13 +19,13 @@
 }
 
 .SimpleBrowserHeader .InputBox {
-  color: white;
+  color: var(--InputBoxForeground, var(--WorkbenchForeground));
   flex: 1;
 }
 
 .SimpleBrowserTabs {
   align-items: stretch;
-  background: var(--TitleBarBackground, var(--EditorBackground));
+  background: var(--TabsBackground, var(--MainBackground, var(--EditorBackground)));
   border-bottom: 1px solid var(--PanelBorder, transparent);
   box-sizing: border-box;
   contain: strict;
@@ -145,6 +148,7 @@
 }
 
 .SimpleBrowserIframe {
+  background: var(--EditorBackground, var(--MainBackground));
   width: 100%;
   height: 100%;
   contain: strict;
@@ -171,7 +175,7 @@
 }
 
 .SimpleBrowserPreview {
-  background: white;
+  background: var(--EditorBackground, var(--MainBackground));
   contain: strict;
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
Use the active workbench theme colors for the Simple Browser frame and new-tab page, including refreshing open blank tabs when the theme changes.