### PR TITLE
fix: hide disabled extension commands from quick pick

### DIFF
--- a/packages/extension-host-worker-tests/fixtures/sample.quick-pick-disabled-command/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.quick-pick-disabled-command/extension.json
@@ -1,0 +1,11 @@
+{
+  "id": "sample.quick-pick-disabled-command",
+  "name": "Quick Pick Disabled Command",
+  "version": "0.0.0",
+  "commands": [
+    {
+      "id": "quickPickDisabledCommand.test",
+      "label": "Quick Pick Disabled Command: Test"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/src/viewlet.quick-pick-hides-disabled-extension-commands.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.quick-pick-hides-disabled-extension-commands.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.quick-pick-hides-disabled-extension-commands'
+
+const commandLabel = 'Quick Pick Disabled Command: Test'
+const extensionId = 'sample.quick-pick-disabled-command'
+
+export const test: Test = async ({ Command, expect, Extension, ExtensionDetail, Locator, QuickPick }) => {
+  const extensionUri = new URL('../fixtures/sample.quick-pick-disabled-command', import.meta.url).toString()
+  await Extension.addWebExtension(extensionUri)
+  await QuickPick.open()
+  await QuickPick.setValue(`>${commandLabel}`)
+
+  const command = Locator('.QuickPickItem', { hasText: commandLabel })
+  await expect(command).toBeVisible()
+
+  await Command.execute('Viewlet.closeWidget', 'QuickPick')
+  await ExtensionDetail.open(extensionId)
+  await ExtensionDetail.handleClickDisable()
+  await QuickPick.open()
+  await QuickPick.setValue(`>${commandLabel}`)
+
+  await expect(command).toBeHidden()
+
+  await Command.execute('Viewlet.closeWidget', 'QuickPick')
+  await ExtensionDetail.handleClickEnable()
+}

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostCommands.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostCommands.js
@@ -6,7 +6,7 @@ import * as FileSystemHtml from '../FileSystem/FileSystemHtml.js'
 import * as FileSystemMemory from '../FileSystem/FileSystemMemory.js'
 
 const getCommandsFromExtension = (extension) => {
-  if (!extension || !extension.commands) {
+  if (!extension || extension.disabled || !extension.commands) {
     return []
   }
   return extension.commands.filter((command) => command.internal !== true)

--- a/packages/renderer-worker/test/ExtensionHostCommands.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostCommands.test.ts
@@ -7,6 +7,10 @@ const getExtensions = jest.fn(async () => [
       { id: 'sample.internal', internal: true },
     ],
   },
+  {
+    commands: [{ id: 'sample.disabled', label: 'Sample: Disabled' }],
+    disabled: true,
+  },
 ])
 
 jest.unstable_mockModule('../src/parts/ExtensionMeta/ExtensionMeta.js', () => ({
@@ -15,6 +19,6 @@ jest.unstable_mockModule('../src/parts/ExtensionMeta/ExtensionMeta.js', () => ({
 
 const ExtensionHostCommands = await import('../src/parts/ExtensionHost/ExtensionHostCommands.js')
 
-test('omits internal extension commands from the command palette', async () => {
+test('omits internal and disabled extension commands from the command palette', async () => {
   await expect(ExtensionHostCommands.getCommands('', 1)).resolves.toEqual([{ id: 'sample.visible', label: 'Sample: Visible' }])
 })


### PR DESCRIPTION
Hide commands contributed by disabled extensions from the command quick pick. Add focused unit coverage and a quick-pick e2e regression covering enabled and disabled states.