### PR TITLE
fix: show simple browser history content

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.simple-browser-history.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.simple-browser-history.ts
@@ -1,5 +1,7 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
+const nonZeroPixelWidthRegex = /^[1-9]\d*(?:\.\d+)?px$/
+
 export const name = 'viewlet.simple-browser-history'
 
 export const test: Test = async ({ Command, expect, Locator }) => {
@@ -11,6 +13,7 @@ export const test: Test = async ({ Command, expect, Locator }) => {
 
   const historyView = Locator('.SimpleBrowserHistory')
   await expect(historyView).toBeVisible()
+  await expect(historyView).toHaveCSS('width', nonZeroPixelWidthRegex as unknown as string)
   await expect(historyView.locator('h1')).toHaveText('History')
   await expect(historyView.locator('input')).toHaveAttribute('placeholder', 'Search history')
   const entries = historyView.locator('.SimpleBrowserHistoryEntry')

--- a/static/css/parts/ViewletSimpleBrowserHistory.css
+++ b/static/css/parts/ViewletSimpleBrowserHistory.css
@@ -1,4 +1,5 @@
 .SimpleBrowserHistory {
+  flex: 1;
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary

- let the Simple Browser History view fill its editor container
- assert the rendered history view has non-zero width

## Testing

- `node packages/extension-host-worker-tests/src/_all.js --test-name-prefix=viewlet.simple-browser-history --headless`
- renderer-worker: 394 suites / 1,877 tests passed
- extension-host-worker-tests type-check
- ESLint and Prettier checks on changed files