### PR TITLE
fix: preserve component state editor scroll

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-explorer.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-explorer.ts
@@ -45,6 +45,13 @@ export const test: Test = async ({ Command, Editor, expect, Explorer, FileSystem
   await waitForFocusedIndex(Editor, 1)
 
   const state = JSON.parse(await Editor.getText())
+  await Editor.setDeltaY(120)
+  const firstVisibleLine = Locator('.Editor .LineNumber').first()
+  await expect(firstVisibleLine).not.toHaveText('1')
+  await Command.execute('ComponentState.setState', explorer.uid, state)
+  await new Promise((resolve) => setTimeout(resolve, 250))
+  await expect(firstVisibleLine).not.toHaveText('1')
+
   await Editor.setText(`${JSON.stringify({ ...state, focusedIndex: 0 }, null, 2)}\n`)
   await Main.save()
 

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -1,3 +1,4 @@
+import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletManager from '../ViewletManager/ViewletManager.js'
@@ -83,6 +84,18 @@ const getEditorTabStates = async () => {
   return editorTabStates
 }
 
+const reloadEditorIfContentChanged = async (editorUid, content) => {
+  try {
+    const currentContent = await EditorWorker.invoke('Editor.getText', editorUid)
+    if (currentContent === content) {
+      return
+    }
+  } catch {
+    // Fall back to reloading when the current editor content cannot be read.
+  }
+  await Viewlet.reload(editorUid)
+}
+
 const runRefreshes = async (componentUid, refresh) => {
   try {
     while (refresh.pending) {
@@ -97,7 +110,21 @@ const runRefreshes = async (componentUid, refresh) => {
         const tabState = editorTabStates.get(editorUid)
         return !tabState?.dirty && !(isMainComponent && tabState?.active)
       })
-      await Promise.allSettled(editorUidsToRefresh.map((editorUid) => Viewlet.reload(editorUid)))
+      if (editorUidsToRefresh.length === 0) {
+        continue
+      }
+      let content
+      try {
+        const componentState = await getState(componentUid)
+        content = `${JSON.stringify(componentState, null, 2)}\n`
+      } catch {
+        content = undefined
+      }
+      await Promise.allSettled(
+        editorUidsToRefresh.map((editorUid) =>
+          content === undefined ? Viewlet.reload(editorUid) : reloadEditorIfContentChanged(editorUid, content),
+        ),
+      )
       for (const editorUid of editorUidsToRefresh) {
         mainEditorUidsAwaitingInitialRefresh.delete(editorUid)
       }

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
 
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({
+  invoke: jest.fn(),
+}))
+
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
   invoke: jest.fn(),
 }))
@@ -13,6 +17,7 @@ jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
   reload: jest.fn(),
 }))
 
+const EditorWorker = await import('../src/parts/EditorWorker/EditorWorker.ts')
 const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
@@ -20,6 +25,7 @@ const ComponentState = await import('../src/parts/ComponentState/ComponentState.
 
 beforeEach(() => {
   jest.resetAllMocks()
+  jest.mocked(EditorWorker.invoke).mockResolvedValue('')
   ViewletStates.reset()
 })
 
@@ -159,6 +165,20 @@ test('refreshes an open live component state editor when the component rerenders
   expect(Viewlet.reload).toHaveBeenCalledWith(9)
 })
 
+test('does not refresh an open live component state editor when its content is unchanged', async () => {
+  const componentState = { focusedIndex: 0, uid: 2 }
+  const editorState = { uid: 9, uri: 'live-component-state:///2.json' }
+  ViewletStates.set(2, { factory: {}, moduleId: 'Explorer', renderedState: componentState, state: componentState })
+  ViewletStates.set(9, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+  jest.mocked(EditorWorker.invoke).mockResolvedValue(`${JSON.stringify(componentState, null, 2)}\n`)
+
+  ViewletStates.setRenderedState(2, { ...componentState })
+  await ComponentState.waitForRefreshes()
+
+  expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.getText', 9)
+  expect(Viewlet.reload).not.toHaveBeenCalled()
+})
+
 test('refreshes an open live component state editor with a decimal component uid', async () => {
   const componentUid = 0.5
   const componentState = { focusedIndex: 0, uid: componentUid }
@@ -235,7 +255,7 @@ test('coalesces rerenders while a live component state editor is refreshing', as
   ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
   ViewletStates.setRenderedState(2, { focusedIndex: 2, uid: 2 })
   ViewletStates.setRenderedState(2, { focusedIndex: 3, uid: 2 })
-  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
   finishReload()
   await ComponentState.waitForRefreshes()
 


### PR DESCRIPTION
Avoid reloading live component-state JSON editors when the serialized state is unchanged. This preserves editor scroll position and adds focused unit and end-to-end regression coverage.