### PR TITLE
fix: order text search renders by completion

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -145,20 +145,20 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   const Commands = {}
   const Events = {}
   const { idKey } = state
-  let nextCommandInvocationId = 0
-  const activeCommandInvocations = new Map()
+  let nextRenderInvocationId = 0
+  const activeRenderInvocations = new Map()
 
-  const createCommandInvocation = (uid) => {
-    const invocationId = ++nextCommandInvocationId
-    activeCommandInvocations.set(uid, invocationId)
+  const createRenderInvocation = (uid) => {
+    const invocationId = ++nextRenderInvocationId
+    activeRenderInvocations.set(uid, invocationId)
     return {
       finish() {
-        if (activeCommandInvocations.get(uid) === invocationId) {
-          activeCommandInvocations.delete(uid)
+        if (activeRenderInvocations.get(uid) === invocationId) {
+          activeRenderInvocations.delete(uid)
         }
       },
       isLatest() {
-        return activeCommandInvocations.get(uid) === invocationId
+        return activeRenderInvocations.get(uid) === invocationId
       },
     }
   }
@@ -253,7 +253,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   }
 
   const createCommandWrapper = (command) => {
-    return adapter.wrapCommand(command, wrapCommand, { context, createCommandInvocation, worker })
+    return adapter.wrapCommand(command, wrapCommand, { context, createRenderInvocation, worker })
   }
 
   const wrapConfiguredCommand = (methodName) => {

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -259,14 +259,11 @@ export const textSearch = {
       isSearchEditor: state.uri.startsWith('search-editor://'),
     }
   },
-  wrapCommand(command, _defaultWrapCommand, { createCommandInvocation, worker }) {
+  wrapCommand(command, _defaultWrapCommand, { createRenderInvocation, worker }) {
     return async (state, ...args) => {
-      const invocation = createCommandInvocation(state.uid)
+      await worker.invoke(`TextSearch.${command}`, state.uid, ...args)
+      const invocation = createRenderInvocation(state.uid)
       try {
-        await worker.invoke(`TextSearch.${command}`, state.uid, ...args)
-        if (!invocation.isLatest()) {
-          return state
-        }
         const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
         if (diff.length === 0 || !invocation.isLatest()) {
           return state

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -143,16 +143,18 @@ test('creates command wrappers through the same lifecycle seam', async () => {
   expect(result.commands).toEqual([['setText', 'selected']])
 })
 
-test('text search command wrappers discard rendering from superseded invocations', async () => {
-  const { promise: firstCommand, resolve: resolveFirstCommand } = Promise.withResolvers<void>()
+test('text search command wrappers discard superseded render pipelines', async () => {
+  const { promise: firstDiff, resolve: resolveFirstDiff } = Promise.withResolvers<void>()
+  const { promise: firstDiffStarted, resolve: resolveFirstDiffStarted } = Promise.withResolvers<void>()
   const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
     if (method === 'Example.getCommandIds') {
       return ['update']
     }
-    if (method === 'TextSearch.update' && value === 'first') {
-      await firstCommand
-    }
     if (method === 'TextSearch.diff2') {
+      if (value === 'first') {
+        resolveFirstDiffStarted()
+        await firstDiff
+      }
       return ['latest']
     }
     if (method === 'TextSearch.render2') {
@@ -170,14 +172,15 @@ test('text search command wrappers discard rendering from superseded invocations
   const state = viewlet.create(9, '', 0, 0, 0, 0)
 
   const first = commands.update(state, 'first')
+  await firstDiffStarted
   const second = commands.update(state, 'second')
   const secondResult = await second
-  resolveFirstCommand()
+  resolveFirstDiff()
   const firstResult = await first
 
   expect(secondResult.commands).toEqual([['setText', 'latest']])
   expect(firstResult).toBe(state)
-  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toHaveLength(1)
+  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toHaveLength(2)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.render2')).toHaveLength(1)
 })
 


### PR DESCRIPTION
Start text-search render generations after the worker command completes, so an auxiliary command during a long-running operation cannot suppress that operation’s final render. Superseded overlapping diff/render pipelines are still discarded, with regression coverage for out-of-order rendering.