### PR TITLE
fix: avoid duplicate viewlet error messages

### DIFF
--- a/packages/renderer-worker/src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js
+++ b/packages/renderer-worker/src/parts/GetViewletErrorMessage/GetViewletErrorMessage.js
@@ -12,7 +12,26 @@ export const getViewletErrorTitle = (error) => {
   return PrettyError.getMessage(error)
 }
 
+export const getViewletErrorStack = (error) => {
+  const stack = error?.stack
+  if (!isNonEmptyString(stack)) {
+    return stack
+  }
+  const message = getViewletErrorTitle(error)
+  if (stack === message) {
+    return ''
+  }
+  for (const separator of ['\r\n', '\n']) {
+    const duplicateMessage = `${message}${separator}`
+    if (stack.startsWith(duplicateMessage)) {
+      return stack.slice(duplicateMessage.length)
+    }
+  }
+  return stack
+}
+
 export const getViewletErrorMessage = (error) => {
   const message = getViewletErrorTitle(error)
-  return [message, error?.codeFrame, error?.stack].filter(isNonEmptyString).join('\n\n')
+  const stack = getViewletErrorStack(error)
+  return [message, error?.codeFrame, stack].filter(isNonEmptyString).join('\n\n')
 }

--- a/packages/renderer-worker/src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetViewletErrorVirtualDom/GetViewletErrorVirtualDom.js
@@ -20,7 +20,7 @@ const getTextSectionDom = (value, className, type = VirtualDomElements.Div) => {
 export const getViewletErrorVirtualDom = (error) => {
   const messageDom = getTextSectionDom(GetViewletErrorMessage.getViewletErrorTitle(error), 'ViewletErrorMessage')
   const codeFrameDom = Array.isArray(error?.syntaxHighlightedCodeFrame) ? error.syntaxHighlightedCodeFrame : []
-  const stackDom = getTextSectionDom(error?.stack, 'ViewletErrorStack', VirtualDomElements.Pre)
+  const stackDom = getTextSectionDom(GetViewletErrorMessage.getViewletErrorStack(error), 'ViewletErrorStack', VirtualDomElements.Pre)
   const sections = [messageDom, codeFrameDom, stackDom].filter((section) => section.length > 0)
   return [
     {

--- a/packages/renderer-worker/test/GetViewletErrorMessage.test.ts
+++ b/packages/renderer-worker/test/GetViewletErrorMessage.test.ts
@@ -8,7 +8,8 @@ test('formats the message, code frame, and stack in order', () => {
 > 5 |       throw new Error('create failed')
     |             ^`,
       message: 'create failed',
-      stack: '    at Object.create (main.ts:5:13)',
+      stack: `Error: create failed
+    at Object.create (main.ts:5:13)`,
       type: 'Error',
     }),
   ).toBe(`Error: create failed
@@ -37,6 +38,30 @@ test('does not duplicate a type already included in the prepared message', () =>
       codeFrame: '',
       message: 'Error: create failed',
       stack: '',
+      type: 'Error',
+    }),
+  ).toBe('Error: create failed')
+})
+
+test('preserves a stack whose first line does not duplicate the message', () => {
+  expect(
+    getViewletErrorMessage({
+      message: 'create failed',
+      stack: `Caused by: connection failed
+    at Object.create (main.ts:5:13)`,
+      type: 'Error',
+    }),
+  ).toBe(`Error: create failed
+
+Caused by: connection failed
+    at Object.create (main.ts:5:13)`)
+})
+
+test('omits a stack containing only the duplicate message', () => {
+  expect(
+    getViewletErrorMessage({
+      message: 'create failed',
+      stack: 'Error: create failed',
       type: 'Error',
     }),
   ).toBe('Error: create failed')

--- a/packages/renderer-worker/test/GetViewletErrorVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetViewletErrorVirtualDom.test.ts
@@ -19,7 +19,8 @@ test('getViewletErrorVirtualDom', () => {
   expect(
     getViewletErrorVirtualDom({
       message: 'Oops',
-      stack: '    at test.js:1:1',
+      stack: `TypeError: Oops
+    at test.js:1:1`,
       syntaxHighlightedCodeFrame,
       type: 'TypeError',
     }),


### PR DESCRIPTION
Render the error title once and remove the matching first line from its stack. Preserve non-duplicating stack content and apply the behavior to both plain and syntax-highlighted viewlet errors.