### PR TITLE
fix: report when no update is available

### DIFF
--- a/packages/renderer-worker/src/parts/AutoUpdater/AutoUpdater.js
+++ b/packages/renderer-worker/src/parts/AutoUpdater/AutoUpdater.js
@@ -19,7 +19,7 @@ export const checkForUpdatesWithDependencies = async (updateSetting, silent, dep
   try {
     const latest = await dependencies.getLatestVersion()
     if (!latest) {
-      await dependencies.notify('info', 'You are using the latest version.')
+      await dependencies.notify('info', 'No Update available')
       return
     }
     await dependencies.notify('info', `Update ${latest.version} is available.`)

--- a/packages/renderer-worker/test/AutoUpdater.test.ts
+++ b/packages/renderer-worker/test/AutoUpdater.test.ts
@@ -11,13 +11,13 @@ beforeEach(() => {
   jest.resetAllMocks()
 })
 
-test('reports when the current version is up to date', async () => {
+test('reports when no update is available', async () => {
   dependencies.getLatestVersion.mockResolvedValue(undefined)
 
   await AutoUpdater.checkForUpdatesWithDependencies(undefined, false, dependencies)
 
   expect(dependencies.notify).toHaveBeenNthCalledWith(1, 'info', 'Checking for updates...')
-  expect(dependencies.notify).toHaveBeenNthCalledWith(2, 'info', 'You are using the latest version.')
+  expect(dependencies.notify).toHaveBeenNthCalledWith(2, 'info', 'No Update available')
   expect(dependencies.startUpdate).not.toHaveBeenCalled()
 })
 

--- a/packages/shared-process/src/parts/CompareVersion/CompareVersion.ts
+++ b/packages/shared-process/src/parts/CompareVersion/CompareVersion.ts
@@ -1,3 +1,13 @@
-export const isGreater = (version: any, otherVersion: any): any => {
-  return true
+export const isGreater = (version: string, otherVersion: string): boolean => {
+  const versionParts = version.split('.').map(Number)
+  const otherVersionParts = otherVersion.split('.').map(Number)
+  const partCount = Math.max(versionParts.length, otherVersionParts.length)
+  for (let index = 0; index < partCount; index++) {
+    const versionPart = versionParts[index] || 0
+    const otherVersionPart = otherVersionParts[index] || 0
+    if (versionPart !== otherVersionPart) {
+      return versionPart > otherVersionPart
+    }
+  }
+  return false
 }

--- a/packages/shared-process/test/CompareVersion.test.ts
+++ b/packages/shared-process/test/CompareVersion.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@jest/globals'
+import * as CompareVersion from '../src/parts/CompareVersion/CompareVersion.ts'
+
+test('returns false when versions match', () => {
+  expect(CompareVersion.isGreater('0.112.27', '0.112.27')).toBe(false)
+})
+
+test('returns true when the version is newer', () => {
+  expect(CompareVersion.isGreater('0.112.28', '0.112.27')).toBe(true)
+  expect(CompareVersion.isGreater('0.113.0', '0.112.27')).toBe(true)
+  expect(CompareVersion.isGreater('1.0.0', '0.112.27')).toBe(true)
+})
+
+test('returns false when the version is older', () => {
+  expect(CompareVersion.isGreater('0.112.26', '0.112.27')).toBe(false)
+  expect(CompareVersion.isGreater('0.111.99', '0.112.27')).toBe(false)
+  expect(CompareVersion.isGreater('0.99.99', '1.0.0')).toBe(false)
+})


### PR DESCRIPTION
Fix version comparison so matching installed and release versions are not treated as an update. Show `No Update available` for a manual check when the versions match.