### PR TITLE
feature: update test worker to version 17.17.3

### DIFF
--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -73,7 +73,7 @@
         "@lvce-editor/status-bar-worker": "^3.26.2",
         "@lvce-editor/syntax-highlighting-worker": "^2.5.1",
         "@lvce-editor/terminal-worker": "^2.9.1",
-        "@lvce-editor/test-worker": "^17.17.2",
+        "@lvce-editor/test-worker": "^17.17.3",
         "@lvce-editor/text-measurement-worker": "^1.24.2",
         "@lvce-editor/text-search-view": "^1.17.3",
         "@lvce-editor/text-search-worker": "^7.16.0",
@@ -1325,9 +1325,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "17.17.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.17.2.tgz",
-      "integrity": "sha512-txuza6jiydFjrdjHd2grkZcSQBWzM7TQEFDzc8jyIkOdVjru9UaTkEoKP5ZSTz5qkJ+46trsOkcyJrBPKoviCw==",
+      "version": "17.17.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.17.3.tgz",
+      "integrity": "sha512-6gkYbKqsT65XW2jWqgXS12OOft6pd8+xbvrmqyzMylWrkdSdfpiMfGeiqKCbFz8elmAiiwq/c/rPG9zPW/5XHw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/text-measurement-worker": {

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -105,7 +105,7 @@
     "@lvce-editor/status-bar-worker": "^3.26.2",
     "@lvce-editor/syntax-highlighting-worker": "^2.5.1",
     "@lvce-editor/terminal-worker": "^2.9.1",
-    "@lvce-editor/test-worker": "^17.17.2",
+    "@lvce-editor/test-worker": "^17.17.3",
     "@lvce-editor/text-measurement-worker": "^1.24.2",
     "@lvce-editor/text-search-view": "^1.17.3",
     "@lvce-editor/text-search-worker": "^7.16.0",


### PR DESCRIPTION
## Summary

- update the renderer bundle to test-worker 17.17.3
- include reused-page filesystem and editor isolation in static exports

## Context

Follow-up to lvce-editor/test-worker#1295 and #14634 for text-search-view reused-page e2e coverage.

## Validation

- package lock resolves test-worker 17.17.3
- test-worker 17.17.3 release passed all platform builders