### PR TITLE
fix: open terminals in the devcontainer workspace

### DIFF
--- a/packages/renderer-worker/src/parts/GetTerminalSpawnOptions/GetTerminalSpawnOptions.js
+++ b/packages/renderer-worker/src/parts/GetTerminalSpawnOptions/GetTerminalSpawnOptions.js
@@ -1,7 +1,13 @@
+import * as ExtensionHostCommands from '../ExtensionHost/ExtensionHostCommands.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
+import * as WorkspaceState from '../WorkspaceState/WorkspaceState.js'
 
-export const getTerminalSpawnOptions = async () => {
+export const getTerminalSpawnOptions = async (cwd = '') => {
+  const { workspaceUri } = WorkspaceState.state
+  if (workspaceUri?.startsWith('devcontainers:///')) {
+    return ExtensionHostCommands.executeCommand('devcontainer.getTerminalSpawnOptions', workspaceUri, cwd)
+  }
   const remoteOptions = WorkspaceConnection.getTerminalSpawnOptions()
   if (remoteOptions) {
     return remoteOptions

--- a/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
+++ b/packages/renderer-worker/src/parts/ViewletTerminal2/ViewletTerminal2.ts
@@ -35,11 +35,12 @@ export const create = (id, cwd = '') => {
 }
 
 export const loadContent = async (state, _savedState?: any, configuredSpawnOptions?: any) => {
-  const { command, args } = configuredSpawnOptions || (await GetTerminalSpawnOptions.getTerminalSpawnOptions())
+  const { command, args, cwd = state.cwd } = configuredSpawnOptions || (await GetTerminalSpawnOptions.getTerminalSpawnOptions(state.cwd))
   return {
     ...state,
     command,
     args,
+    cwd,
     xtermMounted: true,
   }
 }

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -134,7 +134,7 @@ export const loadContent = async (state) => {
   if (restoredState) {
     return restoredState
   }
-  const spawnOptions = await GetTerminalSpawnOptions.getTerminalSpawnOptions()
+  const spawnOptions = await GetTerminalSpawnOptions.getTerminalSpawnOptions(cwd)
   const childUid = Id.create()
   const newState = {
     ...state,
@@ -151,7 +151,7 @@ export const loadContent = async (state) => {
 
 export const addTerminal = async (state, cwd = '') => {
   const { activeTerminalUids, focusVersion, tabs: oldTabs } = state
-  const spawnOptions = await GetTerminalSpawnOptions.getTerminalSpawnOptions()
+  const spawnOptions = await GetTerminalSpawnOptions.getTerminalSpawnOptions(cwd)
   const childUid = Id.create()
   const newTab = createTab(childUid, spawnOptions.command)
   const tabs = [...oldTabs, newTab]

--- a/packages/renderer-worker/test/GetTerminalSpawnOptions.test.ts
+++ b/packages/renderer-worker/test/GetTerminalSpawnOptions.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const invoke = jest.fn<(...args: unknown[]) => Promise<unknown>>()
+const executeCommand = jest.fn<(...args: unknown[]) => Promise<unknown>>()
+jest.unstable_mockModule('../src/parts/ExtensionHost/ExtensionHostCommands.js', () => ({ executeCommand }))
 const workspaceState = { workspaceUri: '' }
 jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({ invoke }))
 jest.unstable_mockModule('../src/parts/WorkspaceState/WorkspaceState.js', () => ({ state: workspaceState }))
@@ -11,6 +13,7 @@ beforeEach(() => {
   WorkspaceConnection.reset()
   workspaceState.workspaceUri = 'codespaces://test/work'
   invoke.mockReset()
+  executeCommand.mockReset()
 })
 
 test('uses the remote shell without a local process connection', async () => {
@@ -53,3 +56,26 @@ test.each([{ command: '', args: [] }, { command: 'bash', args: [42] }, { command
     )
   },
 )
+
+test('opens devcontainer terminals through the extension instead of discovering a host shell', async () => {
+  workspaceState.workspaceUri = 'devcontainers:///abc123'
+  const options = { command: '/usr/bin/node', args: ['devcontainer.js', 'exec', 'sh'], cwd: '/host/project' }
+  executeCommand.mockResolvedValue(options)
+  await expect(getTerminalSpawnOptions()).resolves.toEqual(options)
+  expect(executeCommand).toHaveBeenCalledWith('devcontainer.getTerminalSpawnOptions', workspaceState.workspaceUri, '')
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('does not fall back to a host shell when the container is stopped', async () => {
+  workspaceState.workspaceUri = 'devcontainers:///abc123'
+  executeCommand.mockRejectedValue(new Error('Devcontainer is not running'))
+  await expect(getTerminalSpawnOptions()).rejects.toThrow('Devcontainer is not running')
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test('passes an Explorer directory to the container terminal resolver', async () => {
+  workspaceState.workspaceUri = 'devcontainers:///abc123'
+  const cwd = 'devcontainers:///abc123/src'
+  await getTerminalSpawnOptions(cwd)
+  expect(executeCommand).toHaveBeenCalledWith('devcontainer.getTerminalSpawnOptions', workspaceState.workspaceUri, cwd)
+})

--- a/packages/renderer-worker/test/ViewletTerminal2.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminal2.test.ts
@@ -236,3 +236,11 @@ test.each(['javascript:alert(1)', 'file:///tmp/test.html', 'invalid', 'https://'
 test('registers the terminal link handler', () => {
   expect(ViewletTerminal2Commands.Commands.handleLink).toBe(ViewletTerminal2.handleLink)
 })
+
+test('uses the host launch directory supplied by the container terminal resolver', async () => {
+  const state = ViewletTerminal2.create(42, 'devcontainers:///abc123/src')
+  const options = { command: '/usr/bin/node', args: ['devcontainer.js', 'exec', 'sh'], cwd: '/host/project' }
+  const loaded = await ViewletTerminal2.loadContent(state, undefined, options)
+  await ViewletTerminal2.loadContentLater(loaded)
+  expect(terminalWorkerInvoke).toHaveBeenCalledWith('Terminal.create', 42, '/host/project', options.command, options.args, { backend: 'mock' })
+})


### PR DESCRIPTION
Route new terminals in devcontainer workspaces through the Dev Containers extension, preserving the container shell environment and Explorer directory. Use the host launch directory supplied by the extension so container URIs are never passed to the host PTY as filesystem paths.