### PR TITLE
feature: include static problems layout css

### DIFF
--- a/static/css/parts/ViewletProblems.css
+++ b/static/css/parts/ViewletProblems.css
@@ -1,6 +1,28 @@
 .Problems {
   color: var(--WorkbenchForeground, white);
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.ProblemsContent {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.ProblemsList {
+  contain: strict;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+}
+
+.ProblemsContentTable > .ScrollBar {
+  top: 22px;
 }
 
 .ProblemList {
@@ -60,7 +82,7 @@
 .ProblemsTableBody {
   flex: 1;
   contain: strict;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .ProblemsTableRow {


### PR DESCRIPTION
Move the static Problems layout rules from problems-view's CSS renderer into ViewletProblems.css. Preserve the existing layout and virtual scrolling styles while problems-view continues to compute row heights, scrollbar geometry, scrolling offsets, and indents.
