### PR TITLE
feature: expand component context menu e2e coverage

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-show-dom-disabled.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-show-dom-disabled.ts
@@ -1,0 +1,40 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.component-state-show-dom-disabled'
+
+export const test: Test = async ({ Command, Editor, expect, FileSystem, KeyBoard, Locator, Main }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/context-menu.txt`
+  await FileSystem.writeFile(uri, 'Keep this editor open')
+  await Main.openUri(uri)
+  await Command.execute('Layout.showPanel', 'Problems')
+  await expect(Locator('.Problems')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  const components = await Command.execute('ComponentState.getComponents')
+  const component = components.find((item) => item.moduleId === 'Problems')
+  if (!component?.editable || component.domAvailable !== false) {
+    throw new Error('Expected Problems to support state inspection without a DOM API')
+  }
+
+  const card = Locator(`.ComponentStateCard[data-uid="${component.uid}"]`)
+  await expect(card).toBeVisible()
+  // Dispatch the menu event directly: the test runner's right-click helper also emits a normal click.
+  await card.dispatchEvent('contextmenu', {
+    bubbles: true,
+    button: 2,
+    cancelable: true,
+    clientX: 100,
+    clientY: 100,
+  } as unknown as string)
+  const showDom = Locator('.Menu .MenuItem', { hasText: 'Show Dom' })
+  await expect(showDom).toBeVisible()
+  await expect(showDom).toHaveAttribute('aria-disabled', 'true')
+  await showDom.click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText('context-menu.txt')
+  const content = await Editor.getText()
+  if (content !== 'Keep this editor open') {
+    throw new Error(`Disabled Show Dom changed the editor: ${content}`)
+  }
+  await KeyBoard.press('Escape')
+  await expect(Locator('.Menu')).toBeHidden()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-show-dom-dismiss.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-show-dom-dismiss.ts
@@ -1,0 +1,52 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.component-state-show-dom-dismiss'
+
+export const test: Test = async ({ Command, Editor, expect, FileSystem, KeyBoard, Locator, Main }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/context-menu.txt`
+  await FileSystem.writeFile(uri, 'Keep this editor open')
+  await Main.openUri(uri)
+  await Command.execute('Developer.openComponentState')
+  const components = await Command.execute('ComponentState.getComponents')
+  const titleBar = components.find((item) => item.moduleId === 'TitleBar')
+  const statusBar = components.find((item) => item.moduleId === 'StatusBar')
+  if (!titleBar?.domAvailable || !statusBar?.domAvailable) {
+    throw new Error('Expected TitleBar and StatusBar DOM inspection')
+  }
+
+  const titleBarLabel = Locator(`.ComponentStateCard[data-uid="${titleBar.uid}"] .ComponentStateCardTitle`)
+  await expect(titleBarLabel).toBeVisible()
+  // Dispatch the menu event directly: the test runner's right-click helper also emits a normal click.
+  await titleBarLabel.dispatchEvent('contextmenu', {
+    bubbles: true,
+    button: 2,
+    cancelable: true,
+    clientX: 100,
+    clientY: 100,
+  } as unknown as string)
+  await expect(Locator('.Menu .MenuItem', { hasText: 'Show Dom' })).toBeVisible()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText('context-menu.txt')
+  await KeyBoard.press('Escape')
+  await expect(Locator('.Menu')).toBeHidden()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText('context-menu.txt')
+
+  const statusBarLabel = Locator(`.ComponentStateCard[data-uid="${statusBar.uid}"] .ComponentStateCardStatus`)
+  await expect(statusBarLabel).toBeVisible()
+  await statusBarLabel.dispatchEvent('contextmenu', {
+    bubbles: true,
+    button: 2,
+    cancelable: true,
+    clientX: 100,
+    clientY: 100,
+  } as unknown as string)
+  const showDom = Locator('.Menu .MenuItem', { hasText: 'Show Dom' })
+  await expect(showDom).toBeVisible()
+  await showDom.click()
+  await expect(Locator('.Menu')).toBeHidden()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${statusBar.uid}.json`)
+  const dom = JSON.parse(await Editor.getText())
+  if (!Array.isArray(dom) || !dom.some((node) => node.className?.split(' ').includes('StatusBar'))) {
+    throw new Error('Expected StatusBar DOM after reopening the menu on its card')
+  }
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-show-dom.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-show-dom.ts
@@ -15,37 +15,16 @@ export const test: Test = async ({ Command, Editor, expect, ExtensionDetail, Ext
     if (!component?.domAvailable) {
       throw new Error(`Expected a DOM API for ${moduleId}`)
     }
-    const dom = await Command.execute('ComponentState.getDom', component.uid)
-    if (!Array.isArray(dom) || dom.length === 0 || typeof dom[0].childCount !== 'number') {
-      throw new Error(`Expected current virtual DOM for ${moduleId}, got ${JSON.stringify(dom)}`)
-    }
-  }
-  const tmpDir = await FileSystem.getTmpDir()
-  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
-  await Workspace.setPath(tmpDir)
-  await Command.execute('Layout.showSideBar', 'Explorer')
-  await expect(Locator('.Explorer')).toBeVisible()
-  await checkDom('Explorer')
-  await Command.execute('Layout.showSideBar', 'Search')
-  await expect(Locator('.Search')).toBeVisible()
-  await checkDom('Search')
-  await ExtensionSearch.open()
-  await checkDom('Extensions')
-  await ExtensionDetail.open('builtin.theme-atom-one-dark')
-  await expect(Locator('.ExtensionDetail')).toBeVisible()
-  await checkDom('ExtensionDetail')
-  await checkDom('Main')
-  await Command.execute('Developer.openComponentState')
-  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
-  for (const moduleId of ['TitleBar', 'StatusBar']) {
-    const component = components.find((item) => item.moduleId === moduleId)
-    if (!component?.domAvailable) {
-      throw new Error(`Expected DOM inspection for ${moduleId}, got ${JSON.stringify(components)}`)
-    }
     const cardTitle = Locator(`.ComponentStateCard[data-uid="${component.uid}"] .ComponentStateCardTitle`)
-    await cardTitle.click({ button: 'right' })
+    await expect(cardTitle).toBeVisible()
+    // Dispatch the menu event directly: the test runner's right-click helper also emits a normal click.
+    await cardTitle.dispatchEvent('contextmenu', { bubbles: true, button: 2, cancelable: true, clientX: 100, clientY: 100 } as unknown as string)
     await expect(Locator('.Menu')).toBeVisible()
-    await Command.execute('Menu.selectItem', 'Show Dom')
+    const showDom = Locator('.Menu .MenuItem', { hasText: 'Show Dom' })
+    await expect(showDom).toHaveCount(1)
+    await expect(showDom).toHaveAttribute('aria-disabled', null)
+    await showDom.click()
+    await expect(Locator('.Menu')).toBeHidden()
     await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
     await expect(Locator('.Editor')).toContainText('childCount')
     const dom = JSON.parse(await Editor.getText())
@@ -62,4 +41,22 @@ export const test: Test = async ({ Command, Editor, expect, ExtensionDetail, Ext
       throw new Error('Expected formatted virtual DOM JSON')
     }
   }
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Layout.showSideBar', 'Explorer')
+  await expect(Locator('.Explorer')).toBeVisible()
+  await Command.execute('Developer.openComponentState')
+  await checkDom('Explorer')
+  await Command.execute('Layout.showSideBar', 'Search')
+  await expect(Locator('.Search')).toBeVisible()
+  await checkDom('Search')
+  await ExtensionSearch.open()
+  await checkDom('Extensions')
+  await ExtensionDetail.open('builtin.theme-atom-one-dark')
+  await expect(Locator('.ExtensionDetail')).toBeVisible()
+  await checkDom('ExtensionDetail')
+  await checkDom('Main')
+  await checkDom('TitleBar')
+  await checkDom('StatusBar')
 }


### PR DESCRIPTION
Exercise Show Dom through the rendered context-menu item for all seven supported component cards. Add coverage for disabled DOM inspection, Escape dismissal, and reopening the menu on a different card; verify the selected component opens as formatted, read-only JSON.