### PR TITLE
feature: load ports worker keybindings

### DIFF
--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1353,6 +1353,7 @@
         "resize": { "name": "Ports.resize", "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "dimensions" }] },
         "terminate": { "name": "Ports.terminate", "parameters": [] },
         "getCommandIds": { "name": "Ports.getCommandIds", "parameters": [] },
+        "getKeyBindings": { "name": "Ports.getKeyBindings", "parameters": [], "fallback": [] },
         "renderEventListeners": { "name": "Ports.renderEventListeners", "parameters": [] }
       },
       "renderComparison": "emptyCommands",


### PR DESCRIPTION
Load standard keybindings from the ports worker so its keyboard shortcuts participate in the shared keybinding system. Fall back to an empty list for older ports worker versions.