### PR TITLE
fix: finish extension filesystem mutations before refreshing views

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,12 @@ jobs:
         run: npm run e2e:headless:ci
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test saving extension filesystem files
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.main-save-extension-filesystem
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test extension component state names
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/packages/extension-host-worker-tests/fixtures/sample.filesystem-save/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.filesystem-save/extension.json
@@ -1,0 +1,15 @@
+{
+  "id": "sample.filesystem-save",
+  "name": "Filesystem Save",
+  "version": "0.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": [
+    "onFileSystem:save-test"
+  ],
+  "fileSystemProviders": [
+    {
+      "id": "save-test"
+    }
+  ]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.filesystem-save/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.filesystem-save/main.js
@@ -7,6 +7,9 @@ const commandMap = {
   'ExtensionApi.executeFileSystemProviderIsReadonly'() {
     return false
   },
+  'ExtensionApi.executeFileSystemProviderReadDirWithFileTypes'() {
+    return [{ name: 'note.txt', type: 7 }]
+  },
   'ExtensionApi.executeFileSystemProviderReadFile'() {
     return content
   },

--- a/packages/extension-host-worker-tests/fixtures/sample.filesystem-save/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.filesystem-save/main.js
@@ -1,0 +1,33 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.startsWith('/remote/') ? '' : currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+let content = 'before save'
+const commandMap = {
+  'ExtensionApi.executeFileSystemProviderIsReadonly'() {
+    return false
+  },
+  'ExtensionApi.executeFileSystemProviderReadFile'() {
+    return content
+  },
+  'ExtensionApi.executeFileSystemProviderWriteFile'(_id, _uri, value) {
+    content = value
+  },
+  'ExtensionApi.getFileSystemProviderRegistrySnapshot'() {
+    return { providers: [{ id: 'save-test' }] }
+  },
+  'ExtensionApi.getStatusBarItems'() {
+    return []
+  },
+  'ExtensionApi.getViewActions'() {
+    return []
+  },
+  'ExtensionApi.getViewMenuEntries'() {
+    return []
+  },
+  'ExtensionApi.getViewRegistrySnapshot'() {
+    return { views: [] }
+  },
+}
+
+await WebWorkerRpcClient.create({ commandMap })

--- a/packages/extension-host-worker-tests/src/viewlet.main-save-extension-filesystem.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-save-extension-filesystem.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-save-extension-filesystem'
+
+export const test: Test = async ({ Editor, Extension, FileSystem, Main, Workspace }) => {
+  await Workspace.openTmpDir()
+  const extensionUri = new URL('../fixtures/sample.filesystem-save', import.meta.url).toString().replace(/\/$/, '')
+  await Extension.addWebExtension(extensionUri)
+  await Extension.enableWorkspace('sample.filesystem-save')
+  const uri = 'save-test:///note.txt'
+  await Main.openUri(uri)
+  await Editor.shouldHaveText('before save')
+  await Editor.setText('saved through the extension filesystem')
+  await Main.save()
+  await FileSystem.shouldHaveFile(uri, 'saved through the extension filesystem')
+  await Editor.shouldHaveText('saved through the extension filesystem')
+}

--- a/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
+++ b/packages/renderer-worker/src/parts/ExtensionHost/ExtensionHostFileSystem.js
@@ -6,6 +6,8 @@ import * as GetProtocol from '../GetProtocol/GetProtocol.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as ExtensionHostShared from './ExtensionHostShared.js'
 
+// Refresh can call back into the editor or Explorer that is awaiting this mutation.
+// Do not make the completed filesystem operation wait for that refresh.
 const notifyWorkspaceChanged = async (changes) => {
   await Promise.allSettled([Command.execute('Layout.handleWorkspaceRefresh', changes), Command.execute('Layout.refreshSourceControlBadgeCount')])
 }
@@ -79,7 +81,7 @@ export const remove = async (uri) => {
     legacyParams: [path],
     protocol,
   })
-  await notifyWorkspaceChanged({
+  void notifyWorkspaceChanged({
     deleted: [uri],
   })
   return result
@@ -100,7 +102,7 @@ export const rename = async (oldUri, newUri) => {
     legacyParams: [oldPath, newPath],
     protocol,
   })
-  await notifyWorkspaceChanged({
+  void notifyWorkspaceChanged({
     renamed: [[oldUri, newUri]],
   })
   return result
@@ -126,7 +128,7 @@ export const createFile = async (uri) => {
     legacyParams: [path, ''],
     protocol,
   })
-  await notifyWorkspaceChanged({
+  void notifyWorkspaceChanged({
     changed: [uri],
   })
   return result
@@ -152,7 +154,7 @@ export const writeFile = async (uri, content) => {
     legacyParams: [path, content],
     protocol,
   })
-  await notifyWorkspaceChanged({
+  void notifyWorkspaceChanged({
     changed: [uri],
   })
   return result

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -1,4 +1,3 @@
-import { setImmediate } from 'node:timers/promises'
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as DirentType from '../src/parts/DirentType/DirentType.js'
 
@@ -335,19 +334,19 @@ test('isolated provider dispatch unwraps extension host uris', async () => {
 })
 
 test.each([
-  ['writeFile', ['save-test:///note.txt', 'saved']],
-  ['createFile', ['save-test:///note.txt']],
-  ['remove', ['save-test:///note.txt']],
-  ['rename', ['save-test:///note.txt', 'save-test:///renamed.txt']],
-])('%s completes while a workspace refresh is waiting for the caller', async (method, args) => {
+  { name: 'writeFile', mutate: () => ExtensionHostFileSystem.writeFile('save-test:///note.txt', 'saved') },
+  { name: 'createFile', mutate: () => ExtensionHostFileSystem.createFile('save-test:///note.txt') },
+  { name: 'remove', mutate: () => ExtensionHostFileSystem.remove('save-test:///note.txt') },
+  { name: 'rename', mutate: () => ExtensionHostFileSystem.rename('save-test:///note.txt', 'save-test:///renamed.txt') },
+])('$name completes while a workspace refresh is waiting for the caller', async ({ mutate }) => {
   const refresh = Promise.withResolvers<void>()
   invoke.mockResolvedValue({ found: true, result: 'mutation completed' })
   execute.mockReturnValue(refresh.promise)
-  const mutation = ExtensionHostFileSystem[method as keyof typeof ExtensionHostFileSystem](...args)
+  const mutation = mutate()
   try {
     // Model a refresh waiting for the current editor/Explorer command to finish.
     // It must not prevent the filesystem response from reaching that command.
-    const result = await Promise.race([mutation, setImmediate('blocked by refresh')])
+    const result = await Promise.race([mutation, new Promise((resolve) => setTimeout(resolve, 0, 'blocked by refresh'))])
     expect(result).toBe('mutation completed')
     expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
   } finally {

--- a/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
+++ b/packages/renderer-worker/test/ExtensionHostFileSystem.test.ts
@@ -1,3 +1,4 @@
+import { setImmediate } from 'node:timers/promises'
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as DirentType from '../src/parts/DirentType/DirentType.js'
 
@@ -331,4 +332,26 @@ test('isolated provider dispatch unwraps extension host uris', async () => {
   await expect(ExtensionHostFileSystem.readFile('extension-host://remote-ssh:///test-folder/README.md')).resolves.toBe('content')
 
   expect(invoke).toHaveBeenCalledWith('Extensions.executeFileSystemProviderReadFile', 'remote-ssh', 'remote-ssh:///test-folder/README.md')
+})
+
+test.each([
+  ['writeFile', ['save-test:///note.txt', 'saved']],
+  ['createFile', ['save-test:///note.txt']],
+  ['remove', ['save-test:///note.txt']],
+  ['rename', ['save-test:///note.txt', 'save-test:///renamed.txt']],
+])('%s completes while a workspace refresh is waiting for the caller', async (method, args) => {
+  const refresh = Promise.withResolvers<void>()
+  invoke.mockResolvedValue({ found: true, result: 'mutation completed' })
+  execute.mockReturnValue(refresh.promise)
+  const mutation = ExtensionHostFileSystem[method as keyof typeof ExtensionHostFileSystem](...args)
+  try {
+    // Model a refresh waiting for the current editor/Explorer command to finish.
+    // It must not prevent the filesystem response from reaching that command.
+    const result = await Promise.race([mutation, setImmediate('blocked by refresh')])
+    expect(result).toBe('mutation completed')
+    expect(execute).toHaveBeenCalledWith('Layout.refreshSourceControlBadgeCount')
+  } finally {
+    refresh.resolve()
+    await mutation
+  }
 })


### PR DESCRIPTION
Saving a file through an extension filesystem could hang because its workspace refresh called back into the editor waiting for the save to finish. Complete filesystem mutations without waiting for view refreshes, allowing saves, creates, renames, and deletes to finish while views update.