### PR TITLE
feature: scope viewlet ownership to applications

### DIFF
--- a/packages/renderer-worker/src/parts/ApplicationRegistry/ApplicationRegistry.ts
+++ b/packages/renderer-worker/src/parts/ApplicationRegistry/ApplicationRegistry.ts
@@ -1,0 +1,82 @@
+export interface Application {
+  readonly id: string
+  readonly layoutUid: number
+  readonly workspaceUri: string
+  readonly workspacePath: string
+  readonly href: string
+}
+
+const applications = new Map<string, Application>()
+const owners = new Map<number, string>()
+const applicationUids = new Map<string, Set<number>>()
+const savedStates = new Map<string, Map<string | number, unknown>>()
+
+export const get = (applicationId: string): Application => {
+  const application = applications.get(applicationId)
+  if (!application) {
+    throw new Error(`Application not found: ${applicationId}`)
+  }
+  return application
+}
+
+export const getOwner = (uid: number): string | undefined => owners.get(uid)
+
+export const own = (applicationId: string, uid: number): void => {
+  get(applicationId)
+  if (!Number.isFinite(uid) || uid <= 0) {
+    throw new Error(`Invalid component uid: ${uid}`)
+  }
+  const owner = owners.get(uid)
+  if (owner !== undefined && owner !== applicationId) {
+    throw new Error(`Component ${uid} already belongs to application ${owner}`)
+  }
+  owners.set(uid, applicationId)
+  applicationUids.get(applicationId)!.add(uid)
+}
+
+export const create = (application: Application): void => {
+  if (!application.id || applications.has(application.id)) {
+    throw new Error(`Invalid or duplicate application: ${application.id}`)
+  }
+  if (!Number.isFinite(application.layoutUid) || application.layoutUid <= 0 || owners.has(application.layoutUid)) {
+    throw new Error(`Invalid or duplicate layout uid: ${application.layoutUid}`)
+  }
+  applications.set(application.id, Object.freeze({ ...application }))
+  applicationUids.set(application.id, new Set())
+  savedStates.set(application.id, new Map())
+  own(application.id, application.layoutUid)
+}
+
+export const getUids = (applicationId: string): readonly number[] => {
+  get(applicationId)
+  return [...applicationUids.get(applicationId)!]
+}
+
+export const release = (uid: number): void => {
+  const owner = owners.get(uid)
+  if (owner === undefined) {
+    return
+  }
+  owners.delete(uid)
+  applicationUids.get(owner)?.delete(uid)
+}
+
+export const getSavedState = (applicationId: string, key: string | number): unknown => {
+  get(applicationId)
+  return structuredClone(savedStates.get(applicationId)!.get(key))
+}
+
+export const setSavedState = (applicationId: string, key: string | number, value: unknown): void => {
+  get(applicationId)
+  savedStates.get(applicationId)!.set(key, structuredClone(value))
+}
+
+// The caller disposes the application's components before removing its ownership.
+export const remove = (applicationId: string): void => {
+  for (const uid of applicationUids.get(applicationId) || []) {
+    owners.delete(uid)
+  }
+  applicationUids.delete(applicationId)
+  savedStates.delete(applicationId)
+  applications.delete(applicationId)
+}

--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -1,4 +1,5 @@
 import * as AdjustCommands from '../AdjustCommands/AdjustCommands.js'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as AssetDir from '../AssetDir/AssetDir.js'
 import * as Platform from '../Platform/Platform.js'
 import * as WorkerInvokerMap from '../WorkerInvokerMap/WorkerInvokerMap.js'
@@ -77,9 +78,23 @@ const cloneStateValue = (value) => {
   return value
 }
 
+const getApplicationContext = (state, context) => {
+  const applicationId = state.applicationId ?? ApplicationRegistry.getOwner(state.uid ?? state.id)
+  if (applicationId === undefined) {
+    return context
+  }
+  const application = ApplicationRegistry.get(applicationId)
+  return {
+    ...context,
+    applicationId,
+    workspacePath: application.workspacePath,
+    workspaceUri: application.workspaceUri,
+  }
+}
+
 const createInvocation = (state, context, arguments_) => ({
   arguments: arguments_ || {},
-  context,
+  context: getApplicationContext(state, context),
   results: {},
   state,
 })
@@ -192,7 +207,7 @@ const createWorkerViewletInternal = ({ adapter, config, context, worker }) => {
   }
 
   const create = (id, uri, x, y, width, height, args, parentUid) => {
-    const initialState = getStateField(config, id, uri, x, y, width, height, args, parentUid, context)
+    const initialState = getStateField(config, id, uri, x, y, width, height, args, parentUid, getApplicationContext({ uid: id }, context))
     return adapter.transformState(initialState)
   }
 

--- a/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
+++ b/packages/renderer-worker/src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts
@@ -502,7 +502,7 @@ export const getLayoutVirtualDom = (state: LayoutState) => {
 
   dom.push({
     type: VirtualDomElements.Div,
-    id: 'Workbench',
+    id: state.applicationId === undefined ? 'Workbench' : `Workbench-${state.uid}`,
     className: 'Viewlet Layout Workbench new',
     role: 'application',
     childCount: 0,

--- a/packages/renderer-worker/src/parts/LayoutWidgets/LayoutWidgets.ts
+++ b/packages/renderer-worker/src/parts/LayoutWidgets/LayoutWidgets.ts
@@ -2,8 +2,19 @@ import * as ViewletLayoutRenderDom from '../ViewletLayout/ViewletLayoutRenderDom
 import type { LayoutState, WidgetReference } from '../ViewletLayout/LayoutState.ts'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 
 const setWidgetsCommand = 'Viewlet.setWidgets'
+
+const getLayoutForUid = (uid: number): any => {
+  const applicationId = ApplicationRegistry.getOwner(uid)
+  if (applicationId !== undefined) {
+    return ViewletStates.getInstance(ApplicationRegistry.get(applicationId).layoutUid)
+  }
+  return ViewletStates.getValues().find(
+    (instance) => instance.moduleId === ViewletModuleId.Layout && ApplicationRegistry.getOwner(instance.state.uid) === undefined,
+  )
+}
 
 const getWidgets = (state: LayoutState, parentUid: number): readonly number[] => {
   return (state.widgetReferences || []).filter((widget) => widget.parentUid === parentUid).map((widget) => widget.uid)
@@ -117,13 +128,14 @@ const disposeWidgetInstance = (uid: number): void => {
   if (instance?.moduleId && ViewletStates.getInstance(instance.moduleId) === instance) {
     ViewletStates.remove(instance.moduleId)
   }
+  ApplicationRegistry.release(uid)
 }
 
 const updateLayout = (oldState: LayoutState, newState: LayoutState): any[] => {
   if (oldState === newState) {
     return []
   }
-  const layout = ViewletStates.getInstance(ViewletModuleId.Layout)
+  const layout = ViewletStates.getInstance(oldState.uid)
   layout.state = newState
   layout.renderedState = newState
   if (
@@ -135,15 +147,8 @@ const updateLayout = (oldState: LayoutState, newState: LayoutState): any[] => {
   return ViewletLayoutRenderDom.renderDom(oldState, newState)
 }
 
-export const reconcile = (commands: readonly (readonly any[])[]): any[] => {
-  const declarations = commands.filter((command) => command[0] === setWidgetsCommand)
-  if (declarations.length === 0) {
-    return [...commands]
-  }
-  const layout = ViewletStates.getInstance(ViewletModuleId.Layout)
-  if (!layout) {
-    return commands.filter((command) => command[0] !== setWidgetsCommand)
-  }
+const reconcileForLayout = (commands: readonly (readonly any[])[], declarations: readonly (readonly any[])[], layout: any): any[] => {
+  const declarationSet = new Set(declarations)
   const oldLayoutState: LayoutState = layout.state
   let newLayoutState = oldLayoutState
   const removedUids: number[] = []
@@ -156,6 +161,11 @@ export const reconcile = (commands: readonly (readonly any[])[]): any[] => {
     const [, parentUid, revision, widgetUids] = declaration
     const result = setWidgets(newLayoutState, parentUid, revision, widgetUids)
     if (result.accepted) {
+      if (newLayoutState.applicationId !== undefined) {
+        for (const uid of widgetUids) {
+          ApplicationRegistry.own(newLayoutState.applicationId, uid)
+        }
+      }
       newLayoutState = result.newState
       removedUids.push(...result.removedUids)
       for (const uid of widgetUids) {
@@ -188,7 +198,7 @@ export const reconcile = (commands: readonly (readonly any[])[]): any[] => {
   }
 
   const regularCommands = commands.filter((command) => {
-    if (command[0] === setWidgetsCommand) {
+    if (declarationSet.has(command)) {
       return false
     }
     const uid = getCommandUid(command)
@@ -206,8 +216,60 @@ export const reconcile = (commands: readonly (readonly any[])[]): any[] => {
   return [...contentCommands, ...layoutCommands, ...existingDisposeCommands, ...disposeCommands, ...focusCommands]
 }
 
+export const reconcile = (commands: readonly (readonly any[])[]): any[] => {
+  const declarationsByLayout = new Map<any, (readonly any[])[]>()
+  const declaredLayouts = new Map<number, number>()
+  const parents = new Map<number, number>()
+  for (const command of commands) {
+    if (command[0] === setWidgetsCommand) {
+      for (const uid of command[3]) {
+        parents.set(uid, command[1])
+      }
+    }
+  }
+  const resolveLayout = (uid: number): any => {
+    const visited = new Set<number>()
+    while (ApplicationRegistry.getOwner(uid) === undefined && parents.has(uid)) {
+      if (visited.has(uid)) {
+        throw new Error(`Cyclic widget ownership: ${uid}`)
+      }
+      visited.add(uid)
+      uid = parents.get(uid)!
+    }
+    return getLayoutForUid(uid)
+  }
+  for (const command of commands) {
+    if (command[0] !== setWidgetsCommand) {
+      continue
+    }
+    const layout = resolveLayout(command[1])
+    if (!layout) {
+      continue
+    }
+    for (const uid of command[3]) {
+      const owner = ApplicationRegistry.getOwner(uid)
+      if (owner !== undefined && owner !== layout.state.applicationId) {
+        throw new Error(`Component ${uid} already belongs to application ${owner}`)
+      }
+      const declaredLayout = declaredLayouts.get(uid)
+      if (declaredLayout !== undefined && declaredLayout !== layout.state.uid) {
+        throw new Error(`Component ${uid} is declared by multiple applications`)
+      }
+      declaredLayouts.set(uid, layout.state.uid)
+    }
+    const declarations = declarationsByLayout.get(layout) || []
+    declarations.push(command)
+    declarationsByLayout.set(layout, declarations)
+  }
+  let result = [...commands]
+  for (const [layout, declarations] of declarationsByLayout) {
+    result = reconcileForLayout(result, declarations, layout)
+  }
+  return result.filter((command) => command[0] !== setWidgetsCommand)
+}
+
 export const removeOwnedWidgets = (parentUid: number): any[] => {
-  const layout = ViewletStates.getInstance(ViewletModuleId.Layout)
+  const layout = getLayoutForUid(parentUid)
   if (!layout) {
     return []
   }
@@ -222,7 +284,7 @@ export const removeOwnedWidgets = (parentUid: number): any[] => {
 }
 
 export const removeWidget = (uid: number): any[] => {
-  const layout = ViewletStates.getInstance(ViewletModuleId.Layout)
+  const layout = getLayoutForUid(uid)
   if (!layout) {
     return [['Viewlet.dispose', uid]]
   }
@@ -244,7 +306,7 @@ export const removeWidget = (uid: number): any[] => {
 }
 
 export const declareWidget = (parentUid: number, uid: number, commands: readonly (readonly any[])[]): any[] => {
-  const layout = ViewletStates.getInstance(ViewletModuleId.Layout)
+  const layout = getLayoutForUid(parentUid)
   if (!layout) {
     return [...commands]
   }

--- a/packages/renderer-worker/src/parts/SaveState/SaveState.js
+++ b/packages/renderer-worker/src/parts/SaveState/SaveState.js
@@ -1,4 +1,5 @@
 import * as GetViewletStorageKey from '../GetViewletStorageKey/GetViewletStorageKey.js'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as InstanceStorage from '../InstanceStorage/InstanceStorage.js'
 import * as Preferences from '../Preferences/Preferences.js'
@@ -18,7 +19,12 @@ const saveViewletStateAs = async (instanceId, storageId) => {
   if (savedState === undefined) {
     return
   }
-  await InstanceStorage.setJson(getStorageKey(storageId), savedState)
+  const applicationId = ApplicationRegistry.getOwner(instance.state.uid)
+  if (applicationId === undefined) {
+    await InstanceStorage.setJson(getStorageKey(storageId), savedState)
+  } else {
+    ApplicationRegistry.setSavedState(applicationId, storageId, savedState)
+  }
   if (instance && instance.factory.saveChildState) {
     const childIds = instance.factory.saveChildState(instance.state)
     await Promise.all(childIds.map(saveViewletState))
@@ -45,7 +51,10 @@ export const hydrate = async () => {
   await RendererProcess.invoke('Window.onVisibilityChange')
 }
 
-export const getSavedViewletState = (viewletId) => {
+export const getSavedViewletState = (viewletId, applicationId = undefined) => {
+  if (applicationId !== undefined) {
+    return ApplicationRegistry.getSavedState(applicationId, viewletId)
+  }
   return InstanceStorage.getJson(getStorageKey(viewletId))
 }
 

--- a/packages/renderer-worker/src/parts/SaveState/SaveState.js
+++ b/packages/renderer-worker/src/parts/SaveState/SaveState.js
@@ -15,11 +15,14 @@ const getStorageKey = (viewletId) => {
 
 const saveViewletStateAs = async (instanceId, storageId) => {
   const instance = ViewletStates.getInstance(instanceId)
+  const applicationId = ApplicationRegistry.getOwner(instance?.state.uid)
   const savedState = await SerializeViewlet.serializeInstance(instance)
   if (savedState === undefined) {
     return
   }
-  const applicationId = ApplicationRegistry.getOwner(instance.state.uid)
+  if (applicationId !== undefined && ApplicationRegistry.getOwner(instance.state.uid) !== applicationId) {
+    return
+  }
   if (applicationId === undefined) {
     await InstanceStorage.setJson(getStorageKey(storageId), savedState)
   } else {
@@ -51,7 +54,12 @@ export const hydrate = async () => {
   await RendererProcess.invoke('Window.onVisibilityChange')
 }
 
-export const getSavedViewletState = (viewletId, applicationId = undefined) => {
+/**
+ * @param {string | number} viewletId
+ * @param {string=} applicationId
+ * @returns {Promise<any>}
+ */
+export const getSavedViewletState = async (viewletId, applicationId = undefined) => {
   if (applicationId !== undefined) {
     return ApplicationRegistry.getSavedState(applicationId, viewletId)
   }

--- a/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/LayoutState.ts
@@ -21,6 +21,7 @@ export interface WidgetReference {
 }
 
 export interface LayoutState {
+  readonly applicationId?: string
   readonly activityBarHeight: number
   readonly activityBarId: number
   readonly activityBarLeft: number

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1,4 +1,5 @@
 import * as ActivityBarWorker from '../ActivityBarWorker/ActivityBarWorker.js'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as Assert from '../Assert/Assert.ts'
 import { assetDir } from '../AssetDir/AssetDir.js'
 import * as AuthWorker from '../AuthWorker/AuthWorker.js'
@@ -962,11 +963,11 @@ export const openCommandPalette = async (state: LayoutState): Promise<LayoutStat
   }
 }
 
-const getPanelViewChangeCommands = async (moduleId: string, uri = '') => {
+const getPanelViewChangeCommands = async (state: LayoutState, moduleId: string, uri = '') => {
   if (!moduleId) {
     return []
   }
-  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId)
+  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId, state.applicationId)
   if (!instance) {
     return []
   }
@@ -981,7 +982,7 @@ const getPanelViewChangeCommands = async (moduleId: string, uri = '') => {
 
 export const showPanel = async (state: LayoutState, moduleId = state.panelView, uri = '') => {
   if (state.panelVisible) {
-    const commands = await getPanelViewChangeCommands(moduleId, uri)
+    const commands = await getPanelViewChangeCommands(state, moduleId, uri)
     return {
       newState: {
         ...state,
@@ -992,7 +993,7 @@ export const showPanel = async (state: LayoutState, moduleId = state.panelView, 
   }
   // @ts-ignore
   const { newState, commands } = await show(state, LayoutModules.Panel)
-  const panelViewCommands = await getPanelViewChangeCommands(moduleId, uri)
+  const panelViewCommands = await getPanelViewChangeCommands(state, moduleId, uri)
   return {
     newState: {
       ...newState,
@@ -1046,7 +1047,7 @@ export const hidePanel = (state: LayoutState) => {
 }
 
 const getCurrentPanelView = async (state: LayoutState): Promise<string> => {
-  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId)
+  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId, state.applicationId)
   if (!instance) {
     return state.panelView
   }
@@ -1590,6 +1591,7 @@ export const createViewlet = async (
       parentUid: -1,
       append: false,
       args,
+      applicationId: state.applicationId,
     },
     false,
     true,
@@ -1637,6 +1639,7 @@ export const createPanelViewlet = async (
       parentUid: -1,
       append: false,
       args: [],
+      applicationId: state.applicationId,
       shouldRenderEvents: false,
     },
     focus,
@@ -1727,6 +1730,8 @@ const loadIfVisible = async (
           width,
           height,
           uid: childUid,
+          parentUid: state.uid,
+          applicationId: state.applicationId,
           // render: false,
         },
         false,
@@ -1734,7 +1739,7 @@ const loadIfVisible = async (
         restoreState,
       )
     }
-    const latestState = ViewletStates.getState(ViewletModuleId.Layout)
+    const latestState = ViewletStates.getState(state.uid)
     if (visible && !isEqual(state, latestState, kTop, kLeft, kWidth, kHeight)) {
       const resizeCommands = await Viewlet.resize(childUid, {
         x: latestState[kLeft],
@@ -2151,7 +2156,7 @@ const getResizeCommands = async (oldState: LayoutState, newState: LayoutState) =
 }
 
 const getPanelLayoutChangeCommands = async (newState: LayoutState) => {
-  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId)
+  const instance = ViewletStates.getInstance(LayoutModules.Panel.moduleId, newState.applicationId)
   if (!instance) {
     return []
   }
@@ -2511,6 +2516,9 @@ export const getAllQuickPickMenuEntries = async () => {
 
 const callGlobalEvent = async (state: LayoutState, eventName, ...args): Promise<LayoutStateResult> => {
   const instances = Object.entries(ViewletStates.getAllInstances()).filter(([, value]) => {
+    if (state.applicationId !== undefined && ApplicationRegistry.getOwner(value.state.uid) !== state.applicationId) {
+      return false
+    }
     // @ts-ignore
     return value.factory.Commands && value.factory.Commands[eventName]
   })
@@ -2718,7 +2726,7 @@ export const refreshSourceControlBadgeCount = async (state: LayoutState): Promis
   try {
     const badgeCount = await SourceControlWorker.invoke(
       'SourceControl.getWorkspaceBadgeCount',
-      Workspace.state.workspacePath,
+      state.applicationId === undefined ? Workspace.state.workspacePath : ApplicationRegistry.get(state.applicationId).workspacePath,
       assetDir,
       Platform.platform,
     )

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import * as Assert from '../Assert/Assert.ts'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as Command from '../Command/Command.js'
 import * as ErrorHandling from '../ErrorHandling/ErrorHandling.js'
 import { CancelationError } from '../Errors/CancelationError.js'
@@ -87,9 +88,13 @@ const runFn = async (instance, id, key, fn, args) => {
     console.info(`cannot execute viewlet command ${id}.${key}: no active instance for ${id}`)
     return
   }
+  id = instance.state.uid
   if (instance.factory && instance.factory.hasFunctionalRender) {
     const oldState = instance.state
     const newState = await fn(oldState, ...args)
+    if (ViewletStates.getByUid(id) !== instance) {
+      return
+    }
 
     if (
       key === 'getActiveSideBarView' ||
@@ -141,8 +146,12 @@ const runFnWithSideEffect = async (instance, id, key, fn, ...args) => {
     console.info(`cannot execute viewlet command ${id}.${key}: no active instance for ${id}`)
     return
   }
+  id = instance.state.uid
   const oldState = instance.state
   const result = await fn(oldState, ...args)
+  if (ViewletStates.getByUid(id) !== instance) {
+    return
+  }
   const { newState, commands } = result
   Assert.object(newState)
   const latestState = instance.state
@@ -245,6 +254,33 @@ const wrapViewletCommandWithSideEffectLazy = (id, key, importFn) => {
   }
   NameAnonymousFunction.nameAnonymousFunction(lazyCommand, `${id}/lazy/${key}`)
   return lazyCommand
+}
+
+export const executeForApplication = async (applicationId, command, ...args) => {
+  ApplicationRegistry.get(applicationId)
+  const separator = command.indexOf('.')
+  const moduleId = command.slice(0, separator)
+  const key = command.slice(separator + 1)
+  const instance = ViewletStates.getInstance(moduleId, applicationId)
+  if (!instance) {
+    throw new Error(`No ${moduleId} instance in application ${applicationId}`)
+  }
+  const module = instance.factory
+  const lazyImport = module.LazyCommands?.[key] || module.CommandsWithSideEffectsLazy?.[key]
+  const fn = module.Commands?.[key] || module.CommandsWithSideEffects?.[key] || (lazyImport && (await lazyImport())[key])
+  if (typeof fn !== 'function') {
+    throw new Error(`Viewlet command not found: ${command}`)
+  }
+  if (ViewletStates.getInstance(instance.state.uid, applicationId) !== instance) {
+    throw new CancelationError()
+  }
+  if (fn.returnValue) {
+    return fn(instance.state, ...args)
+  }
+  if (module.CommandsWithSideEffects?.[key] || module.CommandsWithSideEffectsLazy?.[key]) {
+    return runFnWithSideEffect(instance, instance.state.uid, key, fn, ...args)
+  }
+  return runFn(instance, instance.state.uid, key, fn, args)
 }
 /**
  *
@@ -581,6 +617,13 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
   let state = ViewletState.Default
   // @ts-ignore
   const viewletUid = viewlet.uid || Id.create()
+  const applicationId = viewlet.applicationId ?? ApplicationRegistry.getOwner(viewlet.parentUid)
+  if (applicationId !== undefined) {
+    if (ViewletStates.getByUid(viewletUid)) {
+      throw new Error(`Component uid is already in use: ${viewletUid}`)
+    }
+    ApplicationRegistry.own(applicationId, viewletUid)
+  }
   let module
   try {
     viewlet.type = 1
@@ -607,6 +650,9 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     }
 
     const initialViewletState = module.create(viewletUid, viewlet.uri, x, y, width, height, viewlet.args, parentUid)
+    if (applicationId !== undefined) {
+      initialViewletState.applicationId = applicationId
+    }
 
     let viewletState = initialViewletState
     viewletState.uid ||= viewletUid
@@ -614,7 +660,10 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     let instanceSavedState
     if (restore) {
       const storageKey = module.getStorageKey ? module.getStorageKey(viewletState) : viewlet.id
-      instanceSavedState = await SaveState.getSavedViewletState(storageKey)
+      instanceSavedState =
+        applicationId === undefined
+          ? await SaveState.getSavedViewletState(storageKey)
+          : await SaveState.getSavedViewletState(storageKey, applicationId)
     } else if (restoreState) {
       instanceSavedState = restoreState
     }
@@ -724,7 +773,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
       moduleId,
     }
     ViewletStates.set(viewletUid, instance)
-    if (viewlet.id === ViewletModuleId.Layout) {
+    if (viewlet.id === ViewletModuleId.Layout && applicationId === undefined) {
       ViewletStates.set(ViewletModuleId.Layout, instance)
     }
     ViewletStates.setFocusedInstanceByType(viewletUid, moduleId)

--- a/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
+++ b/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 
 // TODO instances should be keyed by numeric id
 // to allow having multiple instances of the same
@@ -43,12 +44,13 @@ const normalizeModuleId = (key) => {
   return key
 }
 
-const getFocusedInstanceForModuleId = (moduleId) => {
-  const focusedUid = getFocusedInstanceByType(moduleId)
+const getFocusedInstanceForModuleId = (moduleId, applicationId) => {
+  const focusedUid = getFocusedInstanceByType(moduleId, applicationId)
   if (typeof focusedUid !== 'number') {
     return undefined
   }
-  return getByUid(focusedUid)
+  const instance = getByUid(focusedUid)
+  return belongsToApplication(instance, applicationId) ? instance : undefined
 }
 
 export const set = (key, value) => {
@@ -57,6 +59,11 @@ export const set = (key, value) => {
   Assert.object(value.factory)
   Assert.object(value.state)
   Assert.object(value.renderedState)
+  const uid = value.renderedState.uid
+  const applicationId = value.state.applicationId ?? ApplicationRegistry.getOwner(uid)
+  if (applicationId !== undefined) {
+    ApplicationRegistry.own(applicationId, uid)
+  }
   state.instances[key] = value
   emit('add', value)
 }
@@ -70,30 +77,34 @@ export const getByUid = (uid) => {
   return undefined
 }
 
-export const getInstance = (key) => {
+const belongsToApplication = (instance, applicationId) => {
+  return instance && (applicationId === undefined || ApplicationRegistry.getOwner(instance.renderedState.uid) === applicationId)
+}
+
+export const getInstance = (key, applicationId = undefined) => {
   const fast = state.instances[key]
-  if (fast) {
+  if (belongsToApplication(fast, applicationId)) {
     return fast
   }
   if (typeof key === 'number') {
     const byUid = getByUid(key)
-    if (byUid) {
+    if (belongsToApplication(byUid, applicationId)) {
       return byUid
     }
   }
   const normalizedKey = normalizeModuleId(key)
   if (normalizedKey !== key) {
     const normalizedFast = state.instances[normalizedKey]
-    if (normalizedFast) {
+    if (belongsToApplication(normalizedFast, applicationId)) {
       return normalizedFast
     }
   }
-  const focusedInstance = getFocusedInstanceForModuleId(key) || getFocusedInstanceForModuleId(normalizedKey)
+  const focusedInstance = getFocusedInstanceForModuleId(key, applicationId) || getFocusedInstanceForModuleId(normalizedKey, applicationId)
   if (focusedInstance) {
     return focusedInstance
   }
   for (const value of Object.values(state.instances)) {
-    if (value.moduleId === key || value.moduleId === normalizedKey) {
+    if (belongsToApplication(value, applicationId) && (value.moduleId === key || value.moduleId === normalizedKey)) {
       return value
     }
   }
@@ -142,8 +153,8 @@ export const hasState = (key) => {
   return Boolean(instance)
 }
 
-export const getState = (key) => {
-  const instance = getInstance(key)
+export const getState = (key, applicationId = undefined) => {
+  const instance = getInstance(key, applicationId)
   if (!instance) {
     throw new Error(`instance not found ${key}`)
   }
@@ -198,6 +209,10 @@ export const setFocusedInstanceByType = (uid, moduleId) => {
     return
   }
   state.focusedInstanceByType[moduleId] = uid
+  const applicationId = ApplicationRegistry.getOwner(uid)
+  if (applicationId !== undefined) {
+    state.focusedInstanceByType[JSON.stringify([applicationId, moduleId])] = uid
+  }
 }
 
 /**
@@ -205,8 +220,9 @@ export const setFocusedInstanceByType = (uid, moduleId) => {
  * @param {string} moduleId - The module ID/type
  * @returns {number|undefined} The UID of the focused instance, or undefined
  */
-export const getFocusedInstanceByType = (moduleId) => {
-  return state.focusedInstanceByType[moduleId]
+export const getFocusedInstanceByType = (moduleId, applicationId = undefined) => {
+  const key = applicationId === undefined ? moduleId : JSON.stringify([applicationId, moduleId])
+  return state.focusedInstanceByType[key]
 }
 
 /**
@@ -217,5 +233,10 @@ export const getFocusedInstanceByType = (moduleId) => {
 export const clearFocusedInstanceByType = (uid, moduleId) => {
   if (state.focusedInstanceByType[moduleId] === uid) {
     delete state.focusedInstanceByType[moduleId]
+  }
+  const applicationId = ApplicationRegistry.getOwner(uid)
+  const key = JSON.stringify([applicationId, moduleId])
+  if (state.focusedInstanceByType[key] === uid) {
+    delete state.focusedInstanceByType[key]
   }
 }

--- a/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
+++ b/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
@@ -6,6 +6,7 @@ import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry
 // type. for example multiple editors
 
 export const state = {
+  /** @type {Record<string, any>} */
   instances: Object.create(null),
   /**
    * @type {any}
@@ -81,6 +82,10 @@ const belongsToApplication = (instance, applicationId) => {
   return instance && (applicationId === undefined || ApplicationRegistry.getOwner(instance.renderedState.uid) === applicationId)
 }
 
+/**
+ * @param {string | number} key
+ * @param {string=} applicationId
+ */
 export const getInstance = (key, applicationId = undefined) => {
   const fast = state.instances[key]
   if (belongsToApplication(fast, applicationId)) {
@@ -153,6 +158,10 @@ export const hasState = (key) => {
   return Boolean(instance)
 }
 
+/**
+ * @param {string | number} key
+ * @param {string=} applicationId
+ */
 export const getState = (key, applicationId = undefined) => {
   const instance = getInstance(key, applicationId)
   if (!instance) {
@@ -218,6 +227,7 @@ export const setFocusedInstanceByType = (uid, moduleId) => {
 /**
  * Get the focused instance UID for a given module type
  * @param {string} moduleId - The module ID/type
+ * @param {string=} applicationId
  * @returns {number|undefined} The UID of the focused instance, or undefined
  */
 export const getFocusedInstanceByType = (moduleId, applicationId = undefined) => {

--- a/packages/renderer-worker/test/ApplicationRegistry.test.ts
+++ b/packages/renderer-worker/test/ApplicationRegistry.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, expect, test } from '@jest/globals'
+import * as ApplicationRegistry from '../src/parts/ApplicationRegistry/ApplicationRegistry.ts'
+
+const source = { id: 'source', layoutUid: 1, workspacePath: 'memfs:///source', workspaceUri: 'memfs:///source', href: '' }
+const preview = { ...source, id: 'preview', layoutUid: 2 }
+
+afterEach(() => {
+  ApplicationRegistry.remove('source')
+  ApplicationRegistry.remove('preview')
+})
+
+test('rejects component ownership collisions without changing either application', () => {
+  ApplicationRegistry.create(source)
+  ApplicationRegistry.create(preview)
+  ApplicationRegistry.own('source', 3)
+
+  expect(() => ApplicationRegistry.own('preview', 3)).toThrow('already belongs to application source')
+  expect(ApplicationRegistry.getUids('source')).toEqual([1, 3])
+  expect(ApplicationRegistry.getUids('preview')).toEqual([2])
+  expect(ApplicationRegistry.getOwner(3)).toBe('source')
+})
+
+test('rejects duplicate layouts before registering a second application', () => {
+  ApplicationRegistry.create(source)
+  expect(() => ApplicationRegistry.create({ ...preview, layoutUid: 1 })).toThrow('duplicate layout uid')
+  expect(() => ApplicationRegistry.get('preview')).toThrow('Application not found')
+})
+
+test('removing one application releases only its ownership', () => {
+  ApplicationRegistry.create(source)
+  ApplicationRegistry.create(preview)
+  ApplicationRegistry.own('source', 3)
+  ApplicationRegistry.own('preview', 4)
+  ApplicationRegistry.remove('preview')
+
+  expect(ApplicationRegistry.getOwner(2)).toBeUndefined()
+  expect(ApplicationRegistry.getOwner(4)).toBeUndefined()
+  expect(ApplicationRegistry.getUids('source')).toEqual([1, 3])
+  expect(() => ApplicationRegistry.own('preview', 5)).toThrow('Application not found')
+})
+
+test('stores an immutable application snapshot', () => {
+  const options = { ...source }
+  ApplicationRegistry.create(options)
+  options.workspaceUri = 'memfs:///changed'
+  expect(ApplicationRegistry.get('source').workspaceUri).toBe(source.workspaceUri)
+  expect(Object.isFrozen(ApplicationRegistry.get('source'))).toBe(true)
+})
+
+test('view state is isolated even for identical storage keys and resets with the application', () => {
+  ApplicationRegistry.create(source)
+  ApplicationRegistry.create(preview)
+  const value = { selected: ['src/main.ts'] }
+  ApplicationRegistry.setSavedState('source', 'Explorer', value)
+  ApplicationRegistry.setSavedState('preview', 'Explorer', { selected: ['README.md'] })
+  value.selected.push('extension.json')
+  expect(ApplicationRegistry.getSavedState('source', 'Explorer')).toEqual({ selected: ['src/main.ts'] })
+  expect(ApplicationRegistry.getSavedState('preview', 'Explorer')).toEqual({ selected: ['README.md'] })
+  ApplicationRegistry.remove('preview')
+  ApplicationRegistry.create(preview)
+  expect(ApplicationRegistry.getSavedState('preview', 'Explorer')).toBeUndefined()
+  expect(ApplicationRegistry.getSavedState('source', 'Explorer')).toEqual({ selected: ['src/main.ts'] })
+})

--- a/packages/renderer-worker/test/LayoutWidgetsApplications.test.ts
+++ b/packages/renderer-worker/test/LayoutWidgetsApplications.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import * as ApplicationRegistry from '../src/parts/ApplicationRegistry/ApplicationRegistry.ts'
+import * as LayoutWidgets from '../src/parts/LayoutWidgets/LayoutWidgets.ts'
+import * as ViewletLayout from '../src/parts/ViewletLayout/ViewletLayout.ts'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+import { getLayoutVirtualDom } from '../src/parts/GetLayoutVirtualDom/GetLayoutVirtualDom.ts'
+
+const createLayout = (applicationId: string, uid: number): void => {
+  ApplicationRegistry.create({ id: applicationId, layoutUid: uid, workspacePath: '', workspaceUri: '', href: '' })
+  const state = { ...ViewletLayout.create(uid), applicationId }
+  ViewletStates.set(uid, { state, renderedState: state, moduleId: 'Layout', factory: {} })
+}
+
+beforeEach(() => {
+  ViewletStates.reset()
+  createLayout('source', 1)
+  createLayout('preview', 2)
+  ApplicationRegistry.own('source', 10)
+  ApplicationRegistry.own('preview', 11)
+})
+
+afterEach(() => {
+  ViewletStates.reset()
+  ApplicationRegistry.remove('source')
+  ApplicationRegistry.remove('preview')
+})
+
+test('application workbenches have distinct DOM ids', () => {
+  expect(getLayoutVirtualDom(ViewletStates.getState(1))[0].id).toBe('Workbench-1')
+  expect(getLayoutVirtualDom(ViewletStates.getState(2))[0].id).toBe('Workbench-2')
+})
+
+test('routes mixed widget batches to their owning layout', () => {
+  const commands = LayoutWidgets.reconcile([
+    ['Viewlet.createFunctionalRoot', 'FindWidget', 20, true],
+    ['Viewlet.createFunctionalRoot', 'FindWidget', 21, true],
+    ['Viewlet.setWidgets', 10, 1, [20]],
+    ['Viewlet.setWidgets', 11, 1, [21]],
+  ])
+
+  expect(ViewletStates.getState(1).widgetReferences).toEqual([{ parentUid: 10, uid: 20 }])
+  expect(ViewletStates.getState(2).widgetReferences).toEqual([{ parentUid: 11, uid: 21 }])
+  expect(ApplicationRegistry.getOwner(20)).toBe('source')
+  expect(ApplicationRegistry.getOwner(21)).toBe('preview')
+  expect(
+    commands
+      .filter((command) => command[0] === 'Viewlet.setDom2')
+      .map((command) => command[1])
+      .sort(),
+  ).toEqual([1, 2])
+
+  const disposeCommands = LayoutWidgets.removeOwnedWidgets(11)
+  expect(disposeCommands).toContainEqual(['Viewlet.dispose', 21])
+  expect(disposeCommands).not.toContainEqual(['Viewlet.dispose', 20])
+  expect(ViewletStates.getState(1).widgetReferences).toEqual([{ parentUid: 10, uid: 20 }])
+})
+
+test('resolves nested declarations even when the child declaration comes first', () => {
+  LayoutWidgets.reconcile([
+    ['Viewlet.setWidgets', 20, 1, [30]],
+    ['Viewlet.setWidgets', 10, 1, [20]],
+  ])
+
+  expect(ApplicationRegistry.getOwner(20)).toBe('source')
+  expect(ApplicationRegistry.getOwner(30)).toBe('source')
+  expect(ViewletStates.getState(2).widgetReferences).toEqual([])
+})
+
+test('rejects cross-application widget reuse before updating either layout', () => {
+  expect(() =>
+    LayoutWidgets.reconcile([
+      ['Viewlet.setWidgets', 10, 1, [30]],
+      ['Viewlet.setWidgets', 11, 1, [10]],
+    ]),
+  ).toThrow('already belongs to application source')
+  expect(ViewletStates.getState(1).widgetReferences).toEqual([])
+  expect(ViewletStates.getState(2).widgetReferences).toEqual([])
+})
+
+test('rejects a new uid claimed by both applications in the same batch', () => {
+  expect(() =>
+    LayoutWidgets.reconcile([
+      ['Viewlet.setWidgets', 10, 1, [30]],
+      ['Viewlet.setWidgets', 11, 1, [30]],
+    ]),
+  ).toThrow('declared by multiple applications')
+  expect(ViewletStates.getState(1).widgetReferences).toEqual([])
+  expect(ViewletStates.getState(2).widgetReferences).toEqual([])
+  expect(ApplicationRegistry.getOwner(30)).toBeUndefined()
+})

--- a/packages/renderer-worker/test/ViewletManagerApplications.test.ts
+++ b/packages/renderer-worker/test/ViewletManagerApplications.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import * as ApplicationRegistry from '../src/parts/ApplicationRegistry/ApplicationRegistry.ts'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({ invoke: jest.fn(async () => {}) }))
+
+const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+
+const addLayout = (applicationId: string, uid: number, commands: object): void => {
+  ApplicationRegistry.create({ id: applicationId, layoutUid: uid, workspacePath: '', workspaceUri: '', href: '' })
+  const state = { uid, applicationId, value: 'initial' }
+  ViewletStates.set(uid, {
+    state,
+    renderedState: state,
+    moduleId: 'Layout',
+    factory: { hasFunctionalRender: true, render: [], Commands: commands },
+  })
+}
+
+beforeEach(() => {
+  ViewletStates.reset()
+  jest.clearAllMocks()
+})
+
+afterEach(() => {
+  ViewletStates.reset()
+  ApplicationRegistry.remove('source')
+  ApplicationRegistry.remove('preview')
+})
+
+test('concurrent commands retain their application across await and focus changes', async () => {
+  const pending = Promise.withResolvers<void>()
+  const commands = {
+    async update(state, value) {
+      if (state.applicationId === 'source') {
+        await pending.promise
+      }
+      return { ...state, value }
+    },
+  }
+  addLayout('source', 1, commands)
+  addLayout('preview', 2, commands)
+
+  const sourceUpdate = ViewletManager.executeForApplication('source', 'Layout.update', 'source change')
+  ViewletStates.setFocusedInstanceByType(2, 'Layout')
+  await ViewletManager.executeForApplication('preview', 'Layout.update', 'preview change')
+  pending.resolve()
+  await sourceUpdate
+
+  expect(ViewletStates.getState(1).value).toBe('source change')
+  expect(ViewletStates.getState(2).value).toBe('preview change')
+})
+
+test('a command finishing after its view is removed cannot render into another application', async () => {
+  const pending = Promise.withResolvers<void>()
+  addLayout('source', 1, {
+    async update(state) {
+      await pending.promise
+      return { ...state, value: 'late change' }
+    },
+  })
+  addLayout('preview', 2, {})
+  const update = ViewletManager.executeForApplication('source', 'Layout.update')
+  ViewletStates.remove(1)
+  pending.resolve()
+  await update
+
+  expect(ViewletStates.getInstance(1)).toBeUndefined()
+  expect(ViewletStates.getState(2).value).toBe('initial')
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/ViewletStatesApplications.test.ts
+++ b/packages/renderer-worker/test/ViewletStatesApplications.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import * as ApplicationRegistry from '../src/parts/ApplicationRegistry/ApplicationRegistry.ts'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+const addInstance = (uid: number, moduleId: string, applicationId: string): void => {
+  ViewletStates.set(uid, {
+    factory: {},
+    moduleId,
+    renderedState: { uid, applicationId },
+    state: { uid, applicationId },
+  })
+}
+
+beforeEach(() => {
+  ViewletStates.reset()
+  ApplicationRegistry.create({ id: 'source', layoutUid: 1, workspacePath: '', workspaceUri: '', href: '' })
+  ApplicationRegistry.create({ id: 'preview', layoutUid: 2, workspacePath: '', workspaceUri: '', href: '' })
+})
+
+afterEach(() => {
+  ViewletStates.reset()
+  ApplicationRegistry.remove('source')
+  ApplicationRegistry.remove('preview')
+})
+
+test('module lookup and legacy aliases cannot select the other application', () => {
+  addInstance(1, 'Layout', 'source')
+  addInstance(2, 'Layout', 'preview')
+  ViewletStates.set('Layout', ViewletStates.getByUid(1))
+
+  expect(ViewletStates.getInstance('Layout', 'preview')?.state.uid).toBe(2)
+  expect(ViewletStates.getInstance(1, 'preview')).toBeUndefined()
+  expect(ViewletStates.getInstance('Layout', 'missing')).toBeUndefined()
+})
+
+test('focus is tracked separately for each application and supports editor aliases', () => {
+  addInstance(3, 'EditorText', 'source')
+  addInstance(4, 'EditorText', 'source')
+  addInstance(5, 'EditorText', 'preview')
+  ViewletStates.setFocusedInstanceByType(4, 'EditorText')
+  ViewletStates.setFocusedInstanceByType(5, 'EditorText')
+
+  expect(ViewletStates.getInstance('Editor', 'source')?.state.uid).toBe(4)
+  expect(ViewletStates.getInstance('Editor', 'preview')?.state.uid).toBe(5)
+  ViewletStates.remove(4)
+  expect(ViewletStates.getInstance('Editor', 'source')?.state.uid).toBe(3)
+  expect(ViewletStates.getFocusedInstanceByType('EditorText', 'preview')).toBe(5)
+})
+
+test('rejects overwriting another application component with the same uid', () => {
+  addInstance(3, 'Explorer', 'source')
+  expect(() => addInstance(3, 'Explorer', 'preview')).toThrow('already belongs')
+  expect(ViewletStates.getInstance(3, 'source')?.moduleId).toBe('Explorer')
+})


### PR DESCRIPTION
Add explicit application ownership for layouts, viewlets, widgets, command lookup, and session view state. This prepares the extension playground to host two IDE layouts in one renderer without sharing focused-view lookup or DOM IDs.