### PR TITLE
fix: preserve started text search diffs

### DIFF
--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -267,8 +267,11 @@ export const textSearch = {
       const invocation = createRenderInvocation(state.uid)
       return enqueueRender(state.uid, async () => {
         try {
+          if (!invocation.isLatest()) {
+            return state
+          }
           const diff = await worker.invoke('TextSearch.diff2', state.uid, ...args)
-          if (diff.length === 0 || !invocation.isLatest()) {
+          if (diff.length === 0) {
             return state
           }
           const commands = await worker.invoke('TextSearch.render2', state.uid, diff)

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -143,19 +143,24 @@ test('creates command wrappers through the same lifecycle seam', async () => {
   expect(result.commands).toEqual([['setText', 'selected']])
 })
 
-test('text search command wrappers discard superseded render pipelines', async () => {
+test('text search command wrappers preserve a diff that has already started', async () => {
   const { promise: firstDiff, resolve: resolveFirstDiff } = Promise.withResolvers<void>()
   const { promise: firstDiffStarted, resolve: resolveFirstDiffStarted } = Promise.withResolvers<void>()
+  let hasPendingDiff = true
   const invoke = jest.fn(async (method: string, _uid?: number, value?: string) => {
     if (method === 'Example.getCommandIds') {
       return ['update']
     }
     if (method === 'TextSearch.diff2') {
+      if (!hasPendingDiff) {
+        return []
+      }
+      hasPendingDiff = false
       if (value === 'first') {
         resolveFirstDiffStarted()
         await firstDiff
       }
-      return ['latest']
+      return ['pending']
     }
     if (method === 'TextSearch.render2') {
       return [['setText', 'latest']]
@@ -178,10 +183,55 @@ test('text search command wrappers discard superseded render pipelines', async (
   resolveFirstDiff()
   const [firstResult, secondResult] = await Promise.all([first, second])
 
-  expect(secondResult.commands).toEqual([['setText', 'latest']])
-  expect(firstResult).toBe(state)
+  expect(firstResult.commands).toEqual([['setText', 'latest']])
+  expect(secondResult).toBe(state)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toHaveLength(2)
   expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.render2')).toHaveLength(1)
+})
+
+test('text search command wrappers discard superseded pipelines before diff starts', async () => {
+  const { promise: pendingRender, resolve: resolvePendingRender } = Promise.withResolvers<void>()
+  const { promise: pendingRenderStarted, resolve: resolvePendingRenderStarted } = Promise.withResolvers<void>()
+  const invoke = jest.fn(async (method: string) => {
+    if (method === 'Example.getCommandIds') {
+      return ['update']
+    }
+    if (method === 'Example.diff3') {
+      return ['pending']
+    }
+    if (method === 'Example.render3') {
+      resolvePendingRenderStarted()
+      await pendingRender
+      return [['setText', 'pending']]
+    }
+    if (method === 'TextSearch.diff2') {
+      return ['latest']
+    }
+    if (method === 'TextSearch.render2') {
+      return [['setText', 'latest']]
+    }
+    return undefined
+  })
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: createConfig(),
+    context: { platform: 1 },
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+
+  const requestedRender = commands.__renderPending(state)
+  await pendingRenderStarted
+  const first = commands.update(state, 'first')
+  const second = commands.update(state, 'second')
+  resolvePendingRender()
+  const [requestedResult, firstResult, secondResult] = await Promise.all([requestedRender, first, second])
+
+  expect(requestedResult.commands).toEqual([['setText', 'pending']])
+  expect(firstResult).toBe(state)
+  expect(secondResult.commands).toEqual([['setText', 'latest']])
+  expect(invoke.mock.calls.filter(([method]) => method === 'TextSearch.diff2')).toEqual([['TextSearch.diff2', 9, 'second']])
 })
 
 test('text search command wrappers preserve a render that has already started', async () => {


### PR DESCRIPTION
## Summary

- cancel superseded text-search render pipelines before they call `diff2`
- always render a diff once `diff2` has started, because reading it advances the worker diff baseline
- cover both a started diff and a superseded pipeline that is still waiting in the render queue

This closes the remaining lost-render race observed in lvce-editor/text-search-view#48: a pipeline could consume a value change from `diff2`, become superseded, discard its commands, and leave all later renders with an empty diff.

## Validation

- focused renderer-worker tests: 52 passed, 2 skipped
- full renderer-worker suite: 399 suites passed; 1,911 tests passed, 231 skipped
- `npm run type-check`
- `npm run build:server`
- `npm run test:server`
- `git diff --check`