### PR TITLE
feature: show Problems in live component state

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,6 +102,12 @@ jobs:
         run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-auto-update
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Problems live component state
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-edit-problems
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build Electron App (deb)
         if: matrix.os == 'ubuntu-24.04'
         run: npm run build:electron:deb

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-problems.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-problems.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-problems'
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+  await Command.execute('Layout.showPanel', 'Problems')
+  const filter = Locator('.Panel .InputBox')
+  await expect(filter).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'Problems')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable Problems component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, filterValue: 'live state filter', inputSource: 2 }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.filterValue !== 'live state filter') {
+    throw new Error(`Expected Problems filter to update, got ${updatedState.filterValue}`)
+  }
+  await expect(filter).toHaveValue('live state filter')
+}

--- a/packages/renderer-worker/src/parts/ViewletProblems/ViewletProblems.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletProblems/ViewletProblems.ipc.js
@@ -1,7 +1,7 @@
 import { createWorkerViewlet } from '../CreateWorkerViewlet/CreateWorkerViewlet.js'
 
 export const {
-  Commands, Css, Events, Variables, create, dispose, getBadgeCount, getCommands, getKeyBindings, getMenus, getQuickPickMenuEntries,
+  Commands, Css, Events, Variables, create, dispose, getBadgeCount, getCommands, getComponentState, getKeyBindings, getMenus, getQuickPickMenuEntries,
   getStorageKey, getTitle, hasDirectRender, hasFunctionalEvents, hasFunctionalRender, hasFunctionalResize, hasFunctionalRootRender, hotReload,
-  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, resizeWithDependencies, saveState,
+  loadContent, menus, name, render, renderActions, renderEventListeners, renderTitle, resize, resizeWithDependencies, saveState, setComponentState,
 } = createWorkerViewlet({ workerId: 'problemsViewWorker' })

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1375,9 +1375,13 @@
         "resize": { "name": "Problems.resize", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "dimensions" }] },
         "saveState": { "name": "Problems.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getCommandIds": { "name": "Problems.getCommandIds", "parameters": [] },
+        "getComponentState": { "name": "Problems.getComponentState", "parameters": [{ "source": "state", "name": "uid" }] },
         "getMenuEntryIds": { "name": "Problems.getMenuIds", "parameters": [] },
         "getMenuEntries": { "name": "Problems.getMenuEntries2", "parameters": [{ "source": "argument", "name": "args", "spread": true }] },
-        "renderEventListeners": { "name": "Problems.renderEventListeners", "parameters": [] }
+        "renderEventListeners": { "name": "Problems.renderEventListeners", "parameters": [] },
+        "setComponentState": { "name": "Problems.setComponentState", "parameters": [
+          { "source": "state", "name": "uid" }, { "source": "argument", "name": "componentState" }
+        ] }
       },
       "outputs": [{ "stateField": "actionsDom", "method": { "name": "Problems.renderActions", "parameters": [{ "source": "state", "name": "uid" }] } }],
       "renderActionsComparison": "always",


### PR DESCRIPTION
Show Problems as an editable component in Live Component State by connecting its worker state APIs. Opening the Problems card displays its JSON state, and saving changes updates the Problems view.