### PR TITLE
fix: detect settings.json as JSONC

### DIFF
--- a/packages/renderer-worker/src/parts/Languages/Languages.js
+++ b/packages/renderer-worker/src/parts/Languages/Languages.js
@@ -13,21 +13,22 @@ import * as IconThemeWorker from '../IconThemeWorker/IconThemeWorker.js'
 
 export const getLanguageId = (fileName) => {
   Assert.string(fileName)
+  const baseName = fileName.slice(fileName.lastIndexOf('/') + 1)
+  const baseNameLower = baseName.toLowerCase()
+  if (LanguagesState.hasLanguageByFileName(baseNameLower)) {
+    return LanguagesState.getLanguageByFileName(baseNameLower)
+  }
   // TODO this is inefficient for icon theme, as file extension is computed twice
-  const extensionIndex = GetFileExtension.getFileExtensionIndex(fileName)
-  const extension = fileName.slice(extensionIndex)
+  const extensionIndex = GetFileExtension.getFileExtensionIndex(baseName)
+  const extension = baseName.slice(extensionIndex)
   const extensionLower = extension.toLowerCase()
   if (LanguagesState.hasLanguageByExtension(extensionLower)) {
     return LanguagesState.getLanguageByExtension(extensionLower)
   }
-  const fileNameLower = fileName.toLowerCase()
-  const secondExtensionIndex = GetFileExtension.getNthFileExtension(fileName, extensionIndex - 1)
-  const secondExtension = fileName.slice(secondExtensionIndex)
+  const secondExtensionIndex = GetFileExtension.getNthFileExtension(baseName, extensionIndex - 1)
+  const secondExtension = baseName.slice(secondExtensionIndex).toLowerCase()
   if (secondExtensionIndex !== -1 && LanguagesState.hasLanguageByExtension(secondExtension)) {
     return LanguagesState.getLanguageByExtension(secondExtension)
-  }
-  if (LanguagesState.hasLanguageByFileName(fileNameLower)) {
-    return LanguagesState.getLanguageByFileName(fileNameLower)
   }
   return 'unknown'
 }

--- a/packages/renderer-worker/test/Languages.test.ts
+++ b/packages/renderer-worker/test/Languages.test.ts
@@ -51,6 +51,41 @@ test('getLanguageConfiguration - error - languages must be loaded before request
   })
 })
 
+test('getLanguageConfiguration - uses file name language over extension language', async () => {
+  await Languages.addLanguages([
+    {
+      id: 'json',
+      extensions: ['.json'],
+    },
+    {
+      id: 'jsonc',
+      fileNames: ['settings.json'],
+    },
+  ])
+  LanguagesState.setLoaded(true)
+  // @ts-ignore
+  SharedProcess.invoke.mockImplementation((method, languageId) => {
+    if (method === 'ExtensionHost.getLanguageConfiguration' && languageId === 'jsonc') {
+      return {
+        comments: {
+          lineComment: '//',
+        },
+      }
+    }
+    throw new Error('unexpected message')
+  })
+  const editor = {
+    uri: 'app://settings.json',
+    languageId: 'json',
+  }
+  expect(await Languages.getLanguageConfiguration(editor)).toEqual({
+    comments: {
+      lineComment: '//',
+    },
+  })
+  expect(editor.languageId).toBe('jsonc')
+})
+
 test('getLanguageConfiguration - error - languages must be loaded before requesting language configuration', async () => {
   // @ts-ignore
   SharedProcess.invoke.mockImplementation((method, ...parameters) => {
@@ -128,6 +163,34 @@ test('getLanguageId - by file name', async () => {
     },
   ])
   expect(Languages.getLanguageId('Dockerfile')).toBe('dockerfile')
+})
+
+test('getLanguageId - file name has priority over extension', async () => {
+  await Languages.addLanguages([
+    {
+      id: 'json',
+      extensions: ['.json'],
+    },
+    {
+      id: 'jsonc',
+      fileNames: ['settings.json'],
+    },
+  ])
+  expect(Languages.getLanguageId('settings.json')).toBe('jsonc')
+})
+
+test('getLanguageId - by file name in uri', async () => {
+  await Languages.addLanguages([
+    {
+      id: 'json',
+      extensions: ['.json'],
+    },
+    {
+      id: 'jsonc',
+      fileNames: ['settings.json'],
+    },
+  ])
+  expect(Languages.getLanguageId('app://settings.json')).toBe('jsonc')
 })
 
 test("addLanguage - don't override tokenize path", async () => {


### PR DESCRIPTION
Prioritizes exact language filename matches over generic extensions, including for app URIs, so settings.json keeps its JSONC language and comment configuration.