### PR TITLE
fix: render error dialogs and contain notification text

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,18 @@ jobs:
         run: npm run e2e:fonts
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test notification text layout
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:notification-layout
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test error dialog and notification rendering
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.error-
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Build static site
         run: npm run build:static:ignore-icon-theme
         env:

--- a/packages/extension-host-worker-tests/package.json
+++ b/packages/extension-host-worker-tests/package.json
@@ -11,6 +11,7 @@
     "e2e:headless": "node src/_all.js --headless",
     "#e2e:headless:ci": "node src/_all.js --headless --ci",
     "e2e:headless:ci": "echo ok",
+    "e2e:notification-layout": "node scripts/test-notification-layout.mjs",
     "e2e:fonts": "node scripts/test-font-loading.mjs",
     "type-check": "tsc"
   },

--- a/packages/extension-host-worker-tests/scripts/test-notification-layout.mjs
+++ b/packages/extension-host-worker-tests/scripts/test-notification-layout.mjs
@@ -1,0 +1,57 @@
+import { chromium, expect } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+const css = await readFile(new URL('../../../static/css/parts/Notification.css', import.meta.url), 'utf8')
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage()
+  const cases = [
+    { message: 'Saved', width: 1280, height: 720 },
+    { message: 'Failed to open devcontainer workspace: DevContainerNode.cliUp failed with exit code 1', width: 1280, height: 720 },
+    { message: 'Failed to open devcontainer workspace: DevContainerNode.cliUp failed with exit code 1', width: 320, height: 240 },
+    { message: `Failed to open file:///${'long-path-segment'.repeat(100)}`, width: 320, height: 240 },
+    { message: 'Docker was not found. Install Docker and check PATH. '.repeat(100), width: 1280, height: 320 },
+  ]
+  for (const { message, width, height } of cases) {
+    await page.setViewportSize({ width, height })
+    await page.setContent(`<style>* { box-sizing: border-box } body { font: 16px system-ui } ${css}</style>
+      <div class="Notification"><p class="NotificationMessage"></p><button class="NotificationCloseButton">Close</button></div>`)
+    await page.locator('.NotificationMessage').evaluate((element, text) => {
+      element.textContent = text
+    }, message)
+    const checkBounds = async () =>
+      page.evaluate(() => {
+        const notification = document.querySelector('.Notification')
+        const message = document.querySelector('.NotificationMessage')
+        const close = document.querySelector('.NotificationCloseButton')
+        const outer = notification.getBoundingClientRect()
+        for (const element of [message, close]) {
+          const rect = element.getBoundingClientRect()
+          if (rect.left < outer.left || rect.right > outer.right || rect.top < outer.top || rect.bottom > outer.bottom) {
+            return `${element.className} extends outside the notification: ${JSON.stringify({ outer: outer.toJSON(), inner: rect.toJSON() })}`
+          }
+        }
+        if (outer.left < 0 || outer.top < 0 || outer.right > innerWidth || outer.bottom > innerHeight) {
+          return 'Notification extends outside the viewport'
+        }
+        if (message.scrollWidth > message.clientWidth) {
+          return 'Notification text overflows horizontally'
+        }
+        if (message.scrollHeight > message.clientHeight && getComputedStyle(message).overflowY !== 'auto') {
+          return 'Long notification text is not scrollable'
+        }
+        return ''
+      })
+    assert.equal(await checkBounds(), '', `Notification must contain its text at ${width}x${height}`)
+    await expect(page.locator('.NotificationMessage')).toHaveText(message)
+    await page.locator('.NotificationMessage').evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+    })
+    assert.equal(await checkBounds(), '', 'The close button must stay visible when scrolling')
+    await expect(page.locator('.NotificationCloseButton')).toBeVisible()
+  }
+  console.log('Notification text wraps, stays within the viewport, and scrolls without hiding the close button')
+} finally {
+  await browser.close()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.error-dialog.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.error-dialog.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.error-dialog'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  const message = 'DevContainerNode.cliUp failed with exit code 1'
+  await Command.execute('Dialog.showMessage', { message, type: 'Error' })
+  const dialog = Locator('.DialogContent')
+  await expect(dialog).toBeVisible()
+  await expect(Locator('.DialogErrorIcon')).toBeVisible()
+  await expect(Locator('.DialogErrorIcon')).toHaveAttribute('aria-label', 'Error')
+  await expect(Locator('.DialogHeading')).toHaveText('Error')
+  await expect(Locator('.DialogMessage')).toHaveText(message)
+  await Locator('.DialogClose').click()
+  await expect(dialog).toHaveCount(0)
+}

--- a/packages/extension-host-worker-tests/src/viewlet.error-notification.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.error-notification.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.error-notification'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  const message = 'Failed to open devcontainer workspace: DevContainerNode.cliUp failed with exit code 1'
+  await Command.execute('Notification.create', 'error', message)
+  const notification = Locator('.Notification')
+  const text = Locator('.NotificationMessage')
+  await expect(notification).toBeVisible()
+  await expect(text).toHaveText(message)
+  await expect(text).toHaveCSS('overflow-wrap', 'anywhere')
+  await expect(text).toHaveCSS('overflow-y', 'auto')
+  await Locator('.NotificationCloseButton').click()
+  await expect(notification).toHaveCount(0)
+}

--- a/packages/renderer-worker/src/parts/Dialog/Dialog.js
+++ b/packages/renderer-worker/src/parts/Dialog/Dialog.js
@@ -98,7 +98,12 @@ export const showMessage = async (message, options) => {
     }
     await handleClick(index)
   } else {
-    await Viewlet.openWidget(ViewletModuleId.Dialog, message, options)
+    // Prepared errors use `type` for the error class, not the dialog severity.
+    await Viewlet.openWidget(ViewletModuleId.Dialog, {
+      message: message.message,
+      title: message.type || message.name || 'Error',
+      type: 'error',
+    })
   }
 }
 

--- a/packages/renderer-worker/test/Dialog.test.ts
+++ b/packages/renderer-worker/test/Dialog.test.ts
@@ -153,3 +153,17 @@ test.skip('close - web', async () => {
   expect(RendererProcess.invoke).toHaveBeenCalledTimes(2)
   expect(RendererProcess.invoke).toHaveBeenCalledWith(7836)
 })
+
+test.each(['Error', 'TypeError', 'DockerNotInstalledError'])('showMessage maps prepared %s errors to dialog options', async (type) => {
+  jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({
+    assetDir: '',
+    getPlatform: () => PlatformType.Remote,
+  }))
+  jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({ openWidget: jest.fn() }))
+  const Dialog = await import('../src/parts/Dialog/Dialog.js')
+  const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+  const error = { message: 'DevContainerNode.cliUp failed with exit code 1', type }
+  await Dialog.showMessage(error)
+  expect(Viewlet.openWidget).toHaveBeenCalledWith('Dialog', { message: error.message, title: type, type: 'error' })
+  expect(error.type).toBe(type)
+})

--- a/static/css/parts/Notification.css
+++ b/static/css/parts/Notification.css
@@ -13,7 +13,10 @@
   right: 30px;
   bottom: 30px;
   width: 250px;
-  height: 75px;
+  max-width: calc(100vw - 60px);
+  max-height: calc(100vh - 60px);
+  display: flex;
+  flex-direction: column;
   padding: 10px 5px;
   background: rgb(40, 46, 47);
   box-shadow: rgb(0 0 0 / 36%) 0px 0px 8px 2px;
@@ -21,8 +24,9 @@
 
 .NotificationMessage {
   line-height: 22px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+  min-height: 0;
   flex: 1;
   user-select: text;
   margin: 0;


### PR DESCRIPTION
Error dialogs now translate prepared error class names into the dialog severity, fixing the getIcon crash when a devcontainer command fails. Notifications grow to fit wrapped text and scroll within the viewport for long messages, keeping the close button visible. Adds dialog, notification, and browser layout regressions.