### PR TITLE
fix: avoid misleading font and disposed render warnings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,6 +74,12 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test bundled font loading
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:fonts
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build static site
         run: npm run build:static:ignore-icon-theme
         env:

--- a/packages/extension-host-worker-tests/package.json
+++ b/packages/extension-host-worker-tests/package.json
@@ -11,6 +11,7 @@
     "e2e:headless": "node src/_all.js --headless",
     "#e2e:headless:ci": "node src/_all.js --headless --ci",
     "e2e:headless:ci": "echo ok",
+    "e2e:fonts": "node scripts/test-font-loading.mjs",
     "type-check": "tsc"
   },
   "keywords": [],

--- a/packages/extension-host-worker-tests/scripts/test-font-loading.mjs
+++ b/packages/extension-host-worker-tests/scripts/test-font-loading.mjs
@@ -1,0 +1,52 @@
+import { chromium } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+
+const css = await readFile(new URL('../../../static/css/parts/_Global.css', import.meta.url), 'utf8')
+const font = await readFile(new URL('../../../static/fonts/FiraCode-VariableFont.ttf', import.meta.url))
+const fontPath = '/fonts/FiraCode-VariableFont.ttf'
+const requests = []
+const server = createServer((request, response) => {
+  response.setHeader('Cache-Control', 'no-store')
+  if (request.url === fontPath) {
+    requests.push(request.url)
+    response.setHeader('Content-Type', 'font/ttf')
+    response.end(font)
+    return
+  }
+  response.setHeader('Content-Type', 'text/html')
+  response.end(`<style>${css}</style><p style="font-family: 'Fira Code'">Bundled editor font</p>`)
+})
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+let browser
+try {
+  // A connection estimate can affect bundled fonts even though they need no internet access.
+  browser = await chromium.launch({
+    headless: true,
+    // The headless shell does not reproduce Chromium's font intervention.
+    channel: 'chromium',
+    args: ['--force-effective-connection-type=2G'],
+  })
+  const page = await browser.newPage()
+  const session = await page.context().newCDPSession(page)
+  const interventions = []
+  session.on('Log.entryAdded', ({ entry }) => {
+    if (entry.text.includes('Slow network is detected')) {
+      interventions.push(entry.text)
+    }
+  })
+  await session.send('Log.enable')
+  await page.goto(`http://127.0.0.1:${server.address().port}`)
+  const loaded = await page.evaluate(async () => {
+    await document.fonts.ready
+    return [...document.fonts].some((font) => font.family === 'Fira Code' && font.status === 'loaded')
+  })
+  assert.equal(loaded, true, 'The bundled editor font must finish loading')
+  assert.deepEqual(requests, [fontPath])
+  assert.deepEqual(interventions, [], 'Local font loading must not trigger a slow-network intervention')
+  console.log('Bundled editor font loads without slow-network warnings')
+} finally {
+  await browser?.close()
+  await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+}

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -618,7 +618,8 @@ export const getFocusCommands = async (id) => {
 const executeViewletCommandInternal = async (uid, fnName, ...args) => {
   const instance = ViewletStates.getInstance(uid)
   if (!instance) {
-    if (fnName !== DomEventListenerFunctions.HandleBlur) {
+    // Worker render notifications can arrive or leave the command queue after disposal.
+    if (fnName !== DomEventListenerFunctions.HandleBlur && fnName !== '__renderPending') {
       Logger.warn(`cannot execute ${fnName} instance not found ${uid}`)
     }
     return

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -214,6 +214,60 @@ test('requestRender renders pending worker state without executing the event aga
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', [['Viewlet.setText', 'updated']])
 })
 
+test('requestRender ignores a notification arriving after disposal', async () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const state = { uid: 2 }
+  const renderPending = jest.fn(async () => state)
+  ViewletStates.set(2, {
+    state,
+    renderedState: state,
+    moduleId: 'Test',
+    factory: { Commands: { __renderPending: renderPending } },
+  })
+  await ViewletStates.dispose(2)
+
+  await Viewlet.requestRender(2)
+
+  expect(warn).not.toHaveBeenCalled()
+  expect(renderPending).not.toHaveBeenCalled()
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+})
+
+test('requestRender ignores a queued notification when disposal overtakes it', async () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const { promise: updateFinished, resolve: finishUpdate } = Promise.withResolvers<void>()
+  const { promise: updateStarted, resolve: startUpdate } = Promise.withResolvers<void>()
+  const state = { uid: 2, value: 'old' }
+  const renderPending = jest.fn(async () => ({ ...state, value: 'pending' }))
+  ViewletStates.set(2, {
+    state,
+    renderedState: state,
+    moduleId: 'Test',
+    factory: {
+      serializeCommands: true,
+      Commands: {
+        __renderPending: renderPending,
+        update: async () => {
+          startUpdate()
+          await updateFinished
+          return { ...state, value: 'updated' }
+        },
+      },
+    },
+  })
+  const update = Viewlet.executeViewletCommand(2, 'update')
+  await updateStarted
+  const render = Viewlet.requestRender(2)
+  await ViewletStates.dispose(2)
+  finishUpdate()
+  await Promise.all([update, render])
+
+  expect(warn).not.toHaveBeenCalled()
+  expect(renderPending).not.toHaveBeenCalled()
+  expect(RendererProcess.invoke).not.toHaveBeenCalled()
+  expect(ViewletStates.getInstance(2)).toBeUndefined()
+})
+
 test('getTitle', async () => {
   const getTitle = jest.fn(async (_uid = 0) => 'Test Title')
   const state = { uid: 1 }

--- a/static/css/parts/ViewletEditor.css
+++ b/static/css/parts/ViewletEditor.css
@@ -16,7 +16,6 @@
   letter-spacing: var(--EditorLetterSpacing);
   font-feature-settings: var(--EditorFontFeatureSettings);
   tab-size: var(--EditorTabSize);
-  font-display: block;
   cursor: text;
   font-weight: var(--EditorFontWeight);
   display: flex;

--- a/static/css/parts/ViewletEditorHover.css
+++ b/static/css/parts/ViewletEditorHover.css
@@ -50,7 +50,6 @@
   letter-spacing: var(--EditorLetterSpacing);
   font-feature-settings: var(--EditorFontFeatureSettings);
   tab-size: var(--EditorTabSize);
-  font-display: block;
   padding: 4px 8px;
 }
 

--- a/static/css/parts/_Global.css
+++ b/static/css/parts/_Global.css
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Fira Code';
   src: url(/fonts/FiraCode-VariableFont.ttf) format('truetype');
+  font-display: block;
 }
 
 /* TODO check if contain strict also makes sense for html and body */


### PR DESCRIPTION
Apply the bundled Fira Code font's display policy on its `@font-face` rule so Chromium does not report a slow network for local font loading.

Ignore late worker render notifications after their viewlet is disposed, including notifications overtaken by disposal while queued. Other missing-viewlet command warnings remain visible.
