### PR TITLE
Expose file size to worker clients

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -199,6 +199,7 @@ export const commandMap = {
   'FileSystemMemory.writeFile': lazy('FileSystemMemory.writeFile'),
   'FileSystem.exists': lazy('FileSystem.exists'),
   'FileSystem.getBlob': lazy('FileSystem.getBlob'),
+  'FileSystem.getFileSize': lazy('FileSystem.getFileSize'),
   'FileSystem.getFolderSize': lazy('FileSystem.getFolderSize'),
   'FileSystem.getRealPath': lazy('FileSystem.getRealPath'),
   'FileSystem.mkdir': lazy('FileSystem.mkdir'),

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.ipc.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.ipc.js
@@ -7,6 +7,7 @@ export const Commands = {
   copy: FileSystem.copy,
   exists: FileSystem.exists,
   getBlob: FileSystem.getBlob,
+  getFileSize: FileSystem.getFileSize,
   getFolderSize: FileSystem.getFolderSize,
   getRealPath: FileSystem.getRealPath,
   isReadonly: FileSystem.isReadonly,

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystem.js
@@ -139,6 +139,15 @@ export const getFolderSize = async (uri) => {
   return fileSystem.getFolderSize(uri)
 }
 
+export const getFileSize = async (uri) => {
+  const protocol = GetProtocol.getProtocol(uri)
+  const fileSystem = await GetFileSystem.getFileSystem(protocol)
+  if (!fileSystem.getFileSize) {
+    throw new Error(`File size is not supported for ${protocol} files`)
+  }
+  return fileSystem.getFileSize(uri)
+}
+
 export const chmod = async (uri, permissions) => {
   const protocol = GetProtocol.getProtocol(uri)
   const fileSystem = await GetFileSystem.getFileSystem(protocol)

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemDisk.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemDisk.js
@@ -86,6 +86,11 @@ export const getRealPath = (path) => {
   return FileSystemWorker.invoke('FileSystem.getRealPath', /* path */ path)
 }
 
+export const getFileSize = (path) => {
+  path = toUri(path)
+  return FileSystemWorker.invoke('FileSystem.getFileSize', /* path */ path)
+}
+
 export const stat = (path) => {
   path = toUri(path)
   return FileSystemWorker.invoke('FileSystem.stat', /* path */ path)

--- a/packages/renderer-worker/test/FileSystem.test.ts
+++ b/packages/renderer-worker/test/FileSystem.test.ts
@@ -9,6 +9,7 @@ const writeFile = jest.fn()
 const remove = jest.fn()
 const isReadonly = jest.fn()
 const getBlobUrl = jest.fn()
+const getFileSize = jest.fn()
 
 FileSystemState.registerAll({
   test() {
@@ -18,7 +19,11 @@ FileSystemState.registerAll({
       remove,
       isReadonly,
       getBlobUrl,
+      getFileSize,
     }
+  },
+  unsupported() {
+    return {}
   },
 })
 
@@ -57,6 +62,18 @@ test('getBlobUrl forwards the media type', async () => {
 
   await expect(FileSystem.getBlobUrl('test://some-file.svg', 'image/svg+xml')).resolves.toBe('blob:https://example.com/image-id')
   expect(getBlobUrl).toHaveBeenCalledWith('test://some-file.svg', 'image/svg+xml')
+})
+
+test('getFileSize returns the size without reading the file', async () => {
+  getFileSize.mockReturnValue(1024)
+
+  await expect(FileSystem.getFileSize('test://some-file.txt')).resolves.toBe(1024)
+  expect(getFileSize).toHaveBeenCalledWith('test://some-file.txt')
+  expect(readFile).not.toHaveBeenCalled()
+})
+
+test('getFileSize reports unsupported providers', async () => {
+  await expect(FileSystem.getFileSize('unsupported://some-file.txt')).rejects.toThrow('File size is not supported for unsupported files')
 })
 
 test.skip('removeFile - error', async () => {

--- a/static/css/parts/ViewletMain.css
+++ b/static/css/parts/ViewletMain.css
@@ -25,3 +25,16 @@
   display: flex;
   flex-direction: column;
 }
+
+.EditorLargeFileWarningIcon {
+  color: var(--WarningForeground, #cca700);
+  flex-shrink: 0;
+  height: 48px;
+  width: 48px;
+  --MaskIconSize: 48px;
+}
+
+.EditorContentLargeFileActions {
+  display: flex;
+  gap: 8px;
+}


### PR DESCRIPTION
Routes file-size metadata through the renderer filesystem API without loading file contents, enabling workers to guard oversized file opens.