### PR TITLE
fix: preserve browser input when showing suggestions and theme new tabs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,11 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Simple Browser suggestions and new-tab theme
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          node packages/main-process/node_modules/electron/install.js
+          xvfb-run -a npm run test:simple-browser-address
       - name: Test Simple Browser workspace switching
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test-static-export": "node packages/build/src/parts/TestStaticExport/TestStaticExport.ts",
     "test:gpu-diagnostics": "node --test scripts/test/diagnose-gpu-process.test.mjs",
     "e2e:ci": "node packages/extension-host-worker-tests/src/_all.js --ci",
-    "test:simple-browser-workspace": "node scripts/test-simple-browser-workspace.mjs"
+    "test:simple-browser-workspace": "node scripts/test-simple-browser-workspace.mjs",
+    "test:simple-browser-address": "node scripts/test-simple-browser-address.mjs"
   },
   "keywords": [],
   "author": "",

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -233,7 +233,6 @@ export const getSimpleBrowserVirtualDom = (
     onFocus: DomEventListenerFunctions.HandleFocus,
     name: InputName.SimpleBrowserAddress,
     onBlur: DomEventListenerFunctions.HandleBlurSimpleBrowserAddress,
-    value,
   })
   if (inlineSuggestion) {
     dom.push(

--- a/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserNewTabPage/SimpleBrowserNewTabPage.js
@@ -49,7 +49,18 @@ const getThemeVariables = (css) => {
         --WidgetBackground: ${escapeHtml(widgetBackground)};`
 }
 
-const getHtml = (colorThemeCss) => `${marker}<!doctype html>
+const lightThemeCss = `:root {
+  --EditorBackground: #ffffff;
+  --WorkbenchForeground: #24292f;
+  --InputBoxBackground: #f1f3f5;
+  --InputBoxForeground: #24292f;
+  --InputBoxPlaceholderForeground: #68717d;
+  --InputBoxBorder: #d4dce4;
+  --FocusOutline: #1769ba;
+  --WidgetBackground: #eef0f2;
+}`
+
+const getHtml = (colorThemeCss, chromeTheme) => `${marker}<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">
@@ -58,7 +69,7 @@ const getHtml = (colorThemeCss) => `${marker}<!doctype html>
     <title>New Tab</title>
     <style>
       :root {
-        color-scheme: dark;
+        color-scheme: ${chromeTheme === 'inherit' ? 'dark' : 'light'};
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         background: var(--EditorBackground);
         color: var(--WorkbenchForeground);${getThemeVariables(colorThemeCss)}
@@ -210,8 +221,9 @@ const getHtml = (colorThemeCss) => `${marker}<!doctype html>
   </body>
 </html>`
 
-export const getUrl = (colorThemeCss = ColorTheme.getColorThemeCss()) => {
-  return `${dataUrlPrefix}${encodeURIComponent(getHtml(colorThemeCss))}`
+export const getUrl = (colorThemeCss = ColorTheme.getColorThemeCss(), chromeTheme = 'light') => {
+  const css = chromeTheme === 'inherit' ? colorThemeCss : lightThemeCss
+  return `${dataUrlPrefix}${encodeURIComponent(getHtml(css, chromeTheme))}`
 }
 
 export const url = getUrl()

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -147,6 +147,7 @@ export const create = (id, uri, x, y, width, height) => {
     headerHeight: getHeaderHeight(true),
     iframeSrc: '',
     inputValue: '',
+    addressValueVersion: 0,
     title: '',
     browserViewId: 0,
     canGoForward: true,
@@ -239,7 +240,10 @@ export const backgroundLoadContent = async (state, savedState) => {
   const browserViewId = await ElectronWebContentsView.createWebContentsView(0)
   Assert.number(browserViewId)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, x, y + headerHeight, width, height - headerHeight)
-  const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl())
+  const { newTitle } = await ElectronWebContentsViewFunctions.setIframeSrc(
+    browserViewId,
+    iframeSrc || SimpleBrowserNewTabPage.getUrl(undefined, state.chromeTheme),
+  )
   const title = newTitle || 'Simple Browser'
   const tabs = [createTab({ browserViewId, iframeSrc, inputValue: iframeSrc, title })]
   return {
@@ -298,7 +302,7 @@ export const loadContent = async (state, savedState) => {
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
   Assert.number(browserViewId)
   if (!iframeSrc || !id || id !== browserViewId) {
-    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl())
+    await ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc || SimpleBrowserNewTabPage.getUrl(undefined, state.chromeTheme))
   }
   const { title, canGoBack, canGoForward, isAudioMuted } = await ElectronWebContentsViewFunctions.getStats(browserViewId)
   const restoredTabs =
@@ -368,13 +372,13 @@ const createUnloadedTab = async (state) => {
 
 const createEmptyTab = async (state) => {
   const tab = await createUnloadedTab(state)
-  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.getUrl())
+  await ElectronWebContentsViewFunctions.setIframeSrc(tab.browserViewId, SimpleBrowserNewTabPage.getUrl(undefined, state.chromeTheme))
   return tab
 }
 
 export const handleColorThemeChanged = async (state) => {
   const { tabs } = state
-  const newTabUrl = SimpleBrowserNewTabPage.getUrl()
+  const newTabUrl = SimpleBrowserNewTabPage.getUrl(undefined, state.chromeTheme)
   await Promise.all(
     tabs
       .filter((tab) => !tab.iframeSrc && tab.browserViewId)
@@ -1040,7 +1044,7 @@ const navigate = (state, value) => {
   void ElectronWebContentsViewFunctions.setIframeSrc(state.browserViewId, iframeSrc)
   void ElectronWebContentsViewFunctions.focus(state.browserViewId)
   const stateWithSearchHistory = addToSearchHistory(state, value)
-  return updateTab(stateWithSearchHistory, state.browserViewId, {
+  return updateTab({ ...stateWithSearchHistory, addressValueVersion: state.addressValueVersion + 1 }, state.browserViewId, {
     iframeSrc,
     inputValue: value,
     isLoading: true,
@@ -1066,7 +1070,7 @@ export const setUrl = async (state, value) => {
   void ElectronWebContentsViewFunctions.setIframeSrc(browserViewId, iframeSrc)
   const stateWithSearchHistory = addToSearchHistory(newState1, inputValue)
 
-  return updateTab(stateWithSearchHistory, browserViewId, {
+  return updateTab({ ...stateWithSearchHistory, addressValueVersion: state.addressValueVersion + 1 }, browserViewId, {
     iframeSrc,
     isLoading: true,
   })
@@ -1235,10 +1239,13 @@ export const focusAddress = async (state) => {
   return state
 }
 
-export const handleSettingsChanged = (state) => ({
-  ...state,
-  chromeTheme: Preferences.get('simpleBrowser.chromeTheme') === 'inherit' ? 'inherit' : 'light',
-})
+export const handleSettingsChanged = async (state) => {
+  const chromeTheme = Preferences.get('simpleBrowser.chromeTheme') === 'inherit' ? 'inherit' : 'light'
+  if (chromeTheme === state.chromeTheme) {
+    return state
+  }
+  return handleColorThemeChanged({ ...state, chromeTheme })
+}
 
 export const handleFaviconError = (state, index, src) => {
   const tab = state.tabs[Number(index)]

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserComponentState.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserComponentState.js
@@ -7,5 +7,8 @@ export const setComponentState = (currentState, state) => {
   if (state.uid !== currentState.uid) {
     throw new Error(`SimpleBrowser state uid must remain ${currentState.uid}`)
   }
+  if (state.inputValue !== currentState.inputValue) {
+    return { ...state, addressValueVersion: (currentState.addressValueVersion || 0) + 1 }
+  }
   return state
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -188,6 +188,7 @@ const renderDom = {
       oldState.isLoading === newState.isLoading &&
       oldState.snapshot === newState.snapshot &&
       oldState.suggestions === newState.suggestions &&
+      (oldState.inputValue === newState.inputValue || newState.suggestions.length === 0) &&
       oldState.selectedSuggestionIndex === newState.selectedSuggestionIndex &&
       oldState.selectedTabIndex === newState.selectedTabIndex &&
       oldState.tabsEnabled === newState.tabsEnabled &&

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserRender.js
@@ -199,11 +199,11 @@ const renderDom = {
   },
   apply(oldState, newState) {
     const newDom = getDom(newState)
-    const commands =
-      oldState.browserViewId === 0
-        ? [['Viewlet.setDom2', newState.uid, newDom]]
-        : [['Viewlet.setPatches', newState.uid, diffTree(getDom(oldState), newDom)]]
-    return commands
+    if (oldState.browserViewId === 0) {
+      return [['Viewlet.setDom2', newState.uid, newDom]]
+    }
+    const patches = diffTree(getDom(oldState), newDom)
+    return [['Viewlet.setTreePatches', newState.uid, patches]]
   },
   multiple: true,
 }
@@ -219,7 +219,11 @@ export const renderTitle = {
 
 const renderAddressValue = {
   isEqual(oldState, newState) {
-    return oldState.browserViewId === newState.browserViewId
+    return (
+      oldState.browserViewId === newState.browserViewId &&
+      oldState.iframeSrc === newState.iframeSrc &&
+      oldState.addressValueVersion === newState.addressValueVersion
+    )
   },
   apply(oldState, newState) {
     return [['Viewlet.setValueByName', newState.uid, InputName.SimpleBrowserAddress, newState.inputValue]]

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -338,7 +338,7 @@ test('rejects missing components and components without a DOM API', async () => 
 
 test('exposes Simple Browser state and renders edits through its component state hooks', async () => {
   const factory = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.ipc.js')
-  const state = factory.create(10, 'simple-browser://', 0, 0, 800, 600)
+  const state = { ...factory.create(10, 'simple-browser://', 0, 0, 800, 600), browserViewId: 12 }
   ViewletStates.set(10, { factory, moduleId: 'SimpleBrowser', renderedState: state, state })
 
   expect(ComponentState.getComponents()).toEqual([
@@ -347,14 +347,16 @@ test('exposes Simple Browser state and renders edits through its component state
   await expect(ComponentState.getState(10)).resolves.toBe(state)
 
   const editedState = { ...state, inputValue: 'Live browser state' }
-  const domCommands = factory.render[0].apply(state, editedState)
+  const renderedState = { ...editedState, addressValueVersion: 1 }
+  expect(factory.render[1].isEqual(state, renderedState)).toBe(false)
+  const domCommands = factory.render[1].apply(state, renderedState)
   jest.mocked(ViewletManager.render).mockReturnValue(domCommands)
   await ComponentState.setState(10, editedState)
 
-  await expect(ComponentState.getState(10)).resolves.toBe(editedState)
-  expect(ViewletManager.render).toHaveBeenCalledWith(factory, state, editedState, 10, undefined)
+  await expect(ComponentState.getState(10)).resolves.toEqual(renderedState)
+  expect(ViewletManager.render).toHaveBeenCalledWith(factory, state, renderedState, 10, undefined)
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.sendMultiple', domCommands)
-  expect(domCommands).toEqual([['Viewlet.setDom2', 10, expect.arrayContaining([expect.objectContaining({ value: 'Live browser state' })])]])
+  expect(domCommands).toEqual([['Viewlet.setValueByName', 10, 'simple-browser-address', 'Live browser state']])
 })
 
 test('exposes Layout state and renders edits through its component state hooks', async () => {

--- a/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
+++ b/packages/renderer-worker/test/GetSimpleBrowserVirtualDom.test.ts
@@ -127,7 +127,9 @@ test('renders the first matching suggestion inline without changing the input va
     }),
   )
   expect(dom).toContainEqual(expect.objectContaining({ className: 'SimpleBrowserInlineSuggestionSuffix' }))
-  expect(dom).toContainEqual(expect.objectContaining({ name: 'simple-browser-address', value: 'cheese' }))
+  const input = dom.find((node) => node.name === 'simple-browser-address')
+  expect(input).toBeDefined()
+  expect(input).not.toHaveProperty('value')
   expect(dom).toContainEqual(expect.objectContaining({ text: 'burger' }))
 })
 

--- a/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserNewTabPage.test.ts
@@ -5,6 +5,16 @@ const prefix = 'data:text/html;charset=utf-8,'
 
 const getHtml = (url: string = SimpleBrowserNewTabPage.url): string => decodeURIComponent(url.slice(prefix.length))
 
+test('uses light browser colors even when the workbench theme is dark', () => {
+  const html = getHtml(SimpleBrowserNewTabPage.getUrl(':root { --EditorBackground: #193549; --WorkbenchForeground: #c5c5c5; }'))
+
+  expect(html).toContain('color-scheme: light;')
+  expect(html).toContain('--EditorBackground: #ffffff;')
+  expect(html).toContain('--WorkbenchForeground: #24292f;')
+  expect(html).toContain('--InputBoxBackground: #f1f3f5;')
+  expect(html).toContain('--InputBoxForeground: #24292f;')
+})
+
 test('provides a self-contained new tab page', () => {
   expect(SimpleBrowserNewTabPage.url.startsWith(prefix)).toBe(true)
   expect(getHtml()).toContain('<title>New Tab</title>')
@@ -17,7 +27,8 @@ test('provides a self-contained new tab page', () => {
 })
 
 test('uses workbench theme colors', () => {
-  const url = SimpleBrowserNewTabPage.getUrl(`:root {
+  const url = SimpleBrowserNewTabPage.getUrl(
+    `:root {
     --EditorBackground: #193549;
     --WorkbenchForeground: #c5c5c5;
     --InputBoxBackground: #15232d;
@@ -26,7 +37,9 @@ test('uses workbench theme colors', () => {
     --InputBoxBorder: #0d3a58;
     --FocusOutline: #0088ff;
     --WidgetBackground: #122738;
-  }`)
+  }`,
+    'inherit',
+  )
   const html = getHtml(url)
 
   expect(html).toContain('--EditorBackground: #193549;')
@@ -37,10 +50,13 @@ test('uses workbench theme colors', () => {
 })
 
 test('falls back from the legacy empty EditorBackGround color to MainBackground', () => {
-  const url = SimpleBrowserNewTabPage.getUrl(`:root {
+  const url = SimpleBrowserNewTabPage.getUrl(
+    `:root {
     --EditorBackGround: ;
     --MainBackground: #193549;
-  }`)
+  }`,
+    'inherit',
+  )
 
   expect(getHtml(url)).toContain('--EditorBackground: #193549;')
 })

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
 afterEach(() => {
   BrowserSuggestionRequests.cancel(7)
   jest.useRealTimers()
+  delete Preferences.state['simpleBrowser.chromeTheme']
 })
 
 beforeEach(() => {
@@ -531,7 +532,7 @@ test('updates open new tab pages when the color theme changes', async () => {
   ColorTheme.state.colorThemeCss = ':root { --EditorBackground: #193549; --InputBoxBackground: #15232d; }'
   // @ts-ignore
   ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
-  const state = createTwoTabState()
+  const state = { ...createTwoTabState(), chromeTheme: 'inherit' }
   const { tabs } = state
   tabs[0].iframeSrc = ''
 
@@ -539,7 +540,29 @@ test('updates open new tab pages when the color theme changes', async () => {
 
   expect(newState).toBe(state)
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
-  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, SimpleBrowserNewTabPage.getUrl())
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, SimpleBrowserNewTabPage.getUrl(undefined, 'inherit'))
+})
+
+test.each(['light', 'inherit'])('updates open new tab pages when browser chrome changes to %s', async (chromeTheme) => {
+  Preferences.state['simpleBrowser.chromeTheme'] = chromeTheme
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.setIframeSrc.mockResolvedValue(undefined)
+  const state = { ...createTwoTabState(), chromeTheme: chromeTheme === 'light' ? 'inherit' : 'light' }
+  state.tabs[0].iframeSrc = ''
+
+  const newState = await ViewletSimpleBrowser.handleSettingsChanged(state)
+
+  expect(newState.chromeTheme).toBe(chromeTheme)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(12, SimpleBrowserNewTabPage.getUrl(undefined, chromeTheme))
+})
+
+test('does not reload new tab pages for unrelated settings changes', async () => {
+  const state = { ...createTwoTabState(), chromeTheme: 'light' }
+  state.tabs[0].iframeSrc = ''
+
+  expect(await ViewletSimpleBrowser.handleSettingsChanged(state)).toBe(state)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).not.toHaveBeenCalled()
 })
 
 test('opens a target blank link in a new selected tab by default', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -76,7 +76,7 @@ test('renders suggestions incrementally without taking keyboard focus', () => {
 
   const commands = ViewletSimpleBrowserRender.render[0].apply(state, newState)
 
-  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setPatches', 42])
+  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setTreePatches', 42])
   expect(commands[0][2]).not.toHaveLength(0)
   expect(commands.some((command) => command[0] === 'Viewlet.focusElementByName')).toBe(false)
 })
@@ -91,6 +91,18 @@ test('renders the initial dom in full', () => {
 
   expect(commands).toHaveLength(1)
   expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setDom2', 42])
+})
+
+test('keeps the browser root when adding history suggestions without an inline completion', () => {
+  const oldState = { ...state, iframeSrc: '', inputValue: 'example' }
+  const newState = { ...oldState, suggestions: [{ value: 'https://example.com', favicon: '', type: 'url' }] }
+
+  const commands = ViewletSimpleBrowserRender.render[0].apply(oldState, newState)
+
+  expect(commands[0].slice(0, 2)).toEqual(['Viewlet.setTreePatches', 42])
+  expect(commands[0][2]).toEqual([
+    expect.objectContaining({ type: 6, nodes: expect.arrayContaining([expect.objectContaining({ className: 'SimpleBrowserSuggestions' })]) }),
+  ])
 })
 
 test('does not focus the address input after suggestions close', () => {
@@ -111,6 +123,29 @@ test('synchronizes the native address value when selecting another tab', () => {
   expect(ViewletSimpleBrowserRender.render[1].isEqual(oldState, newState)).toBe(false)
   expect(ViewletSimpleBrowserRender.render[1].multiple).toBe(true)
   expect(ViewletSimpleBrowserRender.render[1].apply(oldState, newState)).toEqual([['Viewlet.setValueByName', 42, 'simple-browser-address', '']])
+})
+
+test('synchronizes the address after navigation in the current tab', () => {
+  const newState = { ...state, iframeSrc: 'https://other.example', inputValue: 'https://other.example' }
+
+  expect(ViewletSimpleBrowserRender.render[1].isEqual(state, newState)).toBe(false)
+  expect(ViewletSimpleBrowserRender.render[1].apply(state, newState)).toEqual([
+    ['Viewlet.setValueByName', 42, 'simple-browser-address', 'https://other.example'],
+  ])
+})
+
+test('does not overwrite newer native typing when suggestions arrive', () => {
+  const newState = { ...state, inputValue: 'wh', suggestions: ['what is'] }
+
+  expect(ViewletSimpleBrowserRender.render[1].isEqual(state, newState)).toBe(true)
+  const patches = ViewletSimpleBrowserRender.render[0].apply(state, newState)[0][2]
+  expect(patches).not.toContainEqual(expect.objectContaining({ key: 'value' }))
+})
+
+test('synchronizes the address when navigating to the same URL again', () => {
+  const newState = { ...state, addressValueVersion: 1 }
+
+  expect(ViewletSimpleBrowserRender.render[1].isEqual(state, newState)).toBe(false)
 })
 
 test('focuses the address input for a new empty tab', () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserRender.test.ts
@@ -42,6 +42,15 @@ test('rerenders when suggestions change', () => {
   expect(ViewletSimpleBrowserRender.render[0].isEqual(state, newState)).toBe(false)
 })
 
+test('updates inline completion when the input changes but suggestions stay the same', () => {
+  const oldState = { ...state, inputValue: 'what is', suggestions: ['what is'] }
+  const newState = { ...oldState, inputValue: 'what' }
+
+  expect(ViewletSimpleBrowserRender.render[0].isEqual(oldState, newState)).toBe(false)
+  const commands = ViewletSimpleBrowserRender.render[0].apply(oldState, newState)
+  expect(commands[0][2]).not.toContainEqual(expect.objectContaining({ key: 'value' }))
+})
+
 test('rerenders when the audio indicator setting changes', () => {
   const oldState = {
     ...state,

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -59,6 +59,10 @@ try {
   app = await _electron.launch(launchOptions)
   await app.evaluate(({ session, net }) => {
     session.defaultSession.protocol.handle('https', async (request) => {
+      if (request.url.startsWith('https://suggestqueries.google.com/')) {
+        const query = new URL(request.url).searchParams.get('q')
+        return new Response(JSON.stringify([query, [query + ' result']]), { headers: { 'Content-Type': 'application/json' } })
+      }
       if (request.url === 'https://example.com/') return new Response('<title>Example Domain</title>', { headers: { 'Content-Type': 'text/html' } })
       return net.fetch(request.url, { bypassCustomProtocolHandlers: true })
     })
@@ -129,6 +133,17 @@ try {
   await expect(address).toHaveValue('known.example/article')
   assert.equal(await address.evaluate((input) => input === window.browserAddressInput), true)
   await expect(address).toBeFocused()
+  await address.press('Escape')
+  await expect(suggestions).toHaveCount(0)
+
+  await address.fill('known')
+  await expect(page.locator('.SimpleBrowserInlineSuggestion')).toBeVisible()
+  await address.press('End')
+  await page.keyboard.type(' query')
+  await expect(address).toHaveValue('known query')
+  await expect(page.getByRole('option', { name: 'known query result', exact: true })).toBeVisible()
+  await expect(address).toHaveValue('known query')
+  assert.equal(await address.evaluate((input) => input === window.browserAddressInput), true)
   await address.press('Escape')
   await expect(suggestions).toHaveCount(0)
 

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { parseKeyBindingString } from '../packages/renderer-worker/src/parts/ParseKeyBindingString/ParseKeyBindingString.js'
+import { createServer } from 'node:http'
+import { createRequire } from 'node:module'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireTests = createRequire(join(root, 'packages/extension-host-worker-tests/package.json'))
+const requireBuild = createRequire(join(root, 'packages/build/package.json'))
+const { _electron } = requireTests('playwright')
+const { expect } = requireTests('@playwright/test')
+const { build } = requireBuild('esbuild')
+const profile = await mkdtemp(join(tmpdir(), 'lvce-browser-address-'))
+await mkdir(join(profile, 'config/lvce-oss'), { recursive: true })
+const settingsPath = join(profile, 'config/lvce-oss/settings.json')
+await writeFile(settingsPath, JSON.stringify({ 'simpleBrowser.suggestions': true }))
+await writeFile(
+  join(profile, 'config/lvce-oss/keybindings.json'),
+  JSON.stringify([
+    { source: 'User', key: parseKeyBindingString('Ctrl+Alt+1'), command: 'Preferences.update', args: [{ 'simpleBrowser.chromeTheme': 'inherit' }] },
+    { source: 'User', key: parseKeyBindingString('Ctrl+Alt+2'), command: 'Preferences.update', args: [{ 'simpleBrowser.chromeTheme': 'light' }] },
+    { source: 'User', key: parseKeyBindingString('Ctrl+Alt+3'), command: 'Layout.handleSettingsChanged' },
+  ]),
+)
+const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js')
+const rendererSource = await readFile(rendererPath, 'utf8')
+const bundleUrl = '/packages/renderer-worker/dist/browserAddressTestMain.js'
+await build({
+  entryPoints: [join(root, 'packages/renderer-worker/src/rendererWorkerMain.ts')],
+  outfile: join(root, bundleUrl),
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  external: ['node:*', '/static/*', 'electron'],
+  logLevel: 'error',
+})
+const server = createServer((_request, response) => {
+  response.setHeader('Content-Type', 'text/html')
+  response.end('<!doctype html><title>Local article</title><h1>Local article</h1><script>window.documentToken=crypto.randomUUID()</script>')
+})
+await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen))
+const url = `http://127.0.0.1:${server.address().port}/article`
+let app
+try {
+  await writeFile(rendererPath, rendererSource.replace('/packages/renderer-worker/src/rendererWorkerMain.ts', bundleUrl))
+  const env = { ...process.env, DEV: '1', LVCE_ROOT: root, LVCE_SHARED_PROCESS_PATH: join(root, 'packages/shared-process/src/sharedProcessMain.ts') }
+  delete env.ELECTRON_RUN_AS_NODE
+  for (const key of ['CONFIG', 'DATA', 'STATE', 'CACHE']) env[`XDG_${key}_HOME`] = join(profile, key.toLowerCase())
+  const launchOptions = {
+    executablePath: join(root, 'packages/main-process/node_modules/electron/dist/electron'),
+    args: ['--no-sandbox', '--disable-http-cache', '.', profile],
+    cwd: join(root, 'packages/main-process'),
+    env,
+    timeout: 60000,
+  }
+  app = await _electron.launch(launchOptions)
+  await app.evaluate(({ session, net }) => {
+    session.defaultSession.protocol.handle('https', async (request) => {
+      if (request.url === 'https://example.com/') return new Response('<title>Example Domain</title>', { headers: { 'Content-Type': 'text/html' } })
+      return net.fetch(request.url, { bypassCustomProtocolHandlers: true })
+    })
+  })
+  const page = await app.firstWindow()
+  page.setDefaultTimeout(15000)
+  page.on('console', (message) => {
+    if (message.type() === 'error') console.error('APP ERROR', message.text())
+  })
+  await expect(page.locator('#Workbench')).toBeVisible()
+  const runCommand = async (label) => {
+    await page.keyboard.press('Control+Shift+P')
+    const input = page.locator('[name="QuickPickInput"]')
+    await expect(input).toBeVisible()
+    await input.fill(`>${label}`)
+    await expect(page.getByRole('option', { name: label, exact: true })).toBeVisible()
+    await input.press('Enter')
+  }
+  await page.evaluate(() => {
+    localStorage.setItem('simple-browser-search-history', JSON.stringify(['known first', 'known second', 'offline local']))
+    localStorage.setItem('simple-browser-history', JSON.stringify([{ date: Date.now(), url: 'https://known.example/article' }]))
+  })
+  await runCommand('Simple Browser: Toggle Full Width')
+  await expect(page.locator('.BrowserFullWidth')).toBeVisible()
+  const address = page.locator('[name="simple-browser-address"]')
+  await address.fill(url)
+  await address.press('Enter')
+  await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Local article')
+  const articleToken = () =>
+    app.evaluate(async ({ webContents }, url) => {
+      const article = webContents.getAllWebContents().find((item) => item.getURL() === url)
+      return article?.executeJavaScript('window.documentToken')
+    }, url)
+  await expect.poll(articleToken).toBeTruthy()
+  const token = await articleToken()
+  await page.getByRole('button', { name: 'New Tab', exact: true }).click()
+  await expect(address).toHaveValue('')
+  const newTabStyles = () =>
+    app.evaluate(async ({ webContents }) => {
+      const tabs = webContents.getAllWebContents().filter((item) => item.getURL().startsWith('data:text/html'))
+      return Promise.all(
+        tabs.map((tab) =>
+          tab.executeJavaScript(
+            '({ background: getComputedStyle(document.documentElement).backgroundColor, foreground: getComputedStyle(document.documentElement).color, scheme: getComputedStyle(document.documentElement).colorScheme, input: getComputedStyle(document.querySelector(".SearchBox")).backgroundColor })',
+          ),
+        ),
+      )
+    })
+  const lightStyle = { background: 'rgb(255, 255, 255)', foreground: 'rgb(36, 41, 47)', scheme: 'light', input: 'rgb(241, 243, 245)' }
+  await expect.poll(newTabStyles).toEqual([lightStyle])
+
+  // This matches the middle of a history URL, so there is no inline completion.
+  // The resulting single Add patch must append the dropdown, never replace the browser.
+  await address.fill('known.example')
+  const suggestions = page.locator('.SimpleBrowserSuggestions')
+  await expect(suggestions).toBeVisible()
+  await expect(address).toBeVisible()
+  await expect(address).toBeFocused()
+  const addressBounds = await address.boundingBox()
+  const suggestionBounds = await suggestions.boundingBox()
+  assert(suggestionBounds.y >= addressBounds.y + addressBounds.height, 'Suggestions must stay below the address input')
+  await address.evaluate((input) => {
+    window.browserAddressInput = input
+  })
+  await address.click()
+  await address.press('End')
+  await page.keyboard.type('/article')
+  await expect(address).toHaveValue('known.example/article')
+  assert.equal(await address.evaluate((input) => input === window.browserAddressInput), true)
+  await expect(address).toBeFocused()
+  await address.press('Escape')
+  await expect(suggestions).toHaveCount(0)
+
+  // Switching settings updates both the visible and a background new-tab page.
+  await page.getByRole('button', { name: 'New Tab', exact: true }).click()
+  await expect.poll(newTabStyles).toEqual([lightStyle, lightStyle])
+  await address.focus()
+  await page.keyboard.press('Control+Alt+1')
+  await expect.poll(async () => JSON.parse(await readFile(settingsPath, 'utf8'))['simpleBrowser.chromeTheme']).toBe('inherit')
+  await page.keyboard.press('Control+Alt+3')
+  await expect(page.locator('.SimpleBrowserLight')).toHaveCount(0)
+  await expect.poll(async () => (await newTabStyles()).map((style) => style.scheme)).toEqual(['dark', 'dark'])
+  assert((await newTabStyles()).every((style) => style.background !== lightStyle.background))
+  await page.keyboard.press('Control+Alt+2')
+  await expect.poll(async () => JSON.parse(await readFile(settingsPath, 'utf8'))['simpleBrowser.chromeTheme']).toBe('light')
+  await page.keyboard.press('Control+Alt+3')
+  await expect(page.locator('.SimpleBrowserLight')).toHaveCount(1)
+  await expect.poll(newTabStyles).toEqual([lightStyle, lightStyle])
+  assert.equal(await articleToken(), token, 'Theme changes must not reload normal pages')
+  await mkdir(join(root, '.tmp/browser-address-evidence'), { recursive: true })
+  await address.fill('known.example')
+  await expect(suggestions).toBeVisible()
+  await page.screenshot({ path: join(root, '.tmp/browser-address-evidence/suggestions.png') })
+  console.log('History suggestions preserve the toolbar and typing; visible and background new-tab pages follow the browser theme')
+} finally {
+  await app?.close()
+  await writeFile(rendererPath, rendererSource)
+  await new Promise((resolveClose) => server.close(resolveClose))
+  await rm(profile, { recursive: true, force: true })
+}


### PR DESCRIPTION
Keep URL-history suggestions below the address field by applying tree patches without replacing the browser root, and prevent delayed suggestion updates from overwriting newer typing.

New-tab pages now follow the browser’s light or inherited theme, including already-open tabs when that setting changes.
