### PR TITLE
fix: submit simple browser address input

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -23,6 +23,10 @@ export const renderEventListeners = () => {
       params: ['reload'],
     },
     {
+      name: DomEventListenerFunctions.HandleInput,
+      params: ['handleInput', 'event.target.value'],
+    },
+    {
       name: DomEventListenerFunctions.HandleFocusInSimpleBrowser,
       params: ['handleFocusIn', 'event.target.name'],
     },

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -171,6 +171,13 @@ test.each([
   })
 })
 
+test('routes address input changes to the simple browser state', () => {
+  expect(ViewletSimpleBrowserRender.renderEventListeners()).toContainEqual({
+    name: DomEventListenerFunctions.HandleInput,
+    params: ['handleInput', 'event.target.value'],
+  })
+})
+
 test('routes browser chrome focus with the focused element name', () => {
   expect(ViewletSimpleBrowserRender.renderEventListeners()).toContainEqual({
     name: DomEventListenerFunctions.HandleFocusInSimpleBrowser,


### PR DESCRIPTION
Routes Simple Browser address-bar input changes into view state so pressing Enter navigates to the typed URL, including local addresses such as http://localhost:3000.