### PR TITLE
feature: expose simple browser state in live component editor

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-simple-browser.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-simple-browser.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-simple-browser'
+
+// The standard e2e runner is browser-only; this view requires Electron WebContentsView.
+export const skip = 1
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+  await Command.execute('Layout.showPreview', 'simple-browser://')
+  await expect(Locator('.SimpleBrowser')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'SimpleBrowser')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable SimpleBrowser component, got ${JSON.stringify(components)}`)
+  }
+
+  await Locator(`.ComponentStateCard[data-uid="${component.uid}"]`).click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, inputValue: 'Live browser state' }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.inputValue !== 'Live browser state') {
+    throw new Error(`Expected SimpleBrowser input to update, got ${JSON.stringify(updatedState.inputValue)}`)
+  }
+  await expect(Locator('.SimpleBrowserHeader input.InputBox')).toHaveValue('Live browser state')
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.ipc.js
@@ -2,6 +2,7 @@ export const name = 'SimpleBrowser'
 
 export * from './ViewletSimpleBrowser.js'
 export * from './ViewletSimpleBrowserCommands.js'
+export * from './ViewletSimpleBrowserComponentState.js'
 export * from './ViewletSimpleBrowserCss.js'
 export * from './ViewletSimpleBrowserKeyBindings.js'
 export * from './ViewletSimpleBrowserMenuEntries.js'

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserComponentState.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserComponentState.js
@@ -1,0 +1,11 @@
+export const getComponentState = (state) => state
+
+export const setComponentState = (currentState, state) => {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('SimpleBrowser state must be an object')
+  }
+  if (state.uid !== currentState.uid) {
+    throw new Error(`SimpleBrowser state uid must remain ${currentState.uid}`)
+  }
+  return state
+}

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -301,3 +301,22 @@ test('stops refreshing after the live component state editor is disposed', async
   expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
   expect(Viewlet.reload).not.toHaveBeenCalled()
 })
+
+test('exposes Simple Browser state and renders edits through its component state hooks', async () => {
+  const factory = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.ipc.js')
+  const state = factory.create(10, 'simple-browser://', 0, 0, 800, 600)
+  ViewletStates.set(10, { factory, moduleId: 'SimpleBrowser', renderedState: state, state })
+
+  expect(ComponentState.getComponents()).toEqual([{ displayName: 'SimpleBrowser', editable: true, moduleId: 'SimpleBrowser', uid: 10 }])
+  await expect(ComponentState.getState(10)).resolves.toBe(state)
+
+  const editedState = { ...state, inputValue: 'Live browser state' }
+  const domCommands = factory.render[0].apply(state, editedState)
+  jest.mocked(ViewletManager.render).mockReturnValue(domCommands)
+  await ComponentState.setState(10, editedState)
+
+  await expect(ComponentState.getState(10)).resolves.toBe(editedState)
+  expect(ViewletManager.render).toHaveBeenCalledWith(factory, state, editedState, 10, undefined)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', domCommands)
+  expect(domCommands).toEqual([['Viewlet.setDom2', 10, expect.arrayContaining([expect.objectContaining({ value: 'Live browser state' })])]])
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowserComponentState.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserComponentState.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import * as ComponentState from '../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserComponentState.js'
+
+test.each([null, [], 'invalid', 42])('rejects non-object state %p', (state) => {
+  expect(() => ComponentState.setComponentState({ uid: 1 }, state)).toThrow('SimpleBrowser state must be an object')
+})
+
+test('rejects changing the component uid', () => {
+  expect(() => ComponentState.setComponentState({ uid: 1 }, { uid: 2 })).toThrow('SimpleBrowser state uid must remain 1')
+})


### PR DESCRIPTION
Make Simple Browser available for inspection and editing in Live Component State. Expose its renderer state through the component-state hooks so edits update the view through the existing render pipeline while preserving the component UID.