### PR TITLE
fix: serialize text search commands with renders

### DIFF
--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -469,6 +469,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
     renderTitle,
     resize,
     saveState,
+    serializeCommands: Boolean(adapter.serializeCommands),
     setComponentState,
     workspaceChangeEvent,
     workspaceChangeEventPrepend,

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -18,6 +18,29 @@ import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import * as ViewletElectron from './ViewletElectron.js'
 
+const commandQueues = new Map()
+
+const enqueueCommand = async (uid, command) => {
+  const previous = commandQueues.get(uid) || Promise.resolve()
+  const run = async () => {
+    try {
+      await previous
+    } catch {
+      // The previous caller receives its error; later commands must still run.
+    }
+    return command()
+  }
+  const current = run()
+  commandQueues.set(uid, current)
+  try {
+    return await current
+  } finally {
+    if (commandQueues.get(uid) === current) {
+      commandQueues.delete(uid)
+    }
+  }
+}
+
 const getKeyBindingSetId = (instance, fallback) => {
   return instance.moduleId || fallback
 }
@@ -587,7 +610,7 @@ export const getFocusCommands = async (id) => {
   return commands
 }
 
-export const executeViewletCommand = async (uid, fnName, ...args) => {
+const executeViewletCommandInternal = async (uid, fnName, ...args) => {
   const instance = ViewletStates.getInstance(uid)
   if (!instance) {
     if (fnName !== DomEventListenerFunctions.HandleBlur) {
@@ -617,6 +640,14 @@ export const executeViewletCommand = async (uid, fnName, ...args) => {
   if (ViewletStates.getInstance(uid) === instance && instance.factory.afterRender) {
     await instance.factory.afterRender(oldState, actualNewState)
   }
+}
+
+export const executeViewletCommand = (uid, fnName, ...args) => {
+  const instance = ViewletStates.getInstance(uid)
+  if (instance?.factory.serializeCommands) {
+    return enqueueCommand(uid, () => executeViewletCommandInternal(uid, fnName, ...args))
+  }
+  return executeViewletCommandInternal(uid, fnName, ...args)
 }
 
 export const requestRender = (uid) => {

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -245,6 +245,7 @@ export const settings = {
 }
 
 export const textSearch = {
+  serializeCommands: true,
   serializeRenderPipelines: true,
   extendModule(_workerViewlet, { wrapCommand }) {
     return {

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -267,11 +267,8 @@ export const textSearch = {
       const invocation = createRenderInvocation(state.uid)
       return enqueueRender(state.uid, async () => {
         try {
-          if (!invocation.isLatest()) {
-            return state
-          }
           const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
-          if (diff.length === 0) {
+          if (diff.length === 0 || !invocation.isLatest()) {
             return state
           }
           const commands = await worker.invoke('TextSearch.render2', state.uid, diff)

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -267,8 +267,11 @@ export const textSearch = {
       const invocation = createRenderInvocation(state.uid)
       return enqueueRender(state.uid, async () => {
         try {
+          if (!invocation.isLatest()) {
+            return state
+          }
           const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
-          if (diff.length === 0 || !invocation.isLatest()) {
+          if (diff.length === 0) {
             return state
           }
           const commands = await worker.invoke('TextSearch.render2', state.uid, diff)

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -143,24 +143,19 @@ test('creates command wrappers through the same lifecycle seam', async () => {
   expect(result.commands).toEqual([['setText', 'selected']])
 })
 
-test('text search command wrappers preserve a diff that has already started', async () => {
+test('text search command wrappers discard superseded render pipelines', async () => {
   const { promise: firstDiff, resolve: resolveFirstDiff } = Promise.withResolvers<void>()
   const { promise: firstDiffStarted, resolve: resolveFirstDiffStarted } = Promise.withResolvers<void>()
-  let hasPendingDiff = true
   const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
     if (method === 'Example.getCommandIds') {
       return ['update']
     }
     if (method === 'TextSearch.diff2') {
-      if (!hasPendingDiff) {
-        return []
-      }
-      hasPendingDiff = false
       if (value === 'first') {
         resolveFirstDiffStarted()
         await firstDiff
       }
-      return ['pending']
+      return ['latest']
     }
     if (method === 'TextSearch.render2') {
       return [['setText', 'latest']]
@@ -183,55 +178,10 @@ test('text search command wrappers preserve a diff that has already started', as
   resolveFirstDiff()
   const [firstResult, secondResult] = await Promise.all([first, second])
 
-  expect(firstResult.commands).toEqual([['setText', 'latest']])
-  expect(secondResult).toBe(state)
+  expect(secondResult.commands).toEqual([['setText', 'latest']])
+  expect(firstResult).toBe(state)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toHaveLength(2)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.render2')).toHaveLength(1)
-})
-
-test('text search command wrappers discard superseded pipelines before diff starts', async () => {
-  const { promise: pendingRender, resolve: resolvePendingRender } = Promise.withResolvers<void>()
-  const { promise: pendingRenderStarted, resolve: resolvePendingRenderStarted } = Promise.withResolvers<void>()
-  const invoke = jest.fn(async (method: string) => {
-    if (method === 'Example.getCommandIds') {
-      return ['update']
-    }
-    if (method === 'Example.diff3') {
-      return ['pending']
-    }
-    if (method === 'Example.render3') {
-      resolvePendingRenderStarted()
-      await pendingRender
-      return [['setText', 'pending']]
-    }
-    if (method === 'TextSearch.diff2') {
-      return ['latest']
-    }
-    if (method === 'TextSearch.render2') {
-      return [['setText', 'latest']]
-    }
-    return undefined
-  })
-  const viewlet = createWorkerViewletWithDependencies({
-    adapter: getWorkerViewletAdapter('textSearchView'),
-    config: createConfig(),
-    context: { platform: 1 },
-    worker: { invoke, restart: jest.fn() },
-  })
-  const commands = await viewlet.getCommands!()
-  const state = viewlet.create(9, '', 0, 0, 0, 0)
-
-  const requestedRender = commands.__renderPending(state)
-  await pendingRenderStarted
-  const first = commands.update(state, 'first')
-  const second = commands.update(state, 'second')
-  resolvePendingRender()
-  const [requestedResult, firstResult, secondResult] = await Promise.all([requestedRender, first, second])
-
-  expect(requestedResult.commands).toEqual([['setText', 'pending']])
-  expect(firstResult).toBe(state)
-  expect(secondResult.commands).toEqual([['setText', 'latest']])
-  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toEqual([['TextSearch.diff2', 9, 'second']])
 })
 
 test('text search command wrappers preserve a render that has already started', async () => {

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -168,6 +168,7 @@ test('text search command wrappers discard superseded render pipelines', async (
     context: { platform: 1 },
     worker: { invoke, restart: jest.fn() },
   })
+  expect(viewlet.serializeCommands).toBe(true)
   const commands = await viewlet.getCommands!()
   const state = viewlet.create(9, '', 0, 0, 0, 0)
 

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -143,19 +143,24 @@ test('creates command wrappers through the same lifecycle seam', async () => {
   expect(result.commands).toEqual([['setText', 'selected']])
 })
 
-test('text search command wrappers discard superseded render pipelines', async () => {
+test('text search command wrappers preserve a diff that has already started', async () => {
   const { promise: firstDiff, resolve: resolveFirstDiff } = Promise.withResolvers<void>()
   const { promise: firstDiffStarted, resolve: resolveFirstDiffStarted } = Promise.withResolvers<void>()
+  let hasPendingDiff = true
   const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
     if (method === 'Example.getCommandIds') {
       return ['update']
     }
     if (method === 'TextSearch.diff2') {
+      if (!hasPendingDiff) {
+        return []
+      }
+      hasPendingDiff = false
       if (value === 'first') {
         resolveFirstDiffStarted()
         await firstDiff
       }
-      return ['latest']
+      return ['pending']
     }
     if (method === 'TextSearch.render2') {
       return [['setText', 'latest']]
@@ -178,10 +183,55 @@ test('text search command wrappers discard superseded render pipelines', async (
   resolveFirstDiff()
   const [firstResult, secondResult] = await Promise.all([first, second])
 
-  expect(secondResult.commands).toEqual([['setText', 'latest']])
-  expect(firstResult).toBe(state)
+  expect(firstResult.commands).toEqual([['setText', 'latest']])
+  expect(secondResult).toBe(state)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toHaveLength(2)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.render2')).toHaveLength(1)
+})
+
+test('text search command wrappers discard superseded pipelines before diff starts', async () => {
+  const { promise: pendingRender, resolve: resolvePendingRender } = Promise.withResolvers<void>()
+  const { promise: pendingRenderStarted, resolve: resolvePendingRenderStarted } = Promise.withResolvers<void>()
+  const invoke = jest.fn(async (method: string) => {
+    if (method === 'Example.getCommandIds') {
+      return ['update']
+    }
+    if (method === 'Example.diff3') {
+      return ['pending']
+    }
+    if (method === 'Example.render3') {
+      resolvePendingRenderStarted()
+      await pendingRender
+      return [['setText', 'pending']]
+    }
+    if (method === 'TextSearch.diff2') {
+      return ['latest']
+    }
+    if (method === 'TextSearch.render2') {
+      return [['setText', 'latest']]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: createConfig(),
+    context: { platform: 1 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+
+  const requestedRender = commands.__renderPending(state)
+  await pendingRenderStarted
+  const first = commands.update(state, 'first')
+  const second = commands.update(state, 'second')
+  resolvePendingRender()
+  const [requestedResult, firstResult, secondResult] = await Promise.all([requestedRender, first, second])
+
+  expect(requestedResult.commands).toEqual([['setText', 'pending']])
+  expect(firstResult).toBe(state)
+  expect(secondResult.commands).toEqual([['setText', 'latest']])
+  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toEqual([['TextSearch.diff2', 9, 'second']])
 })
 
 test('text search command wrappers preserve a render that has already started', async () => {

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -130,6 +130,47 @@ test('executeViewletCommand runs afterRender after updating the renderer', async
   expect(afterRender).toHaveBeenCalledWith(oldState, newState)
 })
 
+test('executeViewletCommand serializes commands for factories that require it', async () => {
+  const { promise: firstCommand, resolve: resolveFirstCommand } = Promise.withResolvers<void>()
+  const { promise: firstCommandStarted, resolve: resolveFirstCommandStarted } = Promise.withResolvers<void>()
+  const callOrder: string[] = []
+  const update = jest.fn(async (state: { uid: number; value: string }, value: string) => {
+    callOrder.push(`command-${value}`)
+    if (value === 'first') {
+      resolveFirstCommandStarted()
+      await firstCommand
+    }
+    return { ...state, value }
+  })
+  ViewletStates.set(2, {
+    factory: {
+      Commands: { update },
+      name: 'Test',
+      serializeCommands: true,
+    },
+    moduleId: 'Test',
+    renderedState: { uid: 2, value: 'initial' },
+    state: { uid: 2, value: 'initial' },
+  })
+  jest.mocked(ViewletManager.render).mockImplementation((_factory, _oldState, newState) => [['Viewlet.setText', newState.value]])
+  jest.mocked(RendererProcess.invoke).mockImplementation(async (_method, commands): Promise<void> => {
+    callOrder.push(`render-${commands[0][1]}`)
+  })
+
+  const first = Viewlet.executeViewletCommand(2, 'update', 'first')
+  await firstCommandStarted
+  const second = Viewlet.executeViewletCommand(2, 'update', 'second')
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(update).toHaveBeenCalledTimes(1)
+  resolveFirstCommand()
+  await Promise.all([first, second])
+
+  expect(callOrder).toEqual(['command-first', 'render-first', 'command-second', 'render-second'])
+  expect(ViewletStates.getState(2)).toEqual({ uid: 2, value: 'second' })
+})
+
 test('requestRender renders pending worker state without executing the event again', async () => {
   const renderPending = jest.fn(async (state: { commands: unknown[]; uid: number }) => ({
     ...state,


### PR DESCRIPTION
## Summary

- serialize the complete renderer-worker command lifecycle for text-search viewlets
- keep state update, renderer-process delivery, and after-render effects in that queue
- discard superseded render pipelines only before their stateful diff starts
- preserve and render every diff that has already begun
- add regressions for command mutation ordering, pre-diff supersession, and in-flight diff preservation

## Why

Direct browser events mutate the text-search worker and request renders asynchronously. A scripted command could overtake that renderer update. Separately, a render pipeline could consume diff state, become superseded, and discard its commands; the newer pipeline then observed an empty diff, leaving worker state current while the DOM stayed stale.

The command-only implementation still reproduced the downstream stale status on attempt 5 of 20. Moving the supersession check before diff consumption closes the second race while retaining safe cancellation for work that has not started.

## Validation

- regression test fails on the prior post-diff supersession behavior and passes on this branch
- renderer-worker focused tests: 54 passed, 2 skipped
- renderer-worker full suite: 399 suites passed, 1,911 tests passed; 21 suites and 231 tests skipped
- renderer-worker type-check passed
- repository lint passed
- downstream file-replacement e2e with command-only fix: failed on attempt 5 of 20
- downstream file-replacement e2e with combined clean local server: 20 of 20 passed