### PR TITLE
test: enable live component DOM JSON editing regression

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-live-dom-edit.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-live-dom-edit.ts
@@ -2,9 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.component-state-live-dom-edit'
 
-// Enable after the component-state-worker release makes DOM files editable.
-export const skip = 1
-
 export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Settings, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, 'first')


### PR DESCRIPTION
Enable browser coverage for live DOM JSON edits, incomplete JSON, saving previews, editor focus, and normal component rendering after structural edits now that component-state-worker 0.11.0 is integrated.