### PR TITLE
feature: integrate local and uploaded session replay

### DIFF
--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -106,9 +106,17 @@
   },
   {
     "category": "workbench",
-    "description": "Records the current session for replay",
-    "heading": "Session Replay",
+    "description": "Records visual content and messages locally for replay. Includes visible source text. Changing this setting starts a new recording segment.",
+    "heading": "Local Session Replay",
     "id": "sessionReplay.enabled",
+    "type": "boolean",
+    "value": false
+  },
+  {
+    "category": "workbench",
+    "description": "Sends recorded visual content and messages to the backend. Independent of local recording. Changing this setting starts a new recording segment.",
+    "heading": "Upload Session Replay",
+    "id": "sessionReplay.uploadEnabled",
     "type": "boolean",
     "value": false
   },

--- a/packages/renderer-worker/src/parts/SessionReplay/SessionReplay.js
+++ b/packages/renderer-worker/src/parts/SessionReplay/SessionReplay.js
@@ -1,187 +1,63 @@
-import * as Assert from '../Assert/Assert.ts'
+import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as Command from '../Command/Command.js'
-import * as GetSessionEvents from '../GetSessionEvents/GetSessionEvents.js'
 import * as GetSessionId from '../GetSessionId/GetSessionId.js'
-import * as HandleIpc from '../HandleIpc/HandleIpc.js'
-import * as Json from '../Json/Json.js'
 import * as Location from '../Location/Location.js'
-import * as Promises from '../Promises/Promises.js'
+import * as Preferences from '../Preferences/Preferences.js'
+import * as Product from '../Product/Product.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
-import * as SessionReplayStorage from '../SessionReplayStorage/SessionReplayStorage.js'
-import * as SharedProcessState from '../SharedProcessState/SharedProcessState.js'
-import * as Timeout from '../Timeout/Timeout.js'
-import * as Timestamp from '../Timestamp/Timestamp.js'
-import { VError } from '../VError/VError.js'
 
-export const getEvents = GetSessionEvents.getSessionEvents
+const state = { authState: undefined, configuration: '', pending: Promise.resolve() }
 
-export const handleMessage = async (source, timestamp, message) => {
-  try {
-    const sessionId = GetSessionId.getSessionId()
-    await SessionReplayStorage.saveValue(sessionId, {
-      source,
-      timestamp,
-      sessionId,
-      ...message,
-    })
-  } catch (error) {
-    console.error(error)
-    // @ts-ignore
-    if (error.cause) {
-      // @ts-ignore
-      console.error(error.cause)
-    }
-    // await ErrorHandling.handleError(error)
-  }
+export const startRecording = async (authState) => {
+  const local = Preferences.get('sessionReplay.enabled') === true
+  const upload = Preferences.get('sessionReplay.uploadEnabled') === true
+  const backendUrl = Preferences.get('layout.backendUrl') || Product.getBackendUrl()
+  const endpoint = new URL('/session-replay', backendUrl || 'https://lvce-editor.dev')
+  const href = await Location.getHref()
+  if (new URL(href).searchParams.get('allowAnonymous') === 'true') endpoint.searchParams.set('allowAnonymous', 'true')
+  const options = { local, upload, endpoint: endpoint.href, token: authState?.token || authState?.accessToken || '' }
+  const configuration = JSON.stringify(options)
+  if (configuration === state.configuration || (!state.configuration && !local && !upload)) return
+  const id = await RendererProcess.invoke('SessionReplay.configure', options)
+  state.configuration = configuration
+  GetSessionId.state.sessionId = id
 }
 
-const addSearchParam = (href, key, value) => {
-  const parsedUrl = new URL(href)
-  parsedUrl.searchParams.set('replayId', GetSessionId.getSessionId())
-  return parsedUrl.toString()
+export const getSessionContent = async () => JSON.stringify(await RendererProcess.invoke('SessionReplay.getSession'))
+
+export const downloadSession = async () => {
+  const session = await RendererProcess.invoke('SessionReplay.getSession')
+  await Command.execute('Download.downloadJson', session, `${session.id}.json`)
+}
+
+export const replaySession = async (sessionId) => {
+  const url = new URL(await Location.getHref())
+  url.search = ''
+  url.hash = ''
+  url.searchParams.set('replayId', sessionId)
+  await Command.execute('Open.openUrl', url.href)
 }
 
 export const replayCurrentSession = async () => {
-  if (!GetSessionId.state.sessionId) {
-    throw new VError('session replay is disabled in settings')
-  }
-  // TODO
-  // 1. read commands from indexeddb
-  // 2. open new window
-  // 3. replay ui with commands from indexeddb
-
-  const href = await Location.getHref()
-  const replayUrl = addSearchParam(href, 'replayId', GetSessionId.getSessionId())
-  await Command.execute('Open.openUrl', /* url */ replayUrl)
-}
-
-export const getSessionContent = async () => {
-  const sessionId = GetSessionId.getSessionId()
-  const events = await GetSessionEvents.getSessionEvents(sessionId)
-  return Json.stringify(events)
-}
-
-const DONT_REPLAY = new Set(['Open.openUrl', 'Download.downloadFile'])
-
-export const replaySession = async (sessionId) => {
-  const events = await GetSessionEvents.getSessionEvents(sessionId)
-  const originalIpc = RendererProcess.state.rpc.ipc
-  HandleIpc.unhandleIpc(originalIpc)
-  const originalSend = originalIpc.send.bind(originalIpc)
-  const originalAddEventListsner = originalIpc.addEventListener.bind(originalIpc)
-  const wrappedSend = () => {}
-  const wrappedOnMessage = async (event) => {
-    const { data } = event
-    if ('result' in data || 'error' in data) {
-      callbacks[data.id](data)
-      delete callbacks[data.id]
-    } else if ('method' in data) {
-      switch (data.method) {
-        case 'TitleBar.handleTitleBarButtonClickClose':
-          RendererProcess.state.rpc.ipc.onmessage = originalAddEventListsner
-          RendererProcess.state.rpc.ipc.send = originalSend
-          await Command.execute('ElectronWindow.close')
-          RendererProcess.state.rpc.ipc.onmessage = wrappedOnMessage
-          RendererProcess.state.rpc.ipc.send = wrappedSend
-          break
-        case 'TitleBar.handleTitleBarButtonClickMinimize':
-          RendererProcess.state.rpc.ipc.onmessage = originalAddEventListsner
-          RendererProcess.state.rpc.ipc.send = originalSend
-          await Command.execute('ElectronWindow.minimize')
-          RendererProcess.state.rpc.ipc.onmessage = wrappedOnMessage
-          RendererProcess.state.rpc.ipc.send = wrappedSend
-          break
-        case 'TitleBar.handleTitleBarButtonClickToggleMaximize':
-          RendererProcess.state.rpc.ipc.onmessage = originalAddEventListsner
-          RendererProcess.state.rpc.ipc.send = originalSend
-          await Command.execute('ElectronWindow.maximize')
-          RendererProcess.state.rpc.ipc.onmessage = wrappedOnMessage
-          RendererProcess.state.rpc.ipc.send = wrappedSend
-          break
-        default:
-          break
-      }
-    } else {
-      throw new Error('unexpected message from renderer worker')
-    }
-  }
-  RendererProcess.state.rpc.send = wrappedSend
-  RendererProcess.state.rpc.addEventListener('message', wrappedOnMessage)
-  const callbacks = Object.create(null)
-  const invoke = (event) => {
-    const { resolve, promise } = Promises.withResolvers()
-    callbacks[event.id] = resolve
-    originalSend(event)
-    return promise
-  }
-  let now = 0
-  for (const event of events) {
-    if (event.source === 'to-renderer-process' && !DONT_REPLAY.has(event.method)) {
-      // console.log(event.timestamp)
-      const timeDifference = event.timestamp - now
-      await Timeout.sleep(timeDifference)
-      await invoke(event)
-      now = event.timestamp
-    }
-    // if (event.source === 'from-renderer-process') {
-    //   console.log(event)
-    // }
-  }
-  // console.log({ events })
-}
-
-export const downloadSession = async () => {
-  try {
-    const sessionId = GetSessionId.getSessionId()
-    const events = await GetSessionEvents.getSessionEvents(sessionId)
-    const fileName = `${sessionId}.json`
-    await Command.execute(/* Download.downloadJson */ 'Download.downloadJson', /* json */ events, /* fileName */ fileName)
-  } catch (error) {
-    throw new VError(error, 'Failed to download session')
-  }
-}
-
-const wrapIpc = (ipc, name, getData) => {
-  if (!ipc) {
-    return
-  }
-  Assert.object(ipc)
-  Assert.string(name)
-  Assert.fn(getData)
-  const nameFrom = `from-${name}`
-  const nameTo = `to-${name}`
-  const wrappedIpc = {
-    async send(message) {
-      ipc.send(message)
-      const timestamp = Timestamp.now()
-      await handleMessage(nameTo, timestamp, message)
-    },
-    sendAndTransfer(message, transferables) {
-      ipc.sendAndTransfer(message, transferables)
-    },
-    get onmessage() {
-      return ipc.onmessage
-    },
-    set onmessage(listener) {
-      ipc.onmessage = listener
-    },
-  }
-  // TODO use addeventlistener
-  const originalOnMessage = wrappedIpc.onmessage
-  wrappedIpc.onmessage = async (event) => {
-    const message = getData(event)
-    const timestamp = Timestamp.now()
-    await originalOnMessage(event)
-    await handleMessage(nameFrom, timestamp, message)
-  }
-  return wrappedIpc
-}
-
-export const startRecording = () => {
-  RendererProcess.state.rpc.ipc = wrapIpc(RendererProcess.state.rpc, 'renderer-process', (event) => event.data)
-  SharedProcessState.state.ipc = wrapIpc(SharedProcessState.state.ipc, 'shared-process', (event) => event)
+  const sessionId = GetSessionId.state.sessionId
+  if (!sessionId || !Preferences.get('sessionReplay.enabled')) throw new Error('Enable local session replay in settings first')
+  await replaySession(sessionId)
 }
 
 export const openSession = async () => {
-  await Command.execute(/* Main.openUri */ 'Main.openUri', /* uri */ 'app://session.json')
+  const url = new URL(await Location.getHref())
+  url.search = '?sessionReplay=true'
+  url.hash = ''
+  await Command.execute('Open.openUrl', url.href)
+}
+
+const handlePreferencesChanged = () => {
+  state.pending = state.pending.catch(() => {}).then(() => startRecording(state.authState))
+  return state.pending
+}
+
+export const initialize = async (authState) => {
+  state.authState = authState
+  GlobalEventBus.addListener('preferences.changed', handlePreferencesChanged)
+  await handlePreferencesChanged()
 }

--- a/packages/renderer-worker/src/parts/Workbench/Workbench.js
+++ b/packages/renderer-worker/src/parts/Workbench/Workbench.js
@@ -142,13 +142,6 @@ export const startup = async (platform, assetDir) => {
 
   const promptOptions = platform === PlatformType.Electron ? await PromptMode.getPromptOptions() : undefined
 
-  if (initData.Location.href.includes('?replayId')) {
-    const url = new URL(initData.Location.href)
-    const replayId = url.searchParams.get('replayId')
-    await SessionReplay.replaySession(replayId)
-    return
-  }
-
   Bounds.set(initData.Layout.bounds.windowWidth, initData.Layout.bounds.windowHeight)
 
   Performance.mark(PerformanceMarkerType.WillLoadPreferences)
@@ -160,13 +153,6 @@ export const startup = async (platform, assetDir) => {
 
   LaunchTestWorker.preloadTestWorker(initData.Location.href, promptOptions !== undefined)
 
-  // TODO only load this if session replay is enabled in preferences
-  if (promptOptions === undefined && Preferences.get('sessionReplay.enabled')) {
-    Performance.mark(PerformanceMarkerType.WillLoadSessionReplay)
-    await SessionReplay.startRecording()
-    Performance.mark(PerformanceMarkerType.DidLoadSessionReplay)
-  }
-
   const hasAuthCallback = HasCodeQueryParam.hasCodeQueryParam(initData.Location.href)
   if (hasAuthCallback) {
     await CleanAuthCallbackUrl.cleanAuthCallbackUrl(initData.Location.href)
@@ -174,6 +160,16 @@ export const startup = async (platform, assetDir) => {
   const authState = shouldInitializeAuth(hasAuthCallback, promptOptions !== undefined)
     ? await StartupAuth.initializeAuth(platform, initData.Location.href)
     : undefined
+
+  if (promptOptions === undefined) {
+    Performance.mark(PerformanceMarkerType.WillLoadSessionReplay)
+    try {
+      await SessionReplay.initialize(authState)
+    } catch (error) {
+      console.warn('Failed to start session replay', error)
+    }
+    Performance.mark(PerformanceMarkerType.DidLoadSessionReplay)
+  }
 
   LifeCycle.mark(LifeCyclePhase.Twelve)
 

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "sessionReplayWorker",
+    "fileName": "sessionReplayWorkerMain.js",
+    "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/sessionReplayWorkerMain.js",
+    "productionPath": "/packages/renderer-process/dist/sessionReplayWorkerMain.js",
+    "settingName": "develop.sessionReplayWorkerPath",
+    "hotReloadCommand": "",
+    "contentSecurityPolicy": [
+      "default-src 'none'",
+      "connect-src 'self' https: http://127.0.0.1:* http://localhost:*",
+      "script-src 'self'"
+    ]
+  },
+  {
     "id": "componentState",
     "fileName": "componentStateWorkerMain.js",
     "defaultPath": "/packages/renderer-worker/node_modules/@lvce-editor/component-state-worker/dist/componentStateWorkerMain.js",

--- a/packages/renderer-worker/test/SessionReplay.test.ts
+++ b/packages/renderer-worker/test/SessionReplay.test.ts
@@ -1,6 +1,6 @@
 import { expect, jest, test } from '@jest/globals'
 
-const invoke = jest.fn<any>()
+const invoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>()
 const execute = jest.fn<any>()
 const get = jest.fn<any>()
 jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({ invoke }))

--- a/packages/renderer-worker/test/SessionReplay.test.ts
+++ b/packages/renderer-worker/test/SessionReplay.test.ts
@@ -1,86 +1,42 @@
-import { beforeAll, beforeEach, expect, jest, test } from '@jest/globals'
-import * as ModuleId from '../src/parts/ModuleId/ModuleId.js'
+import { expect, jest, test } from '@jest/globals'
 
-beforeEach(() => {
-  jest.resetAllMocks()
-  jest.useFakeTimers().setSystemTime(new Date('2020-01-01'))
-})
-
-jest.unstable_mockModule('../src/parts/Download/Download.js', () => {
-  return {
-    downloadFile: jest.fn(() => {
-      throw new Error('not implemented')
-    }),
-    downloadJson: jest.fn(() => {
-      throw new Error('not implemented')
-    }),
-  }
-})
-
-jest.unstable_mockModule('../src/parts/IndexedDb/IndexedDb.js', () => {
-  return {
-    getValuesByIndexName: jest.fn(() => {
-      throw new Error('not implemented')
-    }),
-  }
-})
-
-const Download = await import('../src/parts/Download/Download.js')
+const invoke = jest.fn<any>()
+const execute = jest.fn<any>()
+const get = jest.fn<any>()
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({ invoke }))
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({ execute }))
+jest.unstable_mockModule('../src/parts/Location/Location.js', () => ({
+  getHref: () => 'https://lvce-editor.dev/?allowAnonymous=true&folder=test#token',
+}))
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({ get }))
+jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({ getBackendUrl: () => 'https://backend.example' }))
 const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
-const IndexedDb = await import('../src/parts/IndexedDb/IndexedDb.js')
-const Command = await import('../src/parts/Command/Command.js')
 
-beforeAll(() => {
-  Command.setLoad((moduleId) => {
-    switch (moduleId) {
-      case ModuleId.Download:
-        return import('../src/parts/Download/Download.ipc.js')
-      default:
-        throw new Error(`module not found ${moduleId}`)
-    }
+test('local recording and upload have independent settings', async () => {
+  get.mockImplementation((key) => key === 'sessionReplay.uploadEnabled')
+  invoke.mockResolvedValue('session-id')
+  await SessionReplay.startRecording({ accessToken: 'test-token' })
+  expect(invoke).toHaveBeenCalledWith('SessionReplay.configure', {
+    local: false,
+    upload: true,
+    endpoint: 'https://backend.example/session-replay?allowAnonymous=true',
+    token: 'test-token',
   })
 })
 
-test('downloadSession - error with download', async () => {
-  // @ts-ignore
-  Download.downloadJson.mockImplementation(() => {
-    throw new TypeError('x is not a function')
-  })
-  // @ts-ignore
-  IndexedDb.getValuesByIndexName.mockImplementation(() => {
-    return []
-  })
-  await expect(SessionReplay.downloadSession()).rejects.toThrow(new Error('Failed to download session: TypeError: x is not a function'))
-})
-
-test('downloadSession', async () => {
-  // @ts-ignore
-  Download.downloadJson.mockImplementation(() => {})
-  // @ts-ignore
-  IndexedDb.getValuesByIndexName.mockImplementation(() => {
-    return []
-  })
+test('download exports the versioned worker recording', async () => {
+  const session = { version: 1, id: 'test', events: [] }
+  invoke.mockResolvedValue(session)
   await SessionReplay.downloadSession()
-  expect(Download.downloadJson).toHaveBeenCalledTimes(1)
-  expect(Download.downloadJson).toHaveBeenCalledWith([], 'session-2020-01-01T00:00:00.000Z.json')
+  expect(execute).toHaveBeenCalledWith('Download.downloadJson', session, 'test.json')
 })
 
-test('getEvents - error with indexeddb', async () => {
-  // @ts-ignore
-  IndexedDb.getValuesByIndexName.mockImplementation(() => {
-    throw new DOMException("Failed to execute 'index' on 'IDBObjectStore': The specified index was not found.")
-  })
-  await expect(SessionReplay.getEvents('')).rejects.toThrow(
-    new Error("failed to get session replay events: DOMException: Failed to execute 'index' on 'IDBObjectStore': The specified index was not found."),
-  )
+test('replay link drops original workspace and authentication parameters', async () => {
+  await SessionReplay.replaySession('test-id')
+  expect(execute).toHaveBeenCalledWith('Open.openUrl', 'https://lvce-editor.dev/?replayId=test-id')
 })
 
-test('getEvents', async () => {
-  // @ts-ignore
-  IndexedDb.getValuesByIndexName.mockImplementation(() => {
-    return []
-  })
-  expect(await SessionReplay.getEvents('test')).toEqual([])
-  expect(IndexedDb.getValuesByIndexName).toHaveBeenCalledTimes(1)
-  expect(IndexedDb.getValuesByIndexName).toHaveBeenCalledWith('session', 'sessionId', 'test')
+test('file replay opens a separate replay layout', async () => {
+  await SessionReplay.openSession()
+  expect(execute).toHaveBeenCalledWith('Open.openUrl', 'https://lvce-editor.dev/?sessionReplay=true')
 })

--- a/packages/static-server/test/GetHeadersSessionReplayWorker.test.ts
+++ b/packages/static-server/test/GetHeadersSessionReplayWorker.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@jest/globals'
+import * as GetHeaders from '../src/parts/GetHeaders/GetHeaders.ts'
+
+test('session replay worker is isolated and can upload to the backend', () => {
+  const headers = GetHeaders.getHeaders({
+    absolutePath: '/packages/renderer-process/dist/sessionReplayWorkerMain.js',
+    etag: 'test',
+    isImmutable: false,
+    isForElectronProduction: false,
+  })
+  expect(headers['Cross-Origin-Embedder-Policy']).toBe('require-corp')
+  expect(headers['Content-Security-Policy']).toContain("connect-src 'self' https:")
+})


### PR DESCRIPTION
Replaces the old session replay integration with independent opt-in settings for local recording and backend uploads. Adds replay commands, live setting updates, and the worker registration needed for local and packaged builds.
