### PR TITLE
fix: serialize all text search render pipelines

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -209,7 +209,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     return newState
   }
 
-  const runRenderPipeline = async (
+  const runRenderPipelineInternal = async (
     currentState,
     invocationArguments = {},
     diffMethod = methods.diff,
@@ -225,6 +225,14 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     }
     const newState = await applyOutputs(renderedState, invocation, isHotReload)
     return adapter.transformRenderedState(newState)
+  }
+
+  const runRenderPipeline = (currentState, ...args) => {
+    const render = () => runRenderPipelineInternal(currentState, ...args)
+    if (adapter.serializeRenderPipelines) {
+      return enqueueRender(currentState[idKey], render)
+    }
+    return render()
   }
 
   const runLoadContent = async (currentState, savedState, args, createMethod, loadMethod, isHotReload) => {
@@ -243,7 +251,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     return runLoadContent(currentState, savedState, args, methods.create, methods.loadContent, false)
   }
 
-  const runCommandRenderPipeline = async (currentState, args) => {
+  const runCommandRenderPipelineInternal = async (currentState, args) => {
     const invocation = createInvocation(currentState, context, { args })
     invocation.results.diff = await invokeConfiguredMethod(worker, methods.commandDiff || methods.diff, invocation)
     if (config.commandSkipRenderWhenDiffEmpty && invocation.results.diff.length === 0) {
@@ -259,6 +267,14 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     }
     const newState = await applyOutputs(renderedState, invocation)
     return adapter.transformRenderedState(newState)
+  }
+
+  const runCommandRenderPipeline = (currentState, args) => {
+    const render = () => runCommandRenderPipelineInternal(currentState, args)
+    if (adapter.serializeRenderPipelines) {
+      return enqueueRender(currentState[idKey], render)
+    }
+    return render()
   }
 
   Object.defineProperty(Commands, '__renderPending', {

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -245,6 +245,7 @@ export const settings = {
 }
 
 export const textSearch = {
+  serializeRenderPipelines: true,
   extendModule(_workerViewlet, { wrapCommand }) {
     return {
       dispose(state) {

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -227,6 +227,50 @@ test('text search command wrappers preserve a render that has already started', 
   expect(secondDiffStarted).toBe(true)
 })
 
+test('text search command wrappers serialize requested renders with command renders', async () => {
+  const { promise: firstRender, resolve: resolveFirstRender } = Promise.withResolvers<void>()
+  const { promise: firstRenderStarted, resolve: resolveFirstRenderStarted } = Promise.withResolvers<void>()
+  let diffCount = 0
+  const invoke = jest.fn(async (method: string) => {
+    if (method === 'Example.getCommandIds') {
+      return ['update']
+    }
+    if (method === 'TextSearch.diff2' || method === 'Example.diff3') {
+      diffCount++
+      return ['diff']
+    }
+    if (method === 'TextSearch.render2' || method === 'Example.render3') {
+      if (diffCount === 1) {
+        resolveFirstRenderStarted()
+        await firstRender
+      }
+      return [['setText', `render-${diffCount}`]]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: createConfig(),
+    context: { platform: 1 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+
+  const commandRender = commands.update(state)
+  await firstRenderStarted
+  const requestedRender = commands.__renderPending(state)
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(diffCount).toBe(1)
+  resolveFirstRender()
+  const [commandResult, requestedResult] = await Promise.all([commandRender, requestedRender])
+
+  expect(commandResult.commands).toEqual([['setText', 'render-1']])
+  expect(requestedResult.commands).toEqual([['setText', 'render-2']])
+  expect(diffCount).toBe(2)
+})
+
 test('recomputes configured outputs after commands', async () => {
   const config: any = createConfig()
   config.outputs = [{ method: { name: 'Example.renderActions', parameters: [stateParameter('uid')] }, stateField: 'actionsDom' }]


### PR DESCRIPTION
Text-search command diff/render pipelines are serialized, but worker-requested pending renders still use the generic render pipeline. Those paths can run concurrently, consume the same stateful diff, and leave the model current while the DOM remains stale.

Route every text-search render pipeline through the same per-viewlet queue. Worker commands remain concurrent; only their stateful diff/render work is ordered.

Adds a regression that overlaps a command render with a requested pending render and verifies the second diff cannot start until the first render completes. The test fails without the adapter-level serialization because both diffs start concurrently. Downstream, the text-search-view file replacement scenario still reproduced the stale status on attempt 6 of 20 with server 0.112.24.