### PR TITLE
fix: update ports view for initial styles

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -53,7 +53,7 @@
         "@lvce-editor/opener-worker": "^1.17.0",
         "@lvce-editor/output-view": "^2.22.0",
         "@lvce-editor/panel-worker": "^2.12.0",
-        "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#b263ce35fbd83db2e840e3f82df3380825c25d4b",
+        "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#4da1d4aa920ad60fcef379cc88852ea9dd5d5918",
         "@lvce-editor/preview-sandbox-worker": "^4.15.0",
         "@lvce-editor/preview-worker": "^6.17.1",
         "@lvce-editor/problems-view": "^1.34.2",
@@ -1195,7 +1195,7 @@
     },
     "node_modules/@lvce-editor/ports-view": {
       "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/lvce-editor/ports-view.git#b263ce35fbd83db2e840e3f82df3380825c25d4b",
+      "resolved": "git+ssh://git@github.com/lvce-editor/ports-view.git#4da1d4aa920ad60fcef379cc88852ea9dd5d5918",
       "integrity": "sha512-Hb9XQcj1Zivy76n2mtFkM83BS00F0bD9iBuGksTtPPEUotL9zNXfneVXKNz5edcYg6WkOGLZOGnPrkR15ZnrIg==",
       "license": "MIT",
       "workspaces": [

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -85,7 +85,7 @@
     "@lvce-editor/opener-worker": "^1.17.0",
     "@lvce-editor/output-view": "^2.22.0",
     "@lvce-editor/panel-worker": "^2.12.0",
-    "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#b263ce35fbd83db2e840e3f82df3380825c25d4b",
+    "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#4da1d4aa920ad60fcef379cc88852ea9dd5d5918",
     "@lvce-editor/preview-sandbox-worker": "^4.15.0",
     "@lvce-editor/preview-worker": "^6.17.1",
     "@lvce-editor/problems-view": "^1.34.2",


### PR DESCRIPTION
## Change

Update the immutable Ports view dependency to merged [ports-view#10](https://github.com/lvce-editor/ports-view/pull/10), which emits the stylesheet on initial load.

This follows installed-Debian acceptance of v0.112.13: the Ports worker and DOM loaded, but the first CSS diff was suppressed, leaving the root at 0px high and the panel visually blank.

## Verification

- ports-view: 49/49 tests, type-check, lint, Linux/macOS/Windows CI
- renderer focused tests: 36/36
- renderer TypeScript check
- clean dependency install
- static LVCE build
- bundled Ports worker contains the initial CSS condition and is 64,801 bytes