### PR TITLE
feature: add independently mounted application lifecycles

### DIFF
--- a/packages/renderer-worker/src/parts/Application/Application.ipc.js
+++ b/packages/renderer-worker/src/parts/Application/Application.ipc.js
@@ -1,0 +1,11 @@
+import * as Application from './Application.ts'
+
+export const name = 'Application'
+
+export const Commands = {
+  create: Application.create,
+  dispose: Application.dispose,
+  execute: Application.execute,
+  executeForView: Application.executeForView,
+  resize: Application.resize,
+}

--- a/packages/renderer-worker/src/parts/Application/Application.ts
+++ b/packages/renderer-worker/src/parts/Application/Application.ts
@@ -129,6 +129,11 @@ const disposeApplication = async (applicationId: string): Promise<void> => {
     } catch (error) {
       errors.push(error)
       ViewletStates.remove(uid)
+      try {
+        await RendererProcess.invoke('Viewlet.dispose', uid)
+      } catch (rendererError) {
+        errors.push(rendererError)
+      }
     }
   }
   ApplicationRegistry.remove(applicationId)

--- a/packages/renderer-worker/src/parts/Application/Application.ts
+++ b/packages/renderer-worker/src/parts/Application/Application.ts
@@ -1,0 +1,150 @@
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
+import * as Command from '../Command/Command.js'
+import * as Id from '../Id/Id.js'
+import * as RendererProcess from '../RendererProcess/RendererProcess.js'
+import * as Viewlet from '../Viewlet/Viewlet.js'
+import * as ViewletManager from '../ViewletManager/ViewletManager.js'
+import * as ViewletModule from '../ViewletModule/ViewletModule.js'
+import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+
+export interface ApplicationOptions {
+  readonly height: number
+  readonly href: string
+  readonly id: string
+  readonly rootId: string
+  readonly width: number
+  readonly workspacePath: string
+  readonly workspaceUri: string
+}
+
+const disposals = new Map<string, Promise<void>>()
+
+const initialize = async (options: ApplicationOptions, layoutUid: number): Promise<number> => {
+  const commands = await ViewletManager.load(
+    {
+      applicationId: options.id,
+      getModule: ViewletModule.load,
+      id: ViewletModuleId.Layout,
+      type: 0,
+      uid: layoutUid,
+      uri: '',
+      show: false,
+      focus: false,
+    },
+    false,
+    false,
+    {
+      Layout: { bounds: { windowWidth: options.width, windowHeight: options.height } },
+      restore: false,
+    },
+  )
+  const initialCommands = commands.filter((command) => command[0] !== 'Viewlet.setDom2')
+  initialCommands.push(['Viewlet.appendToRoot', layoutUid, options.rootId])
+  initialCommands.push(['Viewlet.setBounds', layoutUid, 0, 0, options.width, options.height])
+  await RendererProcess.invoke('Viewlet.executeCommands', initialCommands)
+  for (const part of ['Main', 'SideBar', 'SecondarySideBar', 'Panel', 'ActivityBar', 'StatusBar', 'TitleBar']) {
+    await ViewletManager.executeForApplication(options.id, `Layout.load${part}IfVisible`)
+  }
+  return layoutUid
+}
+
+// Internal host entry point; normal workbench startup still owns its existing layout.
+export const create = async (options: ApplicationOptions): Promise<number> => {
+  if (!options.rootId || !Number.isFinite(options.width) || !Number.isFinite(options.height) || options.width <= 0 || options.height <= 0) {
+    throw new Error('Invalid application root or dimensions')
+  }
+  const layoutUid = Id.create()
+  ApplicationRegistry.create({
+    id: options.id,
+    layoutUid,
+    href: options.href,
+    workspacePath: options.workspacePath,
+    workspaceUri: options.workspaceUri,
+  })
+  try {
+    return await ApplicationRegistry.track(options.id, () => initialize(options, layoutUid))
+  } catch (error) {
+    try {
+      await dispose(options.id)
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], `Failed to create application ${options.id}`)
+    }
+    throw error
+  }
+}
+
+export const execute = (applicationId: string, command: string, ...args: readonly any[]): Promise<any> => {
+  const application = ApplicationRegistry.assertOpen(applicationId)
+  switch (command) {
+    case 'Workspace.getUri':
+    case 'Workspace.getWorkspaceUri':
+      return Promise.resolve(application.workspaceUri)
+    case 'Workspace.getPath':
+    case 'Workspace.getWorkspacePath':
+      return Promise.resolve(application.workspacePath)
+    case 'Layout.getHref':
+      return Promise.resolve(application.href)
+    case 'Preferences.get':
+    case 'Preferences.update':
+      return Promise.resolve(Command.execute(command, ...args))
+    default:
+      return ApplicationRegistry.track(applicationId, () => ViewletManager.executeForApplication(applicationId, command, ...args))
+  }
+}
+
+export const executeForView = (uid: number, command: string, ...args: readonly any[]): Promise<any> => {
+  const applicationId = ApplicationRegistry.getOwner(uid)
+  if (applicationId === undefined) {
+    if (!ViewletStates.getByUid(uid)) {
+      return Promise.reject(new Error(`Component not found: ${uid}`))
+    }
+    return Promise.resolve(Command.execute(command, ...args))
+  }
+  return execute(applicationId, command, ...args)
+}
+
+export const resize = (applicationId: string, width: number, height: number): Promise<void> => {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    throw new Error('Invalid application dimensions')
+  }
+  return ApplicationRegistry.track(applicationId, async () => {
+    const { layoutUid } = ApplicationRegistry.get(applicationId)
+    await execute(applicationId, 'Layout.handleResize', width, height)
+    await RendererProcess.invoke('Viewlet.setBounds', layoutUid, 0, 0, width, height)
+  })
+}
+
+const disposeApplication = async (applicationId: string): Promise<void> => {
+  ApplicationRegistry.close(applicationId)
+  await ApplicationRegistry.waitForOperations(applicationId)
+  const errors: unknown[] = []
+  for (const uid of [...ApplicationRegistry.getUids(applicationId)].reverse()) {
+    try {
+      if (ViewletStates.getByUid(uid)) {
+        await Viewlet.dispose(uid)
+      } else {
+        await RendererProcess.invoke('Viewlet.dispose', uid)
+      }
+    } catch (error) {
+      errors.push(error)
+      ViewletStates.remove(uid)
+    }
+  }
+  ApplicationRegistry.remove(applicationId)
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `Failed to dispose application ${applicationId}`)
+  }
+}
+
+export const dispose = (applicationId: string): Promise<void> => {
+  const existing = disposals.get(applicationId)
+  if (existing) {
+    return existing
+  }
+  const operation = disposeApplication(applicationId)
+  disposals.set(applicationId, operation)
+  const result = operation.finally(() => disposals.delete(applicationId))
+  disposals.set(applicationId, result)
+  return result
+}

--- a/packages/renderer-worker/src/parts/ApplicationRegistry/ApplicationRegistry.ts
+++ b/packages/renderer-worker/src/parts/ApplicationRegistry/ApplicationRegistry.ts
@@ -10,6 +10,40 @@ const applications = new Map<string, Application>()
 const owners = new Map<number, string>()
 const applicationUids = new Map<string, Set<number>>()
 const savedStates = new Map<string, Map<string | number, unknown>>()
+const operations = new Map<string, Set<Promise<unknown>>>()
+const closing = new Set<string>()
+
+export const assertOpen = (applicationId: string): Application => {
+  const application = get(applicationId)
+  if (closing.has(applicationId)) {
+    throw new Error(`Application is closing: ${applicationId}`)
+  }
+  return application
+}
+
+export const track = async <T>(applicationId: string, operation: () => Promise<T>): Promise<T> => {
+  assertOpen(applicationId)
+  const pending = operations.get(applicationId)!
+  const promise = Promise.try(operation)
+  pending.add(promise)
+  try {
+    return await promise
+  } finally {
+    pending.delete(promise)
+  }
+}
+
+export const close = (applicationId: string): void => {
+  get(applicationId)
+  closing.add(applicationId)
+}
+
+export const waitForOperations = async (applicationId: string): Promise<void> => {
+  const pending = operations.get(applicationId)
+  while (pending?.size) {
+    await Promise.allSettled(pending)
+  }
+}
 
 export const get = (applicationId: string): Application => {
   const application = applications.get(applicationId)
@@ -22,7 +56,7 @@ export const get = (applicationId: string): Application => {
 export const getOwner = (uid: number): string | undefined => owners.get(uid)
 
 export const own = (applicationId: string, uid: number): void => {
-  get(applicationId)
+  assertOpen(applicationId)
   if (!Number.isFinite(uid) || uid <= 0) {
     throw new Error(`Invalid component uid: ${uid}`)
   }
@@ -44,6 +78,7 @@ export const create = (application: Application): void => {
   applications.set(application.id, Object.freeze({ ...application }))
   applicationUids.set(application.id, new Set())
   savedStates.set(application.id, new Map())
+  operations.set(application.id, new Set())
   own(application.id, application.layoutUid)
 }
 
@@ -79,4 +114,6 @@ export const remove = (applicationId: string): void => {
   applicationUids.delete(applicationId)
   savedStates.delete(applicationId)
   applications.delete(applicationId)
+  operations.delete(applicationId)
+  closing.delete(applicationId)
 }

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -8,6 +8,11 @@ const lazy =
   }
 
 export const commandMap = {
+  'Application.create': lazy('Application.create'),
+  'Application.dispose': lazy('Application.dispose'),
+  'Application.execute': lazy('Application.execute'),
+  'Application.executeForView': lazy('Application.executeForView'),
+  'Application.resize': lazy('Application.resize'),
   'About.showAbout': lazy('About.showAbout'),
   'Ajax.getBlob': lazy('Ajax.getBlob'),
   'Ajax.getJson': lazy('Ajax.getJson'),

--- a/packages/renderer-worker/src/parts/Id/Id.js
+++ b/packages/renderer-worker/src/parts/Id/Id.js
@@ -3,5 +3,17 @@ export const state = {
 }
 
 export const create = () => {
-  return ++state.id
+  const { start } = reserve(1)
+  return start
+}
+
+// Reserve disjoint integer ranges for workers that create components locally.
+// Ranges are never recycled, including after a worker or application restart.
+export const reserve = (count) => {
+  if (!Number.isSafeInteger(count) || count <= 0 || count > Number.MAX_SAFE_INTEGER - state.id) {
+    throw new Error('Invalid or exhausted component id range')
+  }
+  const start = state.id + 1
+  state.id += count
+  return { start, end: state.id }
 }

--- a/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/LaunchIsolatedExtensionHostWorker/LaunchIsolatedExtensionHostWorker.js
@@ -7,38 +7,66 @@ import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as RendererProcessIpcParentType from '../RendererProcessIpcParentType/RendererProcessIpcParentType.js'
 
-const workerIds = Object.create(null)
-const workerUrls = Object.create(null)
+const workers = new Map()
+
+const assertCurrent = (extensionId, worker) => {
+  if (workers.get(extensionId) !== worker) {
+    throw new Error(`Extension worker launch canceled: ${extensionId}`)
+  }
+}
 
 export const launchIsolatedExtensionHostWorker = async (port, extensionId, url, workerName = '', contentSecurityPolicy = '') => {
+  if (workers.has(extensionId)) {
+    throw new Error(`Extension worker already exists: ${extensionId}`)
+  }
   const suffix = extensionId ? `: ${extensionId}` : ''
   const fallbackName = Platform.getPlatform() === PlatformType.Electron ? `Extension API (Electron)${suffix}` : `Extension API${suffix}`
   const name = workerName || fallbackName
   const id = Id.create()
-  if (contentSecurityPolicy) {
-    const pathName = new URL(url, 'http://localhost').pathname
-    await ContentSecurityPolicy.set(pathName, contentSecurityPolicy)
+  const worker = { id, url, starting: false }
+  workers.set(extensionId, worker)
+  try {
+    if (contentSecurityPolicy) {
+      const pathName = new URL(url, 'http://localhost').pathname
+      await ContentSecurityPolicy.set(pathName, contentSecurityPolicy)
+    }
+    assertCurrent(extensionId, worker)
+    const workerPort = await IpcTrace.maybeCreateProxy({
+      id,
+      name,
+      port,
+      traceId: extensionId,
+    })
+    if (workers.get(extensionId) !== worker) {
+      workerPort.close?.()
+      assertCurrent(extensionId, worker)
+    }
+    worker.starting = true
+    await RendererProcess.invokeAndTransfer('IpcParent.create', {
+      method: RendererProcessIpcParentType.ModuleWorkerWithMessagePort,
+      name,
+      port: workerPort,
+      raw: true,
+      url,
+      id,
+    })
+    assertCurrent(extensionId, worker)
+  } catch (error) {
+    if (workers.get(extensionId) === worker) {
+      workers.delete(extensionId)
+    }
+    port.close?.()
+    if (worker.starting) {
+      // Creation can finish after disposal; only terminate this launch's numeric
+      // id, never a replacement that happens to share the extension id.
+      await RendererProcess.invoke('IpcParent.dispose', id)
+    }
+    throw error
   }
-  const workerPort = await IpcTrace.maybeCreateProxy({
-    id,
-    name,
-    port,
-    traceId: extensionId,
-  })
-  await RendererProcess.invokeAndTransfer('IpcParent.create', {
-    method: RendererProcessIpcParentType.ModuleWorkerWithMessagePort,
-    name,
-    port: workerPort,
-    raw: true,
-    url,
-    id,
-  })
-  workerIds[extensionId] = id
-  workerUrls[extensionId] = url
 }
 
 export const getMemoryUsage = async (extensionId) => {
-  const workerUrl = workerUrls[extensionId]
+  const workerUrl = workers.get(extensionId)?.url
   if (typeof workerUrl !== 'string') {
     return 0
   }
@@ -47,18 +75,16 @@ export const getMemoryUsage = async (extensionId) => {
 }
 
 export const disposeIsolatedExtensionHostWorker = async (extensionId) => {
-  const id = workerIds[extensionId]
-  if (typeof id !== 'number') {
+  const worker = workers.get(extensionId)
+  if (!worker) {
     return
   }
-  delete workerIds[extensionId]
-  delete workerUrls[extensionId]
-  await RendererProcess.invoke('IpcParent.dispose', id)
+  workers.delete(extensionId)
+  if (worker.starting) {
+    await RendererProcess.invoke('IpcParent.dispose', worker.id)
+  }
 }
 
 export const clear = () => {
-  for (const extensionId of Object.keys(workerIds)) {
-    delete workerIds[extensionId]
-    delete workerUrls[extensionId]
-  }
+  workers.clear()
 }

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -44,6 +44,8 @@ export const load = (moduleId) => {
       return import('../ContextMenu/ContextMenu.ipc.js')
     case ModuleId.ComponentState:
       return import('../ComponentState/ComponentState.ipc.js')
+    case ModuleId.Application:
+      return import('../Application/Application.ipc.js')
     case ModuleId.Debug:
       return import('../Debug/Debug.ipc.js')
     case ModuleId.DebugSharedProcess:

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -118,3 +118,4 @@ export const WebSocketCapability = 153
 export const ExtensionHotReload = 154
 export const RevealInExplorer = 155
 export const ComponentState = 156
+export const Application = 157

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -57,6 +57,8 @@ export const getModuleId = (commandId) => {
       return ModuleId.ContextMenu
     case 'ComponentState':
       return ModuleId.ComponentState
+    case 'Application':
+      return ModuleId.Application
     case 'DebugSharedProcess':
       return ModuleId.DebugSharedProcess
     case 'Developer':

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -1,4 +1,5 @@
 import * as Assert from '../Assert/Assert.ts'
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
 import * as ElectronBrowserView from '../ElectronBrowserView/ElectronBrowserView.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
@@ -43,6 +44,14 @@ const enqueueCommand = async (uid, command) => {
 
 const getKeyBindingSetId = (instance, fallback) => {
   return instance.moduleId || fallback
+}
+
+const removeUnusedKeyBindings = (instance, fallback) => {
+  const key = getKeyBindingSetId(instance, fallback)
+  const inUse = ViewletStates.getAllInstances().some((other) => other !== instance && getKeyBindingSetId(other, other.state.uid) === key)
+  if (!inUse) {
+    KeyBindingsState.removeKeyBindings(key)
+  }
 }
 
 const getCssDisposeCommands = (instance) => {
@@ -226,7 +235,7 @@ export const dispose = async (id) => {
       await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     }
     if (instance.factory.getKeyBindings) {
-      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, instanceUid))
+      removeUnusedKeyBindings(instance, instanceUid)
     }
   } catch (error) {
     console.error(error)
@@ -266,13 +275,17 @@ export const disposeFunctional = (id) => {
     ]
 
     if (instance.factory.getKeyBindings) {
-      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, id))
+      removeUnusedKeyBindings(instance, id)
     }
     if (instance.factory.getChildren) {
       const children = instance.factory.getChildren(instance.state)
       for (const child of children) {
         if (child.id) {
-          commands.push(...disposeFunctional(child.id))
+          const applicationId = ApplicationRegistry.getOwner(uid)
+          const childId = applicationId === undefined ? child.id : child.uid || ViewletStates.getInstance(child.id, applicationId)?.state.uid
+          if (childId) {
+            commands.push(...disposeFunctional(childId))
+          }
         }
       }
     }

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -46,14 +46,6 @@ const getKeyBindingSetId = (instance, fallback) => {
   return instance.moduleId || fallback
 }
 
-const removeUnusedKeyBindings = (instance, fallback) => {
-  const key = getKeyBindingSetId(instance, fallback)
-  const inUse = ViewletStates.getAllInstances().some((other) => other !== instance && getKeyBindingSetId(other, other.state.uid) === key)
-  if (!inUse) {
-    KeyBindingsState.removeKeyBindings(key)
-  }
-}
-
 const getCssDisposeCommands = (instance) => {
   if (!instance.cssLoaded) {
     return []
@@ -235,7 +227,7 @@ export const dispose = async (id) => {
       await RendererProcess.invoke(/* Viewlet.dispose */ 'Viewlet.dispose', /* id */ instanceUid)
     }
     if (instance.factory.getKeyBindings) {
-      removeUnusedKeyBindings(instance, instanceUid)
+      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, instanceUid))
     }
   } catch (error) {
     console.error(error)
@@ -275,7 +267,7 @@ export const disposeFunctional = (id) => {
     ]
 
     if (instance.factory.getKeyBindings) {
-      removeUnusedKeyBindings(instance, id)
+      KeyBindingsState.removeKeyBindings(getKeyBindingSetId(instance, id))
     }
     if (instance.factory.getChildren) {
       const children = instance.factory.getChildren(instance.state)

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -594,7 +594,33 @@ export const backgroundLoad = async ({ getModule, id, x, y, width, height, props
  * @param {{getModule:()=>any, type:number, id:string, disposed:boolean }} viewlet
  * @returns
  */
+const pendingLoads = new Set()
+
+/**
+ * @param {any} viewlet
+ * @param {boolean} focus
+ * @param {boolean} restore
+ * @param {any} restoreState
+ */
 export const load = async (viewlet, focus = false, restore = false, restoreState = undefined) => {
+  const applicationId = viewlet.applicationId ?? ApplicationRegistry.getOwner(viewlet.parentUid)
+  if (applicationId === undefined) {
+    return loadInternal(viewlet, focus, restore, restoreState)
+  }
+  const uid = viewlet.uid || Id.create()
+  if (pendingLoads.has(uid) || ViewletStates.getByUid(uid)) {
+    throw new Error(`Component uid is already in use: ${uid}`)
+  }
+  viewlet.uid = uid
+  pendingLoads.add(uid)
+  try {
+    return await ApplicationRegistry.track(applicationId, () => loadInternal(viewlet, focus, restore, restoreState))
+  } finally {
+    pendingLoads.delete(uid)
+  }
+}
+
+const loadInternal = async (viewlet, focus, restore, restoreState) => {
   // console.time(`load/${viewlet.id}`)
   // TODO
   if (
@@ -625,6 +651,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     ApplicationRegistry.own(applicationId, viewletUid)
   }
   let module
+  let partialState
   try {
     viewlet.type = 1
     if (viewlet.disposed) {
@@ -650,6 +677,7 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
     }
 
     const initialViewletState = module.create(viewletUid, viewlet.uri, x, y, width, height, viewlet.args, parentUid)
+    partialState = initialViewletState
     if (applicationId !== undefined) {
       initialViewletState.applicationId = applicationId
     }
@@ -863,6 +891,18 @@ export const load = async (viewlet, focus = false, restore = false, restoreState
 
     return commands
   } catch (error) {
+    if (applicationId !== undefined) {
+      if (!ViewletStates.getByUid(viewletUid)) {
+        try {
+          if (partialState && module?.dispose) {
+            await module.dispose(partialState)
+          }
+        } finally {
+          ApplicationRegistry.release(viewletUid)
+        }
+      }
+      throw error
+    }
     if (error && error instanceof CancelationError) {
       return
     }

--- a/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
+++ b/packages/renderer-worker/src/parts/ViewletStates/ViewletStates.js
@@ -130,6 +130,7 @@ export const remove = (key) => {
   if (instance) {
     clearFocusedInstanceByType(instance.renderedState?.uid, instance.moduleId)
     if (!Object.values(state.instances).includes(instance)) {
+      ApplicationRegistry.release(instance.renderedState?.uid)
       emit('remove', instance)
     }
   }
@@ -141,6 +142,7 @@ export const dispose = async (key) => {
   if (instance) {
     clearFocusedInstanceByType(instance.renderedState?.uid, instance.moduleId)
     if (!Object.values(state.instances).includes(instance)) {
+      ApplicationRegistry.release(instance.renderedState?.uid)
       emit('remove', instance)
     }
   }

--- a/packages/renderer-worker/test/Application.test.ts
+++ b/packages/renderer-worker/test/Application.test.ts
@@ -98,6 +98,7 @@ test('a failed component teardown still releases application registrations', asy
   await expect(Application.dispose('preview')).rejects.toThrow('Failed to dispose application')
   expect(ViewletStates.getByUid(uid)).toBeUndefined()
   expect(ApplicationRegistry.getOwner(uid)).toBeUndefined()
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.dispose', uid)
 })
 
 test('invalid dimensions never register an application', async () => {

--- a/packages/renderer-worker/test/Application.test.ts
+++ b/packages/renderer-worker/test/Application.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import * as ApplicationRegistry from '../src/parts/ApplicationRegistry/ApplicationRegistry.ts'
+import * as Id from '../src/parts/Id/Id.js'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({ invoke: jest.fn(async () => {}) }))
+jest.unstable_mockModule('../src/parts/ViewletModule/ViewletModule.js', () => ({ load: jest.fn() }))
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({ dispose: jest.fn(async (uid) => ViewletStates.remove(uid)) }))
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => ({
+  load: jest.fn(async () => []),
+  executeForApplication: jest.fn(async () => {}),
+}))
+
+const Application = await import('../src/parts/Application/Application.ts')
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const ViewletManager = await import('../src/parts/ViewletManager/ViewletManager.js')
+const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+
+const options = (id: string) => ({
+  id,
+  rootId: `${id}-root`,
+  width: 600,
+  height: 800,
+  href: '/samples',
+  workspacePath: id,
+  workspaceUri: `memfs:///${id}`,
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  Id.state.id = 0
+  ViewletStates.reset()
+})
+
+afterEach(() => {
+  ApplicationRegistry.remove('source')
+  ApplicationRegistry.remove('preview')
+  ViewletStates.reset()
+})
+
+test('mounts independently owned layouts into two separate host roots', async () => {
+  const source = await Application.create(options('source'))
+  const preview = await Application.create(options('preview'))
+  expect(source).not.toBe(preview)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.executeCommands', [
+    ['Viewlet.appendToRoot', source, 'source-root'],
+    ['Viewlet.setBounds', source, 0, 0, 600, 800],
+  ])
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.executeCommands', [
+    ['Viewlet.appendToRoot', preview, 'preview-root'],
+    ['Viewlet.setBounds', preview, 0, 0, 600, 800],
+  ])
+  expect(await Application.execute('source', 'Workspace.getUri')).toBe('memfs:///source')
+  expect(await Application.execute('preview', 'Workspace.getPath')).toBe('preview')
+  expect(await Application.execute('source', 'Layout.getHref')).toBe('/samples')
+  await Application.executeForView(preview, 'Main.openInput', 'memfs:///README.md')
+  expect(ViewletManager.executeForApplication).toHaveBeenCalledWith('preview', 'Main.openInput', 'memfs:///README.md')
+  await Application.resize('source', 500, 700)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.setBounds', source, 0, 0, 500, 700)
+})
+
+test('failed mounting releases partial ownership and permits retrying the same application id', async () => {
+  jest.mocked(RendererProcess.invoke).mockRejectedValueOnce(new Error('missing root'))
+  await expect(Application.create(options('preview'))).rejects.toThrow('missing root')
+  expect(() => ApplicationRegistry.get('preview')).toThrow('Application not found')
+  expect(ApplicationRegistry.getOwner(1)).toBeUndefined()
+  expect(await Application.create(options('preview'))).toBe(2)
+})
+
+test('concurrent disposal shares one teardown and preserves the sibling layout', async () => {
+  const source = await Application.create(options('source'))
+  const preview = await Application.create(options('preview'))
+  const gate = Promise.withResolvers<void>()
+  const started = Promise.withResolvers<void>()
+  const pending = ApplicationRegistry.track('preview', async () => {
+    started.resolve()
+    await gate.promise
+  })
+  await started.promise
+  const dispose = Application.dispose('preview')
+  expect(Application.dispose('preview')).toBe(dispose)
+  expect(() => Application.execute('preview', 'Main.openInput')).toThrow('Application is closing')
+  gate.resolve()
+  await pending
+  await dispose
+  expect(ApplicationRegistry.getOwner(source)).toBe('source')
+  expect(ApplicationRegistry.getOwner(preview)).toBeUndefined()
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.dispose', preview)
+  expect(RendererProcess.invoke).not.toHaveBeenCalledWith('Viewlet.dispose', source)
+  await expect(Application.executeForView(preview, 'Main.openInput')).rejects.toThrow('Component not found')
+})
+
+test('a failed component teardown still releases application registrations', async () => {
+  const uid = await Application.create(options('preview'))
+  const state = { uid, applicationId: 'preview' }
+  ViewletStates.set(uid, { state, renderedState: state, moduleId: 'Layout', factory: {} })
+  jest.mocked(Viewlet.dispose).mockRejectedValueOnce(new Error('broken component'))
+  await expect(Application.dispose('preview')).rejects.toThrow('Failed to dispose application')
+  expect(ViewletStates.getByUid(uid)).toBeUndefined()
+  expect(ApplicationRegistry.getOwner(uid)).toBeUndefined()
+})
+
+test('invalid dimensions never register an application', async () => {
+  await expect(Application.create({ ...options('preview'), width: 0 })).rejects.toThrow('Invalid application root or dimensions')
+  expect(() => ApplicationRegistry.get('preview')).toThrow('Application not found')
+})

--- a/packages/renderer-worker/test/ApplicationRegistry.test.ts
+++ b/packages/renderer-worker/test/ApplicationRegistry.test.ts
@@ -61,3 +61,33 @@ test('view state is isolated even for identical storage keys and resets with the
   expect(ApplicationRegistry.getSavedState('preview', 'Explorer')).toBeUndefined()
   expect(ApplicationRegistry.getSavedState('source', 'Explorer')).toEqual({ selected: ['src/main.ts'] })
 })
+
+test('closing blocks new operations and claims but waits for previously accepted work', async () => {
+  ApplicationRegistry.create(source)
+  ApplicationRegistry.create(preview)
+  const gate = Promise.withResolvers<void>()
+  const running = ApplicationRegistry.track('source', () => gate.promise)
+  ApplicationRegistry.close('source')
+  expect(() => ApplicationRegistry.own('source', 3)).toThrow('Application is closing')
+  await expect(ApplicationRegistry.track('source', async () => {})).rejects.toThrow('Application is closing')
+  ApplicationRegistry.own('preview', 4)
+  const waiting = ApplicationRegistry.waitForOperations('source')
+  gate.resolve()
+  await running
+  await waiting
+  expect(ApplicationRegistry.getOwner(4)).toBe('preview')
+  ApplicationRegistry.remove('source')
+  ApplicationRegistry.create(source)
+  expect(ApplicationRegistry.assertOpen('source').id).toBe('source')
+})
+
+test('failed operations do not keep application teardown pending', async () => {
+  ApplicationRegistry.create(source)
+  await expect(
+    ApplicationRegistry.track('source', async () => {
+      throw new Error('failed')
+    }),
+  ).rejects.toThrow('failed')
+  ApplicationRegistry.close('source')
+  await ApplicationRegistry.waitForOperations('source')
+})

--- a/packages/renderer-worker/test/Id.test.ts
+++ b/packages/renderer-worker/test/Id.test.ts
@@ -1,7 +1,29 @@
-import { expect, test } from '@jest/globals'
+import { beforeEach, expect, test } from '@jest/globals'
 import * as Id from '../src/parts/Id/Id.js'
+
+beforeEach(() => {
+  Id.state.id = 0
+})
 
 test('generate', () => {
   expect(Id.create()).toBe(1)
   expect(Id.create()).toBe(2)
+})
+
+test('worker ranges do not collide with renderer ids or later ranges', () => {
+  expect(Id.create()).toBe(1)
+  expect(Id.reserve(2 ** 32)).toEqual({ start: 2, end: 2 ** 32 + 1 })
+  expect(Id.create()).toBe(2 ** 32 + 2)
+  expect(Id.reserve(10)).toEqual({ start: 2 ** 32 + 3, end: 2 ** 32 + 12 })
+})
+
+test.each([0, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1])('invalid range size %s does not consume ids', (count) => {
+  expect(() => Id.reserve(count)).toThrow('Invalid or exhausted')
+  expect(Id.create()).toBe(1)
+})
+
+test('exhaustion never wraps or returns unsafe ids', () => {
+  expect(Id.reserve(Number.MAX_SAFE_INTEGER).end).toBe(Number.MAX_SAFE_INTEGER)
+  expect(() => Id.create()).toThrow('Invalid or exhausted')
+  expect(() => Id.reserve(2)).toThrow('Invalid or exhausted')
 })

--- a/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/LaunchIsolatedExtensionHostWorker.test.ts
@@ -184,3 +184,42 @@ test('disposeIsolatedExtensionHostWorker only disposes a worker once', async () 
 
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(1)
 })
+
+test('disposal during security policy setup prevents worker creation', async () => {
+  const gate = Promise.withResolvers<void>()
+  jest.mocked(ContentSecurityPolicy.set).mockImplementationOnce(() => gate.promise)
+  const close = jest.fn()
+  const launch = LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker({ close }, 'preview', '/old.js', '', 'policy')
+  const result = launch.catch((error: unknown) => error)
+  await LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker('preview')
+  gate.resolve()
+  expect(await result).toEqual(expect.objectContaining({ message: 'Extension worker launch canceled: preview' }))
+  expect(RendererProcess.invokeAndTransfer).not.toHaveBeenCalled()
+  expect(close).toHaveBeenCalledTimes(1)
+})
+
+test('a late worker launch cannot overwrite or terminate a replacement', async () => {
+  const started = Promise.withResolvers<void>()
+  const gate = Promise.withResolvers<void>()
+  jest.mocked(RendererProcess.invokeAndTransfer).mockImplementationOnce(async () => {
+    started.resolve()
+    await gate.promise
+  })
+  const old = LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker({}, 'preview', '/old.js')
+  const result = old.catch((error: unknown) => error)
+  await started.promise
+  await LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker('preview')
+  jest.mocked(Id.create).mockReturnValue(43)
+  await LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker({}, 'preview', '/new.js')
+  gate.resolve()
+  expect(await result).toEqual(expect.objectContaining({ message: 'Extension worker launch canceled: preview' }))
+  expect(RendererProcess.invoke).not.toHaveBeenCalledWith('IpcParent.dispose', 43)
+  await LaunchIsolatedExtensionHostWorker.disposeIsolatedExtensionHostWorker('preview')
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('IpcParent.dispose', 43)
+})
+
+test('rejects duplicate live extension ids without replacing the first worker', async () => {
+  await LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker({}, 'preview', '/first.js')
+  await expect(LaunchIsolatedExtensionHostWorker.launchIsolatedExtensionHostWorker({}, 'preview', '/second.js')).rejects.toThrow('already exists')
+  expect(RendererProcess.invokeAndTransfer).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -57,6 +57,23 @@ const Id = await import('../src/parts/Id/Id.js')
 const SaveState = await import('../src/parts/SaveState/SaveState.js')
 const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
 const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+const KeyBindingsState = await import('../src/parts/KeyBindingsState/KeyBindingsState.js')
+
+test('disposing sibling components releases one shared keybinding reference at a time', async () => {
+  jest.mocked(RendererProcess.invoke).mockResolvedValue(undefined as never)
+  const moduleId = 'ApplicationTestComponent'
+  const factory = { getKeyBindings: () => [] }
+  for (const uid of [10, 11]) {
+    const state = { uid }
+    ViewletStates.set(uid, { state, renderedState: state, moduleId, factory })
+    KeyBindingsState.addKeyBindings(moduleId, [])
+  }
+  await Viewlet.dispose(10)
+  expect(KeyBindingsState.state.keyBindingSetCounts[moduleId]).toBe(1)
+  expect(ViewletStates.getByUid(11)).toBeDefined()
+  await Viewlet.dispose(11)
+  expect(KeyBindingsState.state.keyBindingSets[moduleId]).toBeUndefined()
+})
 
 test.skip('focus', () => {
   // RendererProcess.state.send = jest.fn()

--- a/packages/renderer-worker/test/ViewletManagerApplications.test.ts
+++ b/packages/renderer-worker/test/ViewletManagerApplications.test.ts
@@ -70,3 +70,33 @@ test('a command finishing after its view is removed cannot render into another a
   expect(ViewletStates.getState(2).value).toBe('initial')
   expect(RendererProcess.invoke).not.toHaveBeenCalled()
 })
+
+test('concurrent loads cannot claim the same uid even inside one application', async () => {
+  ApplicationRegistry.create({ id: 'source', layoutUid: 1, workspacePath: '', workspaceUri: '', href: '' })
+  const gate = Promise.withResolvers<void>()
+  const entered = Promise.withResolvers<void>()
+  const dispose = jest.fn(async () => {})
+  const module = {
+    create: (uid: number) => ({ uid }),
+    loadContent: async (state) => {
+      entered.resolve()
+      await gate.promise
+      return state
+    },
+    dispose,
+    hasFunctionalRender: true,
+    render: [],
+  }
+  const viewlet = { applicationId: 'source', uid: 3, id: 'TestApplicationView', type: 0, show: false, getModule: async () => module }
+  const first = ViewletManager.load({ ...viewlet })
+  const result = Promise.allSettled([first])
+  await entered.promise
+  await expect(ViewletManager.load({ ...viewlet })).rejects.toThrow('already in use')
+  ApplicationRegistry.close('source')
+  gate.resolve()
+  await ApplicationRegistry.waitForOperations('source')
+  expect(await result).toEqual([{ status: 'rejected', reason: expect.objectContaining({ message: 'Application is closing: source' }) }])
+  expect(dispose).toHaveBeenCalledTimes(1)
+  expect(ViewletStates.getByUid(3)).toBeUndefined()
+  expect(ApplicationRegistry.getOwner(3)).toBeUndefined()
+})


### PR DESCRIPTION
Add internal application roots with scoped workspace queries, resize, and teardown. Reserve non-overlapping component ID ranges, reject concurrent UID claims, and prevent canceled extension launches from replacing newer workers.