### PR TITLE
feature: support protected branch commit dialogs

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -99,6 +99,7 @@ export const commandMap = {
   'Dialog.openFolder': lazy('Dialog.openFolder'),
   'Dialog.show': lazy('Dialog.show'),
   'Dialog.showMessage': lazy('Dialog.showMessage'),
+  'Dialog.showMessageBox': lazy('Dialog.showMessageBox'),
   'Dialog.showWarning': lazy('Dialog.showWarning'),
   'Document.getSelectionText': lazy('Document.getSelectionText'),
   'Download.downloadFile': lazy('Download.downloadFile'),

--- a/packages/renderer-worker/src/parts/Dialog/Dialog.ipc.js
+++ b/packages/renderer-worker/src/parts/Dialog/Dialog.ipc.js
@@ -9,5 +9,6 @@ export const Commands = {
   openFolder: OpenFolder.openFolder,
   show: Dialog.show,
   showMessage: Dialog.showMessage,
+  showMessageBox: Dialog.showMessageBox,
   showWarning: Dialog.showWarning,
 }

--- a/packages/renderer-worker/src/parts/Dialog/Dialog.js
+++ b/packages/renderer-worker/src/parts/Dialog/Dialog.js
@@ -114,3 +114,9 @@ export const show = async (options) => {
 export const showWarning = async (options) => {
   await DialogWorker.invoke('Dialog.showWarning', options)
 }
+
+// Public dialog entry point for isolated extensions. The host owns the window
+// and product identity; callers supply only the message and available choices.
+export const showMessageBox = async ({ buttons, defaultId, message, type = 'info' }) => {
+  return ElectronDialog.showMessageBox({ buttons, defaultId, message, type })
+}

--- a/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
+++ b/packages/renderer-worker/src/parts/WorkerViewletAdapters/WorkerViewletAdapters.js
@@ -206,6 +206,11 @@ export const processExplorer = {
 }
 
 export const quickPick = {
+  extendCommands(Commands) {
+    // Custom inputs resolve in the renderer; the worker's callback command
+    // must not replace QuickPick.executeCallback with a view command.
+    delete Commands.executeCallback
+  },
   extendModule() {
     return {
       dispose(state) {

--- a/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewlet.test.ts
@@ -666,3 +666,17 @@ test('text search workspace changes forward the current remote URI', async () =>
 
   expect(invoke).toHaveBeenCalledWith('TextSearch.handleWorkspaceChange', 9, context.workspaceUri)
 })
+
+test('quick pick view commands preserve the renderer custom-input callback', async () => {
+  const invoke = jest.fn(async () => ['executeCallback', 'selectCurrentIndex', 'close'])
+  const viewlet = createWorkerViewletWithDependencies({
+    adapter: getWorkerViewletAdapter('quickPickWorker'),
+    config: createConfig({ commandPrefix: 'QuickPick', name: 'QuickPick' }),
+    context: {},
+    worker: { invoke, restart: jest.fn() },
+  })
+  const commands = await viewlet.getCommands()
+  expect(commands).not.toHaveProperty('executeCallback')
+  expect(commands.selectCurrentIndex).toEqual(expect.any(Function))
+  expect(commands.close).toEqual(expect.any(Function))
+})

--- a/packages/renderer-worker/test/Dialog.test.ts
+++ b/packages/renderer-worker/test/Dialog.test.ts
@@ -169,7 +169,7 @@ test.each(['Error', 'TypeError', 'DockerNotInstalledError'])('showMessage maps p
 })
 
 test.each([0, 1, 2, undefined])('showMessageBox returns the selected option %s', async (response) => {
-  const showMessageBox = jest.fn(async () => response)
+  const showMessageBox = jest.fn<(options: unknown) => Promise<number | undefined>>().mockResolvedValue(response)
   jest.unstable_mockModule('../src/parts/ElectronDialog/ElectronDialog.js', () => ({ showMessageBox }))
   const Dialog = await import('../src/parts/Dialog/Dialog.js')
   const options = {

--- a/packages/renderer-worker/test/Dialog.test.ts
+++ b/packages/renderer-worker/test/Dialog.test.ts
@@ -167,3 +167,19 @@ test.each(['Error', 'TypeError', 'DockerNotInstalledError'])('showMessage maps p
   expect(Viewlet.openWidget).toHaveBeenCalledWith('Dialog', { message: error.message, title: type, type: 'error' })
   expect(error.type).toBe(type)
 })
+
+test.each([0, 1, 2, undefined])('showMessageBox returns the selected option %s', async (response) => {
+  const showMessageBox = jest.fn(async () => response)
+  jest.unstable_mockModule('../src/parts/ElectronDialog/ElectronDialog.js', () => ({ showMessageBox }))
+  const Dialog = await import('../src/parts/Dialog/Dialog.js')
+  const options = {
+    buttons: ['Commit Anyway', 'Cancel', 'Commit to a New Branch'],
+    defaultId: 2,
+    message: 'You are trying to commit to a protected branch.',
+    type: 'warning',
+  }
+  const untrustedOptions = { ...options, productName: 'Untrusted title', windowId: 123 }
+  const result = await Dialog.showMessageBox(untrustedOptions)
+  expect(result).toBe(response)
+  expect(showMessageBox).toHaveBeenCalledWith(options)
+})


### PR DESCRIPTION
Expose Dialog.showMessageBox so isolated extensions can present native choices while the host retains control of the window and product identity. Preserve the renderer callback for custom quick inputs so confirming or canceling a branch name resolves correctly.