### PR TITLE
feature: expose extension view component state

### DIFF
--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -116,6 +116,9 @@ const isEditable = (instance) => {
   if (!isWorkerBacked(instance)) {
     return true
   }
+  if (typeof instance.factory.isComponentStateAvailable === 'function') {
+    return instance.factory.isComponentStateAvailable(instance.state)
+  }
   return typeof instance.factory.getComponentState === 'function' && typeof instance.factory.setComponentState === 'function'
 }
 

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -22,6 +22,7 @@ interface CreateViewInstanceSuccess {
   readonly eventListeners?: readonly unknown[]
   readonly ok: true
   readonly result: ViewRenderResult
+  readonly stateful?: boolean
 }
 
 interface CreateViewInstanceError {
@@ -172,6 +173,7 @@ export const create = (
     kind: '',
     parentUid,
     patches: [],
+    stateful: false,
     title: '',
     uid: id,
     uri,
@@ -220,6 +222,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
       cssId,
       eventListeners,
       kind: view.kind,
+      stateful: createResult.ok === true && createResult.stateful === true,
     }
     return {
       ...newState,
@@ -296,6 +299,28 @@ export const rerender = async (state: ViewletExtensionViewState): Promise<Viewle
   }
   const result = await ExtensionManagementWorker.invoke('Extensions.renderViewInstance', state.viewId, state.uid, assetDir, getPlatform())
   const newState = renderVirtualDomResult(state, result as ViewRenderResult)
+  return {
+    ...newState,
+    actionsDom: await getActionsDom(newState),
+  }
+}
+
+export const isComponentStateAvailable = (state: ViewletExtensionViewState): boolean => state.kind === 'virtualDom' && state.stateful
+
+export const getComponentState = async (state: ViewletExtensionViewState): Promise<unknown> => {
+  return ExtensionManagementWorker.invoke('Extensions.getViewInstanceState', state.viewId, state.uid, assetDir, getPlatform())
+}
+
+export const setComponentState = async (state: ViewletExtensionViewState, componentState: unknown): Promise<ViewletExtensionViewState> => {
+  const result = await ExtensionManagementWorker.invoke(
+    'Extensions.setViewInstanceState',
+    state.viewId,
+    state.uid,
+    componentState,
+    assetDir,
+    getPlatform(),
+  )
+  const newState = renderVirtualDomResult(state, result as ViewRenderResult | undefined)
   return {
     ...newState,
     actionsDom: await getActionsDom(newState),

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -14,6 +14,7 @@ export interface ViewletExtensionViewState {
   readonly kind: string
   readonly parentUid?: number
   readonly patches: readonly unknown[]
+  readonly stateful: boolean
   readonly title: string
   readonly uid: number
   readonly uri: string

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -58,6 +58,26 @@ test('lists native and supported worker-backed components once', () => {
   ])
 })
 
+test('uses a worker-backed component state availability check', () => {
+  const rendererState = { stateful: true, uid: 4 }
+  const isComponentStateAvailable = jest.fn((_state: typeof rendererState) => true)
+  ViewletStates.set(4, {
+    factory: {
+      getComponentState: jest.fn(),
+      hasFunctionalRender: true,
+      isComponentStateAvailable,
+      name: 'ExtensionView',
+      setComponentState: jest.fn(),
+    },
+    moduleId: 'ExtensionView',
+    renderedState: rendererState,
+    state: rendererState,
+  })
+
+  expect(ComponentState.getComponents()).toEqual([{ editable: true, moduleId: 'ExtensionView', uid: 4 }])
+  expect(isComponentStateAvailable).toHaveBeenCalledWith(rendererState)
+})
+
 test('gets renderer-native state', async () => {
   const state = { uid: 1, value: 'native' }
   ViewletStates.set(1, { factory: {}, moduleId: 'Layout', renderedState: state, state })

--- a/packages/renderer-worker/test/ViewletExtensionView.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionView.test.ts
@@ -31,6 +31,7 @@ const createState = () => {
     iframeSrc: '',
     kind: 'virtualDom',
     patches: [],
+    stateful: false,
     title: 'Testing',
     uid: 1,
     uri: 'sample.views.testing',
@@ -119,6 +120,36 @@ test('loadContent uses rendered title for virtual dom views', async () => {
   })
 })
 
+test('loadContent exposes managed extension view state', async () => {
+  const invoke = ExtensionManagementWorker.invoke as any
+  invoke.mockImplementation((method) => {
+    if (method === 'Extensions.getViews') {
+      return [{ id: 'sample.views.testing', kind: 'virtualDom', title: 'Testing' }]
+    }
+    if (method === 'Extensions.getAllExtensions') {
+      return []
+    }
+    if (method === 'Extensions.createViewInstance') {
+      return {
+        ok: true,
+        result: { dom: [], type: 'setDom' },
+        stateful: true,
+      }
+    }
+    if (method === 'Extensions.getViewActionsDom') {
+      return undefined
+    }
+    if (method === 'Extensions.getViewActions') {
+      return []
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  const state = await ViewletExtensionView.loadContent(createState(), undefined)
+
+  expect(ViewletExtensionView.isComponentStateAvailable(state)).toBe(true)
+})
+
 test('sidebar dom uses custom view title instead of id', () => {
   const dom = GetSideBarDom.getSideBarDom({
     actionsUid: -1,
@@ -180,6 +211,45 @@ test('rerender requests virtual dom patches from extension management worker', a
   })
 
   expect(invoke).toHaveBeenCalledWith('Extensions.renderViewInstance', 'sample.views.testing', 1, expect.any(String), expect.any(Number))
+})
+
+test('gets managed extension view state', async () => {
+  const componentState = { count: 1 }
+  const invoke = ExtensionManagementWorker.invoke as any
+  invoke.mockResolvedValue(componentState)
+
+  await expect(ViewletExtensionView.getComponentState(createState())).resolves.toBe(componentState)
+
+  expect(invoke).toHaveBeenCalledWith('Extensions.getViewInstanceState', 'sample.views.testing', 1, expect.any(String), expect.any(Number))
+})
+
+test('sets managed extension view state and returns the renderer state', async () => {
+  const componentState = { count: 2 }
+  const patches = [['setText', 0, '2']]
+  const invoke = ExtensionManagementWorker.invoke as any
+  invoke.mockImplementation((method) => {
+    if (method === 'Extensions.setViewInstanceState') {
+      return { patches, type: 'setPatches' }
+    }
+    if (method === 'Extensions.getViewActionsDom') {
+      return undefined
+    }
+    if (method === 'Extensions.getViewActions') {
+      return []
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+
+  await expect(ViewletExtensionView.setComponentState(createState(), componentState)).resolves.toMatchObject({ patches })
+
+  expect(invoke).toHaveBeenCalledWith(
+    'Extensions.setViewInstanceState',
+    'sample.views.testing',
+    1,
+    componentState,
+    expect.any(String),
+    expect.any(Number),
+  )
 })
 
 test('rerender updates the title rendered by the parent sidebar', async () => {


### PR DESCRIPTION
Makes managed extension-contributed virtual DOM views available to Component State.

- marks only stateful extension views editable
- reads managed state through the extension host
- replaces managed state and applies returned render patches
- keeps legacy extension views visible but non-editable
- adds renderer unit coverage