### PR TITLE
feature: live update component state editors

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-explorer.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-explorer.ts
@@ -8,7 +8,20 @@ interface ComponentInfo {
 
 export const name = 'viewlet.component-state-edit-explorer'
 
-export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Workspace }) => {
+const waitForFocusedIndex = async (Editor, focusedIndex: number): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const state = JSON.parse(await Editor.getText())
+    if (state.focusedIndex === focusedIndex) {
+      return
+    }
+    if (attempt === 99) {
+      throw new Error(`Expected live Explorer focusedIndex to be ${focusedIndex}, got ${state.focusedIndex}`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+}
+
+export const test: Test = async ({ Command, Editor, expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
   await Workspace.setPath(tmpDir)
@@ -28,6 +41,9 @@ export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator,
   await card.click()
 
   await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${explorer.uid}.json`)
+  await Explorer.focusIndex(1)
+  await waitForFocusedIndex(Editor, 1)
+
   const state = JSON.parse(await Editor.getText())
   await Editor.setText(`${JSON.stringify({ ...state, focusedIndex: 0 }, null, 2)}\n`)
   await Main.save()

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -1,8 +1,114 @@
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
+const liveComponentStatePattern = /^live-component-state:\/\/\/(\d+)\.json$/
+const editorUidsByComponentUid = new Map()
+const componentUidByEditorUid = new Map()
+const refreshes = new Map()
+
 const getUid = (instance) => instance.state?.uid ?? instance.renderedState?.uid
+
+const getLiveComponentUid = (instance) => {
+  const uri = instance.state?.uri
+  if (typeof uri !== 'string') {
+    return undefined
+  }
+  const match = liveComponentStatePattern.exec(uri)
+  return match ? Number(match[1]) : undefined
+}
+
+const subscribe = (instance) => {
+  const componentUid = getLiveComponentUid(instance)
+  const editorUid = getUid(instance)
+  if (componentUid === undefined || typeof editorUid !== 'number') {
+    return
+  }
+  editorUidsByComponentUid.set(componentUid, editorUidsByComponentUid.get(componentUid)?.add(editorUid) || new Set([editorUid]))
+  componentUidByEditorUid.set(editorUid, componentUid)
+}
+
+const unsubscribeEditor = (editorUid) => {
+  const componentUid = componentUidByEditorUid.get(editorUid)
+  if (componentUid === undefined) {
+    return
+  }
+  componentUidByEditorUid.delete(editorUid)
+  const editorUids = editorUidsByComponentUid.get(componentUid)
+  editorUids?.delete(editorUid)
+  if (editorUids?.size === 0) {
+    editorUidsByComponentUid.delete(componentUid)
+  }
+}
+
+const unsubscribeComponent = (componentUid) => {
+  const editorUids = editorUidsByComponentUid.get(componentUid)
+  if (!editorUids) {
+    return
+  }
+  editorUidsByComponentUid.delete(componentUid)
+  for (const editorUid of editorUids) {
+    componentUidByEditorUid.delete(editorUid)
+  }
+}
+
+const runRefreshes = async (componentUid, refresh) => {
+  try {
+    while (refresh.pending) {
+      refresh.pending = false
+      const editorUids = [...(editorUidsByComponentUid.get(componentUid) || [])]
+      await Promise.allSettled(editorUids.map((editorUid) => Viewlet.reload(editorUid)))
+    }
+  } finally {
+    refreshes.delete(componentUid)
+  }
+}
+
+export const refreshOpenEditors = (componentUid) => {
+  const existingRefresh = refreshes.get(componentUid)
+  if (existingRefresh) {
+    existingRefresh.pending = true
+    return existingRefresh.promise
+  }
+  const refresh = {
+    pending: true,
+    promise: Promise.resolve(),
+  }
+  refreshes.set(componentUid, refresh)
+  refresh.promise = runRefreshes(componentUid, refresh)
+  return refresh.promise
+}
+
+export const waitForRefreshes = async () => {
+  while (refreshes.size > 0) {
+    await Promise.all([...refreshes.values()].map((refresh) => refresh.promise))
+  }
+}
+
+const handleViewletStateChange = (type, instance) => {
+  const uid = getUid(instance)
+  if (typeof uid !== 'number') {
+    return
+  }
+  if (type === 'add') {
+    subscribe(instance)
+    return
+  }
+  if (type === 'remove') {
+    unsubscribeEditor(uid)
+    unsubscribeComponent(uid)
+    return
+  }
+  if (type === 'render' && editorUidsByComponentUid.has(uid)) {
+    void refreshOpenEditors(uid)
+  }
+}
+
+ViewletStates.addListener(handleViewletStateChange)
+for (const instance of ViewletStates.getValues()) {
+  subscribe(instance)
+}
 
 const isWorkerBacked = (instance) => Boolean(instance.factory?.hasFunctionalRender)
 

--- a/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
+++ b/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
@@ -18,6 +18,18 @@ export const state = {
   focusedInstanceByType: Object.create(null),
 }
 
+const listeners = new Set()
+
+const emit = (type, instance) => {
+  for (const listener of listeners) {
+    listener(type, instance)
+  }
+}
+
+export const addListener = (listener) => {
+  listeners.add(listener)
+}
+
 const normalizeModuleId = (key) => {
   if (key === 'Editor') {
     return 'EditorText'
@@ -46,6 +58,7 @@ export const set = (key, value) => {
   Assert.object(value.state)
   Assert.object(value.renderedState)
   state.instances[key] = value
+  emit('add', value)
 }
 
 export const getByUid = (uid) => {
@@ -93,10 +106,13 @@ export const hasInstance = (key) => {
 
 export const remove = (key) => {
   const instance = state.instances[key]
+  delete state.instances[key]
   if (instance) {
     clearFocusedInstanceByType(instance.renderedState?.uid, instance.moduleId)
+    if (!Object.values(state.instances).includes(instance)) {
+      emit('remove', instance)
+    }
   }
-  delete state.instances[key]
 }
 
 export const dispose = async (key) => {
@@ -104,6 +120,9 @@ export const dispose = async (key) => {
   delete state.instances[key]
   if (instance) {
     clearFocusedInstanceByType(instance.renderedState?.uid, instance.moduleId)
+    if (!Object.values(state.instances).includes(instance)) {
+      emit('remove', instance)
+    }
   }
   if (instance.factory.dispose) {
     await instance.factory.dispose(instance.state)
@@ -151,9 +170,13 @@ export const setRenderedState = (key, newState) => {
   }
   instance.renderedState = newState
   instance.state = newState
+  emit('render', instance)
 }
 
 export const reset = () => {
+  for (const instance of new Set(Object.values(state.instances))) {
+    emit('remove', instance)
+  }
   state.instances = Object.create(null)
   state.focusedInstanceByType = Object.create(null)
 }

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -9,7 +9,12 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
   render: jest.fn(() => []),
 }))
 
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
+  reload: jest.fn(),
+}))
+
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
 const ComponentState = await import('../src/parts/ComponentState/ComponentState.js')
 
@@ -120,4 +125,51 @@ test('rejects missing, unsupported, invalid, and retargeted component state', as
   ViewletStates.set(3, { factory: {}, moduleId: 'Layout', renderedState: nativeState, state: nativeState })
   await expect(ComponentState.setState(3, [])).rejects.toThrow('Component state must be an object')
   await expect(ComponentState.setState(3, { uid: 4 })).rejects.toThrow('Component state uid must remain 3')
+})
+
+test('refreshes an open live component state editor when the component rerenders', async () => {
+  const componentState = { focusedIndex: 0, uid: 2 }
+  const editorState = { uid: 9, uri: 'live-component-state:///2.json' }
+  ViewletStates.set(2, { factory: {}, moduleId: 'Explorer', renderedState: componentState, state: componentState })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+
+  ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
+  await ComponentState.waitForRefreshes()
+
+  expect(Viewlet.reload).toHaveBeenCalledWith(9)
+})
+
+test('coalesces rerenders while a live component state editor is refreshing', async () => {
+  let finishReload
+  jest.mocked(Viewlet.reload).mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        finishReload = resolve
+      }),
+  )
+  const componentState = { focusedIndex: 0, uid: 2 }
+  const editorState = { uid: 9, uri: 'live-component-state:///2.json' }
+  ViewletStates.set(2, { factory: {}, moduleId: 'Explorer', renderedState: componentState, state: componentState })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+
+  ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
+  ViewletStates.setRenderedState(2, { focusedIndex: 2, uid: 2 })
+  ViewletStates.setRenderedState(2, { focusedIndex: 3, uid: 2 })
+  finishReload()
+  await ComponentState.waitForRefreshes()
+
+  expect(Viewlet.reload).toHaveBeenCalledTimes(2)
+})
+
+test('stops refreshing after the live component state editor is disposed', async () => {
+  const componentState = { focusedIndex: 0, uid: 2 }
+  const editorState = { uid: 9, uri: 'live-component-state:///2.json' }
+  ViewletStates.set(2, { factory: {}, moduleId: 'Explorer', renderedState: componentState, state: componentState })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+  ViewletStates.remove(9)
+
+  ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
+  await ComponentState.waitForRefreshes()
+
+  expect(Viewlet.reload).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Live-update open component-state JSON editors whenever their source component rerenders. Subscriptions follow renderer viewlet lifecycles, coalesce rapid updates, and are removed when the editor closes; the Explorer integration test now covers the live refresh.