### PR TITLE
fix: automatically update live component state

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,12 @@ jobs:
         run: npm run e2e:headless:ci
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test live component automatic updates
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-auto-update
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build Electron App (deb)
         if: matrix.os == 'ubuntu-24.04'
         run: npm run build:electron:deb

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-auto-update.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-auto-update.ts
@@ -1,0 +1,54 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-auto-update'
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Layout.showSideBar', 'Explorer')
+  await expect(Locator('.Explorer')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const view = Locator('.ComponentStateView')
+  await expect(view).toBeVisible()
+
+  const assertComponents = async () => {
+    const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+    const editableComponents = components.filter((component) => component.editable)
+    if (editableComponents.length === 0) {
+      throw new Error('Expected live components without manually refreshing')
+    }
+    await expect(view.locator('.ComponentStateDescription')).toHaveText(`${editableComponents.length} live components`)
+    for (const component of editableComponents) {
+      await expect(view.locator(`.ComponentStateCard[data-uid="${component.uid}"]`)).toBeVisible()
+    }
+    return editableComponents
+  }
+
+  const initial = await assertComponents()
+  const explorer = initial.find((component) => component.moduleId === 'Explorer')
+  if (!explorer) {
+    throw new Error('Expected Explorer in the initial component list')
+  }
+
+  await Command.execute('Layout.showSideBar', 'Search')
+  await expect(Locator('.Search')).toBeVisible()
+  await expect(view.locator(`.ComponentStateCard[data-uid="${explorer.uid}"]`)).toHaveCount(0)
+  await assertComponents()
+
+  await Command.execute('Layout.openSecondarySideBarViewlet', 'Explorer')
+  await expect(view).toHaveCount(0)
+  await Command.execute('Developer.openComponentState')
+  await expect(view).toBeVisible()
+  await assertComponents()
+
+  await Command.execute('Layout.showSideBar', 'Explorer')
+  await expect(Locator('.Explorer')).toBeVisible()
+  await assertComponents()
+}

--- a/packages/renderer-worker/src/parts/ComponentStateSubscription/ComponentStateSubscription.ts
+++ b/packages/renderer-worker/src/parts/ComponentStateSubscription/ComponentStateSubscription.ts
@@ -1,0 +1,55 @@
+import * as Logger from '../Logger/Logger.js'
+import * as Viewlet from '../Viewlet/Viewlet.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+
+interface Subscription {
+  listener: (type: string, instance: unknown) => void
+  pending: boolean
+  promise: Promise<void> | undefined
+}
+
+const subscriptions = new Map<number, Subscription>()
+
+export const unsubscribe = (uid: number): void => {
+  const subscription = subscriptions.get(uid)
+  if (!subscription) {
+    return
+  }
+  subscriptions.delete(uid)
+  ViewletStates.removeListener(subscription.listener)
+}
+
+export const subscribe = (uid: number): Promise<void> | undefined => {
+  const instance = ViewletStates.getByUid(uid)
+  if (!instance || subscriptions.has(uid)) {
+    return
+  }
+  const subscription: Subscription = { listener: () => {}, pending: false, promise: undefined }
+  const isActive = () => subscriptions.get(uid) === subscription && ViewletStates.getByUid(uid) === instance
+  const refresh = () => {
+    subscription.pending = true
+    subscription.promise ||= Promise.resolve().then(async () => {
+      try {
+        while (subscription.pending && isActive()) {
+          subscription.pending = false
+          await Viewlet.executeViewletCommand(uid, 'refresh')
+        }
+      } catch (error) {
+        Logger.error(error)
+      } finally {
+        subscription.promise = undefined
+      }
+    })
+    return subscription.promise
+  }
+  subscription.listener = (type, changedInstance) => {
+    if (type === 'remove' && changedInstance === instance) {
+      unsubscribe(uid)
+    } else if (type === 'add' || type === 'remove') {
+      void refresh()
+    }
+  }
+  subscriptions.set(uid, subscription)
+  ViewletStates.addListener(subscription.listener)
+  return refresh()
+}

--- a/packages/renderer-worker/src/parts/ViewletComponentState/ViewletComponentState.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletComponentState/ViewletComponentState.ipc.js
@@ -1,4 +1,7 @@
+import * as ComponentStateSubscription from '../ComponentStateSubscription/ComponentStateSubscription.ts'
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
+
+const workerViewlet = createWorkerViewlet({ workerId: 'componentState' })
 
 export const {
   Commands,
@@ -6,7 +9,6 @@ export const {
   Events,
   Variables,
   create,
-  dispose,
   getCommands,
   getKeyBindings,
   getMenus,
@@ -24,4 +26,13 @@ export const {
   renderTitle,
   resize,
   saveState,
-} = createWorkerViewlet({ workerId: 'componentState' })
+} = workerViewlet
+
+export const serializeCommands = true
+
+Commands.loadContentLater = (state) => ComponentStateSubscription.subscribe(state.uid)
+
+export const dispose = (state) => {
+  ComponentStateSubscription.unsubscribe(state.uid)
+  return workerViewlet.dispose(state)
+}

--- a/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
+++ b/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
@@ -30,6 +30,10 @@ export const addListener = (listener) => {
   listeners.add(listener)
 }
 
+export const removeListener = (listener) => {
+  listeners.delete(listener)
+}
+
 const normalizeModuleId = (key) => {
   if (key === 'Editor') {
     return 'EditorText'

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -21,6 +21,7 @@
             { "source": "state", "name": "width" }, { "source": "state", "name": "height" }
           ]
         },
+        "dispose": { "name": "ComponentState.dispose", "parameters": [{ "source": "state", "name": "uid" }] },
         "loadContent": { "name": "ComponentState.loadContent", "parameters": [{ "source": "state", "name": "uid" }] },
         "diff": { "name": "ComponentState.diff2", "parameters": [{ "source": "state", "name": "uid" }] },
         "render": {

--- a/packages/renderer-worker/test/ComponentStateSubscription.test.ts
+++ b/packages/renderer-worker/test/ComponentStateSubscription.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
+  executeViewletCommand: jest.fn(),
+}))
+
+jest.unstable_mockModule('../src/parts/Logger/Logger.js', () => ({
+  error: jest.fn(),
+}))
+
+const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+const Logger = await import('../src/parts/Logger/Logger.js')
+const { subscribe, unsubscribe } = await import('../src/parts/ComponentStateSubscription/ComponentStateSubscription.ts')
+
+const addComponent = (uid, moduleId = 'Explorer') => {
+  const state = { uid }
+  const instance = { factory: {}, moduleId, renderedState: state, state }
+  ViewletStates.set(uid, instance)
+  return instance
+}
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+beforeEach(() => {
+  ViewletStates.reset()
+  jest.resetAllMocks()
+  addComponent(1, 'ComponentState')
+})
+
+afterEach(() => {
+  unsubscribe(1)
+  unsubscribe(2)
+})
+
+test('refreshes the initial snapshot after the view is mounted', async () => {
+  addComponent(3)
+  await subscribe(1)
+
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(1, 'refresh')
+})
+
+test('automatically refreshes after additions and removals, but not renders', async () => {
+  await subscribe(1)
+  jest.mocked(Viewlet.executeViewletCommand).mockClear()
+  addComponent(3)
+  await flush()
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+
+  ViewletStates.setRenderedState(3, { uid: 3 })
+  await flush()
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+
+  ViewletStates.remove(3)
+  await flush()
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(2)
+})
+
+test('coalesces bursts and catches changes that arrive during refresh', async () => {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  jest.mocked(Viewlet.executeViewletCommand).mockImplementationOnce(() => promise)
+  const initialRefresh = subscribe(1)
+  addComponent(3)
+  addComponent(4)
+  await flush()
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+
+  addComponent(5)
+  ViewletStates.remove(3)
+  resolve()
+  await initialRefresh
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(2)
+})
+
+test('does not register duplicate subscriptions', async () => {
+  await subscribe(1)
+  await subscribe(1)
+  addComponent(3)
+  await flush()
+
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(2)
+})
+
+test('unsubscribing removes the listener and cancels a queued refresh', async () => {
+  const initialRefresh = subscribe(1)
+  unsubscribe(1)
+  unsubscribe(1)
+  addComponent(3)
+  await initialRefresh
+
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
+})
+
+test('removing the view stops pending follow-up refreshes', async () => {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  jest.mocked(Viewlet.executeViewletCommand).mockImplementationOnce(() => promise)
+  const initialRefresh = subscribe(1)
+  await flush()
+  addComponent(3)
+  ViewletStates.remove(1)
+  addComponent(4)
+  resolve()
+  await initialRefresh
+
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+})
+
+test('reopening the view installs a fresh subscription', async () => {
+  await subscribe(1)
+  ViewletStates.remove(1)
+  addComponent(1, 'ComponentState')
+  await subscribe(1)
+  addComponent(3)
+  await flush()
+
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(3)
+})
+
+test('disposing one inspector keeps the other inspector subscribed', async () => {
+  addComponent(2, 'ComponentState')
+  await subscribe(1)
+  await subscribe(2)
+  unsubscribe(1)
+  jest.mocked(Viewlet.executeViewletCommand).mockClear()
+  addComponent(3)
+  await flush()
+
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(2, 'refresh')
+})
+
+test('does not subscribe an already disposed view', async () => {
+  ViewletStates.remove(1)
+  await subscribe(1)
+  addComponent(3)
+  await flush()
+
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
+})
+
+test('reports refresh errors and can refresh again on the next change', async () => {
+  const error = new Error('refresh failed')
+  jest.mocked(Viewlet.executeViewletCommand).mockRejectedValueOnce(error)
+  await subscribe(1)
+  addComponent(3)
+  await flush()
+
+  expect(Logger.error).toHaveBeenCalledWith(error)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(2)
+})

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -613,3 +613,15 @@ test('reports unknown workers and workers without viewlet metadata', () => {
   expect(() => getWorkerViewletConfig('missing-worker')).toThrow('worker not found: missing-worker')
   expect(() => getWorkerViewletConfig('authWorker')).toThrow('viewlet configuration not found: authWorker')
 })
+
+test('disposes the component state worker view', async () => {
+  const invoke = jest.fn(async (..._args: readonly unknown[]) => undefined)
+  const viewlet = createWorkerViewletWithDependencies({
+    config: getWorkerViewletConfig('componentState'),
+    worker: { invoke, restart: jest.fn() },
+  })
+
+  await viewlet.dispose({ uid: 7 })
+
+  expect(invoke).toHaveBeenCalledWith('ComponentState.dispose', 7)
+})


### PR DESCRIPTION
Refresh Live Component State after the view mounts and automatically when components are added or removed, so a page loaded with the inspector open no longer stays at zero components.

Coalesce lifecycle changes, remove the subscription when the view is disposed, and wire up worker-side view disposal.
