### PR TITLE
fix: avoid simple browser overlay flicker

### DIFF
--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -611,10 +611,12 @@ export const executeViewletCommand = async (uid, fnName, ...args) => {
   }
   UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
   ViewletStates.setRenderedState(uid, actualNewState)
-  if (commands.length === 0) {
-    return
+  if (commands.length > 0) {
+    await RendererProcess.invoke(/* Viewlet.sendMultiple */ 'Viewlet.sendMultiple', /* commands */ commands)
   }
-  await RendererProcess.invoke(/* Viewlet.sendMultiple */ 'Viewlet.sendMultiple', /* commands */ commands)
+  if (ViewletStates.getInstance(uid) === instance && instance.factory.afterRender) {
+    await instance.factory.afterRender(oldState, actualNewState)
+  }
 }
 
 export const requestRender = (uid) => {

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -128,6 +128,9 @@ const runFn = async (instance, id, key, fn, args) => {
     ViewletStates.setRenderedState(id, newState)
     await RendererProcess.invoke(/* Viewlet.sendMultiple */ kSendMultiple, /* commands */ commands)
     runLoadContentLaterForCreatedViewlets(commands)
+    if (ViewletStates.getInstance(id) === instance && instance.factory.afterRender) {
+      await instance.factory.afterRender(oldState, newState)
+    }
   } else {
     return fn(instance.state, ...args)
   }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -660,7 +660,6 @@ export const showOverlay = async (state, overlayId) => {
       const bytes = await ElectronWebContentsViewFunctions.capturePage(state.browserViewId)
       snapshot = SimpleBrowserSnapshot.create(bytes)
     }
-    await ElectronWebContentsViewFunctions.hide(state.browserViewId)
     return {
       ...state,
       overlayIds,
@@ -670,6 +669,21 @@ export const showOverlay = async (state, overlayId) => {
     SimpleBrowserSnapshot.dispose(snapshot)
     console.error('[renderer-worker] Failed to capture Simple Browser page', error)
     return state
+  }
+}
+
+export const afterRender = async (oldState, newState) => {
+  const { overlayIds: oldOverlayIds } = oldState
+  const { browserViewId, overlayIds, selectedTabIndex, tabs } = newState
+  const didShowFirstOverlay = oldOverlayIds.length === 0 && overlayIds.length > 0
+  const selectedTab = tabs[selectedTabIndex]
+  if (!didShowFirstOverlay || selectedTab?.pageSnapshot) {
+    return
+  }
+  try {
+    await ElectronWebContentsViewFunctions.hide(browserViewId)
+  } catch (error) {
+    console.error('[renderer-worker] Failed to hide Simple Browser page', error)
   }
 }
 

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -100,6 +100,36 @@ test('executeViewletCommand warns when another command targets a missing viewlet
   expect(warn).toHaveBeenCalledWith('cannot execute handleInput instance not found 2')
 })
 
+test('executeViewletCommand runs afterRender after updating the renderer', async () => {
+  const oldState = { content: 'old', uid: 2 }
+  const newState = { content: 'new', uid: 2 }
+  const callOrder: string[] = []
+  const afterRender = jest.fn(async (_oldState: Readonly<typeof oldState>, _newState: Readonly<typeof newState>): Promise<void> => {
+    callOrder.push('afterRender')
+  })
+  ViewletStates.set(2, {
+    factory: {
+      afterRender,
+      Commands: {
+        update: jest.fn(async (): Promise<typeof newState> => newState),
+      },
+      name: 'Test',
+    },
+    moduleId: 'Test',
+    renderedState: oldState,
+    state: oldState,
+  })
+  jest.mocked(ViewletManager.render).mockReturnValue([['Viewlet.setText', 'new']])
+  jest.mocked(RendererProcess.invoke).mockImplementation(async (): Promise<void> => {
+    callOrder.push('render')
+  })
+
+  await Viewlet.executeViewletCommand(2, 'update')
+
+  expect(callOrder).toEqual(['render', 'afterRender'])
+  expect(afterRender).toHaveBeenCalledWith(oldState, newState)
+})
+
 test('requestRender renders pending worker state without executing the event again', async () => {
   const renderPending = jest.fn(async (state: { commands: unknown[]; uid: number }) => ({
     ...state,

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -536,6 +536,51 @@ test('functional getStatusBarVisible command returns its boolean value', async (
   await expect(Command.execute('StatusBarQueryTest.getStatusBarVisible')).resolves.toBe(false)
 })
 
+test('functional commands run afterRender after updating the renderer', async () => {
+  const callOrder: string[] = []
+  const oldState = { content: 'old', uid: 15 }
+  const newState = { content: 'new', uid: 15 }
+  const afterRender = jest.fn(async (_oldState: Readonly<typeof oldState>, _newState: Readonly<typeof newState>): Promise<void> => {
+    callOrder.push('afterRender')
+  })
+  const mockModule = {
+    Commands: {
+      update: jest.fn(async (): Promise<typeof newState> => newState),
+    },
+    afterRender,
+    create: jest.fn((): typeof oldState => oldState),
+    hasFunctionalRender: true,
+    hasFunctionalRootRender: true,
+    loadContent: jest.fn((state: Readonly<typeof oldState>): Readonly<typeof oldState> => state),
+    render: [
+      {
+        apply: jest.fn((): string[][] => [['Viewlet.setText', 'new']]),
+        isEqual: jest.fn((): boolean => false),
+        multiple: true,
+      },
+    ],
+  }
+  const viewlet = {
+    disposed: false,
+    focus: false,
+    getModule: async (): Promise<typeof mockModule> => mockModule,
+    id: 'AfterRenderTest',
+    show: false,
+    type: 0,
+    uid: 15,
+    uri: '',
+  }
+  await ViewletManager.load(viewlet)
+  jest.mocked(RendererProcess.invoke).mockImplementation(async (): Promise<void> => {
+    callOrder.push('render')
+  })
+
+  await Command.execute('AfterRenderTest.update')
+
+  expect(callOrder).toEqual(['render', 'afterRender'])
+  expect(afterRender).toHaveBeenCalledWith(oldState, newState)
+})
+
 test('extension view render sends a dynamic title to its parent', () => {
   const dom = []
   const oldState = {

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -1167,7 +1167,7 @@ test('keeps the internal new tab URL out of the address state', async () => {
   expect(loadedState).toMatchObject({ iframeSrc: '', inputValue: '', isLoading: false })
 })
 
-test('showOverlay captures and hides the WebContentsView', async () => {
+test('showOverlay captures the WebContentsView without hiding it before the snapshot is rendered', async () => {
   const png = new Uint8Array([137, 80, 78, 71])
   // @ts-ignore
   ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(png)
@@ -1185,6 +1185,21 @@ test('showOverlay captures and hides the WebContentsView', async () => {
   })
   expect(ElectronWebContentsViewFunctions.capturePage).toHaveBeenCalledWith(12)
   expect(SimpleBrowserSnapshot.create).toHaveBeenCalledWith(png)
+  expect(ElectronWebContentsViewFunctions.hide).not.toHaveBeenCalled()
+})
+
+test('afterRender hides the WebContentsView once the snapshot is rendered', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  const oldState = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
+  const newState = {
+    ...oldState,
+    overlayIds: ['tab-hover'],
+    snapshot: 'blob:https://example.com/snapshot',
+  }
+
+  await ViewletSimpleBrowser.afterRender(oldState, newState)
+
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
 })
 
@@ -1202,6 +1217,7 @@ test('overlays keep a cached page preview in place while its WebContentsView loa
   }
 
   const withOverlay = await ViewletSimpleBrowser.showOverlay(state, 'menu')
+  await ViewletSimpleBrowser.afterRender(state, withOverlay)
   const restored = await ViewletSimpleBrowser.hideOverlay(withOverlay, 'menu')
 
   expect(withOverlay).toMatchObject({ overlayIds: ['menu'], snapshot: '' })
@@ -1223,6 +1239,7 @@ test('overlays share one snapshot and restore after the last overlay closes', as
   const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
 
   const withQuickPick = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
+  await ViewletSimpleBrowser.afterRender(state, withQuickPick)
   const withBoth = await ViewletSimpleBrowser.showOverlay(withQuickPick, 'menu')
   const withMenu = await ViewletSimpleBrowser.hideOverlay(withBoth, 'quick-pick')
   const restored = await ViewletSimpleBrowser.hideOverlay(withMenu, 'menu')
@@ -1239,21 +1256,21 @@ test('overlays share one snapshot and restore after the last overlay closes', as
   })
 })
 
-test('showOverlay revokes a new snapshot when hiding the WebContentsView fails', async () => {
+test('afterRender logs when hiding the WebContentsView fails', async () => {
   const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
   try {
     // @ts-ignore
-    ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(new Uint8Array([137, 80, 78, 71]))
-    // @ts-ignore
     ElectronWebContentsViewFunctions.hide.mockRejectedValue(new Error('Failed to hide'))
-    // @ts-ignore
-    SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/snapshot')
-    const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
+    const oldState = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
+    const newState = {
+      ...oldState,
+      overlayIds: ['quick-pick'],
+      snapshot: 'blob:https://example.com/snapshot',
+    }
 
-    const newState = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
+    await ViewletSimpleBrowser.afterRender(oldState, newState)
 
-    expect(newState).toBe(state)
-    expect(SimpleBrowserSnapshot.dispose).toHaveBeenCalledWith('blob:https://example.com/snapshot')
+    expect(consoleError).toHaveBeenCalledWith('[renderer-worker] Failed to hide Simple Browser page', new Error('Failed to hide'))
   } finally {
     consoleError.mockRestore()
   }
@@ -1503,6 +1520,10 @@ test('applySuggestions does not capture a page for an empty new tab', async () =
     ],
   })
   expect(ElectronWebContentsViewFunctions.capturePage).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.hide).not.toHaveBeenCalled()
+
+  await ViewletSimpleBrowser.afterRender(state, newState)
+
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
 })
 


### PR DESCRIPTION
Render the Simple Browser snapshot before hiding its WebContentsView so tab hovers and other overlays do not expose a blank frame.

Add post-render ordering coverage for direct and registered viewlet commands.