### PR TITLE
fix: preserve started text search renders

### DIFF
--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -269,9 +269,6 @@ export const textSearch = {
           return state
         }
         const commands = await worker.invoke('TextSearch.render2', state.uid, diff)
-        if (!invocation.isLatest()) {
-          return state
-        }
         return { ...state, commands }
       } finally {
         invocation.finish()

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -184,6 +184,42 @@ test('text search command wrappers discard superseded render pipelines', async (
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.render2')).toHaveLength(1)
 })
 
+test('text search command wrappers preserve a render that has already started', async () => {
+  const { promise: firstRender, resolve: resolveFirstRender } = Promise.withResolvers<void>()
+  const { promise: firstRenderStarted, resolve: resolveFirstRenderStarted } = Promise.withResolvers<void>()
+  const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
+    if (method === 'Example.getCommandIds') {
+      return ['update']
+    }
+    if (method === 'TextSearch.diff2') {
+      return value === 'first' ? ['first'] : []
+    }
+    if (method === 'TextSearch.render2') {
+      resolveFirstRenderStarted()
+      await firstRender
+      return [['setText', 'first']]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: createConfig(),
+    context: { platform: 1 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+
+  const first = commands.update(state, 'first')
+  await firstRenderStarted
+  const secondResult = await commands.update(state, 'second')
+  resolveFirstRender()
+  const firstResult = await first
+
+  expect(firstResult.commands).toEqual([['setText', 'first']])
+  expect(secondResult).toBe(state)
+})
+
 test('recomputes configured outputs after commands', async () => {
   const config: any = createConfig()
   config.outputs = [{ method: { name: 'Example.renderActions', parameters: [stateParameter('uid')] }, stateField: 'actionsDom' }]


### PR DESCRIPTION
A text-search render can be superseded after render2 has already consumed the worker's pending diff. If the newer command has no diff, both command wrappers return without delivering the only DOM update. This leaves model state current while the rendered view remains stale.\n\nKeep the pre-render supersession check, but allow every render2 invocation that has already started to return its commands. Adds a regression test for a later no-diff command arriving while the first render is in progress.\n\nThe downstream text-search-view replacement scenario reproduced the stale render in 5 of 20 isolated CI attempts.