### PR TITLE
fix: prevent search badge styles from affecting Problems

### DIFF
--- a/static/css/parts/ViewletSearch.css
+++ b/static/css/parts/ViewletSearch.css
@@ -45,7 +45,8 @@
   background: var(--ToolBarHoverBackground);
 }
 
-.Badge {
+.SearchBadge,
+.Search .Badge {
   display: var(--SearchBadgeDisplay);
 }
 


### PR DESCRIPTION
Scope search badge visibility styling to SearchBadge and badges inside Search so opening Search no longer overrides the Problems badge display. Keep support for the currently published search package.