### PR TITLE
fix: use theme editor background for terminals

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,6 +86,18 @@ jobs:
         run: npm run e2e:notification-layout
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test terminal theme backgrounds
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:terminal-background
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test integrated terminal rendering
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.terminal-xterm
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test error dialog and notification rendering
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/packages/extension-host-worker-tests/package.json
+++ b/packages/extension-host-worker-tests/package.json
@@ -12,6 +12,7 @@
     "#e2e:headless:ci": "node src/_all.js --headless --ci",
     "e2e:headless:ci": "echo ok",
     "e2e:notification-layout": "node scripts/test-notification-layout.mjs",
+    "e2e:terminal-background": "node scripts/test-terminal-background.mjs",
     "e2e:fonts": "node scripts/test-font-loading.mjs",
     "type-check": "tsc"
   },

--- a/packages/extension-host-worker-tests/scripts/test-terminal-background.mjs
+++ b/packages/extension-host-worker-tests/scripts/test-terminal-background.mjs
@@ -1,0 +1,38 @@
+import { chromium, expect } from '@playwright/test'
+import { readFile } from 'node:fs/promises'
+
+const terminalCss = await readFile(new URL('../../../static/css/parts/ViewletTerminal.css', import.meta.url), 'utf8')
+const xtermCss = await readFile(new URL('../../../static/lib-css/xterm.css', import.meta.url), 'utf8')
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage()
+  for (const styles of [[terminalCss, xtermCss], [xtermCss, terminalCss]]) {
+    await page.setContent(`<style>${styles.join('\n')}</style>
+      <style id="theme"></style>
+      <div class="XtermTerminal" style="height: 200px">
+        <div class="xterm">
+          <div class="xterm-viewport"></div>
+          <div class="xterm-screen"><span style="background-color: rgb(128, 0, 0)">ANSI background</span></div>
+        </div>
+      </div>`)
+    const cases = [
+      { colors: '--EditorBackground: #1e2324; --PanelBackground: #1b2020;', expected: 'rgb(30, 35, 36)' },
+      { colors: '--EditorBackground: #fafafa; --PanelBackground: #eeeeee;', expected: 'rgb(250, 250, 250)' },
+      { colors: '--EditorBackground: #fafafa; --TerminalBackground: #123456;', expected: 'rgb(18, 52, 86)' },
+      { colors: '--EditorBackground: #fafafa; --TerminalBackground: #000000;', expected: 'rgb(0, 0, 0)' },
+      { colors: '--EditorBackGround: #1e2324;', expected: 'rgb(30, 35, 36)' },
+      { colors: '--MainBackground: #292d3e;', expected: 'rgb(41, 45, 62)' },
+    ]
+    for (const { colors, expected } of cases) {
+      await page.locator('#theme').evaluate((element, css) => {
+        element.textContent = `:root { ${css} }`
+      }, colors)
+      await expect(page.locator('.XtermTerminal')).toHaveCSS('background-color', expected)
+      await expect(page.locator('.xterm-viewport')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+      await expect(page.locator('.xterm-screen span')).toHaveCSS('background-color', 'rgb(128, 0, 0)')
+    }
+  }
+  console.log('Terminal background follows theme changes and overrides without covering ANSI backgrounds')
+} finally {
+  await browser.close()
+}

--- a/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-xterm.ts
@@ -23,6 +23,8 @@ export const test = async ({ Command, KeyBoard, Locator, Settings, expect }) => 
   const terminal = Locator('.XtermTerminal')
   await expect(terminal).toBeVisible()
   const terminalViewport = terminal.locator('.xterm-viewport')
+  await expect(terminal).toHaveCSS('background-color', 'rgb(30, 35, 36)')
+  await expect(terminalViewport).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
   await expect(terminalViewport).toHaveCSS('scrollbar-color', 'rgba(57, 71, 71, 0.6) rgba(0, 0, 0, 0)')
   const terminalInput = terminal.locator('.xterm-helper-textarea')
   await expect(terminalInput).toBeFocused()

--- a/static/css/parts/ViewletTerminal.css
+++ b/static/css/parts/ViewletTerminal.css
@@ -26,7 +26,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: var(--PanelBackground);
+  background: var(--TerminalBackground, var(--EditorBackground, var(--EditorBackGround, var(--MainBackground))));
 }
 
 .XtermTerminal .xterm {
@@ -34,6 +34,7 @@
   height: 100%;
 }
 
-.XtermTerminal .xterm-viewport {
+.XtermTerminal .xterm .xterm-viewport {
+  background-color: transparent;
   scrollbar-color: var(--EditorScrollBarBackground, rgba(57, 71, 71, 0.6)) transparent;
 }


### PR DESCRIPTION
Use the active theme’s editor background for integrated terminals, with support for a TerminalBackground override. Make the xterm viewport transparent so its bundled black background no longer covers the theme color, including when switching themes.