### PR TITLE
feature: verify session replay settings opt-in

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,6 +110,12 @@ jobs:
         run: npm run e2e:terminal-background
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test session replay settings
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=session-replay.settings
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test output channel selection
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,12 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test session replay settings
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=session-replay.settings
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test Simple Browser suggestions and new-tab theme
         if: matrix.os == 'ubuntu-24.04'
         run: |
@@ -108,12 +114,6 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests
         run: npm run e2e:terminal-background
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: 0
-      - name: Test session replay settings
-        if: matrix.os == 'ubuntu-24.04'
-        working-directory: ./packages/extension-host-worker-tests
-        run: npm run e2e:headless -- --test-name-prefix=session-replay.settings
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test output channel selection

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -140,3 +140,10 @@ test('rejects conflicting settings contributions', () => {
     ]),
   ).toThrow('Conflicting builtin setting chat.enabled')
 })
+
+test('session replay settings default to disabled', async () => {
+  const settings = JSON.parse(await readFile(new URL('../../renderer-worker/settings.json', import.meta.url), 'utf8'))
+  for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled']) {
+    expect(settings.find((setting) => setting.id === id)).toMatchObject({ type: 'boolean', value: false })
+  }
+})

--- a/packages/extension-host-worker-tests/src/session-replay.settings.ts
+++ b/packages/extension-host-worker-tests/src/session-replay.settings.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'session-replay.settings'
+
+export const test: Test = async ({ Command, Settings }) => {
+  const assertDisabled = async () => {
+    try {
+      await Command.execute('FileSystem.readFile', 'app://session.json')
+    } catch (error) {
+      if (String(error).includes('Session replay is disabled in settings')) return
+      throw error
+    }
+    throw new Error('Session replay must be disabled until the user opts in')
+  }
+
+  await assertDisabled()
+  await Settings.update({ 'sessionReplay.enabled': true })
+  try {
+    if (await Command.execute('Preferences.get', 'sessionReplay.uploadEnabled')) {
+      throw new Error('Enabling local replay must not enable uploads')
+    }
+    const session = JSON.parse(await Command.execute('FileSystem.readFile', 'app://session.json'))
+    if (session.version !== 1 || !session.id || !session.events.some((event) => event.type === 'frame')) {
+      throw new Error('Local session replay must capture a versioned recording with a visual frame')
+    }
+  } finally {
+    await Settings.update({ 'sessionReplay.enabled': false })
+  }
+  await assertDisabled()
+}

--- a/packages/renderer-worker/src/parts/SessionReplay/SessionReplay.js
+++ b/packages/renderer-worker/src/parts/SessionReplay/SessionReplay.js
@@ -11,13 +11,14 @@ const state = { authState: undefined, configuration: '', pending: Promise.resolv
 export const startRecording = async (authState) => {
   const local = Preferences.get('sessionReplay.enabled') === true
   const upload = Preferences.get('sessionReplay.uploadEnabled') === true
+  if (!state.configuration && !local && !upload) return
   const backendUrl = Preferences.get('layout.backendUrl') || Product.getBackendUrl()
   const endpoint = new URL('/session-replay', backendUrl || 'https://lvce-editor.dev')
   const href = await Location.getHref()
   if (new URL(href).searchParams.get('allowAnonymous') === 'true') endpoint.searchParams.set('allowAnonymous', 'true')
   const options = { local, upload, endpoint: endpoint.href, token: authState?.token || authState?.accessToken || '' }
   const configuration = JSON.stringify(options)
-  if (configuration === state.configuration || (!state.configuration && !local && !upload)) return
+  if (configuration === state.configuration) return
   const id = await RendererProcess.invoke('SessionReplay.configure', options)
   state.configuration = configuration
   GetSessionId.state.sessionId = id

--- a/packages/renderer-worker/test/SessionReplaySettings.test.ts
+++ b/packages/renderer-worker/test/SessionReplaySettings.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { readFile } from 'node:fs/promises'
+
+const invoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>().mockResolvedValue('session-id')
+const get = jest.fn<(key: string) => unknown>()
+const getHref = jest.fn<() => Promise<string>>().mockResolvedValue('https://lvce-editor.dev/')
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({ invoke }))
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({ execute: jest.fn() }))
+jest.unstable_mockModule('../src/parts/Location/Location.js', () => ({ getHref }))
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({ get }))
+jest.unstable_mockModule('../src/parts/Product/Product.js', () => ({ getBackendUrl: () => 'https://lvce-editor.dev' }))
+
+beforeEach(() => {
+  jest.resetModules()
+  jest.clearAllMocks()
+  get.mockReturnValue(undefined)
+})
+
+test('local recording and upload default to false in the settings UI', async () => {
+  const settings = JSON.parse(await readFile(new URL('../settings.json', import.meta.url), 'utf8'))
+  for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled']) {
+    expect(settings.find((setting) => setting.id === id)).toMatchObject({ type: 'boolean', value: false })
+  }
+})
+
+test.each([undefined, false, 'true', 1])('recording requires explicit opt-in, not %p', async (value) => {
+  get.mockReturnValue(value)
+  const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
+  await SessionReplay.initialize(undefined)
+  expect(invoke).not.toHaveBeenCalled()
+  expect(getHref).not.toHaveBeenCalled()
+})
+
+test('preference changes start local recording without uploads and stop recording without a reload', async () => {
+  const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
+  const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+  await SessionReplay.initialize(undefined)
+  get.mockImplementation((key) => key === 'sessionReplay.enabled')
+  await GlobalEventBus.emitEvent('preferences.changed')
+  expect(invoke).toHaveBeenLastCalledWith('SessionReplay.configure', {
+    local: true,
+    upload: false,
+    endpoint: 'https://lvce-editor.dev/session-replay',
+    token: '',
+  })
+  await GlobalEventBus.emitEvent('preferences.changed')
+  expect(invoke).toHaveBeenCalledTimes(1)
+  get.mockReturnValue(false)
+  await GlobalEventBus.emitEvent('preferences.changed')
+  expect(invoke).toHaveBeenLastCalledWith('SessionReplay.configure', {
+    local: false,
+    upload: false,
+    endpoint: 'https://lvce-editor.dev/session-replay',
+    token: '',
+  })
+})

--- a/packages/renderer-worker/test/SessionReplaySettings.test.ts
+++ b/packages/renderer-worker/test/SessionReplaySettings.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
-import { readFile } from 'node:fs/promises'
 
 const invoke = jest.fn<(...args: readonly unknown[]) => Promise<unknown>>().mockResolvedValue('session-id')
 const get = jest.fn<(key: string) => unknown>()
@@ -14,13 +13,6 @@ beforeEach(() => {
   jest.resetModules()
   jest.clearAllMocks()
   get.mockReturnValue(undefined)
-})
-
-test('local recording and upload default to false in the settings UI', async () => {
-  const settings = JSON.parse(await readFile(new URL('../settings.json', import.meta.url), 'utf8'))
-  for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled']) {
-    expect(settings.find((setting) => setting.id === id)).toMatchObject({ type: 'boolean', value: false })
-  }
 })
 
 test.each([undefined, false, 'true', 1])('recording requires explicit opt-in, not %p', async (value) => {


### PR DESCRIPTION
Keep session replay inactive until users explicitly enable it in settings. Add coverage for default-off behavior, local recording without uploads, and stopping recording when the setting is disabled.