### PR TITLE
fix: integrate ports view worker

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -53,6 +53,7 @@
         "@lvce-editor/opener-worker": "^1.17.0",
         "@lvce-editor/output-view": "^2.22.0",
         "@lvce-editor/panel-worker": "^2.12.0",
+        "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#b263ce35fbd83db2e840e3f82df3380825c25d4b",
         "@lvce-editor/preview-sandbox-worker": "^4.15.0",
         "@lvce-editor/preview-worker": "^6.17.1",
         "@lvce-editor/problems-view": "^1.34.2",
@@ -1191,6 +1192,15 @@
       "resolved": "https://registry.npmjs.org/@lvce-editor/panel-worker/-/panel-worker-2.12.0.tgz",
       "integrity": "sha512-/i8mUXn1QfI8oZUtUU1lNGCijl7WHtoBKKfB/K2fyU7ZThu/yDtR/ZbmAI0VqY7Q/SN7Jda37Nos+jXr3jebDA==",
       "license": "MIT"
+    },
+    "node_modules/@lvce-editor/ports-view": {
+      "version": "0.0.0-dev",
+      "resolved": "git+ssh://git@github.com/lvce-editor/ports-view.git#b263ce35fbd83db2e840e3f82df3380825c25d4b",
+      "integrity": "sha512-Hb9XQcj1Zivy76n2mtFkM83BS00F0bD9iBuGksTtPPEUotL9zNXfneVXKNz5edcYg6WkOGLZOGnPrkR15ZnrIg==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ]
     },
     "node_modules/@lvce-editor/preview-sandbox-worker": {
       "version": "4.15.0",

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -85,6 +85,7 @@
     "@lvce-editor/opener-worker": "^1.17.0",
     "@lvce-editor/output-view": "^2.22.0",
     "@lvce-editor/panel-worker": "^2.12.0",
+    "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#b263ce35fbd83db2e840e3f82df3380825c25d4b",
     "@lvce-editor/preview-sandbox-worker": "^4.15.0",
     "@lvce-editor/preview-worker": "^6.17.1",
     "@lvce-editor/problems-view": "^1.34.2",

--- a/packages/renderer-worker/src/parts/LaunchPortsViewWorker/LaunchPortsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchPortsViewWorker/LaunchPortsViewWorker.ts
@@ -1,0 +1,15 @@
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import * as HandleIpc from '../HandleIpc/HandleIpc.js'
+import * as IpcParent from '../IpcParent/IpcParent.js'
+import * as IpcParentType from '../IpcParentType/IpcParentType.js'
+import * as PortsViewWorkerUrl from '../PortsViewWorkerUrl/PortsViewWorkerUrl.ts'
+
+export const launchPortsViewWorker = async (): Promise<any> => {
+  const ipc = await IpcParent.create({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Ports View Worker',
+    url: GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.portsViewPath', PortsViewWorkerUrl.portsViewWorkerUrl),
+  })
+  HandleIpc.handleIpc(ipc)
+  return ipc
+}

--- a/packages/renderer-worker/src/parts/PortsViewWorker/PortsViewWorker.ts
+++ b/packages/renderer-worker/src/parts/PortsViewWorker/PortsViewWorker.ts
@@ -1,0 +1,6 @@
+import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
+import { launchPortsViewWorker } from '../LaunchPortsViewWorker/LaunchPortsViewWorker.ts'
+
+const { invoke, restart } = GetOrCreateWorker.getOrCreateWorker(launchPortsViewWorker)
+
+export { invoke, restart }

--- a/packages/renderer-worker/src/parts/PortsViewWorkerUrl/PortsViewWorkerUrl.ts
+++ b/packages/renderer-worker/src/parts/PortsViewWorkerUrl/PortsViewWorkerUrl.ts
@@ -1,0 +1,3 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+
+export const portsViewWorkerUrl = `${AssetDir.assetDir}/packages/renderer-worker/node_modules/@lvce-editor/ports-view/dist/portsViewWorkerMain.js`

--- a/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleId/ViewletModuleId.js
@@ -70,6 +70,8 @@ export const Output = 'Output'
 
 export const Panel = 'Panel'
 
+export const Ports = 'Ports'
+
 export const Problems = 'Problems'
 
 export const ProcessExplorer = 'ProcessExplorer'

--- a/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
+++ b/packages/renderer-worker/src/parts/ViewletModuleMap/ViewletModuleMap.js
@@ -40,6 +40,7 @@ export const map = {
   [ViewletModuleId.Noop]: () => import('../ViewletNoop/ViewletNoop.ipc.js'),
   [ViewletModuleId.Output]: () => import('../ViewletOutput/ViewletOutput.ipc.ts'),
   [ViewletModuleId.Panel]: () => import('../ViewletPanel/ViewletPanel.ipc.ts'),
+  [ViewletModuleId.Ports]: () => import('../ViewletPorts/ViewletPorts.ipc.ts'),
   [ViewletModuleId.Problems]: () => import('../ViewletProblems/ViewletProblems.ipc.js'),
   [ViewletModuleId.ProcessExplorer]: LoadProcessExplorerViewletModule.loadProcessExplorerViewletModule,
   [ViewletModuleId.FileWatcherExplorer]: LoadFileWatcherExplorerViewletModule.loadFileWatcherExplorerViewletModule,

--- a/packages/renderer-worker/src/parts/ViewletPorts/ViewletPorts.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletPorts/ViewletPorts.ipc.ts
@@ -1,0 +1,28 @@
+import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
+
+export const {
+  Commands,
+  Css,
+  Events,
+  Variables,
+  create,
+  dispose,
+  getCommands,
+  getKeyBindings,
+  getMenus,
+  getTitle,
+  hasDirectRender,
+  hasFunctionalEvents,
+  hasFunctionalRender,
+  hasFunctionalResize,
+  hasFunctionalRootRender,
+  hotReload,
+  loadContent,
+  menus,
+  name,
+  render,
+  renderEventListeners,
+  renderTitle,
+  resize,
+  saveState,
+} = createWorkerViewlet({ workerId: 'portsView' })

--- a/packages/renderer-worker/src/parts/WorkerInvokerMap/WorkerInvokerMap.js
+++ b/packages/renderer-worker/src/parts/WorkerInvokerMap/WorkerInvokerMap.js
@@ -16,6 +16,7 @@ import * as NotificationCenterViewWorker from '../NotificationCenterViewWorker/N
 import * as OutputViewWorker from '../OutputViewWorker/OutputViewWorker.js'
 import * as PanelWorker from '../PanelWorker/PanelWorker.js'
 import * as PreviewWorker from '../PreviewWorker/PreviewWorker.js'
+import * as PortsViewWorker from '../PortsViewWorker/PortsViewWorker.ts'
 import * as ProblemsWorker from '../ProblemsWorker/ProblemsWorker.ts'
 import * as ProcessExplorerWorker from '../ProcessExplorerWorker/ProcessExplorerWorker.js'
 import * as FileWatcherViewWorker from '../FileWatcherViewWorker/FileWatcherViewWorker.js'
@@ -46,6 +47,7 @@ const workerInvokers = {
   output: OutputViewWorker,
   panel: PanelWorker,
   preview: PreviewWorker,
+  portsView: PortsViewWorker,
   problemsViewWorker: ProblemsWorker,
   processExplorer: ProcessExplorerWorker,
   fileWatcherView: FileWatcherViewWorker,

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1243,6 +1243,45 @@
     "hotReloadCommand": ""
   },
   {
+    "id": "portsView",
+    "fileName": "portsViewWorkerMain.js",
+    "contentSecurityPolicy": ["default-src 'none'"],
+    "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/ports-view/dist/portsViewWorkerMain.js",
+    "productionPath": "/packages/ports-view/dist/portsViewWorkerMain.js",
+    "settingName": "develop.portsViewPath",
+    "hotReloadCommand": "",
+    "viewlet": {
+      "name": "Ports",
+      "state": {
+        "idKey": "uid",
+        "fields": ["parentUid", "uri", "x", "y", "width", "height"],
+        "contextFields": ["platform", "assetDir"]
+      },
+      "commandPrefix": "Ports",
+      "methods": {
+        "create": {
+          "name": "Ports.create",
+          "parameters": [
+            { "source": "state", "name": "uid" }, { "source": "state", "name": "uri" }, { "source": "state", "name": "x" },
+            { "source": "state", "name": "y" }, { "source": "state", "name": "width" }, { "source": "state", "name": "height" },
+            { "source": "state", "name": "platform" }, { "source": "state", "name": "assetDir" },
+            { "source": "state", "name": "parentUid" }
+          ]
+        },
+        "loadContent": { "name": "Ports.loadContent", "parameters": [{ "source": "state", "name": "uid" }] },
+        "diff": { "name": "Ports.diff2", "parameters": [{ "source": "state", "name": "uid" }] },
+        "render": { "name": "Ports.render2", "parameters": [{ "source": "state", "name": "uid" }, { "source": "result", "name": "diff" }] },
+        "dispose": { "name": "Ports.dispose", "parameters": [{ "source": "state", "name": "uid" }] },
+        "resize": { "name": "Ports.resize", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "dimensions" }] },
+        "terminate": { "name": "Ports.terminate", "parameters": [] },
+        "getCommandIds": { "name": "Ports.getCommandIds", "parameters": [] },
+        "renderEventListeners": { "name": "Ports.renderEventListeners", "parameters": [] }
+      },
+      "renderComparison": "emptyCommands",
+      "capabilities": { "events": true, "render": true, "resize": true, "rootRender": true }
+    }
+  },
+  {
     "id": "problemsViewWorker",
     "fileName": "problemsViewWorkerMain.js",
     "contentSecurityPolicy": ["default-src 'none'"],

--- a/packages/renderer-worker/test/LaunchPortsViewWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchPortsViewWorker.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as IpcParentType from '../src/parts/IpcParentType/IpcParentType.js'
+
+jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => ({
+  getConfiguredWorkerUrl: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/HandleIpc/HandleIpc.js', () => ({
+  handleIpc: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/IpcParent/IpcParent.js', () => ({
+  create: jest.fn(),
+}))
+
+const GetConfiguredWorkerUrl = await import('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts')
+const HandleIpc = await import('../src/parts/HandleIpc/HandleIpc.js')
+const IpcParent = await import('../src/parts/IpcParent/IpcParent.js')
+const { launchPortsViewWorker } = await import('../src/parts/LaunchPortsViewWorker/LaunchPortsViewWorker.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('launches the ports view worker', async () => {
+  const ipc = { send() {} }
+  jest.mocked(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).mockReturnValue('file:///ports-view-worker.js')
+  jest.mocked(IpcParent.create).mockResolvedValue(ipc as any)
+
+  await expect(launchPortsViewWorker()).resolves.toBe(ipc)
+
+  expect(GetConfiguredWorkerUrl.getConfiguredWorkerUrl).toHaveBeenCalledWith(
+    'develop.portsViewPath',
+    expect.stringContaining('/@lvce-editor/ports-view/dist/portsViewWorkerMain.js'),
+  )
+  expect(IpcParent.create).toHaveBeenCalledWith({
+    method: IpcParentType.ModuleWorkerAndWorkaroundForChromeDevtoolsBug,
+    name: 'Ports View Worker',
+    url: 'file:///ports-view-worker.js',
+  })
+  expect(HandleIpc.handleIpc).toHaveBeenCalledWith(ipc)
+})

--- a/packages/renderer-worker/test/ViewletModuleMap.test.ts
+++ b/packages/renderer-worker/test/ViewletModuleMap.test.ts
@@ -67,6 +67,7 @@ const genericWorkerViewlets = [
   ViewletModuleId.NotificationCenter,
   ViewletModuleId.Output,
   ViewletModuleId.Panel,
+  ViewletModuleId.Ports,
   ViewletModuleId.Preview,
   ViewletModuleId.Problems,
   ViewletModuleId.ProcessExplorer,

--- a/packages/renderer-worker/test/ViewletPorts.test.ts
+++ b/packages/renderer-worker/test/ViewletPorts.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/PortsViewWorker/PortsViewWorker.ts', () => ({
+  invoke: jest.fn(async (command) => {
+    if (command === 'Ports.diff2' || command === 'Ports.render2') {
+      return []
+    }
+    if (command === 'Ports.getCommandIds') {
+      return ['addPort', 'removePort']
+    }
+    return undefined
+  }),
+}))
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: jest.fn(() => 2),
+}))
+
+jest.unstable_mockModule('../src/parts/AssetDir/AssetDir.js', () => ({
+  assetDir: '/test-assets',
+}))
+
+const PortsViewWorker = await import('../src/parts/PortsViewWorker/PortsViewWorker.ts')
+const ViewletPorts = await import('../src/parts/ViewletPorts/ViewletPorts.ipc.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('loads the ports view with platform, assets, and parent uid', async () => {
+  const state = ViewletPorts.create(1, 'ports://', 10, 20, 800, 600, {}, 99)
+
+  await ViewletPorts.loadContent(state)
+
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(1, 'Ports.create', 1, 'ports://', 10, 20, 800, 600, 2, '/test-assets', 99)
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(2, 'Ports.loadContent', 1)
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(3, 'Ports.diff2', 1)
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(4, 'Ports.render2', 1, [])
+})
+
+test('registers ports view commands', async () => {
+  await ViewletPorts.getCommands()
+
+  expect(typeof ViewletPorts.Commands.addPort).toBe('function')
+  expect(typeof ViewletPorts.Commands.removePort).toBe('function')
+})
+
+test('resizes and rerenders the ports view', async () => {
+  const state = ViewletPorts.create(1, 'ports://', 10, 20, 800, 600)
+
+  const result = await ViewletPorts.resize(state, { height: 400, width: 700 })
+
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(1, 'Ports.resize', 1, { height: 400, width: 700 })
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(2, 'Ports.diff2', 1)
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(3, 'Ports.render2', 1, [])
+  expect(result).toEqual({ ...state, commands: [], height: 400, width: 700 })
+})


### PR DESCRIPTION
## Summary

- register the Ports panel module in the renderer
- launch and route the worker-backed Ports view lifecycle
- bundle a commit-pinned Ports worker in static and Electron builds
- cover module loading, worker launch, lifecycle arguments, commands, and resize

## Root cause

The panel worker advertised the `Ports` view, but the renderer had no matching module-map entry, worker invoker, worker manifest, or packaged worker dependency. Selecting the tab therefore failed with `Ports module not found in renderer process` and left the panel blank.

## Testing

- renderer focused tests: 36 passed
- renderer TypeScript check
- clean dependency install from `ports-view@b263ce35…`
- static build; verified `packages/ports-view/dist/portsViewWorkerMain.js` is present (64,782 bytes)

## Related

- lvce-editor/ports-view#8
- lvce-editor/ports-view#9

The attempted first npm release v0.2.0 built successfully on all platforms but could not bootstrap trusted publishing for a package that does not yet exist, so this pins the reviewed git dependency over HTTPS instead.