### PR TITLE
fix: discard superseded text search renders

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -145,6 +145,23 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   const Commands = {}
   const Events = {}
   const { idKey } = state
+  let nextCommandInvocationId = 0
+  const activeCommandInvocations = new Map()
+
+  const createCommandInvocation = (uid) => {
+    const invocationId = ++nextCommandInvocationId
+    activeCommandInvocations.set(uid, invocationId)
+    return {
+      finish() {
+        if (activeCommandInvocations.get(uid) === invocationId) {
+          activeCommandInvocations.delete(uid)
+        }
+      },
+      isLatest() {
+        return activeCommandInvocations.get(uid) === invocationId
+      },
+    }
+  }
 
   if (capabilities.directRender) {
     Object.defineProperty(Commands, '__directEventRpcId', {
@@ -236,7 +253,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   }
 
   const createCommandWrapper = (command) => {
-    return adapter.wrapCommand(command, wrapCommand, { context, worker })
+    return adapter.wrapCommand(command, wrapCommand, { context, createCommandInvocation, worker })
   }
 
   const wrapConfiguredCommand = (methodName) => {

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -259,15 +259,26 @@ export const textSearch = {
       isSearchEditor: state.uri.startsWith('search-editor://'),
     }
   },
-  wrapCommand(command, _defaultWrapCommand, { worker }) {
+  wrapCommand(command, _defaultWrapCommand, { createCommandInvocation, worker }) {
     return async (state, ...args) => {
-      await worker.invoke(`TextSearch.${command}`, state.uid, ...args)
-      const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
-      if (diff.length === 0) {
-        return state
+      const invocation = createCommandInvocation(state.uid)
+      try {
+        await worker.invoke(`TextSearch.${command}`, state.uid, ...args)
+        if (!invocation.isLatest()) {
+          return state
+        }
+        const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
+        if (diff.length === 0 || !invocation.isLatest()) {
+          return state
+        }
+        const commands = await worker.invoke('TextSearch.render2', state.uid, diff)
+        if (!invocation.isLatest()) {
+          return state
+        }
+        return { ...state, commands }
+      } finally {
+        invocation.finish()
       }
-      const commands = await worker.invoke('TextSearch.render2', state.uid, diff)
-      return { ...state, commands }
     }
   },
 }

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -143,6 +143,44 @@ test('creates command wrappers through the same lifecycle seam', async () => {
   expect(result.commands).toEqual([['setText', 'selected']])
 })
 
+test('text search command wrappers discard rendering from superseded invocations', async () => {
+  const { promise: firstCommand, resolve: resolveFirstCommand } = Promise.withResolvers<void>()
+  const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
+    if (method === 'Example.getCommandIds') {
+      return ['update']
+    }
+    if (method === 'TextSearch.update' && value === 'first') {
+      await firstCommand
+    }
+    if (method === 'TextSearch.diff2') {
+      return ['latest']
+    }
+    if (method === 'TextSearch.render2') {
+      return [['setText', 'latest']]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: createConfig(),
+    context: { platform: 1 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+
+  const first = commands.update(state, 'first')
+  const second = commands.update(state, 'second')
+  const secondResult = await second
+  resolveFirstCommand()
+  const firstResult = await first
+
+  expect(secondResult.commands).toEqual([['setText', 'latest']])
+  expect(firstResult).toBe(state)
+  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toHaveLength(1)
+  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.render2')).toHaveLength(1)
+})
+
 test('recomputes configured outputs after commands', async () => {
   const config: any = createConfig()
   config.outputs = [{ method: { name: 'Example.renderActions', parameters: [stateParameter('uid')] }, stateField: 'actionsDom' }]
@@ -341,9 +379,7 @@ test('rejects invalid parameter sources with a descriptive error', () => {
   config.methods.create.parameters = [{ name: 'uid', source: 'unknown' }]
   expect(() =>
     createWorkerViewletWithDependencies({ config, worker: { invoke: jest.fn(async (..._args: readonly unknown[]) => undefined) } }),
-  ).toThrow(
-    'invalid test viewlet create parameter source: unknown',
-  )
+  ).toThrow('invalid test viewlet create parameter source: unknown')
 })
 
 test('creates independent state from configured defaults', () => {


### PR DESCRIPTION
Discard renderer output from text-search commands superseded by a newer command for the same view. This prevents an older asynchronous search update from overwriting newer results while preserving concurrent worker execution, with regression coverage for the out-of-order completion case.