### PR TITLE
fix: avoid saving startup performance file

### DIFF
--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemApp.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemApp.js
@@ -1,6 +1,7 @@
 export const name = 'App'
 
 const appPrefix = 'app://'
+const readonlyPaths = new Set(['memory-usage', 'session.json', 'startup-performance'])
 
 const getPath = (uri) => {
   if (uri.startsWith(appPrefix)) {
@@ -60,8 +61,8 @@ export const mkdir = async (path) => {
   throw new Error('not allowed')
 }
 
-export const isReadonly = () => {
-  return false
+export const isReadonly = (uri) => {
+  return readonlyPaths.has(getPath(uri))
 }
 
 export const canBeRestored = true

--- a/packages/renderer-worker/test/FileSystemApp.test.ts
+++ b/packages/renderer-worker/test/FileSystemApp.test.ts
@@ -119,6 +119,14 @@ test('mkdir - error', async () => {
   await expect(FileSystemApp.mkdir('my-folder')).rejects.toThrow(new Error('not allowed'))
 })
 
+test.each(['app://memory-usage', 'app://session.json', 'app://startup-performance'])('isReadonly - readonly app resource %s', async (uri) => {
+  expect(await FileSystemApp.isReadonly(uri)).toBe(true)
+})
+
+test.each(['app://keybindings.json', 'app://recently-opened.json', 'app://settings.json'])('isReadonly - writable app resource %s', async (uri) => {
+  expect(await FileSystemApp.isReadonly(uri)).toBe(false)
+})
+
 // TODO test writeFile and writeFile errors
 
 test('readFile - settings - error - file does not exist', async () => {


### PR DESCRIPTION
## Summary

- classify startup performance and other generated app resources as readonly
- keep settings, keybindings, and recently opened app resources writable
- prevent focus-change autosave from attempting a write through editor-worker 19.55.2