### PR TITLE
fix: route node rpc through remote workspaces

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js
+++ b/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js
@@ -1,5 +1,6 @@
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 import * as WebSocketCapability from '../WebSocketCapability/WebSocketCapability.js'
+import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
 
 export const createConnection = async (extensionId, rpcId) => {
   const connection = await WebSocketCapability.create('extension-node-process')
@@ -15,5 +16,8 @@ export const createConnection = async (extensionId, rpcId) => {
 export const supportsDirectConnection = () => true
 
 export const createMessagePort = async (port, extensionId, rpcId) => {
+  if (await WorkspaceConnection.connectMessagePort('extension-node-process', port, { extensionId, rpcId })) {
+    return
+  }
   await SharedProcess.invokeAndTransfer('HandleMessagePortForExtensionNodeProcess.handleMessagePortForExtensionNodeProcess', port, extensionId, rpcId)
 }

--- a/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
+++ b/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
@@ -64,16 +64,25 @@ export const getWebSocketUrlTemplate = () => {
   return state.webSocketUrl
 }
 
-export const getWebSocketUrl = async (type) => {
+const addSearchParams = (value, searchParams) => {
+  const url = new URL(value)
+  for (const [key, parameterValue] of Object.entries(searchParams)) {
+    url.searchParams.set(key, parameterValue)
+  }
+  return url.href
+}
+
+export const getWebSocketUrl = async (type, searchParams = {}) => {
   if (!isActive()) {
     return ''
   }
-  if (state.webSocketUrl) {
-    const url = new URL(state.webSocketUrl)
+  const { command, webSocketUrl } = state
+  if (webSocketUrl) {
+    const url = new URL(webSocketUrl)
     url.pathname = `/websocket/${encodeURIComponent(type)}`
-    return url.href
+    return addSearchParams(url.href, searchParams)
   }
-  const value = await ExtensionHostCommands.executeCommand(state.command, type)
+  const value = await ExtensionHostCommands.executeCommand(command, type)
   if (typeof value !== 'string') {
     throw new TypeError('Workspace connection command returned an invalid WebSocket URL')
   }
@@ -81,15 +90,15 @@ export const getWebSocketUrl = async (type) => {
   if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
     throw new TypeError('Workspace connection command must return a WebSocket URL')
   }
-  return url.href
+  return addSearchParams(url.href, searchParams)
 }
 
-export const connectMessagePort = async (type, port) => {
+export const connectMessagePort = async (type, port, searchParams = {}) => {
   if (!isActive()) {
     return false
   }
   const webSocket = await IpcParentWithWebSocket.create({
-    getUrl: () => getWebSocketUrl(type),
+    getUrl: () => getWebSocketUrl(type, searchParams),
     type,
   })
   webSocket.onmessage = (event) => {

--- a/packages/renderer-worker/test/ExtensionNodeRpc.test.ts
+++ b/packages/renderer-worker/test/ExtensionNodeRpc.test.ts
@@ -12,9 +12,14 @@ jest.unstable_mockModule('../src/parts/WebSocketCapability/WebSocketCapability.j
   create: jest.fn(),
 }))
 
+jest.unstable_mockModule('../src/parts/WorkspaceConnection/WorkspaceConnection.js', () => ({
+  connectMessagePort: jest.fn(async () => false),
+}))
+
 const ExtensionNodeRpc = await import('../src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js')
 const SharedProcess = await import('../src/parts/SharedProcess/SharedProcess.js')
 const WebSocketCapability = await import('../src/parts/WebSocketCapability/WebSocketCapability.js')
+const WorkspaceConnection = await import('../src/parts/WorkspaceConnection/WorkspaceConnection.js')
 
 test('createConnection returns an authenticated remote node process URL', async () => {
   // @ts-ignore
@@ -58,6 +63,21 @@ test('transfers an extension-bound message port to the shared process', async ()
     'builtin.git',
     'git-client',
   )
+  port1.close()
+  port2.close()
+})
+
+test('bridges an extension-bound message port to an active remote workspace', async () => {
+  const { port1, port2 } = new MessageChannel()
+  jest.mocked(WorkspaceConnection.connectMessagePort).mockResolvedValueOnce(true)
+
+  await ExtensionNodeRpc.createMessagePort(port1, 'builtin.git', 'git-client')
+
+  expect(WorkspaceConnection.connectMessagePort).toHaveBeenCalledWith('extension-node-process', port1, {
+    extensionId: 'builtin.git',
+    rpcId: 'git-client',
+  })
+  expect(SharedProcess.invokeAndTransfer).not.toHaveBeenCalled()
   port1.close()
   port2.close()
 })

--- a/packages/renderer-worker/test/WorkspaceConnection.test.ts
+++ b/packages/renderer-worker/test/WorkspaceConnection.test.ts
@@ -101,6 +101,7 @@ test('rejects a non-WebSocket workspace URL', () => {
 test('bridges a message port to the workspace connection', async () => {
   workspaceState.workspaceUri = 'workspace-provider://host/work'
   WorkspaceConnection.set('workspace-provider://host/work', 'workspace-provider.getWebSocketUrl')
+  executeCommand.mockResolvedValue('wss://workspace.example.com/process?token=secret')
   const webSocket: MockWebSocket = {
     send: jest.fn<(value: string) => void>(),
   }
@@ -112,11 +113,19 @@ test('bridges a message port to the workspace connection', async () => {
     start: jest.fn(),
   }
 
-  await expect(WorkspaceConnection.connectMessagePort('terminal-process', port)).resolves.toBe(true)
+  await expect(
+    WorkspaceConnection.connectMessagePort('extension-node-process', port, {
+      extensionId: 'builtin.codex',
+      rpcId: 'builtin.codex.app-server',
+    }),
+  ).resolves.toBe(true)
   expect(create).toHaveBeenCalledWith({
     getUrl: expect.any(Function),
-    type: 'terminal-process',
+    type: 'extension-node-process',
   })
+  const getUrl = create.mock.calls[0]?.[0].getUrl
+  await expect(getUrl()).resolves.toBe('wss://workspace.example.com/process?token=secret&extensionId=builtin.codex&rpcId=builtin.codex.app-server')
+  expect(executeCommand).toHaveBeenCalledWith('workspace-provider.getWebSocketUrl', 'extension-node-process')
   port.onmessage?.({ data: ['request'] })
   expect(webSocket.send).toHaveBeenCalledWith('["request"]')
   webSocket.onmessage?.({ data: '["response"]' })


### PR DESCRIPTION
## Details

Route manifest-declared extension Node RPC message ports through the active workspace connection before falling back to the local shared process. Preserve the workspace connection token while binding the extension and RPC identifiers as WebSocket query parameters.

This makes providers such as `builtin.codex.app-server` run in the Remote SSH server process instead of beneath local Electron.

## Verification

- `npm test -- ExtensionNodeRpc.test.ts WorkspaceConnection.test.ts`
- `npm run type-check` (renderer-worker)
- `npm run lint`
- Packaged Debian candidate exercised through the real Electron UI and loopback Remote SSH transport; Codex process lineage was remote and no Codex child remained below Electron.