### PR TITLE
feature: add Google suggestions to new tab search

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,11 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Simple Browser new tab suggestions
+        if: matrix.os == 'ubuntu-24.04'
+        run: npm run test:simple-browser-new-tab
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test Simple Browser workspace switching
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test-static-export": "node packages/build/src/parts/TestStaticExport/TestStaticExport.ts",
     "test:gpu-diagnostics": "node --test scripts/test/diagnose-gpu-process.test.mjs",
     "e2e:ci": "node packages/extension-host-worker-tests/src/_all.js --ci",
+    "test:simple-browser-new-tab": "node scripts/test-simple-browser-new-tab.mjs",
     "test:simple-browser-workspace": "node scripts/test-simple-browser-workspace.mjs"
   },
   "keywords": [],

--- a/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
@@ -1,4 +1,5 @@
 import * as ColorTheme from '../ColorTheme/ColorTheme.js'
+import * as SimpleBrowserNewTabSuggestions from '../SimpleBrowserNewTabSuggestions/SimpleBrowserNewTabSuggestions.js'
 
 const dataUrlPrefix = 'data:text/html;charset=utf-8,'
 const marker = '<!--lvce-simple-browser-new-tab-->'
@@ -49,12 +50,12 @@ const getThemeVariables = (css) => {
         --WidgetBackground: ${escapeHtml(widgetBackground)};`
 }
 
-const getHtml = (colorThemeCss) => `${marker}<!doctype html>
+const getHtml = (colorThemeCss, suggestionsEnabled) => `${marker}<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; form-action https://www.google.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; ${suggestionsEnabled ? "script-src 'unsafe-inline' https://suggestqueries.google.com/complete/search; " : ''}form-action https://www.google.com">
     <title>New Tab</title>
     <style>
       :root {
@@ -119,7 +120,33 @@ const getHtml = (colorThemeCss) => `${marker}<!doctype html>
       }
 
       form {
+        position: relative;
         width: 100%;
+      }
+
+      .Suggestions {
+        position: absolute;
+        width: 100%;
+        max-height: min(320px, 40vh);
+        overflow-y: auto;
+        margin-top: 8px;
+        padding: 6px;
+        border: 1px solid var(--InputBoxBorder);
+        border-radius: 15px;
+        background: var(--WidgetBackground);
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
+      }
+
+      .Suggestion {
+        padding: 10px 14px;
+        border-radius: 9px;
+        overflow-wrap: anywhere;
+        cursor: pointer;
+      }
+
+      .Suggestion:hover,
+      .Suggestion[aria-selected="true"] {
+        background: color-mix(in srgb, var(--FocusOutline) 20%, var(--WidgetBackground));
       }
 
       .SearchBox {
@@ -203,15 +230,17 @@ const getHtml = (colorThemeCss) => `${marker}<!doctype html>
           <svg class="SearchIcon" viewBox="0 0 24 24" aria-hidden="true">
             <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m20 20-4.2-4.2m1.2-5.3a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0Z"></path>
           </svg>
-          <input type="search" name="q" aria-label="Search with Google" placeholder="Search with Google" autocomplete="off" spellcheck="false">
+          <input type="search" name="q" aria-label="Search with Google" placeholder="Search with Google" autocomplete="off" spellcheck="false"${suggestionsEnabled ? ' role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="suggestions"' : ''}>
         </label>
+        ${suggestionsEnabled ? '<div id="suggestions" class="Suggestions" role="listbox" aria-label="Google suggestions" hidden></div>' : ''}
       </form>
     </main>
+    ${suggestionsEnabled ? `<script>${SimpleBrowserNewTabSuggestions.script}</script>` : ''}
   </body>
 </html>`
 
-export const getUrl = (colorThemeCss = ColorTheme.getColorThemeCss()) => {
-  return `${dataUrlPrefix}${encodeURIComponent(getHtml(colorThemeCss))}`
+export const getUrl = (colorThemeCss = ColorTheme.getColorThemeCss(), suggestionsEnabled = false) => {
+  return `${dataUrlPrefix}${encodeURIComponent(getHtml(colorThemeCss, suggestionsEnabled))}`
 }
 
 export const url = getUrl()

--- a/packages/renderer-worker/src/parts/SimpleBrowserNewTabSuggestions/SimpleBrowserNewTabSuggestions.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserNewTabSuggestions/SimpleBrowserNewTabSuggestions.js
@@ -1,0 +1,131 @@
+// Runs inside the isolated new-tab document, which has no Electron or workbench APIs.
+export const script = String.raw`(() => {
+  const input = document.querySelector('input[name="q"]');
+  const form = input.form;
+  const list = document.querySelector('#suggestions');
+  const callbacks = {};
+  window.lvceGoogleSuggestions = callbacks;
+  let sequence = 0;
+  let timer;
+  let cleanup;
+  let suggestions = [];
+  let selectedIndex = -1;
+  let composing = false;
+
+  const dismiss = () => {
+    sequence++;
+    clearTimeout(timer);
+    if (cleanup) cleanup();
+    suggestions = [];
+    selectedIndex = -1;
+    list.replaceChildren();
+    list.hidden = true;
+    input.setAttribute('aria-expanded', 'false');
+    input.removeAttribute('aria-activedescendant');
+  };
+
+  const select = (index) => {
+    selectedIndex = index;
+    for (let i = 0; i < list.children.length; i++) {
+      list.children[i].setAttribute('aria-selected', String(i === index));
+    }
+    if (index < 0) {
+      input.removeAttribute('aria-activedescendant');
+    } else {
+      const option = list.children[index];
+      input.setAttribute('aria-activedescendant', option.id);
+      option.scrollIntoView({ block: 'nearest' });
+    }
+  };
+
+  const render = (data) => {
+    if (!Array.isArray(data) || !Array.isArray(data[1])) return;
+    suggestions = [...new Set(data[1].filter((value) => typeof value === 'string' && value.trim()))].slice(0, 7);
+    for (const [index, value] of suggestions.entries()) {
+      const option = document.createElement('div');
+      option.className = 'Suggestion';
+      option.id = 'suggestion-' + index;
+      option.setAttribute('role', 'option');
+      option.setAttribute('aria-selected', 'false');
+      option.textContent = value;
+      option.addEventListener('pointerdown', (event) => {
+        if (event.button === 0) event.preventDefault();
+      });
+      option.addEventListener('click', () => {
+        input.value = value;
+        dismiss();
+        form.requestSubmit();
+      });
+      list.append(option);
+    }
+    list.hidden = suggestions.length === 0;
+    input.setAttribute('aria-expanded', String(!list.hidden));
+  };
+
+  const request = (query, id) => {
+    // Google supports JSONP for pages without a privileged network bridge or CORS access.
+    const callback = 'r' + id;
+    const script = document.createElement('script');
+    let timeout;
+    const finish = () => {
+      clearTimeout(timeout);
+      script.remove();
+      delete callbacks[callback];
+      if (cleanup === finish) cleanup = undefined;
+    };
+    cleanup = finish;
+    callbacks[callback] = (data) => {
+      finish();
+      if (id !== sequence || input.value.trim() !== query || document.activeElement !== input) return;
+      render(data);
+    };
+    script.src = 'https://suggestqueries.google.com/complete/search?client=chrome&hl=en&q=' + encodeURIComponent(query) + '&callback=lvceGoogleSuggestions.' + callback;
+    script.referrerPolicy = 'no-referrer';
+    script.onerror = finish;
+    script.onload = finish;
+    timeout = setTimeout(finish, 5000);
+    document.head.append(script);
+  };
+
+  const update = () => {
+    dismiss();
+    const query = input.value.trim();
+    if (composing || query.length < 2 || document.activeElement !== input) return;
+    const id = sequence;
+    timer = setTimeout(() => request(query, id), 150);
+  };
+
+  input.addEventListener('input', update);
+  input.addEventListener('focus', update);
+  input.addEventListener('blur', dismiss);
+  input.addEventListener('compositionstart', () => {
+    composing = true;
+    dismiss();
+  });
+  input.addEventListener('compositionend', () => {
+    composing = false;
+    update();
+  });
+  input.addEventListener('keydown', (event) => {
+    if (composing || event.isComposing) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      dismiss();
+    } else if (suggestions.length && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+      event.preventDefault();
+      select(event.key === 'ArrowDown' ? Math.min(selectedIndex + 1, suggestions.length - 1) : Math.max(selectedIndex - 1, -1));
+    }
+  });
+  form.addEventListener('submit', (event) => {
+    if (composing) {
+      event.preventDefault();
+      return;
+    }
+    if (selectedIndex >= 0) input.value = suggestions[selectedIndex];
+    dismiss();
+  });
+  window.addEventListener('pagehide', dismiss);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) dismiss();
+  });
+})();`

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -239,7 +239,7 @@ export const backgroundLoadContent = async (state, savedState) => {
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
-  const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl())
+  const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl(undefined, suggestionsEnabled))
   const title = newTitle || 'Simple Browser'
   const tabs = [createTab({ browserViewId, iframeSrc, inputValue: iframeSrc, title })]
   return {
@@ -298,7 +298,7 @@ export const loadContent = async (state, savedState) => {
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
   Assert.number(browserViewId)
   if (!iframeSrc || !id || id !== browserViewId) {
-    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl())
+    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl(undefined, suggestionsEnabled))
   }
   const { title, canGoBack, canGoForward, isAudioMuted } = await ElectronWebContentsViewFunctions.getStats(browserViewId)
   const restoredTabs =
@@ -368,13 +368,13 @@ const createUnloadedTab = async (state) => {
 
 const createEmptyTab = async (state) => {
   const tab = await createUnloadedTab(state)
-  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.getUrl())
+  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.getUrl(undefined, state.suggestionsEnabled))
   return tab
 }
 
 export const handleColorThemeChanged = async (state) => {
   const { tabs } = state
-  const newTabUrl = SimpleBrowserNewTabPage.getUrl()
+  const newTabUrl = SimpleBrowserNewTabPage.getUrl(undefined, state.suggestionsEnabled)
   await Promise.all(
     tabs
       .filter((tab) => !tab.iframeSrc && tab.browserViewId)

--- a/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
@@ -50,3 +50,15 @@ test('hides the internal page URL from the address bar', () => {
   expect(SimpleBrowserNewTabPage.toDisplayUrl(SimpleBrowserNewTabPage.getUrl(':root { --EditorBackground: #193549; }'))).toBe('')
   expect(SimpleBrowserNewTabPage.toDisplayUrl('https://example.com')).toBe('https://example.com')
 })
+
+test('enables Google suggestions only when requested', () => {
+  const html = getHtml(SimpleBrowserNewTabPage.getUrl('', true))
+  expect(html).toContain('role="combobox"')
+  expect(html).toContain('aria-controls="suggestions"')
+  expect(html).toContain('role="listbox"')
+  expect(html).toContain('https://suggestqueries.google.com/complete/search')
+  expect(html).toContain('<script>')
+  expect(getHtml()).not.toContain('<script>')
+  expect(getHtml()).not.toContain('script-src')
+  expect(SimpleBrowserNewTabPage.toDisplayUrl(SimpleBrowserNewTabPage.getUrl('', true))).toBe('')
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -502,6 +502,7 @@ test('creates and selects an empty tab while keeping the original view alive', a
   const state = {
     ...ViewletSimpleBrowser.create(7, '', 10, 20, 300, 200),
     browserViewId: 12,
+    suggestionsEnabled: true,
     tabs: [
       {
         browserViewId: 12,
@@ -523,7 +524,7 @@ test('creates and selects an empty tab while keeping the original view alive', a
   expect(ElectronWebContentsView.disposeWebContentsView).not.toHaveBeenCalled()
   expect(ElectronWebContentsViewFunctions.hide).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.show).toHaveBeenCalledWith(13)
-  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, SimpleBrowserNewTabPage.getUrl())
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(13, SimpleBrowserNewTabPage.getUrl(undefined, true))
   expect(ElectronWindow.focus).toHaveBeenCalledTimes(1)
 })
 

--- a/scripts/test-simple-browser-new-tab.mjs
+++ b/scripts/test-simple-browser-new-tab.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { getUrl } from '../packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js'
+
+const requireTests = createRequire(new URL('../packages/extension-host-worker-tests/package.json', import.meta.url))
+const { chromium } = requireTests('playwright')
+const { expect } = requireTests('@playwright/test')
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage()
+  const errors = []
+  const queries = []
+  const pending = new Map()
+  page.on('pageerror', (error) => errors.push(error.message))
+  await page.route('https://suggestqueries.google.com/complete/search?*', async (route) => {
+    const url = new URL(route.request().url())
+    const query = url.searchParams.get('q')
+    const callback = url.searchParams.get('callback')
+    queries.push(query)
+    const respond = async () => {
+      if (query === 'offline') {
+        await route.abort('failed')
+        return
+      }
+      const values = query === 'markup' ? ['<img src=x onerror=alert(1)>', '', 42, 'duplicate', 'duplicate'] : [query + ' first', query + ' second']
+      const data = query === 'malformed' ? {} : [query, values]
+      await route.fulfill({
+        headers: { 'Content-Type': 'text/javascript; charset=UTF-8', 'Content-Disposition': 'attachment; filename="f.txt"' },
+        body: `${callback} && ${callback}(${JSON.stringify(data)})`,
+      })
+    }
+    if (['slow', 'dismiss', 'blur', 'clear'].includes(query)) pending.set(query, respond)
+    else await respond()
+  })
+  await page.route('https://www.google.com/search?*', (route) => route.fulfill({ contentType: 'text/html', body: '<title>Search results</title>' }))
+  const newTab = getUrl('', true)
+  const input = page.getByRole('combobox', { name: 'Search with Google' })
+  const list = page.getByRole('listbox', { name: 'Google suggestions' })
+  const options = page.getByRole('option')
+  await page.goto(newTab)
+  await input.fill('ca')
+  await input.fill('cat')
+  await expect(options).toHaveText(['cat first', 'cat second'])
+  assert.deepEqual(queries, ['cat'])
+  await expect(input).toHaveAttribute('aria-expanded', 'true')
+  await input.press('ArrowDown')
+  await expect(input).toHaveAttribute('aria-activedescendant', 'suggestion-0')
+  await input.press('ArrowDown')
+  await input.press('ArrowUp')
+  await input.press('Enter')
+  await expect(page).toHaveURL('https://www.google.com/search?q=cat+first')
+
+  await page.goto(newTab)
+  await input.fill('mouse & keyboard')
+  await options.nth(1).click()
+  await expect(page).toHaveURL('https://www.google.com/search?q=mouse+%26+keyboard+second')
+
+  await page.goto(newTab)
+  await input.fill('slow')
+  await expect.poll(() => pending.has('slow')).toBe(true)
+  await input.fill('fast')
+  await expect(options).toHaveText(['fast first', 'fast second'])
+  await pending.get('slow')()
+  await expect(options).toHaveText(['fast first', 'fast second'])
+  await input.press('Escape')
+  await expect(list).toBeHidden()
+  await expect(input).toHaveValue('fast')
+  await expect(input).not.toHaveAttribute('aria-activedescendant')
+
+  for (const query of ['dismiss', 'blur', 'clear']) {
+    await input.fill(query)
+    await expect.poll(() => pending.has(query)).toBe(true)
+    if (query === 'dismiss') await input.press('Escape')
+    if (query === 'blur') await input.evaluate((element) => element.blur())
+    if (query === 'clear') await input.fill('')
+    await pending.get(query)()
+    await expect(list).toBeHidden()
+    await expect.poll(() => page.evaluate(() => Object.keys(window.lvceGoogleSuggestions).length)).toBe(0)
+  }
+
+  await input.fill('markup')
+  await expect(options).toHaveText(['<img src=x onerror=alert(1)>', 'duplicate'])
+  await expect(list.locator('img')).toHaveCount(0)
+  await input.fill('malformed')
+  await expect.poll(() => queries.includes('malformed')).toBe(true)
+  await expect(list).toBeHidden()
+  await input.fill('offline')
+  await expect.poll(() => queries.includes('offline')).toBe(true)
+  await expect(list).toBeHidden()
+  await input.press('Enter')
+  await expect(page).toHaveURL('https://www.google.com/search?q=offline')
+
+  await page.goto(newTab)
+  await input.focus()
+  await input.dispatchEvent('compositionstart')
+  await input.fill('composition')
+  await page.waitForTimeout(200)
+  assert(!queries.includes('composition'))
+  await input.dispatchEvent('compositionend')
+  await expect(options).toHaveText(['composition first', 'composition second'])
+  await input.press('ArrowDown')
+  await input.press('ArrowUp')
+  await input.press('Enter')
+  await expect(page).toHaveURL('https://www.google.com/search?q=composition')
+
+  await page.goto(getUrl('', false))
+  const disabledInput = page.getByRole('searchbox', { name: 'Search with Google' })
+  const beforeDisabled = queries.length
+  await disabledInput.fill('disabled')
+  await page.waitForTimeout(200)
+  assert.equal(queries.length, beforeDisabled)
+  await expect(page.locator('script')).toHaveCount(0)
+  await disabledInput.press('Enter')
+  await expect(page).toHaveURL('https://www.google.com/search?q=disabled')
+  assert.deepEqual(errors, [])
+  console.log('Simple Browser new-tab suggestions passed')
+} finally {
+  await browser.close()
+}


### PR DESCRIPTION
Add Google suggestions to the Simple Browser new-tab search when `simpleBrowser.suggestions` is enabled. The themed dropdown supports mouse and keyboard selection, dismisses on Escape or focus loss, and ignores stale responses while keeping ordinary search available when suggestions fail.
