### PR TITLE
fix: preserve search worker across workspace changes

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -14,7 +14,6 @@ import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
 import * as RemoteCli from '../RemoteCli/RemoteCli.js'
 import * as StatusBarWorker from '../StatusBarWorker/StatusBarWorker.js'
-import * as TextSearchWorker from '../TextSearchWorker/TextSearchWorker.js'
 import * as WindowTitle from '../WindowTitle/WindowTitle.js'
 import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
 import { state } from '../WorkspaceState/WorkspaceState.js'
@@ -39,7 +38,8 @@ export const setPath = async (path) => {
   Assert.string(path)
   await validateLocalPath(path)
   await updateWindowTitle(path, pathSeparator)
-  if (path !== state.workspacePath) {
+  const workspaceChanged = path !== state.workspacePath
+  if (workspaceChanged) {
     await GlobalEventBus.emitEvent('workspace.beforeChange', state.workspacePath, path)
   }
   // @ts-ignore
@@ -47,10 +47,11 @@ export const setPath = async (path) => {
   // @ts-ignore
   state.workspaceUri = path
   state.pathSeparator = pathSeparator
-  WorkspaceConnection.reset()
-  RemoteCli.stop()
-  await FileSystemWorker.dispose()
-  await TextSearchWorker.dispose()
+  if (workspaceChanged) {
+    WorkspaceConnection.reset()
+    RemoteCli.stop()
+    await FileSystemWorker.dispose()
+  }
   await onWorkspaceChange()
 }
 
@@ -83,7 +84,6 @@ export const setUri = async (uri, connectionOrPathSeparator, legacyConnection) =
     RemoteCli.stop()
   }
   await FileSystemWorker.dispose()
-  await TextSearchWorker.dispose()
   await onWorkspaceChange()
 }
 

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -91,14 +91,18 @@ test('setPath uses the product name for an empty workspace', async () => {
   await Workspace.setPath('')
 
   expect(setWindowTitle).toHaveBeenCalledWith('Lvce Editor')
-  expect(disposeTextSearchWorker).toHaveBeenCalledTimes(1)
-  expect(disposeFileSystemWorker).toHaveBeenCalledTimes(1)
+  expect(disposeTextSearchWorker).not.toHaveBeenCalled()
+  expect(disposeFileSystemWorker).not.toHaveBeenCalled()
+  expect(stopRemoteCli).not.toHaveBeenCalled()
 })
 
 test('setPath uses the folder name for a workspace', async () => {
   await Workspace.setPath('/home/test/project')
 
   expect(setWindowTitle).toHaveBeenCalledWith('project')
+  expect(disposeTextSearchWorker).not.toHaveBeenCalled()
+  expect(disposeFileSystemWorker).toHaveBeenCalledTimes(1)
+  expect(stopRemoteCli).toHaveBeenCalledTimes(1)
 })
 
 test('setPath skips folder validation during tests', async () => {
@@ -134,6 +138,8 @@ test('setUri preserves the uri and decodes the workspace path', async () => {
   expect(Workspace.state.pathSeparator).toBe('/')
   expect(exists).toHaveBeenCalledWith('/home/test/my folder/#project?')
   expect(setWindowTitle).toHaveBeenCalledWith('#project?')
+  expect(disposeTextSearchWorker).not.toHaveBeenCalled()
+  expect(disposeFileSystemWorker).toHaveBeenCalledTimes(1)
 })
 
 test('setUri preserves the current workspace when a local folder does not exist', async () => {


### PR DESCRIPTION
## Summary

- keep the text-search worker alive across workspace changes so transferred RPC connections remain valid
- avoid resetting workspace connections and the file-system worker when the workspace path is unchanged
- cover both unchanged and changed workspace lifecycle behavior

## Validation

- renderer-worker: 399 suites passed, 1,907 tests passed
- renderer-worker type-check passed