### PR TITLE
fix: restore built-in quick pick commands in web builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,9 @@ jobs:
         run: npm run test:server
       - name: Test Static Export
         run: npm run test-static-export
+      - name: Test static command picker
+        working-directory: ./packages/extension-host-worker-tests
+        run: node src/_all.js --ci --headless --test-name-prefix=viewlet.quick-pick-builtin-commands
       - name: Run extension host worker tests
         working-directory: ./packages/extension-host-worker-tests
         run: npm run e2e:headless:ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Test static command picker
         working-directory: ./packages/extension-host-worker-tests
         run: node src/_all.js --ci --headless --test-name-prefix=viewlet.quick-pick-builtin-commands
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Run extension host worker tests
         working-directory: ./packages/extension-host-worker-tests
         run: npm run e2e:headless:ci

--- a/packages/extension-host-worker-tests/src/viewlet.quick-pick-builtin-commands.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.quick-pick-builtin-commands.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.quick-pick-builtin-commands'
+
+export const test: Test = async ({ Command, expect, Locator, QuickPick }) => {
+  await QuickPick.open()
+  await QuickPick.setValue('>Layout: Toggle Side Bar')
+
+  const toggleSideBar = Locator('.QuickPickItem', { hasText: 'Layout: Toggle Side Bar' })
+  await expect(toggleSideBar).toBeVisible()
+
+  await QuickPick.setValue('>Account: Sign In')
+  const signIn = Locator('.QuickPickItem', { hasText: 'Account: Sign In' })
+  await expect(signIn).toBeVisible()
+
+  await QuickPick.setValue('>Change Language Mode')
+  const changeLanguageMode = Locator('.QuickPickItem', { hasText: 'Change Language Mode' })
+  await expect(changeLanguageMode).toBeVisible()
+
+  await Command.execute('Viewlet.closeWidget', 'QuickPick')
+})

--- a/packages/extension-host-worker-tests/src/viewlet.quick-pick-builtin-commands.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.quick-pick-builtin-commands.ts
@@ -18,4 +18,4 @@ export const test: Test = async ({ Command, expect, Locator, QuickPick }) => {
   await expect(changeLanguageMode).toBeVisible()
 
   await Command.execute('Viewlet.closeWidget', 'QuickPick')
-})
+}

--- a/packages/renderer-worker/src/parts/GetAutoUpdateType/GetAutoUpdateType.js
+++ b/packages/renderer-worker/src/parts/GetAutoUpdateType/GetAutoUpdateType.js
@@ -1,5 +1,11 @@
+import * as AutoUpdateType from '../AutoUpdateType/AutoUpdateType.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 
 export const getAutoUpdateType = () => {
+  if (Platform.getPlatform() === PlatformType.Web) {
+    return AutoUpdateType.None
+  }
   return SharedProcess.invoke('AutoUpdater.getAutoUpdateType')
 }

--- a/packages/renderer-worker/test/ViewletLayoutQuickPickMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutQuickPickMenuEntries.test.ts
@@ -13,7 +13,7 @@ const menuEntries = [
   },
 ]
 
-const mockGetAutoUpdateType = jest.fn(() => AutoUpdateType.None)
+const mockGetAutoUpdateType = jest.fn<(method: string) => string>(() => AutoUpdateType.None)
 const mockGetPlatform = jest.fn(() => PlatformType.Electron)
 
 beforeEach(() => {

--- a/packages/renderer-worker/test/ViewletLayoutQuickPickMenuEntries.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutQuickPickMenuEntries.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as AutoUpdateType from '../src/parts/AutoUpdateType/AutoUpdateType.js'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
 
 const menuEntries = [
   {
@@ -13,10 +14,12 @@ const menuEntries = [
 ]
 
 const mockGetAutoUpdateType = jest.fn(() => AutoUpdateType.None)
+const mockGetPlatform = jest.fn(() => PlatformType.Electron)
 
 beforeEach(() => {
   jest.clearAllMocks()
   mockGetAutoUpdateType.mockImplementation(() => AutoUpdateType.None)
+  mockGetPlatform.mockImplementation(() => PlatformType.Electron)
 })
 
 jest.unstable_mockModule('../src/parts/MenuEntriesState/MenuEntriesState.js', () => {
@@ -25,11 +28,16 @@ jest.unstable_mockModule('../src/parts/MenuEntriesState/MenuEntriesState.js', ()
   }
 })
 
-jest.unstable_mockModule('../src/parts/GetAutoUpdateType/GetAutoUpdateType.js', () => {
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => {
   return {
-    getAutoUpdateType: mockGetAutoUpdateType,
+    invoke: mockGetAutoUpdateType,
   }
 })
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+  getPlatform: mockGetPlatform,
+  platform: PlatformType.Test,
+}))
 
 const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
 
@@ -48,4 +56,22 @@ test('getAllQuickPickMenuEntries - not deb', async () => {
   mockGetAutoUpdateType.mockImplementation(() => AutoUpdateType.AppImage)
 
   expect(await ViewletLayout.getAllQuickPickMenuEntries()).toEqual(menuEntries)
+})
+
+test('getAllQuickPickMenuEntries - web without a shared process', async () => {
+  mockGetPlatform.mockReturnValue(PlatformType.Web)
+  mockGetAutoUpdateType.mockImplementation(() => {
+    throw new Error('shared process is unavailable')
+  })
+
+  expect(await ViewletLayout.getAllQuickPickMenuEntries()).toEqual(menuEntries)
+  expect(mockGetAutoUpdateType).not.toHaveBeenCalled()
+})
+
+test('getAllQuickPickMenuEntries - remote deb', async () => {
+  mockGetPlatform.mockReturnValue(PlatformType.Remote)
+  mockGetAutoUpdateType.mockReturnValue(AutoUpdateType.Deb)
+
+  expect(await ViewletLayout.getAllQuickPickMenuEntries()).toEqual([menuEntries[1]])
+  expect(mockGetAutoUpdateType).toHaveBeenCalledWith('AutoUpdater.getAutoUpdateType')
 })


### PR DESCRIPTION
Restores built-in command picker items in static web builds, including the component-state playground. The command list was discarded when querying the unavailable shared-process update service; web builds now report no automatic updater without making that request.

Adds coverage for web and desktop command lists and a browser regression check against the static export.
