### PR TITLE
fix: preserve simple browser popup authentication

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -98,6 +98,7 @@ export const commandMap = {
   'EditorDiagnostics.hydrate': lazy('EditorDiagnostics.hydrate'),
   'EditorError.3900': lazy('EditorError.3900'),
   'ElectronBrowserView.handleAudioStateChanged': lazy('ElectronBrowserView.handleAudioStateChanged'),
+  'ElectronBrowserView.handleBrowserViewDestroyed': lazy('ElectronBrowserView.handleBrowserViewDestroyed'),
   'ElectronBrowserView.handleContextMenu': lazy('ElectronBrowserView.handleContextMenu'),
   'ElectronBrowserView.handleDidNavigate': lazy('ElectronBrowserView.handleDidNavigate'),
   'ElectronBrowserView.handlePageFaviconUpdated': lazy('ElectronBrowserView.handlePageFaviconUpdated'),

--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.ipc.js
@@ -4,6 +4,7 @@ export const name = 'ElectronBrowserView'
 
 export const Commands = {
   handleAudioStateChanged: ElectronBrowserView.handleAudioStateChanged,
+  handleBrowserViewDestroyed: ElectronBrowserView.handleBrowserViewDestroyed,
   handleContextMenu: ElectronBrowserView.handleContextMenu,
   handleDidNavigate: ElectronBrowserView.handleDidNavigate,
   handleKeyBinding: ElectronBrowserView.handleKeyBinding,

--- a/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.js
+++ b/packages/renderer-worker/src/parts/ElectronBrowserView/ElectronBrowserView.js
@@ -13,6 +13,8 @@ export const handleDidNavigate = dispatch('browser-view-did-navigate')
 
 export const handleAudioStateChanged = dispatch('browser-view-audio-state-changed')
 
+export const handleBrowserViewDestroyed = dispatch('browser-view-destroyed')
+
 export const handleContextMenu = dispatch('browser-view-context-menu')
 
 export const handleKeyBinding = dispatch('browser-view-key-binding')

--- a/packages/renderer-worker/src/parts/ElectronWebContentsView/ElectronWebContentsView.js
+++ b/packages/renderer-worker/src/parts/ElectronWebContentsView/ElectronWebContentsView.js
@@ -4,6 +4,10 @@ const state = {
   refs: 0,
 }
 
+export const adoptWebContentsView = () => {
+  state.refs++
+}
+
 export const createWebContentsView = async (restoreId, fallThroughKeyBindings) => {
   state.refs++
   return EmbedsWorker.invoke('ElectronWebContentsView.createWebContentsView', restoreId, fallThroughKeyBindings)
@@ -11,6 +15,13 @@ export const createWebContentsView = async (restoreId, fallThroughKeyBindings) =
 
 export const disposeWebContentsView = async (id) => {
   await EmbedsWorker.invoke('ElectronWebContentsView.disposeWebContentsView', id)
+  state.refs--
+  if (state.refs === 0) {
+    await EmbedsWorker.dispose()
+  }
+}
+
+export const releaseWebContentsView = async () => {
   state.refs--
   if (state.refs === 0) {
     await EmbedsWorker.dispose()

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -505,18 +505,30 @@ export const openTab = async (state, url, disposition) => {
   return switchToTab(currentState, tabs, currentState.tabs.length)
 }
 
-export const handleWindowOpen = async (state, browserViewId, url, disposition) => {
+export const handleWindowOpen = async (state, browserViewId, childBrowserViewId, url, disposition) => {
   const { tabs: oldTabs, tabsEnabled } = state
   const ownsWebContentsView = oldTabs.some((tab) => tab.browserViewId === Number(browserViewId))
   const openExternalLinks = Preferences.get('simpleBrowser.openExternalLinks') === 'externalBrowser'
   if (!ownsWebContentsView) {
     return state
   }
+  ElectronWebContentsView.adoptWebContentsView()
   if (openExternalLinks || !tabsEnabled) {
+    await ElectronWebContentsView.disposeWebContentsView(childBrowserViewId)
     await Command.execute('Open.openExternal', url)
     return state
   }
-  return openTab(state, url, disposition)
+  const currentState = state.hasSuggestionsOverlay ? await closeSuggestions(state) : state
+  const { headerHeight, height, width, x, y } = currentState
+  await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(childBrowserViewId, getFallThroughKeyBindings())
+  await ElectronWebContentsViewFunctions.resizeWebContentsView(childBrowserViewId, x, y + headerHeight, width, height - headerHeight)
+  const tab = createTab({ browserViewId: Number(childBrowserViewId), iframeSrc: url, inputValue: url, isLoading: true })
+  const tabs = [...currentState.tabs, tab]
+  if (disposition === 'background-tab') {
+    await ElectronWebContentsViewFunctions.hide(childBrowserViewId)
+    return { ...currentState, tabs }
+  }
+  return switchToTab(currentState, tabs, currentState.tabs.length)
 }
 
 export const selectTab = async (state, index) => {
@@ -545,7 +557,7 @@ export const focusPreviousTab = (state) => {
   return selectTab(state, (state.selectedTabIndex - 1 + state.tabs.length) % state.tabs.length)
 }
 
-export const closeTab = async (state, index) => {
+const closeTabInternal = async (state, index, disposeWebContentsView) => {
   if (!state.tabsEnabled) {
     return state
   }
@@ -557,7 +569,9 @@ export const closeTab = async (state, index) => {
   const tab = currentState.tabs[tabIndex]
   if (currentState.tabs.length === 1) {
     const replacement = await createEmptyTab(currentState)
-    await ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)
+    if (disposeWebContentsView) {
+      await ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)
+    }
     await ElectronWebContentsViewFunctions.show(replacement.browserViewId)
     const newState = activateTab(currentState, [replacement], 0)
     return { ...newState, focusAddressVersion: newState.focusAddressVersion + 1 }
@@ -570,7 +584,7 @@ export const closeTab = async (state, index) => {
   } else if (tabIndex < selectedTabIndex) {
     selectedTabIndex--
   }
-  if (tab.browserViewId) {
+  if (disposeWebContentsView && tab.browserViewId) {
     await ElectronWebContentsView.disposeWebContentsView(tab.browserViewId)
   }
   if (!wasSelected) {
@@ -586,6 +600,20 @@ export const closeTab = async (state, index) => {
     await ElectronWebContentsViewFunctions.focus(selectedTab.browserViewId)
   }
   return activateTab(currentState, tabs, selectedTabIndex)
+}
+
+export const closeTab = (state, index) => {
+  return closeTabInternal(state, index, true)
+}
+
+export const handleBrowserViewDestroyed = async (state, browserViewId) => {
+  const tabIndex = state.tabs.findIndex((tab) => tab.browserViewId === Number(browserViewId))
+  if (tabIndex === -1) {
+    return state
+  }
+  const newState = await closeTabInternal(state, tabIndex, false)
+  await ElectronWebContentsView.releaseWebContentsView()
+  return newState
 }
 
 export const closeCurrentTab = (state) => {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -67,6 +67,7 @@ export const LazyCommands = {
 
 export const Events = {
   'browser-view-audio-state-changed': SimpleBrowser.handleAudioStateChanged,
+  'browser-view-destroyed': SimpleBrowser.handleBrowserViewDestroyed,
   'browser-view-context-menu': ViewletSimpleBrowserHandleContextMenu.handleContextMenu,
   'browser-view-did-navigate': SimpleBrowser.handleDidNavigate,
   'browser-view-key-binding': SimpleBrowser.handleKeyBinding,

--- a/packages/renderer-worker/test/CommandMap.test.ts
+++ b/packages/renderer-worker/test/CommandMap.test.ts
@@ -24,6 +24,7 @@ test('registers the simple browser suggestion event bridge commands', () => {
 
 test('registers the simple browser event bridge commands', () => {
   expect(commandMap['ElectronBrowserView.handleAudioStateChanged']).toBeDefined()
+  expect(commandMap['ElectronBrowserView.handleBrowserViewDestroyed']).toBeDefined()
   expect(commandMap['ElectronBrowserView.handleContextMenu']).toBeDefined()
   expect(commandMap['ElectronBrowserView.handlePageFaviconUpdated']).toBeDefined()
   expect(commandMap['ElectronBrowserView.handleWindowOpen']).toBeDefined()

--- a/packages/renderer-worker/test/ElectronWebContentsViewLifecycle.test.ts
+++ b/packages/renderer-worker/test/ElectronWebContentsViewLifecycle.test.ts
@@ -1,0 +1,23 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/EmbedsWorker/EmbedsWorker.js', () => ({
+  dispose: jest.fn(),
+  invoke: jest.fn(() => 12),
+}))
+
+const ElectronWebContentsView = await import('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js')
+const EmbedsWorker = await import('../src/parts/EmbedsWorker/EmbedsWorker.js')
+
+test('tracks an adopted popup until both browser views are closed', async () => {
+  await expect(ElectronWebContentsView.createWebContentsView(0, [])).resolves.toBe(12)
+  ElectronWebContentsView.adoptWebContentsView()
+
+  await ElectronWebContentsView.releaseWebContentsView()
+
+  expect(EmbedsWorker.dispose).not.toHaveBeenCalled()
+
+  await ElectronWebContentsView.disposeWebContentsView(12)
+
+  expect(EmbedsWorker.invoke).toHaveBeenLastCalledWith('ElectronWebContentsView.disposeWebContentsView', 12)
+  expect(EmbedsWorker.dispose).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -50,10 +50,12 @@ jest.unstable_mockModule('../src/parts/ElectronWebContentsViewFunctions/Electron
 })
 jest.unstable_mockModule('../src/parts/ElectronWebContentsView/ElectronWebContentsView.js', () => {
   return {
+    adoptWebContentsView: jest.fn(),
     createWebContentsView: jest.fn(() => {
       return 1
     }),
     disposeWebContentsView: jest.fn(),
+    releaseWebContentsView: jest.fn(),
   }
 })
 
@@ -526,26 +528,29 @@ test('updates open new tab pages when the color theme changes', async () => {
 
 test('opens a target blank link in a new selected tab by default', async () => {
   // @ts-ignore
-  ElectronWebContentsView.createWebContentsView.mockResolvedValue(13)
-  // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
   // @ts-ignore
   ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
   // @ts-ignore
   ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
   // @ts-ignore
-  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setFallthroughKeyBindings.mockResolvedValue(undefined)
   const state = {
     ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
     browserViewId: 12,
     tabs: [{ browserViewId: 12, iframeSrc: 'https://example.com', inputValue: 'https://example.com', title: 'Example' }],
   }
 
-  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'foreground-tab')
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 13, 'https://example.com/docs', 'foreground-tab')
 
   expect(newState).toMatchObject({ browserViewId: 13, iframeSrc: 'https://example.com/docs', selectedTabIndex: 1 })
   expect(newState.tabs).toHaveLength(2)
-  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, 'https://example.com/docs')
+  expect(ElectronWebContentsView.adoptWebContentsView).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsView.createWebContentsView).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.resizeWebContentsView).toHaveBeenCalledWith(13, 10, 85, 300, 135)
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
   expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(13)
@@ -553,25 +558,32 @@ test('opens a target blank link in a new selected tab by default', async () => {
 
 test('keeps a target blank background tab hidden', async () => {
   // @ts-ignore
-  ElectronWebContentsView.createWebContentsView.mockResolvedValue(13)
-  // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
   // @ts-ignore
-  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setFallthroughKeyBindings.mockResolvedValue(undefined)
   const state = {
     ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
     browserViewId: 12,
     tabs: [{ browserViewId: 12, iframeSrc: 'https://example.com', inputValue: 'https://example.com', title: 'Example' }],
   }
 
-  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'background-tab')
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 13, 'https://example.com/docs', 'background-tab')
 
   expect(newState).toMatchObject({ browserViewId: 12, selectedTabIndex: 0 })
   expect(newState.tabs).toHaveLength(2)
+  expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(13)
   expect(ElectronWebContentsViewFunctions.show).not.toHaveBeenCalled()
 })
 
-test('keeps a new background tab unloaded when tab unloading is enabled', async () => {
+test('keeps a popup child loaded when tab unloading is enabled', async () => {
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.resizeWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setFallthroughKeyBindings.mockResolvedValue(undefined)
   const state = {
     ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
     browserViewId: 12,
@@ -579,9 +591,10 @@ test('keeps a new background tab unloaded when tab unloading is enabled', async 
     unloadTabs: true,
   }
 
-  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'background-tab')
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 13, 'https://example.com/docs', 'background-tab')
 
-  expect(newState.tabs[1]).toMatchObject({ browserViewId: 0, iframeSrc: 'https://example.com/docs', isLoading: false })
+  expect(newState.tabs[1]).toMatchObject({ browserViewId: 13, iframeSrc: 'https://example.com/docs', isLoading: true })
+  expect(ElectronWebContentsView.adoptWebContentsView).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsView.createWebContentsView).not.toHaveBeenCalled()
   expect(ElectronWebContentsViewFunctions.setIframeSrc).not.toHaveBeenCalled()
 })
@@ -609,6 +622,8 @@ test('opens a context menu link in a new background web contents view', async ()
 })
 
 test('opens a target blank link in the system browser when configured', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.disposeWebContentsView.mockResolvedValue(undefined)
   Preferences.state['simpleBrowser.openExternalLinks'] = 'externalBrowser'
   const state = {
     ...ViewletSimpleBrowser.create(),
@@ -616,9 +631,11 @@ test('opens a target blank link in the system browser when configured', async ()
     tabs: [{ browserViewId: 12 }],
   }
 
-  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 'https://example.com/docs', 'foreground-tab')
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 12, 13, 'https://example.com/docs', 'foreground-tab')
 
   expect(newState).toBe(state)
+  expect(ElectronWebContentsView.adoptWebContentsView).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsView.disposeWebContentsView).toHaveBeenCalledWith(13)
   expect(Command.execute).toHaveBeenCalledWith('Open.openExternal', 'https://example.com/docs')
   delete Preferences.state['simpleBrowser.openExternalLinks']
 })
@@ -630,9 +647,10 @@ test('ignores a target blank event from another simple browser instance', async 
     tabs: [{ browserViewId: 12 }],
   }
 
-  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 99, 'https://example.com/docs', 'foreground-tab')
+  const newState = await ViewletSimpleBrowser.handleWindowOpen(state, 99, 13, 'https://example.com/docs', 'foreground-tab')
 
   expect(newState).toBe(state)
+  expect(ElectronWebContentsView.adoptWebContentsView).not.toHaveBeenCalled()
   expect(ElectronWebContentsView.createWebContentsView).not.toHaveBeenCalled()
   expect(Command.execute).not.toHaveBeenCalled()
 })
@@ -1019,6 +1037,46 @@ test('closing a tab disposes only its web contents view', async () => {
   expect(newState.tabs).toHaveLength(1)
   expect(newState.browserViewId).toBe(12)
   expect(ElectronWebContentsView.disposeWebContentsView).toHaveBeenCalledWith(13)
+})
+
+test('closes an oauth tab when its child web contents closes itself', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.releaseWebContentsView.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.show.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.focus.mockResolvedValue(undefined)
+  const state = {
+    ...ViewletSimpleBrowser.create(),
+    browserViewId: 13,
+    selectedTabIndex: 1,
+    tabs: [
+      { browserViewId: 12, favicon: '', iframeSrc: 'https://soundcloud.com', inputValue: 'https://soundcloud.com', title: 'SoundCloud' },
+      { browserViewId: 13, favicon: '', iframeSrc: 'https://accounts.google.com', inputValue: 'https://accounts.google.com', title: 'Sign in' },
+    ],
+  }
+
+  const newState = await ViewletSimpleBrowser.handleBrowserViewDestroyed(state, 13)
+
+  expect(newState).toMatchObject({ browserViewId: 12, selectedTabIndex: 0, title: 'SoundCloud' })
+  expect(newState.tabs).toHaveLength(1)
+  expect(ElectronWebContentsView.releaseWebContentsView).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsView.disposeWebContentsView).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(12)
+  expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(12)
+})
+
+test('ignores a destroyed web contents event from another simple browser instance', async () => {
+  const state = {
+    ...ViewletSimpleBrowser.create(),
+    browserViewId: 12,
+    tabs: [{ browserViewId: 12 }],
+  }
+
+  const newState = await ViewletSimpleBrowser.handleBrowserViewDestroyed(state, 13)
+
+  expect(newState).toBe(state)
+  expect(ElectronWebContentsView.releaseWebContentsView).not.toHaveBeenCalled()
 })
 
 test('closes the selected tab from the browser menu', async () => {


### PR DESCRIPTION
## Summary

- adopt Electron-created popup WebContentsViews as Simple Browser tabs so OAuth retains `window.opener` and the shared browser session
- close the adopted tab when the popup closes itself after authentication
- track popup WebContentsView lifetime and forward its destroyed event to the renderer

## Tests

- `npm test -- --runInBand test/ViewletSimpleBrowser.test.ts test/CommandMap.test.ts test/ElectronWebContentsViewLifecycle.test.ts` (98 tests)
- `npm run type-check`