### PR TITLE
feature: add transient cli sessions

### DIFF
--- a/packages/build/src/parts/BuildDeb/BuildDeb.ts
+++ b/packages/build/src/parts/BuildDeb/BuildDeb.ts
@@ -44,7 +44,9 @@ const copyElectronResult = async ({ product, version, arch, debArch, platform, t
     },
     755,
   )
-  await Template.write('linux_cli_js', `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}/resources/app/bin/cli.js`, {})
+  await Template.write('linux_cli_js', `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}/resources/app/bin/cli.js`, {
+    '@@APPLICATION_NAME@@': product.applicationName,
+  })
   await Remove.remove(
     `packages/build/.tmp/linux/deb/${debArch}/app/usr/lib/${product.applicationName}/resources/app/packages/shared-process/node_modules/@lvce-editor/ripgrep`,
   )

--- a/packages/build/src/parts/Template/template_bash_completion.txt
+++ b/packages/build/src/parts/Template/template_bash_completion.txt
@@ -21,7 +21,7 @@ _@@APPNAME@@() {
     esac
 
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $( compgen -W "--built-in-self-test --hot-reload --link --start-dev-server -h --help -v --version --wait install uninstall" -- "$cur" ) )
+        COMPREPLY=( $( compgen -W "--built-in-self-test --hot-reload --link --start-dev-server --transient -h --help -v --version --wait install uninstall" -- "$cur" ) )
         return
     fi
 

--- a/packages/build/src/parts/Template/template_linux_cli_js.txt
+++ b/packages/build/src/parts/Template/template_linux_cli_js.txt
@@ -1,6 +1,9 @@
 import { spawn } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
+const applicationName = '@@APPLICATION_NAME@@'
 const foregroundCommands = new Set(['install', 'list'])
 const electronDiagnosticPattern = /^\[\d+:\d+\/\d+\.\d+:(?:ERROR|WARNING):/
 
@@ -11,6 +14,40 @@ const isForegroundRequest = (args) => {
     return true
   }
   return args.some((arg) => foregroundCommands.has(arg))
+}
+
+const shellQuote = (value) => `'${value.replaceAll("'", "'\\''")}'`
+
+const getTransientLaunchOptions = async (args) => {
+  if (!args.includes('--transient')) {
+    return { args, env: {} }
+  }
+
+  const root = await mkdtemp(join(tmpdir(), `${applicationName}-`))
+  const configHome = join(root, 'config')
+  const dataHome = join(root, 'data')
+  const cacheHome = join(root, 'cache')
+  const stateHome = join(root, 'state')
+  const userDataDir = join(configHome, applicationName, 'electron')
+  const env = {
+    XDG_CACHE_HOME: cacheHome,
+    XDG_CONFIG_HOME: configHome,
+    XDG_DATA_HOME: dataHome,
+    XDG_STATE_HOME: stateHome,
+  }
+  const relaunchArguments = [
+    `XDG_CONFIG_HOME=${shellQuote(configHome)}`,
+    `XDG_DATA_HOME=${shellQuote(dataHome)}`,
+    `XDG_CACHE_HOME=${shellQuote(cacheHome)}`,
+    `XDG_STATE_HOME=${shellQuote(stateHome)}`,
+    applicationName,
+    `--user-data-dir=${shellQuote(userDataDir)}`,
+  ]
+  console.log(`State is temporarily stored. Relaunch this state with: ${relaunchArguments.join(' ')}`)
+  return {
+    args: [...args, `--user-data-dir=${userDataDir}`],
+    env,
+  }
 }
 
 const forwardElectronStderr = (stream) => {
@@ -33,8 +70,8 @@ const forwardElectronStderr = (stream) => {
   })
 }
 
-const launchElectron = async (args) => {
-  const env = { ...process.env }
+const launchElectron = async (args, envOverrides) => {
+  const env = { ...process.env, ...envOverrides }
   delete env.ELECTRON_RUN_AS_NODE
 
   const foreground = isForegroundRequest(args)
@@ -82,7 +119,8 @@ const main = async () => {
     console.log(packageJson.version)
     return 0
   }
-  return launchElectron(args)
+  const launchOptions = await getTransientLaunchOptions(args)
+  return launchElectron(launchOptions.args, launchOptions.env)
 }
 
 try {

--- a/packages/build/test/LinuxCliTemplate.test.ts
+++ b/packages/build/test/LinuxCliTemplate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 import { execFile, spawn } from 'node:child_process'
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
@@ -51,6 +51,12 @@ describe('linux cli templates', () => {
     expect(cli).toContain("new URL('../package.json', import.meta.url)")
   })
 
+  test('includes transient sessions in bash completions', async () => {
+    const completion = await readTemplate('bash_completion')
+
+    expect(completion).toContain('--transient')
+  })
+
   test('prints the packaged version without Electron', async () => {
     const root = await mkdtemp(join(tmpdir(), 'lvce-linux-cli-version-'))
     try {
@@ -73,6 +79,69 @@ describe('linux cli templates', () => {
 
     expect(cli).toContain('detached: true')
     expect(cli).toContain("stdio: foreground ? ['inherit', 'inherit', 'pipe'] : 'ignore'")
+  })
+
+  testPosix('launches transient sessions with isolated application state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'lvce-linux-cli-transient-'))
+    const binPath = join(root, 'bin')
+    const fakeElectronPath = join(root, 'fake-electron')
+    const resultPath = join(root, 'result.json')
+    let transientRoot = ''
+    try {
+      await mkdir(binPath)
+      await writeFile(
+        fakeElectronPath,
+        `#!/usr/bin/env node
+import { writeFileSync } from 'node:fs'
+writeFileSync(process.env.LVCE_TEST_RESULT, JSON.stringify({
+  args: process.argv.slice(2),
+  env: {
+    XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+    XDG_STATE_HOME: process.env.XDG_STATE_HOME,
+  },
+}))
+`,
+      )
+      await chmod(fakeElectronPath, 0o755)
+      const cli = (await readTemplate('linux_cli_js'))
+        .replaceAll('@@APPLICATION_NAME@@', 'lvce')
+        .replace('spawn(process.execPath, args, {', `spawn(${JSON.stringify(fakeElectronPath)}, args, {`)
+      const cliPath = join(binPath, 'cli.js')
+      await writeFile(cliPath, cli)
+
+      const { stdout } = await execFileAsync(process.execPath, [cliPath, '--transient', '--wait'], {
+        env: {
+          ...process.env,
+          LVCE_TEST_RESULT: resultPath,
+          XDG_CACHE_HOME: '/existing/cache',
+          XDG_CONFIG_HOME: '/existing/config',
+          XDG_DATA_HOME: '/existing/data',
+          XDG_STATE_HOME: '/existing/state',
+        },
+      })
+      const result = JSON.parse(await readFile(resultPath, 'utf8'))
+      transientRoot = dirname(result.env.XDG_CONFIG_HOME)
+      const userDataDir = join(result.env.XDG_CONFIG_HOME, 'lvce', 'electron')
+
+      expect(basename(result.env.XDG_CACHE_HOME)).toBe('cache')
+      expect(basename(result.env.XDG_CONFIG_HOME)).toBe('config')
+      expect(basename(result.env.XDG_DATA_HOME)).toBe('data')
+      expect(basename(result.env.XDG_STATE_HOME)).toBe('state')
+      expect(dirname(result.env.XDG_CACHE_HOME)).toBe(transientRoot)
+      expect(dirname(result.env.XDG_DATA_HOME)).toBe(transientRoot)
+      expect(dirname(result.env.XDG_STATE_HOME)).toBe(transientRoot)
+      expect(result.args).toEqual(['--transient', '--wait', `--user-data-dir=${userDataDir}`])
+      expect(stdout).toBe(
+        `State is temporarily stored. Relaunch this state with: XDG_CONFIG_HOME='${result.env.XDG_CONFIG_HOME}' XDG_DATA_HOME='${result.env.XDG_DATA_HOME}' XDG_CACHE_HOME='${result.env.XDG_CACHE_HOME}' XDG_STATE_HOME='${result.env.XDG_STATE_HOME}' lvce --user-data-dir='${userDataDir}'\n`,
+      )
+    } finally {
+      if (transientRoot) {
+        await rm(transientRoot, { recursive: true })
+      }
+      await rm(root, { recursive: true })
+    }
   })
 
   testPosix('forwards SIGINT to the foreground Electron process', async () => {

--- a/packages/shared-process/src/parts/GetHelpString/GetHelpString.ts
+++ b/packages/shared-process/src/parts/GetHelpString/GetHelpString.ts
@@ -6,6 +6,9 @@ export const getHelpString = (): any => {
 Usage:
   ${Platform.applicationName} [path]
 
+General options:
+  --transient             Run with temporary data and extension directories.
+
 Extension development:
   --link <path>             Link an extension for this run. May be repeated.
   --start-dev-server        Run npm run dev in linked extension folders.

--- a/packages/shared-process/test/CliHelp.test.ts
+++ b/packages/shared-process/test/CliHelp.test.ts
@@ -27,6 +27,9 @@ test('handleCliArgs', async () => {
 Usage:
   lvce-oss [path]
 
+General options:
+  --transient             Run with temporary data and extension directories.
+
 Extension development:
   --link <path>             Link an extension for this run. May be repeated.
   --start-dev-server        Run npm run dev in linked extension folders.


### PR DESCRIPTION
Adds a `--transient` CLI option that launches LVCE with isolated temporary config, data, cache, state, extensions, and Electron user data. Prints a command for reopening the temporary state and documents the option in help and shell completion.