### PR TITLE
fix: pass workspace URIs to text search view

### DIFF
--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -261,9 +261,10 @@ export const textSearch = {
       isSearchEditor: state.uri.startsWith('search-editor://'),
     }
   },
-  wrapCommand(command, _defaultWrapCommand, { createRenderInvocation, enqueueRender, worker }) {
+  wrapCommand(command, _defaultWrapCommand, { context, createRenderInvocation, enqueueRender, worker }) {
     return async (state, ...args) => {
-      await worker.invoke(`TextSearch.${command}`, state.uid, ...args)
+      const commandArgs = command === 'handleWorkspaceChange' ? [context.workspaceUri] : args
+      await worker.invoke(`TextSearch.${command}`, state.uid, ...commandArgs)
       const invocation = createRenderInvocation(state.uid)
       return enqueueRender(state.uid, async () => {
         try {

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -216,7 +216,7 @@
           "name": "TextSearch.create",
           "parameters": [
             { "source": "state", "name": "uid" }, { "source": "state", "name": "x" }, { "source": "state", "name": "y" },
-            { "source": "state", "name": "width" }, { "source": "state", "name": "height" }, { "source": "context", "name": "workspacePath" },
+            { "source": "state", "name": "width" }, { "source": "state", "name": "height" }, { "source": "context", "name": "workspaceUri" },
             { "source": "state", "name": "assetDir" }, { "source": "literal", "value": 22 }, { "source": "literal", "value": "" },
             { "source": "literal", "value": "" }, { "source": "state", "name": "platform" }, { "source": "state", "name": "isSearchEditor" }
           ]

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -645,7 +645,7 @@ test('does not expose a DOM getter for workers without the API', () => {
 })
 
 test('text search workspace changes forward the current remote URI', async () => {
-  const invoke = jest.fn(async (method: string) => {
+  const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
     if (method === 'Example.getCommandIds') {
       return ['handleWorkspaceChange']
     }

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -643,3 +643,26 @@ test('does not expose a DOM getter for workers without the API', () => {
   const viewlet = createWorkerViewletWithDependencies({ config: createConfig(), worker: { invoke: jest.fn() } })
   expect(viewlet.getComponentDom).toBeUndefined()
 })
+
+test('text search workspace changes forward the current remote URI', async () => {
+  const invoke = jest.fn(async (method: string) => {
+    if (method === 'Example.getCommandIds') {
+      return ['handleWorkspaceChange']
+    }
+    return []
+  })
+  const context = { platform: 1, workspaceUri: 'file:///old-workspace' }
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('textSearchView'),
+    config: createConfig(),
+    context,
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands!()
+  const state = viewlet.create(9, '', 0, 0, 0, 0)
+  context.workspaceUri = 'vscode-remote://ssh-remote+host/home/project'
+
+  await commands.handleWorkspaceChange(state, '/home/project', {})
+
+  expect(invoke).toHaveBeenCalledWith('TextSearch.handleWorkspaceChange', 9, context.workspaceUri)
+})

--- a/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
@@ -1,6 +1,6 @@
 import { expect, jest, test } from '@jest/globals'
 
-const invoke = jest.fn(async (method: string) => {
+const invoke = jest.fn(async (method: string, ..._args: readonly unknown[]) => {
   if (method.endsWith('.diff2') || method.endsWith('.render2')) {
     return []
   }

--- a/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
 
 const invoke = jest.fn(async (method: string) => {
-  if (method === 'Explorer.diff2' || method === 'Explorer.render2') {
+  if (method.endsWith('.diff2') || method.endsWith('.render2')) {
     return []
   }
   return undefined
@@ -38,4 +38,13 @@ test('reads test mode when the worker viewlet is initialized', async () => {
   await viewlet.loadContent(state, undefined)
 
   expect(invoke.mock.calls[0]).toEqual(['Explorer.create', 7, 'test://explorer', 1, 2, 300, 200, null, 5, 2, 'test://assets', true])
+})
+
+test('creates text search with the workspace URI instead of the filesystem path', async () => {
+  const viewlet = createWorkerViewlet({ workerId: 'textSearchView' })
+  const state = viewlet.create(8, 'search://', 1, 2, 300, 200)
+
+  await viewlet.loadContent(state, undefined)
+
+  expect(invoke).toHaveBeenCalledWith('TextSearch.create', 8, 1, 2, 300, 200, 'file:///workspace', 'test://assets', 22, '', '', 2, false)
 })

--- a/packages/renderer-worker/test/ViewletSearch.test.ts
+++ b/packages/renderer-worker/test/ViewletSearch.test.ts
@@ -19,6 +19,7 @@ jest.unstable_mockModule('../src/parts/TextSearchViewWorker/TextSearchViewWorker
 }))
 
 jest.unstable_mockModule('../src/parts/Workspace/Workspace.js', () => ({
+  getWorkspaceUri: jest.fn(() => 'file:///test-workspace'),
   state: {
     workspacePath: '/test-workspace',
   },
@@ -30,12 +31,12 @@ const Workspace = await import('../src/parts/Workspace/Workspace.js')
 
 beforeEach(() => {
   jest.clearAllMocks()
-  Workspace.state.workspacePath = '/test-workspace'
+  jest.mocked(Workspace.getWorkspaceUri).mockReturnValue('file:///test-workspace')
 })
 
-test('loadContent uses the current workspace path', async () => {
+test('loadContent uses the current workspace URI', async () => {
   const state = ViewletSearch.create(1, 'Search', 10, 20, 800, 600)
-  Workspace.state.workspacePath = '/new-workspace'
+  jest.mocked(Workspace.getWorkspaceUri).mockReturnValue('file:///new-workspace')
 
   await ViewletSearch.loadContent(state, {})
 
@@ -47,7 +48,7 @@ test('loadContent uses the current workspace path', async () => {
     20,
     800,
     600,
-    '/new-workspace',
+    'file:///new-workspace',
     '/test-assets',
     22,
     '',
@@ -86,7 +87,7 @@ test('loadContent passes search editor mode to the text search view', async () =
     20,
     800,
     600,
-    '/test-workspace',
+    'file:///test-workspace',
     '/test-assets',
     22,
     '',


### PR DESCRIPTION
Pass the workspace URI to Text Search when creating the view and handling workspace changes. This preserves remote workspace schemes and avoids passing platform-specific filesystem paths to the search worker.
