### PR TITLE
fix: configure remote workspace terminal shells

### DIFF
--- a/packages/renderer-worker/src/parts/GetTerminalSpawnOptions/GetTerminalSpawnOptions.js
+++ b/packages/renderer-worker/src/parts/GetTerminalSpawnOptions/GetTerminalSpawnOptions.js
@@ -1,5 +1,10 @@
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
 
-export const getTerminalSpawnOptions = () => {
+export const getTerminalSpawnOptions = async () => {
+  const remoteOptions = WorkspaceConnection.getTerminalSpawnOptions()
+  if (remoteOptions) {
+    return remoteOptions
+  }
   return SharedProcess.invoke('GetTerminalSpawnOptions.getTerminalSpawnOptions')
 }

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.js
@@ -82,7 +82,7 @@ export const setUri = async (uri, connectionOrPathSeparator, legacyConnection) =
   state.workspaceUri = uri
   state.pathSeparator = pathSeparator
   if (connection) {
-    WorkspaceConnection.set(uri, connection.command, connection.remoteCliUrl, connection.webSocketUrl)
+    WorkspaceConnection.set(uri, connection.command, connection.remoteCliUrl, connection.webSocketUrl, connection.terminalSpawnOptions)
     if (connection.remoteCliUrl) {
       void RemoteCli.start(connection.remoteCliUrl, connection.remoteCliUrl, handleRemoteCliOpenRequest).catch(() => {})
     } else {
@@ -101,6 +101,7 @@ const handleRemoteCliOpenRequest = async (request) => {
   const command = WorkspaceConnection.getCommand()
   const remoteCliUrl = WorkspaceConnection.getRemoteCliUrl()
   const webSocketUrl = WorkspaceConnection.getWebSocketUrlTemplate()
+  const terminalSpawnOptions = WorkspaceConnection.getTerminalSpawnOptions()
   if (!currentUri || !command) {
     throw new Error('Remote workspace connection is not available')
   }
@@ -109,6 +110,7 @@ const handleRemoteCliOpenRequest = async (request) => {
     command,
     remoteCliUrl,
     webSocketUrl,
+    terminalSpawnOptions,
     workspacePath: resolved.workspacePath,
   })
   if (resolved.fileUri) {

--- a/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
+++ b/packages/renderer-worker/src/parts/WorkspaceConnection/WorkspaceConnection.js
@@ -3,11 +3,14 @@ import * as IpcParentWithWebSocket from '../IpcParentWithWebSocket/IpcParentWith
 import * as Json from '../Json/Json.js'
 import * as WorkspaceState from '../WorkspaceState/WorkspaceState.js'
 
+/** @typedef {{ command: string, args: string[] }} TerminalSpawnOptions */
+
 const state = {
   command: '',
   remoteCliUrl: '',
   webSocketUrl: '',
   workspaceUri: '',
+  terminalSpawnOptions: /** @type {TerminalSpawnOptions | undefined} */ (undefined),
 }
 
 const validateWebSocketUrl = (value, name) => {
@@ -22,16 +25,28 @@ const validateWebSocketUrl = (value, name) => {
   }
 }
 
-export const set = (workspaceUri, command, remoteCliUrl = '', webSocketUrl = '') => {
+/** @param {TerminalSpawnOptions} [terminalSpawnOptions] */
+export const set = (workspaceUri, command, remoteCliUrl = '', webSocketUrl = '', terminalSpawnOptions = undefined) => {
   if (typeof workspaceUri !== 'string' || typeof command !== 'string' || !command) {
     throw new TypeError('Invalid workspace connection')
   }
   validateWebSocketUrl(remoteCliUrl, 'Remote CLI URL')
   validateWebSocketUrl(webSocketUrl, 'Workspace WebSocket URL')
+  if (
+    terminalSpawnOptions !== undefined &&
+    (!terminalSpawnOptions ||
+      typeof terminalSpawnOptions.command !== 'string' ||
+      !terminalSpawnOptions.command ||
+      !Array.isArray(terminalSpawnOptions.args) ||
+      !terminalSpawnOptions.args.every((arg) => typeof arg === 'string'))
+  ) {
+    throw new TypeError('Invalid remote terminal spawn options')
+  }
   state.workspaceUri = workspaceUri
   state.command = command
   state.remoteCliUrl = remoteCliUrl
   state.webSocketUrl = webSocketUrl
+  state.terminalSpawnOptions = terminalSpawnOptions ? { command: terminalSpawnOptions.command, args: [...terminalSpawnOptions.args] } : undefined
 }
 
 export const reset = () => {
@@ -39,9 +54,18 @@ export const reset = () => {
   state.command = ''
   state.remoteCliUrl = ''
   state.webSocketUrl = ''
+  state.terminalSpawnOptions = undefined
 }
 
 export const isActive = () => Boolean(state.command && WorkspaceState.state.workspaceUri === state.workspaceUri)
+
+export const getTerminalSpawnOptions = () => {
+  if (!isActive() || !state.terminalSpawnOptions) {
+    return undefined
+  }
+  const { command, args } = state.terminalSpawnOptions
+  return { command, args: [...args] }
+}
 
 export const getCommand = () => {
   if (!isActive()) {

--- a/packages/renderer-worker/test/GetTerminalSpawnOptions.test.ts
+++ b/packages/renderer-worker/test/GetTerminalSpawnOptions.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn<(...args: unknown[]) => Promise<unknown>>()
+const workspaceState = { workspaceUri: '' }
+jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({ invoke }))
+jest.unstable_mockModule('../src/parts/WorkspaceState/WorkspaceState.js', () => ({ state: workspaceState }))
+const WorkspaceConnection = await import('../src/parts/WorkspaceConnection/WorkspaceConnection.js')
+const { getTerminalSpawnOptions } = await import('../src/parts/GetTerminalSpawnOptions/GetTerminalSpawnOptions.js')
+
+beforeEach(() => {
+  WorkspaceConnection.reset()
+  workspaceState.workspaceUri = 'codespaces://test/work'
+  invoke.mockReset()
+})
+
+test('uses the remote shell without a local process connection', async () => {
+  WorkspaceConnection.set(workspaceState.workspaceUri, 'codespaces.getWebSocketUrl', '', '', { command: 'bash', args: ['-i'] })
+  await expect(getTerminalSpawnOptions()).resolves.toEqual({ command: 'bash', args: ['-i'] })
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('uses local shell discovery after leaving the remote workspace', async () => {
+  WorkspaceConnection.set(workspaceState.workspaceUri, 'codespaces.getWebSocketUrl', '', '', { command: 'bash', args: ['-i'] })
+  workspaceState.workspaceUri = 'file:///local'
+  invoke.mockResolvedValue({ command: 'powershell.exe', args: [] })
+  await expect(getTerminalSpawnOptions()).resolves.toEqual({ command: 'powershell.exe', args: [] })
+  expect(invoke).toHaveBeenCalledWith('GetTerminalSpawnOptions.getTerminalSpawnOptions')
+})
+
+test('keeps local discovery for connections without explicit shell options', async () => {
+  WorkspaceConnection.set(workspaceState.workspaceUri, 'remote.getWebSocketUrl')
+  invoke.mockResolvedValue({ command: 'zsh', args: ['-i'] })
+  await expect(getTerminalSpawnOptions()).resolves.toEqual({ command: 'zsh', args: ['-i'] })
+})
+
+test('does not retain or expose mutable shell arguments', async () => {
+  const options = { command: 'bash', args: ['-i'] }
+  WorkspaceConnection.set(workspaceState.workspaceUri, 'remote.getWebSocketUrl', '', '', options)
+  options.args.push('caller mutation')
+  const result = await getTerminalSpawnOptions()
+  result.args.push('result mutation')
+  await expect(getTerminalSpawnOptions()).resolves.toEqual({ command: 'bash', args: ['-i'] })
+  WorkspaceConnection.reset()
+  expect(WorkspaceConnection.getTerminalSpawnOptions()).toBeUndefined()
+})
+
+test.each([{ command: '', args: [] }, { command: 'bash', args: [42] }, { command: 'bash' }, null])(
+  'rejects invalid remote shell options: %p',
+  (options) => {
+    // @ts-expect-error exercise invalid extension input
+    expect(() => WorkspaceConnection.set(workspaceState.workspaceUri, 'remote.getWebSocketUrl', '', '', options)).toThrow(
+      'Invalid remote terminal spawn options',
+    )
+  },
+)

--- a/packages/renderer-worker/test/WorkspaceSetUri.test.ts
+++ b/packages/renderer-worker/test/WorkspaceSetUri.test.ts
@@ -10,11 +10,7 @@ const isTest = jest.fn<() => boolean>(() => false)
 const getPlatform = jest.fn(() => PlatformType.Test)
 const setWorkspaceUri = jest.fn(async (_uri: string) => {})
 const startRemoteCli = jest.fn<
-  (
-    connectionKey: string,
-    remoteCliUrl: string,
-    handleOpenRequest: (request: unknown) => Promise<void>,
-  ) => Promise<void>
+  (connectionKey: string, remoteCliUrl: string, handleOpenRequest: (request: unknown) => Promise<void>) => Promise<void>
 >(async () => {})
 const stopRemoteCli = jest.fn()
 
@@ -66,6 +62,7 @@ jest.unstable_mockModule('../src/parts/RemoteCli/RemoteCli.js', () => ({
 
 const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
 const Workspace = await import('../src/parts/Workspace/Workspace.js')
+const WorkspaceConnection = await import('../src/parts/WorkspaceConnection/WorkspaceConnection.js')
 
 beforeEach(() => {
   createNotification.mockClear()
@@ -187,11 +184,13 @@ test('setUri uses the workspace connection path', async () => {
     command: 'workspace-provider.getWebSocketUrl',
     remoteCliUrl: 'wss://workspace.example.com/websocket/shared-process',
     workspacePath: '/work',
+    terminalSpawnOptions: { command: 'bash', args: ['-i'] },
   })
 
   expect(Workspace.getWorkspacePath()).toBe('/work')
   expect(Workspace.getWorkspaceUri()).toBe('workspace-provider://host/work')
   expect(Workspace.state.pathSeparator).toBe('/')
+  expect(WorkspaceConnection.getTerminalSpawnOptions()).toEqual({ command: 'bash', args: ['-i'] })
   expect(startRemoteCli).toHaveBeenCalledWith(
     'wss://workspace.example.com/websocket/shared-process',
     'wss://workspace.example.com/websocket/shared-process',


### PR DESCRIPTION
Opening a terminal in a connected static Codespaces workspace fails while querying a nonexistent local shared process for shell options. Allow remote workspace providers to supply the shell and arguments, and use those options while their workspace connection is active.

Local shell discovery remains the fallback for existing connections. Shell options are validated, copied, cleared on reset, and preserved when the remote CLI opens another folder.
