### PR TITLE
feature: remove unused problems initializer

### DIFF
--- a/packages/renderer-worker/src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts
+++ b/packages/renderer-worker/src/parts/LaunchProblemsWorker/LaunchProblemsWorker.ts
@@ -15,7 +15,6 @@ export const launchProblemsWorker = async () => {
     url: GetConfiguredWorkerUrl.getConfiguredWorkerUrl('develop.problemsWorkerPath', ProblemsWorkerUrl.problemsViewWorkerUrl),
   })
   HandleIpc.handleIpc(ipc)
-  await JsonRpc.invoke(ipc, 'Problems.initialize')
   const { port1, port2 } = GetPortTuple.getPortTuple()
   await Promise.all([
     JsonRpc.invokeAndTransfer(ipc, 'Problems.handleMessagePort', port1),


### PR DESCRIPTION
Remove the unused Problems.initialize RPC call when launching the Problems worker.