### PR TITLE
fix: dispose source control worker state with its view

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
+++ b/packages/renderer-worker/src/parts/ViewletSourceControl/ViewletSourceControl.js
@@ -74,7 +74,8 @@ export const loadContentLater = async (state) => {
   await Command.execute('Viewlet.executeViewletCommand', state.uid, 'loadContent', state.savedState)
 }
 
-export const dispose = (state) => {
+export const dispose = async (state) => {
+  await SourceControlWorker.invoke('SourceControl.dispose', state.uid)
   return {
     ...state,
     disposed: true,

--- a/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletSourceControlCommands.test.ts
@@ -13,6 +13,13 @@ beforeEach(() => {
   jest.resetAllMocks()
 })
 
+test('disposes only the owned source control worker state', async () => {
+  const state = { uid: 42, disposed: false }
+  expect(await ViewletSourceControl.dispose(state)).toEqual({ ...state, disposed: true })
+  expect(sourceControlWorkerInvoke.mock.calls).toEqual([['SourceControl.dispose', 42]])
+  expect(state.disposed).toBe(false)
+})
+
 test('renders pending source control worker state without replaying a command', async () => {
   const state = {
     badgeCount: 2,


### PR DESCRIPTION
Release the owned source-control worker state when its view is disposed, so repeated extension playground preview rebuilds do not retain old view states.