### PR TITLE
fix: cover saved live status bar labels in end-to-end tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -131,6 +131,12 @@ jobs:
         run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-edit-problems
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test live status bar component edits
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-edit-status-bar
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build Electron App (deb)
         if: matrix.os == 'ubuntu-24.04'
         run: npm run build:electron:deb

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-status-bar.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-status-bar.ts
@@ -6,9 +6,24 @@ interface ComponentInfo {
   readonly uid: number
 }
 
+interface StatusBarItem {
+  readonly name: string
+}
+
 export const name = 'viewlet.component-state-edit-status-bar'
 
-export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/status-bar.json`
+  await FileSystem.writeFile(uri, '{\n  "value": true\n}\n')
+  await Main.openUri(uri)
+  const encoding = Locator('.StatusBarItem[name="EditorEncoding"]')
+  const indentation = Locator('.StatusBarItem[name="EditorIndentation"]')
+  const position = Locator('.StatusBarItem[name="EditorPosition"]')
+  // eslint-disable-next-line unicorn/text-encoding-identifier-case -- Assert the displayed status label.
+  await expect(encoding).toHaveText('UTF-8')
+  await expect(indentation).toHaveText('Spaces: 2')
+
   await Command.execute('Developer.openComponentState')
   const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
   const component = components.find((item) => item.moduleId === 'StatusBar')
@@ -20,6 +35,14 @@ export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => 
   await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
   await expect(Locator('.Editor')).toContainText('{')
   const state = JSON.parse(await Editor.getText())
+  const { statusBarItemsRight: originalItemsRight } = state
+  const labels: Readonly<Record<string, string>> = {
+    EditorEncoding: 'Live encoding',
+    EditorIndentation: 'Live indentation',
+  }
+  const statusBarItemsRight = (originalItemsRight as readonly StatusBarItem[]).map((item) =>
+    labels[item.name] ? { ...item, elements: [{ type: 'text', value: labels[item.name] }] } : item,
+  )
   const statusBarItemsLeft = [
     {
       ariaLabel: 'Live component state',
@@ -28,7 +51,7 @@ export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => 
       tooltip: 'Live component state',
     },
   ]
-  await Editor.setText(`${JSON.stringify({ ...state, statusBarItemsLeft }, null, 2)}\n`)
+  await Editor.setText(`${JSON.stringify({ ...state, statusBarItemsLeft, statusBarItemsRight }, null, 2)}\n`)
   await Main.save()
 
   const updatedState = await Command.execute('ComponentState.getState', component.uid)
@@ -36,4 +59,22 @@ export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => 
     throw new Error(`Expected StatusBar items to update, got ${JSON.stringify(updatedState.statusBarItemsLeft)}`)
   }
   await expect(Locator('.StatusBarItem[name="component.state.test"]')).toHaveText('Live State')
+  await expect(encoding).toHaveText('Live encoding')
+  await expect(indentation).toHaveText('Live indentation')
+
+  await Editor.setCursor(1, 0)
+  await expect(position).toHaveText('Ln 2, Col 1')
+  await Editor.type(' ')
+  await expect(position).toHaveText('Ln 2, Col 2')
+  await expect(encoding).toHaveText('Live encoding')
+  await expect(indentation).toHaveText('Live indentation')
+  await Main.save()
+
+  await Main.openUri(uri)
+  await expect(encoding).toHaveText('Live encoding')
+  await expect(indentation).toHaveText('Live indentation')
+
+  await Command.execute('Editor.setIndentation', false)
+  await expect(indentation).toHaveText('Tab Size: 2')
+  await expect(encoding).toHaveText('Live encoding')
 }


### PR DESCRIPTION
Extend the live component state regression to save custom encoding and indentation labels, then verify they survive cursor movement, typing, and an equal-value tab switch. A real indentation change must restore its normal label while preserving the custom encoding label.

Run this focused regression explicitly in Linux CI so it executes despite the placeholder broad e2e script.
