### PR TITLE
feature: drag hidden panel open

### DIFF
--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -496,7 +496,7 @@ const getWorkbenchBodyDom = (state: LayoutState) => {
 }
 
 export const getLayoutVirtualDom = (state: LayoutState) => {
-  const { titleBarVisible, titleBarId, panelSashVisible, panelVisible, widgetReferences = [], mountedViewletsBySource = {} } = state
+  const { titleBarVisible, titleBarId, panelSashVisible, widgetReferences = [], mountedViewletsBySource = {} } = state
   const dom: any[] = []
   let workbenchChildCount = 0
 
@@ -516,7 +516,7 @@ export const getLayoutVirtualDom = (state: LayoutState) => {
   workbenchChildCount++
   dom.push(...getWorkbenchBodyDom(state))
 
-  if (panelVisible && panelSashVisible) {
+  if (panelSashVisible) {
     workbenchChildCount++
     dom.push(getSashPanelDom())
   }

--- a/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetLayoutVirtualDom.test.ts
@@ -114,6 +114,40 @@ test('getLayoutVirtualDom does not render the preview close button when preview 
   expect(dom.some((node) => node.className?.includes('PreviewCloseButton'))).toBe(false)
 })
 
+test('getLayoutVirtualDom renders the panel sash when the panel is hidden', () => {
+  const state = {
+    activityBarVisible: false,
+    mainVisible: true,
+    mainId: 1,
+    panelSashVisible: true,
+    panelVisible: false,
+    panelId: -1,
+    previewSashVisible: false,
+    previewVisible: false,
+    previewId: -1,
+    secondarySideBarVisible: false,
+    secondarySideBarId: -1,
+    sideBarLocation: SideBarLocationType.Left,
+    sideBarSashVisible: false,
+    sideBarVisible: false,
+    sideBarId: -1,
+    statusBarVisible: true,
+    statusBarId: 2,
+    titleBarVisible: false,
+    titleBarId: -1,
+  }
+
+  // @ts-ignore
+  const dom = getLayoutVirtualDom(state)
+
+  expect(dom).toContainEqual(
+    expect.objectContaining({
+      className: 'Viewlet Sash SashHorizontal SashPanel',
+      onPointerDown: DomEventListenerFunctions.HandleSashPanelPointerDown,
+    }),
+  )
+})
+
 test.each([
   ['left', SideBarLocationType.Left],
   ['right', SideBarLocationType.Right],


### PR DESCRIPTION
Render the panel sash while the panel is hidden so users can drag upward from above the status bar to reveal the panel.