### PR TITLE
fix: refresh source control badge on save

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.source-control-save-badge/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.source-control-save-badge/extension.json
@@ -1,0 +1,18 @@
+{
+  "id": "sample.source-control-save-badge",
+  "name": "Source Control Save Badge",
+  "version": "0.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onSourceControl:memfs", "onCommand:sourceControlSaveBadge.clear"],
+  "commands": [
+    {
+      "id": "sourceControlSaveBadge.clear"
+    }
+  ],
+  "sourceControlProviders": [
+    {
+      "id": "source-control-save-badge"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.source-control-save-badge/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.source-control-save-badge/main.js
@@ -1,0 +1,48 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.startsWith('/remote/') ? '' : currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+let badgeCount = 1
+
+const commandMap = {
+  'ExtensionApi.executeCommand'() {
+    badgeCount = 0
+  },
+  'ExtensionApi.executeSourceControlGetBadgeCount'() {
+    return badgeCount
+  },
+  'ExtensionApi.executeSourceControlGetFeatures'() {
+    return {}
+  },
+  'ExtensionApi.executeSourceControlGetGroups'() {
+    return []
+  },
+  'ExtensionApi.executeSourceControlIsActive'(_id, scheme) {
+    return scheme === 'memfs'
+  },
+  'ExtensionApi.getStatusBarItems'() {
+    return []
+  },
+  'ExtensionApi.getSourceControlProviderRegistrySnapshot'() {
+    return {
+      providers: [
+        {
+          id: 'source-control-save-badge',
+        },
+      ],
+    }
+  },
+  'ExtensionApi.getViewActions'() {
+    return []
+  },
+  'ExtensionApi.getViewMenuEntries'() {
+    return []
+  },
+  'ExtensionApi.getViewRegistrySnapshot'() {
+    return {
+      views: [],
+    }
+  },
+}
+
+await WebWorkerRpcClient.create({ commandMap })

--- a/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-badge-updates-on-save.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.activity-bar-source-control-badge-updates-on-save.ts
@@ -1,0 +1,37 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.activity-bar-source-control-badge-updates-on-save'
+
+export const test: Test = async ({ ActivityBar, Command, Editor, expect, Extension, FileSystem, Locator, Main, SourceControl, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/settings.json`
+  await FileSystem.writeFile(uri, '{}')
+  await Workspace.setPath(tmpDir)
+
+  const extensionUri = new URL('../fixtures/sample.source-control-save-badge', import.meta.url).toString().replace(/\/$/, '')
+  await Extension.addWebExtension(extensionUri)
+  await Extension.enableWorkspace('sample.source-control-save-badge')
+  await ActivityBar.handleExtensionsChanged()
+  const activationResult = await Command.execute('ExtensionManagement.activateByEvent', 'onSourceControl:memfs', '', 0)
+  if (activationResult.error) {
+    throw activationResult.error
+  }
+  await Command.execute('Layout.handleExtensionsChanged')
+  await SourceControl.show()
+
+  const sourceControlItem = Locator('.ActivityBarItem[title="Source Control"]')
+  const sourceControlBadge = sourceControlItem.locator('.ActivityBarItemBadge')
+  await expect(sourceControlBadge).toHaveText('1')
+
+  await Main.openUri(uri)
+  await Editor.setCursor(0, 1)
+  await Editor.type(' ')
+  await Command.execute('ExtensionHost.executeCommand', 'sourceControlSaveBadge.clear')
+  await Main.save()
+
+  await expect(sourceControlBadge).toHaveCount(0)
+  const badgeCounts = await Command.execute('Layout.getBadgeCounts')
+  if (badgeCounts['Source Control'] !== 0) {
+    throw new Error(`Expected source control badge count to be 0, got ${badgeCounts['Source Control']}`)
+  }
+}

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -4,8 +4,13 @@ import * as EncodingType from '../EncodingType/EncodingType.js'
 import * as GetFileSystem from '../GetFileSystem/GetFileSystem.js'
 import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 
-const notifyWorkspaceChanged = async (changes = {}) => {
-  await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', changes), Command.execute('Layout.refreshSourceControlBadgeCount')])
+const notifyFileSystemChanged = async (changes = {}, refreshWorkspaceViews = true) => {
+  const effects = []
+  if (refreshWorkspaceViews) {
+    effects.push(Command.execute('Layout.handleWorkspaceRefresh', changes))
+  }
+  effects.push(Command.execute('Layout.refreshSourceControlBadgeCount'))
+  await Promise.allSettled(effects)
 }
 
 export const readFile = async (uri, encoding = EncodingType.Utf8) => {
@@ -27,7 +32,7 @@ export const remove = async (uri) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.remove(uri)
-  await notifyWorkspaceChanged({
+  await notifyFileSystemChanged({
     deleted: [uri],
   })
 }
@@ -36,7 +41,7 @@ export const rename = async (oldUri, newUri) => {
   const protocol = GetProtocol.getProtocol(oldUri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.rename(oldUri, newUri)
-  await notifyWorkspaceChanged({
+  await notifyFileSystemChanged({
     renamed: [[oldUri, newUri]],
   })
 }
@@ -47,15 +52,16 @@ export const mkdir = async (uri) => {
   await fileSystem.mkdir(uri)
 }
 
-export const writeFile = async (uri, content, encoding = EncodingType.Utf8, notify = true) => {
+export const writeFile = async (uri, content, encoding = EncodingType.Utf8, refreshWorkspaceViews = true) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)
   await fileSystem.writeFile(uri, content, encoding)
-  if (notify) {
-    await notifyWorkspaceChanged({
+  await notifyFileSystemChanged(
+    {
       changed: [uri],
-    })
-  }
+    },
+    refreshWorkspaceViews,
+  )
 }
 
 export const writeBlob = async (uri, blob) => {

--- a/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
+++ b/packages/renderer-worker/test/FileSystemWorkspaceRefresh.test.ts
@@ -58,9 +58,10 @@ test('writeFile notifies workspace views with the changed uri', async () => {
   expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })
 
-test('writeFile can skip reloading workspace views', async () => {
+test('writeFile can skip reloading workspace views while refreshing the source control badge', async () => {
   await FileSystem.writeFile('test://some-file.txt', 'updated', 'utf8', false)
 
   expect(writeFile).toHaveBeenCalledWith('test://some-file.txt', 'updated', 'utf8')
-  expect(execute).not.toHaveBeenCalled()
+  expect(execute).not.toHaveBeenCalledWith('Layout.handleWorkspaceRefresh', expect.anything())
+  expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
 })


### PR DESCRIPTION
Refresh the Source Control activity badge after successful file writes, even when workspace-view reloads are intentionally skipped. Adds focused unit and browser-level regression coverage for saving a file after its provider state becomes clean.