### PR TITLE
fix: keep workspace uri valid

### DIFF
--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -2,6 +2,7 @@ import * as Assert from '../Assert/Assert.ts'
 import * as Character from '../Character/Character.js'
 import * as Command from '../Command/Command.js'
 import * as FileSystem from '../FileSystem/FileSystem.js'
+import * as FileSystemProtocol from '../FileSystemProtocol/FileSystemProtocol.js'
 import * as FileSystemWorker from '../FileSystemWorker/FileSystemWorker.js'
 import * as GetResolvedRoot from '../GetResolvedRoot/GetResolvedRoot.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
@@ -9,6 +10,7 @@ import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as IsTest from '../IsTest/IsTest.js'
 import * as Location from '../Location/Location.js'
 import * as Notification from '../Notification/Notification.js'
+import * as PathToFileUri from '../PathToFileUri/PathToFileUri.js'
 import * as Platform from '../Platform/Platform.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as Product from '../Product/Product.js'
@@ -19,6 +21,13 @@ import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection
 import { state } from '../WorkspaceState/WorkspaceState.js'
 
 const pathSeparator = '/'
+
+const toWorkspaceUri = (path) => {
+  if (!path || path.startsWith('file://') || GetProtocol.getProtocol(path) !== FileSystemProtocol.Disk) {
+    return path
+  }
+  return PathToFileUri.pathToFileUri(path)
+}
 
 const validateLocalPath = async (path) => {
   if (IsTest.isTest()) {
@@ -45,7 +54,7 @@ export const setPath = async (path) => {
   // @ts-ignore
   state.workspacePath = path
   // @ts-ignore
-  state.workspaceUri = path
+  state.workspaceUri = toWorkspaceUri(path)
   state.pathSeparator = pathSeparator
   if (workspaceChanged) {
     WorkspaceConnection.reset()

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -91,6 +91,7 @@ test('setPath uses the product name for an empty workspace', async () => {
   await Workspace.setPath('')
 
   expect(setWindowTitle).toHaveBeenCalledWith('Lvce Editor')
+  expect(Workspace.getWorkspaceUri()).toBe('')
   expect(disposeTextSearchWorker).not.toHaveBeenCalled()
   expect(disposeFileSystemWorker).not.toHaveBeenCalled()
   expect(stopRemoteCli).not.toHaveBeenCalled()
@@ -100,9 +101,24 @@ test('setPath uses the folder name for a workspace', async () => {
   await Workspace.setPath('/home/test/project')
 
   expect(setWindowTitle).toHaveBeenCalledWith('project')
+  expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/project')
   expect(disposeTextSearchWorker).not.toHaveBeenCalled()
   expect(disposeFileSystemWorker).toHaveBeenCalledTimes(1)
   expect(stopRemoteCli).toHaveBeenCalledTimes(1)
+})
+
+test('setPath encodes reserved characters in a local workspace uri', async () => {
+  await Workspace.setPath('/home/test/my folder/#project?')
+
+  expect(Workspace.getWorkspacePath()).toBe('/home/test/my folder/#project?')
+  expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/my%20folder/%23project%3F')
+})
+
+test('setPath preserves a custom workspace uri', async () => {
+  await Workspace.setPath('html:///workspace')
+
+  expect(Workspace.getWorkspacePath()).toBe('html:///workspace')
+  expect(Workspace.getWorkspaceUri()).toBe('html:///workspace')
 })
 
 test('setPath skips folder validation during tests', async () => {
@@ -117,7 +133,7 @@ test('setPath skips folder validation during tests', async () => {
 
 test('setPath preserves the current workspace when the folder does not exist', async () => {
   Workspace.state.workspacePath = '/home/test/current'
-  Workspace.state.workspaceUri = '/home/test/current'
+  Workspace.state.workspaceUri = 'file:///home/test/current'
   exists.mockResolvedValue(false)
 
   await expect(Workspace.setPath('/home/test/missing')).rejects.toThrow(new Error("Workspace folder does not exist: '/home/test/missing'"))
@@ -127,7 +143,7 @@ test('setPath preserves the current workspace when the folder does not exist', a
   expect(setWindowTitle).not.toHaveBeenCalled()
   expect(disposeTextSearchWorker).not.toHaveBeenCalled()
   expect(Workspace.getWorkspacePath()).toBe('/home/test/current')
-  expect(Workspace.getWorkspaceUri()).toBe('/home/test/current')
+  expect(Workspace.getWorkspaceUri()).toBe('file:///home/test/current')
 })
 
 test('setUri preserves the uri and decodes the workspace path', async () => {


### PR DESCRIPTION
Derive an encoded file URI when a local workspace is opened through Workspace.setPath, while preserving empty and custom-scheme workspace roots. This keeps Workspace.getUri valid for URI-only consumers such as Explorer.