### PR TITLE
fix: select the output channel after rendering its toolbar

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,6 +100,12 @@ jobs:
         run: npm run e2e:terminal-background
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test output channel selection
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.output-open-channel
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test integrated terminal rendering
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/packages/extension-host-worker-tests/src/viewlet.output-open-channel.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.output-open-channel.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.output-open-channel'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  const select = Locator('[name="output"]')
+
+  await Command.execute('Layout.openOutput', 'Window')
+  await expect(select).toHaveValue('Window')
+
+  await Command.execute('Layout.openOutput', 'SharedProcess')
+  await expect(select).toHaveValue('SharedProcess')
+
+  await Command.execute('Layout.hidePanel')
+  await expect(select).toBeHidden()
+  await Command.execute('Layout.openOutput', 'Window')
+  await expect(select).toHaveValue('Window')
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1039,11 +1039,16 @@ export const openProblems = async (state: LayoutState, filterValue?: string): Pr
 }
 
 export const openOutput = async (state: LayoutState, channelId?: string): Promise<LayoutStateResult> => {
-  const result = await showPanel(state, ViewletModuleId.Output)
-  if (channelId !== undefined) {
-    await Command.execute('Output.selectChannel', channelId)
+  if (channelId === undefined) {
+    return showPanel(state, ViewletModuleId.Output)
   }
-  return result
+  // Commit the panel's DOM before updating the channel value in its toolbar.
+  await Viewlet.executeViewletCommand(state.uid, 'showPanel', ViewletModuleId.Output, channelId)
+  await Command.execute('Output.selectChannel', channelId)
+  return {
+    newState: state,
+    commands: [],
+  }
 }
 
 export const openDebugConsole = async (state: LayoutState, inputValue?: string): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const commandExecute = jest.fn()
+const executeViewletCommand = jest.fn()
 const panelWorkerInvocations: any[] = []
 
 jest.unstable_mockModule('../src/parts/Command/Command.js', () => {
@@ -27,11 +28,14 @@ jest.unstable_mockModule('../src/parts/PanelWorker/PanelWorker.js', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({ executeViewletCommand }))
+
 const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
 const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
 
 beforeEach(() => {
   commandExecute.mockClear()
+  executeViewletCommand.mockReset()
   panelWorkerInvocations.length = 0
   ViewletStates.reset()
   ViewletStates.set('Panel', {
@@ -81,7 +85,6 @@ test('adds a focused terminal without reselecting the active terminal panel view
 
 test.each([
   ['openProblems', 'Problems', 'Problems.handleFilterInput', 'typescript'],
-  ['openOutput', 'Output', 'Output.selectChannel', 'Window'],
   ['openDebugConsole', 'Debug Console', 'ViewletDebugConsole.handleInput', 'process.version'],
 ] as const)('opens the requested panel view with its initial option: %s', async (method, panelView, command, value) => {
   const state = {
@@ -115,4 +118,21 @@ test.each([
 
   expect(result.newState.panelView).toBe(panelView)
   expect(commandExecute).not.toHaveBeenCalled()
+})
+
+test('renders the output panel before selecting the requested channel', async () => {
+  const state = ViewletLayout.create(1)
+  const panelRendered = Promise.withResolvers<void>()
+  executeViewletCommand.mockImplementation(() => panelRendered.promise)
+
+  const pending = ViewletLayout.openOutput(state, 'Window')
+
+  expect(executeViewletCommand).toHaveBeenCalledWith(state.uid, 'showPanel', 'Output', 'Window')
+  expect(commandExecute).not.toHaveBeenCalled()
+
+  panelRendered.resolve()
+  const result = await pending
+
+  expect(commandExecute).toHaveBeenCalledWith('Output.selectChannel', 'Window')
+  expect(result).toEqual({ newState: state, commands: [] })
 })


### PR DESCRIPTION
When a devcontainer opens its output channel, render the panel before applying the channel selection so the dropdown matches the displayed logs. Pass the requested channel into the initial load and preserve correct selection when switching or reopening Output.