### PR TITLE
feature: edit more live component states

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-extension-detail.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-extension-detail.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-extension-detail'
+
+export const test: Test = async ({ Command, Editor, expect, ExtensionDetail, Locator, Main }) => {
+  await ExtensionDetail.open('builtin.theme-atom-one-dark')
+  await expect(Locator('.ExtensionDetailName')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'ExtensionDetail')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable ExtensionDetail component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, name: 'Live State Extension' }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.name !== 'Live State Extension') {
+    throw new Error(`Expected ExtensionDetail name to update, got ${updatedState.name}`)
+  }
+  await ExtensionDetail.open('builtin.theme-atom-one-dark')
+  await expect(Locator('.ExtensionDetailName')).toContainText('Live State Extension')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-extension-search.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-extension-search.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-extension-search'
+
+export const test: Test = async ({ Command, Editor, expect, ExtensionSearch, Locator, Main }) => {
+  await ExtensionSearch.open()
+  await expect(Locator('.Extensions [name="extensions"]')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'Extensions')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable Extensions component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, inputSource: 2, searchValue: '@disabled' }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.searchValue !== '@disabled') {
+    throw new Error(`Expected Extensions search value to update, got ${updatedState.searchValue}`)
+  }
+  await expect(Locator('.Extensions [name="extensions"]')).toHaveValue('@disabled')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-main-area.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-main-area.ts
@@ -1,0 +1,58 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-main-area'
+
+const waitForLoadedState = async (Editor) => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      const state = JSON.parse(await Editor.getText())
+      const activeGroup = state.layout.groups.find((group) => group.id === state.layout.activeGroupId)
+      const activeTab = activeGroup?.tabs.find((tab) => tab.id === activeGroup.activeTabId)
+      if (activeTab?.loadingState === 'loaded') {
+        return state
+      }
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error('Expected the Main component-state editor to finish loading')
+}
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'Main')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable Main component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = await waitForLoadedState(Editor)
+  const dragOverlay = { height: 40, width: 80, x: 10, y: 10 }
+  await Editor.setText(`${JSON.stringify({ ...state, dragOverlay }, null, 2)}\n`)
+  await new Promise((resolve) => setTimeout(resolve, 250))
+  if (!JSON.parse(await Editor.getText()).dragOverlay) {
+    throw new Error('Live Main state editor was overwritten before save')
+  }
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.dragOverlay?.width !== 80) {
+    throw new Error(`Expected Main drag overlay to update, got ${JSON.stringify(updatedState.dragOverlay)}`)
+  }
+  if (updatedState.maxOpenEditorGroups !== Infinity || updatedState.maxOpenEditors !== Infinity) {
+    throw new Error('Expected Main editor limits to survive the JSON round trip')
+  }
+  await expect(Locator('.Main .DragOverlay')).toBeVisible()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-source-control.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-source-control.ts
@@ -1,0 +1,45 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-source-control'
+
+export const test: Test = async ({ ActivityBar, Command, Editor, expect, Extension, FileSystem, Locator, Main, SideBar, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+  const extensionUri = new URL('../fixtures/sample.source-control-save-badge', import.meta.url).toString().replace(/\/$/, '')
+  await Extension.addWebExtension(extensionUri)
+  await Extension.enableWorkspace('sample.source-control-save-badge')
+  await ActivityBar.handleExtensionsChanged()
+  const activationResult = await Command.execute('ExtensionManagement.activateByEvent', 'onSourceControl:memfs', '', 0)
+  if (activationResult.error) {
+    throw activationResult.error
+  }
+  await Command.execute('Layout.handleExtensionsChanged')
+  await SideBar.open('Source Control')
+  await expect(Locator('.SideBar textarea[name="SourceControlInput"]')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'Source Control')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable Source Control component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, inputSource: 2, inputValue: 'live state commit' }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.inputValue !== 'live state commit') {
+    throw new Error(`Expected Source Control input value to update, got ${updatedState.inputValue}`)
+  }
+  await expect(Locator('.SideBar textarea[name="SourceControlInput"]')).toHaveValue('live state commit')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-status-bar.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-status-bar.ts
@@ -1,0 +1,39 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-status-bar'
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'StatusBar')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable StatusBar component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  const statusBarItemsLeft = [
+    {
+      ariaLabel: 'Live component state',
+      elements: [{ type: 'text', value: 'Live State' }],
+      name: 'component.state.test',
+      tooltip: 'Live component state',
+    },
+  ]
+  await Editor.setText(`${JSON.stringify({ ...state, statusBarItemsLeft }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.statusBarItemsLeft[0]?.name !== 'component.state.test') {
+    throw new Error(`Expected StatusBar items to update, got ${JSON.stringify(updatedState.statusBarItemsLeft)}`)
+  }
+  await expect(Locator('.StatusBarItem[name="component.state.test"]')).toHaveText('Live State')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-text-search.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-text-search.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-text-search'
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main, SideBar }) => {
+  await SideBar.open('Search')
+  await expect(Locator('.SideBar textarea[name="SearchValue"]')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'Search')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable Search component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, inputSource: 2, value: 'live state query' }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.value !== 'live state query') {
+    throw new Error(`Expected Search value to update, got ${updatedState.value}`)
+  }
+  await expect(Locator('.SideBar textarea[name="SearchValue"]')).toHaveValue('live state query')
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-title-bar.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-title-bar.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-title-bar'
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'TitleBar')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable TitleBar component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, title: 'Live State Title' }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.title !== 'Live State Title') {
+    throw new Error(`Expected TitleBar title to update, got ${updatedState.title}`)
+  }
+  await expect(Locator('.TitleBarTitle')).toHaveText('Live State Title')
+}

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -3,9 +3,10 @@ import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
-const liveComponentStatePattern = /^live-component-state:\/\/\/(\d+)\.json$/
+const liveComponentStatePattern = /^live-component-state:\/\/\/(\d+(?:\.\d+)?)\.json$/
 const editorUidsByComponentUid = new Map()
 const componentUidByEditorUid = new Map()
+const mainEditorUidsAwaitingInitialRefresh = new Set()
 const refreshes = new Map()
 
 const getUid = (instance) => instance.state?.uid ?? instance.renderedState?.uid
@@ -27,6 +28,9 @@ const subscribe = (instance) => {
   }
   editorUidsByComponentUid.set(componentUid, editorUidsByComponentUid.get(componentUid)?.add(editorUid) || new Set([editorUid]))
   componentUidByEditorUid.set(editorUid, componentUid)
+  if (ViewletStates.getByUid(componentUid)?.moduleId === 'Main') {
+    mainEditorUidsAwaitingInitialRefresh.add(editorUid)
+  }
 }
 
 const unsubscribeEditor = (editorUid) => {
@@ -35,6 +39,7 @@ const unsubscribeEditor = (editorUid) => {
     return
   }
   componentUidByEditorUid.delete(editorUid)
+  mainEditorUidsAwaitingInitialRefresh.delete(editorUid)
   const editorUids = editorUidsByComponentUid.get(componentUid)
   editorUids?.delete(editorUid)
   if (editorUids?.size === 0) {
@@ -50,7 +55,32 @@ const unsubscribeComponent = (componentUid) => {
   editorUidsByComponentUid.delete(componentUid)
   for (const editorUid of editorUids) {
     componentUidByEditorUid.delete(editorUid)
+    mainEditorUidsAwaitingInitialRefresh.delete(editorUid)
   }
+}
+
+const getEditorTabStates = async () => {
+  const mainInstance = ViewletStates.getInstance('Main')
+  if (!mainInstance || typeof mainInstance.factory.getComponentState !== 'function') {
+    return new Map()
+  }
+  const mainState = await mainInstance.factory.getComponentState(mainInstance.state)
+  const groups = mainState?.layout?.groups
+  if (!Array.isArray(groups)) {
+    return new Map()
+  }
+  const editorTabStates = new Map()
+  for (const group of groups) {
+    for (const tab of group.tabs || []) {
+      if (typeof tab.editorUid === 'number') {
+        editorTabStates.set(tab.editorUid, {
+          active: Boolean(group.focused && group.activeTabId === tab.id),
+          dirty: Boolean(tab.isDirty),
+        })
+      }
+    }
+  }
+  return editorTabStates
 }
 
 const runRefreshes = async (componentUid, refresh) => {
@@ -58,7 +88,19 @@ const runRefreshes = async (componentUid, refresh) => {
     while (refresh.pending) {
       refresh.pending = false
       const editorUids = [...(editorUidsByComponentUid.get(componentUid) || [])]
-      await Promise.allSettled(editorUids.map((editorUid) => Viewlet.reload(editorUid)))
+      const editorTabStates = await getEditorTabStates()
+      const isMainComponent = ViewletStates.getByUid(componentUid)?.moduleId === 'Main'
+      const editorUidsToRefresh = editorUids.filter((editorUid) => {
+        if (mainEditorUidsAwaitingInitialRefresh.has(editorUid)) {
+          return true
+        }
+        const tabState = editorTabStates.get(editorUid)
+        return !tabState?.dirty && !(isMainComponent && tabState?.active)
+      })
+      await Promise.allSettled(editorUidsToRefresh.map((editorUid) => Viewlet.reload(editorUid)))
+      for (const editorUid of editorUidsToRefresh) {
+        mainEditorUidsAwaitingInitialRefresh.delete(editorUid)
+      }
     }
   } finally {
     refreshes.delete(componentUid)

--- a/packages/renderer-worker/src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionDetail/ViewletExtensionDetail.ipc.ts
@@ -1,7 +1,7 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
-  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, wrapExtensionDetailCommand,
+  Commands, create, Css, dispose, Events, focus, getCommands, getComponentState, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
+  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent,
+  menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, setComponentState, Variables, wrapExtensionDetailCommand,
 } = createWorkerViewlet({ workerId: 'extensionDetail' })

--- a/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletExtensions/ViewletExtensions.ipc.js
@@ -1,7 +1,7 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
+  Commands, Css, Events, Variables, create, dispose, focus, getCommands, getComponentState, getKeyBindings, getMenus, getQuickPickMenuEntries,
   getStorageKey, getTitle, handleExtensionsChanged, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
-  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
+  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, setComponentState,
 } = createWorkerViewlet({ workerId: 'extensionSearch' })

--- a/packages/renderer-worker/src/parts/ViewletMain/ViewletMain.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletMain/ViewletMain.ipc.js
@@ -9,6 +9,7 @@ export const {
   dispose,
   focus,
   getCommands,
+  getComponentState,
   getKeyBindings,
   getMenus,
   getQuickPickMenuEntries,
@@ -31,5 +32,6 @@ export const {
   renderTitle,
   resize,
   saveState,
+  setComponentState,
   saveWithoutFormatting,
 } = createWorkerViewlet({ workerId: 'mainArea' })

--- a/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearch.ipc.ts
+++ b/packages/renderer-worker/src/parts/ViewletSearch/ViewletSearch.ipc.ts
@@ -1,7 +1,7 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, focus, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
-  getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
-  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, wrapTextSearchCommand,
+  Commands, create, Css, dispose, Events, focus, getCommands, getComponentState, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
+  getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload, loadContent,
+  menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, setComponentState, Variables, wrapTextSearchCommand,
 } = createWorkerViewlet({ workerId: 'textSearchView' })

--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -8,6 +8,7 @@ import * as Workspace from '../Workspace/Workspace.js'
 import * as Platform from '../Platform/Platform.js'
 import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as WrapSourceControlCommand from '../WrapSourceControlCommand/WrapSourceControlCommand.ts'
 
 // TODO when accept input is invoked multiple times, it should not lead to errors
 
@@ -89,6 +90,17 @@ export const focus = (state) => {
     ...state,
     commands: [['Viewlet.focusSelector', '[name="SourceControlInput"]']],
   }
+}
+
+export const getComponentState = async (state) => {
+  const { uid } = state
+  return SourceControlWorker.invoke('SourceControl.getComponentState', uid)
+}
+
+export const setComponentState = async (state, componentState) => {
+  const { uid } = state
+  await SourceControlWorker.invoke('SourceControl.setComponentState', uid, componentState)
+  return WrapSourceControlCommand.renderPendingSourceControl(state)
 }
 
 const updateIcon = (displayItem) => {

--- a/packages/renderer-worker/src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletStatusBar/ViewletStatusBar.ipc.js
@@ -13,6 +13,7 @@ export const {
   create,
   dispose,
   getCommands,
+  getComponentState,
   getKeyBindings,
   hasDirectRender,
   hasFunctionalEvents,
@@ -26,6 +27,7 @@ export const {
   renderEventListeners,
   resize,
   saveState,
+  setComponentState,
 } = createWorkerViewlet({ workerId: 'statusBar' })
 
 export * from './ViewletStatusBarMenuEntries.js'

--- a/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBar.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletTitleBar/ViewletTitleBar.ipc.js
@@ -2,6 +2,6 @@ import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.
 
 export const {
   Commands, Css, Events, Variables, create, dispose, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries, getStorageKey,
-  getTitle, handleFocusChange, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
-  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState,
+  getComponentState, getTitle, handleFocusChange, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
+  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, saveState, setComponentState,
 } = createWorkerViewlet({ workerId: 'titleBar' })

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -237,13 +237,17 @@
         "saveState": { "name": "TextSearch.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "terminate": { "name": "TextSearch.terminate", "parameters": [] },
         "getCommandIds": { "name": "TextSearch.getCommandIds", "parameters": [] },
+        "getComponentState": { "name": "TextSearch.getComponentState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getKeyBindings": { "name": "TextSearch.getKeyBindings", "parameters": [] },
         "getMenuEntryIds": { "name": "TextSearch.getMenuEntryIds", "parameters": [] },
         "getMenuEntries": {
           "name": "TextSearch.getMenuEntries",
           "parameters": [{ "source": "argument", "name": "args", "spread": true }]
         },
-        "renderEventListeners": { "name": "TextSearch.renderEventListeners", "parameters": [] }
+        "renderEventListeners": { "name": "TextSearch.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "TextSearch.setComponentState", "parameters": [
+          { "source": "state", "name": "uid" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "outputs": [{ "stateField": "actionsDom", "hotReload": false, "method": { "name": "TextSearch.renderActions", "parameters": [{ "source": "state", "name": "uid" }] } }],
       "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
@@ -721,6 +725,7 @@
         "saveState": { "name": "ExtensionDetail.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "terminate": { "name": "ExtensionDetail.terminate", "parameters": [] },
         "getCommandIds": { "name": "ExtensionDetail.getCommandIds", "parameters": [] },
+        "getComponentState": { "name": "ExtensionDetail.getComponentState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getKeyBindings": { "name": "ExtensionDetail.getKeyBindings", "parameters": [] },
         "getMenuEntryIds": { "name": "ExtensionDetail.getMenuIds", "parameters": [] },
         "getMenuEntries": {
@@ -728,7 +733,10 @@
           "parameters": [{ "source": "argument", "name": "args", "spread": true }]
         },
         "getTitle": { "name": "ExtensionDetail.renderTitle", "parameters": [{ "source": "state", "name": "uid" }] },
-        "renderEventListeners": { "name": "ExtensionDetail.renderEventListeners", "parameters": [] }
+        "renderEventListeners": { "name": "ExtensionDetail.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "ExtensionDetail.setComponentState", "parameters": [
+          { "source": "state", "name": "uid" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "always"
@@ -784,10 +792,14 @@
         "saveState": { "name": "SearchExtensions.saveState", "parameters": [{ "source": "state", "name": "id" }] },
         "terminate": { "name": "SearchExtensions.terminate", "parameters": [] },
         "getCommandIds": { "name": "SearchExtensions.getCommandIds", "parameters": [] },
+        "getComponentState": { "name": "SearchExtensions.getComponentState", "parameters": [{ "source": "state", "name": "id" }] },
         "getKeyBindings": { "name": "SearchExtensions.getKeyBindings", "parameters": [] },
         "getMenuEntryIds": { "name": "SearchExtensions.getMenuIds", "parameters": [] },
         "getMenuEntries": { "name": "SearchExtensions.getMenuEntries2", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
-        "renderEventListeners": { "name": "SearchExtensions.renderEventListeners", "parameters": [] }
+        "renderEventListeners": { "name": "SearchExtensions.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "SearchExtensions.setComponentState", "parameters": [
+          { "source": "state", "name": "id" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "extraCommands": [{ "name": "handleExtensionsChanged", "method": "handleExtensionsChanged" }],
       "title": "Extensions: Installed",
@@ -1078,12 +1090,16 @@
         },
         "saveState": { "name": "MainArea.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getCommandIds": { "name": "MainArea.getCommandIds", "parameters": [] },
+        "getComponentState": { "name": "MainArea.getComponentState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getMenuEntryIds": { "name": "MainArea.getMenuIds", "parameters": [] },
         "getMenuEntries": {
           "name": "MainArea.getMenuEntries",
           "parameters": [{ "source": "argument", "name": "args", "spread": true }]
         },
-        "renderEventListeners": { "name": "MainArea.renderEventListeners", "parameters": [] }
+        "renderEventListeners": { "name": "MainArea.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "MainArea.setComponentState", "parameters": [
+          { "source": "state", "name": "uid" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }
@@ -1745,7 +1761,11 @@
         "saveState": { "name": "StatusBar.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "terminate": { "name": "StatusBar.terminate", "parameters": [] },
         "getCommandIds": { "name": "StatusBar.getCommandIds", "parameters": [] },
-        "renderEventListeners": { "name": "StatusBar.renderEventListeners", "parameters": [] }
+        "getComponentState": { "name": "StatusBar.getComponentState", "parameters": [{ "source": "state", "name": "uid" }] },
+        "renderEventListeners": { "name": "StatusBar.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "StatusBar.setComponentState", "parameters": [
+          { "source": "state", "name": "uid" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true },
       "renderComparison": "commands"
@@ -1835,10 +1855,14 @@
         "resize": { "name": "TitleBar.resize", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "dimensions" }] },
         "terminate": { "name": "TitleBar.terminate", "parameters": [] },
         "getCommandIds": { "name": "TitleBar.getCommandIds", "parameters": [] },
+        "getComponentState": { "name": "TitleBar.getComponentState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getKeyBindings": { "name": "TitleBar.getKeyBindings", "parameters": [] },
         "getMenuEntryIds": { "name": "TitleBar.getMenuIds", "parameters": [] },
         "getMenuEntries": { "name": "TitleBar.getMenuEntries2", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
-        "renderEventListeners": { "name": "TitleBar.renderEventListeners", "parameters": [] }
+        "renderEventListeners": { "name": "TitleBar.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "TitleBar.setComponentState", "parameters": [
+          { "source": "state", "name": "uid" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "capabilities": { "directRender": true, "events": true, "render": true, "resize": true, "rootRender": true }
     }

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -139,6 +139,66 @@ test('refreshes an open live component state editor when the component rerenders
   expect(Viewlet.reload).toHaveBeenCalledWith(9)
 })
 
+test('refreshes an open live component state editor with a decimal component uid', async () => {
+  const componentUid = 0.5
+  const componentState = { focusedIndex: 0, uid: componentUid }
+  const editorState = { uid: 9, uri: `live-component-state:///${componentUid}.json` }
+  ViewletStates.set(componentUid, { factory: {}, moduleId: 'ExtensionDetail', renderedState: componentState, state: componentState })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+
+  ViewletStates.setRenderedState(componentUid, { focusedIndex: 1, uid: componentUid })
+  await ComponentState.waitForRefreshes()
+
+  expect(Viewlet.reload).toHaveBeenCalledWith(9)
+})
+
+test('does not overwrite a dirty live component state editor when the component rerenders', async () => {
+  const componentState = { focusedIndex: 0, uid: 2 }
+  const editorState = { uid: 9, uri: 'live-component-state:///2.json' }
+  const mainRendererState = { commands: [], uid: 3 }
+  const mainComponentState = {
+    layout: {
+      groups: [{ tabs: [{ editorUid: 9, isDirty: true }] }],
+    },
+    uid: 3,
+  }
+  ViewletStates.set(2, { factory: {}, moduleId: 'Explorer', renderedState: componentState, state: componentState })
+  ViewletStates.set(3, {
+    factory: { getComponentState: jest.fn(async () => mainComponentState), hasFunctionalRender: true },
+    moduleId: 'Main',
+    renderedState: mainRendererState,
+    state: mainRendererState,
+  })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+
+  ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
+  await ComponentState.waitForRefreshes()
+
+  expect(Viewlet.reload).not.toHaveBeenCalled()
+})
+
+test('refreshes Main state once after opening, then preserves its active self-referential editor', async () => {
+  const mainRendererState = { commands: [], uid: 3 }
+  const editorState = { uid: 9, uri: 'live-component-state:///3.json' }
+  const mainComponentState = {
+    layout: {
+      groups: [{ activeTabId: 4, focused: true, tabs: [{ editorUid: 9, id: 4, isDirty: false }] }],
+    },
+    uid: 3,
+  }
+  const factory = { getComponentState: jest.fn(async () => mainComponentState), hasFunctionalRender: true }
+  ViewletStates.set(3, { factory, moduleId: 'Main', renderedState: mainRendererState, state: mainRendererState })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+
+  ViewletStates.setRenderedState(3, { commands: [], uid: 3 })
+  await ComponentState.waitForRefreshes()
+  ViewletStates.setRenderedState(3, { commands: [], uid: 3 })
+  await ComponentState.waitForRefreshes()
+
+  expect(Viewlet.reload).toHaveBeenCalledTimes(1)
+  expect(Viewlet.reload).toHaveBeenCalledWith(9)
+})
+
 test('coalesces rerenders while a live component state editor is refreshing', async () => {
   let finishReload
   jest.mocked(Viewlet.reload).mockImplementationOnce(
@@ -155,6 +215,7 @@ test('coalesces rerenders while a live component state editor is refreshing', as
   ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
   ViewletStates.setRenderedState(2, { focusedIndex: 2, uid: 2 })
   ViewletStates.setRenderedState(2, { focusedIndex: 3, uid: 2 })
+  await Promise.resolve()
   finishReload()
   await ComponentState.waitForRefreshes()
 

--- a/packages/renderer-worker/test/ViewletModuleMap.test.ts
+++ b/packages/renderer-worker/test/ViewletModuleMap.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
-import * as ViewletModuleMap from '../src/parts/ViewletModuleMap/ViewletModuleMap.js'
 import * as ViewletModuleId from '../src/parts/ViewletModuleId/ViewletModuleId.js'
+import * as ViewletModuleMap from '../src/parts/ViewletModuleMap/ViewletModuleMap.js'
 
 test('diff editor uses worker-backed module', async () => {
   const module = await ViewletModuleMap.map[ViewletModuleId.DiffEditor]()
@@ -31,8 +31,19 @@ test('file watcher explorer uses worker-backed module', async () => {
   expect(typeof module.getKeyBindings).toBe('function')
 })
 
-test('explorer exposes live component state access', async () => {
-  const module = await ViewletModuleMap.map[ViewletModuleId.Explorer]()
+const componentStateViewlets = [
+  ViewletModuleId.Explorer,
+  ViewletModuleId.ExtensionDetail,
+  ViewletModuleId.Extensions,
+  ViewletModuleId.Main,
+  ViewletModuleId.Search,
+  ViewletModuleId.SourceControl,
+  ViewletModuleId.StatusBar,
+  ViewletModuleId.TitleBar,
+]
+
+test.each(componentStateViewlets)('viewlet %s exposes live component state access', async (moduleId) => {
+  const module = await ViewletModuleMap.map[moduleId]()
 
   expect(typeof module.getComponentState).toBe('function')
   expect(typeof module.setComponentState).toBe('function')

--- a/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
@@ -97,3 +97,34 @@ test('registers the extension contribution refresh command', async () => {
 
   expect(commands.handleExtensionsChanged).toBe(ViewletSourceControl.handleExtensionsChanged)
 })
+
+test('gets and sets authoritative source control component state', async () => {
+  const rendererState = {
+    badgeCount: 0,
+    commands: [],
+    uid: 42,
+  }
+  const componentState = { id: 42, inputValue: 'message' }
+  sourceControlWorkerInvoke.mockImplementation((method): unknown => {
+    switch (method) {
+      case 'SourceControl.diff2':
+        return [1]
+      case 'SourceControl.getBadgeCount':
+        return 0
+      case 'SourceControl.getComponentState':
+        return componentState
+      case 'SourceControl.render2':
+        return [['Viewlet.setDom2', 42, ['div']]]
+      case 'SourceControl.setComponentState':
+        return undefined
+      default:
+        throw new Error(`unexpected method ${method}`)
+    }
+  })
+
+  await expect(ViewletSourceControl.getComponentState(rendererState)).resolves.toBe(componentState)
+  await expect(ViewletSourceControl.setComponentState(rendererState, componentState)).resolves.toEqual({
+    ...rendererState,
+    commands: [['Viewlet.setDom2', 42, ['div']]],
+  })
+})


### PR DESCRIPTION
## Summary

- expose authoritative live component state access for Title Bar, Status Bar, Text Search, Source Control, Extension Search, Extension Detail, and Main Area
- preserve dirty live-state documents and handle decimal component UIDs, including Main Area self-editing
- add browser end-to-end coverage that edits, saves, and verifies the rendered state of every added component

## Testing

- `npm run lint`
- renderer-worker type-check and 57 focused renderer tests
- extension-host-worker-tests type-check
- `npm run build:static`
- `npm run build:server`
- seven targeted component-state editing e2e tests