### PR TITLE
feature: expose Layout for live component state editing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,6 +149,12 @@ jobs:
         run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-edit-status-bar
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test live layout component edits
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: node src/_all.js --headless --ci --test-name-prefix=viewlet.component-state-edit-layout
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build Electron App (deb)
         if: matrix.os == 'ubuntu-24.04'
         run: npm run build:electron:deb

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-layout.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-layout.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+interface ComponentInfo {
+  readonly editable: boolean
+  readonly moduleId: string
+  readonly uid: number
+}
+
+export const name = 'viewlet.component-state-edit-layout'
+
+export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
+  await Command.execute('Developer.openComponentState')
+  const components = (await Command.execute('ComponentState.getComponents')) as readonly ComponentInfo[]
+  const component = components.find((item) => item.moduleId === 'Layout')
+  if (!component?.editable) {
+    throw new Error(`Expected an editable Layout component, got ${JSON.stringify(components)}`)
+  }
+
+  const card = Locator(`.ComponentStateCard[data-uid="${component.uid}"]`)
+  await expect(card).toBeVisible()
+  await card.click()
+  await expect(Locator('.MainTabSelected .TabTitle')).toHaveText(`${component.uid}.json`)
+  await expect(Locator('.Editor')).toContainText('{')
+  await expect(Locator('.StatusBar')).toBeVisible()
+  const state = JSON.parse(await Editor.getText())
+  await Editor.setText(`${JSON.stringify({ ...state, sideBarWidth: 320, statusBarVisible: false }, null, 2)}\n`)
+  await Main.save()
+
+  const updatedState = await Command.execute('ComponentState.getState', component.uid)
+  if (updatedState.sideBarWidth !== 320 || updatedState.statusBarVisible !== false) {
+    throw new Error('Expected Layout state edits to update sidebar width and status bar visibility')
+  }
+  await expect(Locator('.SideBar')).toHaveCSS('width', '320px')
+  await expect(Locator('.StatusBar')).toBeHidden()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-layout.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-layout.ts
@@ -30,6 +30,6 @@ export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => 
   if (updatedState.sideBarWidth !== 320 || updatedState.statusBarVisible !== false) {
     throw new Error('Expected Layout state edits to update sidebar width and status bar visibility')
   }
-  await expect(Locator('.SideBar')).toHaveCSS('width', '320px')
+  await expect(Locator('.Viewlet.SideBar')).toHaveCSS('width', '320px')
   await expect(Locator('.StatusBar')).toBeHidden()
 }

--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-layout.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-layout.ts
@@ -30,6 +30,6 @@ export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => 
   if (updatedState.sideBarWidth !== 320 || updatedState.statusBarVisible !== false) {
     throw new Error('Expected Layout state edits to update sidebar width and status bar visibility')
   }
-  await expect(Locator('.Viewlet.SideBar')).toHaveCSS('width', '320px')
+  await expect(Locator('.SideBar:not(.SecondarySideBar)')).toHaveCSS('width', '320px')
   await expect(Locator('.StatusBar')).toBeHidden()
 }

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ipc.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ipc.js
@@ -1,5 +1,6 @@
 export * from './ViewletLayout.ts'
 export * from './ViewletLayoutCommands.js'
+export * from './ViewletLayoutComponentState.js'
 export * from './ViewletLayoutCss.js'
 export * from './ViewletLayoutKeyBindings.js'
 export * from './ViewletLayoutMenuEntries.js'

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutComponentState.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutComponentState.js
@@ -1,0 +1,11 @@
+export const getComponentState = (state) => state
+
+export const setComponentState = (currentState, state) => {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+    throw new TypeError('Layout state must be an object')
+  }
+  if (state.uid !== currentState.uid) {
+    throw new Error(`Layout state uid must remain ${currentState.uid}`)
+  }
+  return state
+}

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -357,6 +357,28 @@ test('exposes Simple Browser state and renders edits through its component state
   expect(domCommands).toEqual([['Viewlet.setDom2', 10, expect.arrayContaining([expect.objectContaining({ value: 'Live browser state' })])]])
 })
 
+test('exposes Layout state and renders edits through its component state hooks', async () => {
+  const factory = await import('../src/parts/ViewletLayout/ViewletLayout.ipc.js')
+  const state = { ...factory.create(1), initial: false, statusBarId: 6, statusBarVisible: true }
+  ViewletStates.set(1, { factory, moduleId: 'Layout', renderedState: state, state })
+
+  expect(ComponentState.getComponents()).toEqual([{ displayName: 'Layout', domAvailable: false, editable: true, moduleId: 'Layout', uid: 1 }])
+  await expect(ComponentState.getState(1)).resolves.toBe(state)
+
+  const editedState = { ...state, sideBarWidth: 320, statusBarVisible: false }
+  const domCommands = factory.render[0].apply(state, editedState)
+  const cssCommands = factory.render[1].apply(state, editedState)
+  const commands = [...domCommands, ...cssCommands]
+  jest.mocked(ViewletManager.render).mockReturnValue(commands)
+  await ComponentState.setState(1, editedState)
+
+  await expect(ComponentState.getState(1)).resolves.toBe(editedState)
+  expect(ViewletManager.render).toHaveBeenCalledWith(factory, state, editedState, 1, undefined)
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', commands)
+  expect(domCommands[0][2]).not.toEqual(expect.arrayContaining([expect.objectContaining({ uid: 6 })]))
+  expect(cssCommands).toEqual([['Viewlet.setCss', 1, expect.stringContaining('--SideBarWidth: 320px;')]])
+})
+
 test('does not refresh unchanged state with the schema and reordered properties from the live file', async () => {
   const state = { uid: 2, value: { b: 2, a: 1 } }
   const editor = { uid: 9, uri: 'live-component-state:///2.json' }

--- a/packages/renderer-worker/test/ViewletLayoutComponentState.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutComponentState.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals'
+import * as ComponentState from '../src/parts/ViewletLayout/ViewletLayoutComponentState.js'
+
+test.each([null, [], 'invalid', 42])('rejects non-object state %p', (state) => {
+  expect(() => ComponentState.setComponentState({ uid: 1 }, state)).toThrow('Layout state must be an object')
+})
+
+test('rejects changing the component uid', () => {
+  expect(() => ComponentState.setComponentState({ uid: 1 }, { uid: 2 })).toThrow('Layout state uid must remain 1')
+})


### PR DESCRIPTION
Expose Layout in the Live Component State inspector so its JSON state can be opened and edited. Apply edits through the existing Layout rendering pipeline, including sidebar dimensions and component visibility.