### PR TITLE
fix: serialize text search render pipelines

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -147,6 +147,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   const { idKey } = state
   let nextRenderInvocationId = 0
   const activeRenderInvocations = new Map()
+  const renderQueues = new Map()
 
   const createRenderInvocation = (uid) => {
     const invocationId = ++nextRenderInvocationId
@@ -160,6 +161,27 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
       isLatest() {
         return activeRenderInvocations.get(uid) === invocationId
       },
+    }
+  }
+
+  const enqueueRender = async (uid, render) => {
+    const previous = renderQueues.get(uid) || Promise.resolve()
+    const run = async () => {
+      try {
+        await previous
+      } catch {
+        // The previous caller receives its error; later renders must still run.
+      }
+      return render()
+    }
+    const current = run()
+    renderQueues.set(uid, current)
+    try {
+      return await current
+    } finally {
+      if (renderQueues.get(uid) === current) {
+        renderQueues.delete(uid)
+      }
     }
   }
 
@@ -253,7 +275,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   }
 
   const createCommandWrapper = (command) => {
-    return adapter.wrapCommand(command, wrapCommand, { context, createRenderInvocation, worker })
+    return adapter.wrapCommand(command, wrapCommand, { context, createRenderInvocation, enqueueRender, worker })
   }
 
   const wrapConfiguredCommand = (methodName) => {

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -259,20 +259,22 @@ export const textSearch = {
       isSearchEditor: state.uri.startsWith('search-editor://'),
     }
   },
-  wrapCommand(command, _defaultWrapCommand, { createRenderInvocation, worker }) {
+  wrapCommand(command, _defaultWrapCommand, { createRenderInvocation, enqueueRender, worker }) {
     return async (state, ...args) => {
       await worker.invoke(`TextSearch.${command}`, state.uid, ...args)
       const invocation = createRenderInvocation(state.uid)
-      try {
-        const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
-        if (diff.length === 0 || !invocation.isLatest()) {
-          return state
+      return enqueueRender(state.uid, async () => {
+        try {
+          const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
+          if (diff.length === 0 || !invocation.isLatest()) {
+            return state
+          }
+          const commands = await worker.invoke('TextSearch.render2', state.uid, diff)
+          return { ...state, commands }
+        } finally {
+          invocation.finish()
         }
-        const commands = await worker.invoke('TextSearch.render2', state.uid, diff)
-        return { ...state, commands }
-      } finally {
-        invocation.finish()
-      }
+      })
     }
   },
 }

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -174,9 +174,8 @@ test('text search command wrappers discard superseded render pipelines', async (
   const first = commands.update(state, 'first')
   await firstDiffStarted
   const second = commands.update(state, 'second')
-  const secondResult = await second
   resolveFirstDiff()
-  const firstResult = await first
+  const [firstResult, secondResult] = await Promise.all([first, second])
 
   expect(secondResult.commands).toEqual([['setText', 'latest']])
   expect(firstResult).toBe(state)
@@ -187,11 +186,15 @@ test('text search command wrappers discard superseded render pipelines', async (
 test('text search command wrappers preserve a render that has already started', async () => {
   const { promise: firstRender, resolve: resolveFirstRender } = Promise.withResolvers<void>()
   const { promise: firstRenderStarted, resolve: resolveFirstRenderStarted } = Promise.withResolvers<void>()
+  let secondDiffStarted = false
   const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
     if (method === 'Example.getCommandIds') {
       return ['update']
     }
     if (method === 'TextSearch.diff2') {
+      if (value === 'second') {
+        secondDiffStarted = true
+      }
       return value === 'first' ? ['first'] : []
     }
     if (method === 'TextSearch.render2') {
@@ -212,12 +215,16 @@ test('text search command wrappers preserve a render that has already started', 
 
   const first = commands.update(state, 'first')
   await firstRenderStarted
-  const secondResult = await commands.update(state, 'second')
+  const second = commands.update(state, 'second')
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(secondDiffStarted).toBe(false)
   resolveFirstRender()
-  const firstResult = await first
+  const [firstResult, secondResult] = await Promise.all([first, second])
 
   expect(firstResult.commands).toEqual([['setText', 'first']])
   expect(secondResult).toBe(state)
+  expect(secondDiffStarted).toBe(true)
 })
 
 test('recomputes configured outputs after commands', async () => {


### PR DESCRIPTION
Text-search worker commands must remain concurrent so newer searches can supersede older work, but their diff/render pipelines mutate shared rendered state and queue ordered DOM transactions. Running those render pipelines concurrently can consume diffs or commit dependent patches out of order, leaving model state current while the DOM remains stale.\n\nSerialize only the diff/render portion per viewlet uid. Command execution remains concurrent, pre-render supersession still discards obsolete work, and an already-started render completes before the next diff begins.\n\nAdds regression coverage for both a superseded pre-render pipeline and a second command arriving while render2 is active. The downstream text-search-view file replacement scenario reproduced the remaining stale render in 2 of 20 CI attempts on server 0.112.21.