### PR TITLE
fix: trim simple browser url input

### DIFF
--- a/packages/renderer-worker/src/parts/IframeSrc/IframeSrc.js
+++ b/packages/renderer-worker/src/parts/IframeSrc/IframeSrc.js
@@ -58,23 +58,24 @@ export const isSearchInput = (input, shortcuts = []) => {
 }
 
 export const toIframeSrc = (input, shortcuts = []) => {
+  const trimmedInput = input.trim()
   for (const shortcut of shortcuts) {
-    if (shortcut && shortcut.prefix === input && typeof shortcut.url === 'string') {
+    if (shortcut && shortcut.prefix === trimmedInput && typeof shortcut.url === 'string') {
       return shortcut.url
     }
   }
-  if (isValidHttpUrl(input) || isValidFileUrl(input)) {
-    return input
+  if (isValidHttpUrl(trimmedInput) || isValidFileUrl(trimmedInput)) {
+    return trimmedInput
   }
-  if (isLocalHostUrlWithOutHttp(input)) {
-    return `http://${input}`
+  if (isLocalHostUrlWithOutHttp(trimmedInput)) {
+    return `http://${trimmedInput}`
   }
-  if (isValidFilePath(input)) {
-    return 'file://' + input
+  if (isValidFilePath(trimmedInput)) {
+    return 'file://' + trimmedInput
   }
-  const dotIndex = input.indexOf(Character.Dot)
-  if (dotIndex !== -1 && dotIndex !== input.length - 1) {
-    return 'https://' + input
+  const dotIndex = trimmedInput.indexOf(Character.Dot)
+  if (dotIndex !== -1 && dotIndex !== trimmedInput.length - 1) {
+    return 'https://' + trimmedInput
   }
-  return createSearchUrl(input)
+  return createSearchUrl(trimmedInput)
 }

--- a/packages/renderer-worker/test/IframeSrc.test.ts
+++ b/packages/renderer-worker/test/IframeSrc.test.ts
@@ -13,6 +13,10 @@ test('https url', () => {
   expect(IframeSrc.toIframeSrc('https://example.com')).toBe('https://example.com')
 })
 
+test('https url with surrounding whitespace', () => {
+  expect(IframeSrc.toIframeSrc('  https://example.com/?space=ok  ')).toBe('https://example.com/?space=ok')
+})
+
 test('url without protocol', () => {
   expect(IframeSrc.toIframeSrc('example.com')).toBe('https://example.com')
 })


### PR DESCRIPTION
Trim surrounding whitespace before classifying and normalizing Simple Browser address input.

This prevents valid copied URLs from being prefixed as malformed hostnames and adds regression coverage for the exact spaced URL case.

Validation:
- focused IframeSrc tests: 12 passed
- renderer-worker suite: 396 suites / 1,884 tests passed
- renderer-worker type-check passed
- git diff --check passed