### PR TITLE
fix: preserve scroll during live component state updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,12 @@ jobs:
         run: npm run e2e:headless:ci
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test live component state scrolling
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: node src/_all.js --headless --test-name-prefix=viewlet.component-state-refresh-scroll
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build Electron App (deb)
         if: matrix.os == 'ubuntu-24.04'
         run: npm run build:electron:deb

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-refresh-scroll.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-refresh-scroll.ts
@@ -1,0 +1,42 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.component-state-refresh-scroll'
+
+const waitForState = async (Command, focusedIndex: number): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const document = await Command.execute('GetActiveEditor.getTextDocument')
+    if (document?.text && JSON.parse(document.text).focusedIndex === focusedIndex) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`Live component state did not update to focusedIndex ${focusedIndex}`)
+}
+
+export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Settings, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Settings.update({ 'editor.fontFamily': 'monospace', 'editor.lineNumbers': true })
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Layout.showSideBar', 'Explorer')
+  await expect(Locator('.Explorer')).toBeVisible()
+  const components = await Command.execute('ComponentState.getComponents')
+  const explorer = components.find((component) => component.moduleId === 'Explorer')
+  await Main.openUri(`live-component-state:///${explorer.uid}.json`)
+  await expect(Locator('.Editor .LineNumber').first()).toBeVisible()
+  const selections = [2, 1, 2, 3]
+  await Command.execute('GetActiveEditor.setSelections', selections)
+  await Editor.setDeltaY(120)
+  const firstLine = Locator('.Editor .LineNumber').first()
+  await expect(firstLine).toHaveText('7')
+  for (const focusedIndex of [1, 0, 1]) {
+    const state = await Command.execute('ComponentState.getState', explorer.uid)
+    await Command.execute('ComponentState.setState', explorer.uid, { ...state, focusedIndex })
+    await waitForState(Command, focusedIndex)
+    await expect(firstLine).toHaveText('7')
+    const actualSelections = await Command.execute('GetActiveEditor.getSelections')
+    if (JSON.stringify(actualSelections) !== JSON.stringify(selections)) {
+      throw new Error(`Component state refresh changed the selection: ${JSON.stringify(actualSelections)}`)
+    }
+  }
+}

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -84,16 +84,16 @@ const getEditorTabStates = async () => {
   return editorTabStates
 }
 
-const reloadEditorIfContentChanged = async (editorUid, content) => {
+const refreshEditorIfContentChanged = async (editorUid, content) => {
   try {
     const currentContent = await EditorWorker.invoke('Editor.getText', editorUid)
     if (currentContent === content) {
       return
     }
   } catch {
-    // Fall back to reloading when the current editor content cannot be read.
+    // Refresh in place when the current editor content cannot be read.
   }
-  await Viewlet.reload(editorUid)
+  await Viewlet.executeViewletCommand(editorUid, 'loadContent')
 }
 
 const runRefreshes = async (componentUid, refresh) => {
@@ -122,7 +122,7 @@ const runRefreshes = async (componentUid, refresh) => {
       }
       await Promise.allSettled(
         editorUidsToRefresh.map((editorUid) =>
-          content === undefined ? Viewlet.reload(editorUid) : reloadEditorIfContentChanged(editorUid, content),
+          content === undefined ? Viewlet.executeViewletCommand(editorUid, 'loadContent') : refreshEditorIfContentChanged(editorUid, content),
         ),
       )
       for (const editorUid of editorUidsToRefresh) {

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => 
 }))
 
 jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
+  executeViewletCommand: jest.fn(),
   reload: jest.fn(),
 }))
 
@@ -162,7 +163,8 @@ test('refreshes an open live component state editor when the component rerenders
   ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
   await ComponentState.waitForRefreshes()
 
-  expect(Viewlet.reload).toHaveBeenCalledWith(9)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(9, 'loadContent')
+  expect(Viewlet.reload).not.toHaveBeenCalled()
 })
 
 test('does not refresh an open live component state editor when its content is unchanged', async () => {
@@ -176,6 +178,7 @@ test('does not refresh an open live component state editor when its content is u
   await ComponentState.waitForRefreshes()
 
   expect(EditorWorker.invoke).toHaveBeenCalledWith('Editor.getText', 9)
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
   expect(Viewlet.reload).not.toHaveBeenCalled()
 })
 
@@ -189,7 +192,7 @@ test('refreshes an open live component state editor with a decimal component uid
   ViewletStates.setRenderedState(componentUid, { focusedIndex: 1, uid: componentUid })
   await ComponentState.waitForRefreshes()
 
-  expect(Viewlet.reload).toHaveBeenCalledWith(9)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(9, 'loadContent')
 })
 
 test('does not overwrite a dirty live component state editor when the component rerenders', async () => {
@@ -214,6 +217,7 @@ test('does not overwrite a dirty live component state editor when the component 
   ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
   await ComponentState.waitForRefreshes()
 
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
   expect(Viewlet.reload).not.toHaveBeenCalled()
 })
 
@@ -235,13 +239,13 @@ test('refreshes Main state once after opening, then preserves its active self-re
   ViewletStates.setRenderedState(3, { commands: [], uid: 3 })
   await ComponentState.waitForRefreshes()
 
-  expect(Viewlet.reload).toHaveBeenCalledTimes(1)
-  expect(Viewlet.reload).toHaveBeenCalledWith(9)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(1)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(9, 'loadContent')
 })
 
 test('coalesces rerenders while a live component state editor is refreshing', async () => {
   let finishReload
-  jest.mocked(Viewlet.reload).mockImplementationOnce(
+  jest.mocked(Viewlet.executeViewletCommand).mockImplementationOnce(
     () =>
       new Promise((resolve) => {
         finishReload = resolve
@@ -259,7 +263,7 @@ test('coalesces rerenders while a live component state editor is refreshing', as
   finishReload()
   await ComponentState.waitForRefreshes()
 
-  expect(Viewlet.reload).toHaveBeenCalledTimes(2)
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledTimes(2)
 })
 
 test('stops refreshing after the live component state editor is disposed', async () => {
@@ -272,5 +276,6 @@ test('stops refreshing after the live component state editor is disposed', async
   ViewletStates.setRenderedState(2, { focusedIndex: 1, uid: 2 })
   await ComponentState.waitForRefreshes()
 
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
   expect(Viewlet.reload).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Live component state updates recreated the JSON editor, resetting its viewport and selection even after unchanged-content reloads were suppressed. Refresh the existing editor through its command pipeline so real state changes preserve the viewport and selection, and run a browser regression explicitly in CI.