### PR TITLE
fix: keep simple browser tab menus above native pages

### DIFF
--- a/packages/renderer-worker/src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js
@@ -1,26 +1,18 @@
-import * as Command from '../Command/Command.js'
+import * as Viewlet from '../Viewlet/Viewlet.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
-const isVisible = () => {
-  const simpleBrowserInstance = ViewletStates.getInstance(ViewletModuleId.SimpleBrowser)
-  const mainInstance = ViewletStates.getInstance(ViewletModuleId.Main)
-  if (!simpleBrowserInstance || !mainInstance) {
-    return false
-  }
-  const { groups } = mainInstance.state
-  const simpleBrowserUid = simpleBrowserInstance.state.uid
-  return groups.some((group) => group.editors[group.activeIndex]?.uid === simpleBrowserUid)
-}
-
 const run = async (method, overlayId) => {
-  if (!isVisible()) {
-    return
-  }
-  try {
-    await Command.execute(`SimpleBrowser.${method}`, overlayId)
-  } catch (error) {
-    console.error(`[renderer-worker] Failed to ${method} for Simple Browser`, error)
+  const instances = new Set(ViewletStates.getValues())
+  for (const instance of instances) {
+    if (instance.moduleId !== ViewletModuleId.SimpleBrowser || !instance.factory.isVisible(instance.state)) {
+      continue
+    }
+    try {
+      await Viewlet.executeViewletCommand(instance.state.uid, method, overlayId)
+    } catch (error) {
+      console.error(`[renderer-worker] Failed to ${method} for Simple Browser`, error)
+    }
   }
 }
 

--- a/packages/renderer-worker/src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js
@@ -1,4 +1,4 @@
-import * as Viewlet from '../Viewlet/Viewlet.js'
+import * as Command from '../Command/Command.js'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 
@@ -9,7 +9,7 @@ const run = async (method, overlayId) => {
       continue
     }
     try {
-      await Viewlet.executeViewletCommand(instance.state.uid, method, overlayId)
+      await Command.execute('Viewlet.executeViewletCommand', instance.state.uid, method, overlayId)
     } catch (error) {
       console.error(`[renderer-worker] Failed to ${method} for Simple Browser`, error)
     }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -740,7 +740,7 @@ export const showOverlay = async (state, overlayId) => {
   }
   let snapshot = ''
   try {
-    if (state.iframeSrc) {
+    if (state.browserViewId) {
       const bytes = await ElectronWebContentsViewFunctions.capturePage(state.browserViewId)
       snapshot = SimpleBrowserSnapshot.create(bytes)
     }

--- a/packages/renderer-worker/src/parts/WebView/WebView.ts
+++ b/packages/renderer-worker/src/parts/WebView/WebView.ts
@@ -10,6 +10,7 @@ import * as Preferences from '../Preferences/Preferences.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
 import * as Scheme from '../Scheme/Scheme.ts'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+import * as SimpleBrowserOverlay from '../SimpleBrowserOverlay/SimpleBrowserOverlay.js'
 
 export const setPort = async (uid: number, port: MessagePort, origin: string, portType: string): Promise<void> => {
   await RendererProcess.invokeAndTransfer('WebView.setPort', uid, port, origin, portType)
@@ -66,8 +67,13 @@ export const compat = {
   sharedProcessInvoke(...args) {
     return SharedProcess.invoke(...args)
   },
-  rendererProcessInvoke(...args) {
-    return RendererProcess.invoke(...args)
+  async rendererProcessInvoke(...args) {
+    const result = await RendererProcess.invoke(...args)
+    // Menu actions close the menu through this bridge instead of Menu.hide in the renderer worker.
+    if (args[0] === 'Menu.hide') {
+      await SimpleBrowserOverlay.hide('menu')
+    }
+    return result
   },
   rendererProcessInvokeAndTransfer(...args) {
     return RendererProcess.invokeAndTransfer(...args)

--- a/packages/renderer-worker/test/SimpleBrowserOverlay.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserOverlay.test.ts
@@ -87,7 +87,7 @@ test('targets each visible browser by uid even when a hidden browser has focus',
   await SimpleBrowserOverlay.show('menu')
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(Viewlet.executeViewletCommand.mock.calls).toEqual([
+  expect(jest.mocked(Viewlet.executeViewletCommand).mock.calls).toEqual([
     [3, 'showOverlay', 'menu'],
     [4, 'showOverlay', 'menu'],
     [3, 'hideOverlay', 'menu'],

--- a/packages/renderer-worker/test/SimpleBrowserOverlay.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserOverlay.test.ts
@@ -6,11 +6,11 @@ beforeEach(() => {
   ViewletStates.reset()
 })
 
-jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
-  execute: jest.fn(),
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
+  executeViewletCommand: jest.fn(),
 }))
 
-const Command = await import('../src/parts/Command/Command.js')
+const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
 const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
 
 const addMain = (activeEditorUid) => {
@@ -30,12 +30,12 @@ const addMain = (activeEditorUid) => {
   })
 }
 
-const addSimpleBrowser = () => {
-  ViewletStates.set(2, {
-    state: { uid: 2 },
-    renderedState: { uid: 2 },
+const addSimpleBrowser = (uid = 2, visible = true) => {
+  ViewletStates.set(uid, {
+    state: { uid },
+    renderedState: { uid },
     moduleId: 'SimpleBrowser',
-    factory: {},
+    factory: { isVisible: () => visible },
   })
 }
 
@@ -44,16 +44,16 @@ test('does not show an overlay when Simple Browser is not open', async () => {
 
   await SimpleBrowserOverlay.show('menu')
 
-  expect(Command.execute).not.toHaveBeenCalled()
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
 })
 
 test('does not hide an overlay when Simple Browser is not visible', async () => {
   addMain(3)
-  addSimpleBrowser()
+  addSimpleBrowser(2, false)
 
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(Command.execute).not.toHaveBeenCalled()
+  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
 })
 
 test('shows and hides overlays when Simple Browser is visible', async () => {
@@ -63,6 +63,34 @@ test('shows and hides overlays when Simple Browser is visible', async () => {
   await SimpleBrowserOverlay.show('menu')
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(Command.execute).toHaveBeenNthCalledWith(1, 'SimpleBrowser.showOverlay', 'menu')
-  expect(Command.execute).toHaveBeenNthCalledWith(2, 'SimpleBrowser.hideOverlay', 'menu')
+  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(1, 2, 'showOverlay', 'menu')
+  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(2, 2, 'hideOverlay', 'menu')
+})
+
+test('shows and hides overlays for a preview or full-width browser outside Main', async () => {
+  addMain(3)
+  addSimpleBrowser()
+
+  await SimpleBrowserOverlay.show('menu')
+  await SimpleBrowserOverlay.hide('menu')
+
+  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(1, 2, 'showOverlay', 'menu')
+  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(2, 2, 'hideOverlay', 'menu')
+})
+
+test('targets each visible browser by uid even when a hidden browser has focus', async () => {
+  addSimpleBrowser(2, false)
+  addSimpleBrowser(3)
+  addSimpleBrowser(4)
+  ViewletStates.setFocusedInstanceByType(2, 'SimpleBrowser')
+
+  await SimpleBrowserOverlay.show('menu')
+  await SimpleBrowserOverlay.hide('menu')
+
+  expect(Viewlet.executeViewletCommand.mock.calls).toEqual([
+    [3, 'showOverlay', 'menu'],
+    [4, 'showOverlay', 'menu'],
+    [3, 'hideOverlay', 'menu'],
+    [4, 'hideOverlay', 'menu'],
+  ])
 })

--- a/packages/renderer-worker/test/SimpleBrowserOverlay.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserOverlay.test.ts
@@ -6,11 +6,11 @@ beforeEach(() => {
   ViewletStates.reset()
 })
 
-jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({
-  executeViewletCommand: jest.fn(),
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({
+  execute: jest.fn(),
 }))
 
-const Viewlet = await import('../src/parts/Viewlet/Viewlet.js')
+const Command = await import('../src/parts/Command/Command.js')
 const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
 
 const addMain = (activeEditorUid) => {
@@ -44,7 +44,7 @@ test('does not show an overlay when Simple Browser is not open', async () => {
 
   await SimpleBrowserOverlay.show('menu')
 
-  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
+  expect(Command.execute).not.toHaveBeenCalled()
 })
 
 test('does not hide an overlay when Simple Browser is not visible', async () => {
@@ -53,7 +53,7 @@ test('does not hide an overlay when Simple Browser is not visible', async () => 
 
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
+  expect(Command.execute).not.toHaveBeenCalled()
 })
 
 test('shows and hides overlays when Simple Browser is visible', async () => {
@@ -63,8 +63,8 @@ test('shows and hides overlays when Simple Browser is visible', async () => {
   await SimpleBrowserOverlay.show('menu')
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(1, 2, 'showOverlay', 'menu')
-  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(2, 2, 'hideOverlay', 'menu')
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'Viewlet.executeViewletCommand', 2, 'showOverlay', 'menu')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'Viewlet.executeViewletCommand', 2, 'hideOverlay', 'menu')
 })
 
 test('shows and hides overlays for a preview or full-width browser outside Main', async () => {
@@ -74,8 +74,8 @@ test('shows and hides overlays for a preview or full-width browser outside Main'
   await SimpleBrowserOverlay.show('menu')
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(1, 2, 'showOverlay', 'menu')
-  expect(Viewlet.executeViewletCommand).toHaveBeenNthCalledWith(2, 2, 'hideOverlay', 'menu')
+  expect(Command.execute).toHaveBeenNthCalledWith(1, 'Viewlet.executeViewletCommand', 2, 'showOverlay', 'menu')
+  expect(Command.execute).toHaveBeenNthCalledWith(2, 'Viewlet.executeViewletCommand', 2, 'hideOverlay', 'menu')
 })
 
 test('targets each visible browser by uid even when a hidden browser has focus', async () => {
@@ -87,10 +87,10 @@ test('targets each visible browser by uid even when a hidden browser has focus',
   await SimpleBrowserOverlay.show('menu')
   await SimpleBrowserOverlay.hide('menu')
 
-  expect(jest.mocked(Viewlet.executeViewletCommand).mock.calls).toEqual([
-    [3, 'showOverlay', 'menu'],
-    [4, 'showOverlay', 'menu'],
-    [3, 'hideOverlay', 'menu'],
-    [4, 'hideOverlay', 'menu'],
+  expect(jest.mocked(Command.execute).mock.calls).toEqual([
+    ['Viewlet.executeViewletCommand', 3, 'showOverlay', 'menu'],
+    ['Viewlet.executeViewletCommand', 4, 'showOverlay', 'menu'],
+    ['Viewlet.executeViewletCommand', 3, 'hideOverlay', 'menu'],
+    ['Viewlet.executeViewletCommand', 4, 'hideOverlay', 'menu'],
   ])
 })

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -1368,7 +1368,7 @@ test('keeps the internal new tab URL out of the address state', async () => {
   expect(loadedState).toMatchObject({ iframeSrc: '', inputValue: '', isLoading: false })
 })
 
-test('showOverlay captures the WebContentsView without hiding it before the snapshot is rendered', async () => {
+test.each(['https://example.com', ''])('showOverlay captures the WebContentsView for %j before hiding it', async (iframeSrc) => {
   const png = new Uint8Array([137, 80, 78, 71])
   // @ts-ignore
   ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(png)
@@ -1376,7 +1376,7 @@ test('showOverlay captures the WebContentsView without hiding it before the snap
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
   // @ts-ignore
   SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/snapshot')
-  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc: 'https://example.com' }
+  const state = { ...ViewletSimpleBrowser.create(), browserViewId: 12, iframeSrc }
 
   const newState = await ViewletSimpleBrowser.showOverlay(state, 'quick-pick')
 
@@ -1701,9 +1701,13 @@ test('applySuggestions captures the page and shows provider results', async () =
   })
 })
 
-test('applySuggestions does not capture a page for an empty new tab', async () => {
+test('applySuggestions captures the built-in new-tab page', async () => {
   // @ts-ignore
   ElectronWebContentsViewFunctions.hide.mockResolvedValue(undefined)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.capturePage.mockResolvedValue(new Uint8Array([137, 80, 78, 71]))
+  // @ts-ignore
+  SimpleBrowserSnapshot.create.mockReturnValue('blob:https://example.com/new-tab')
   const state = {
     ...ViewletSimpleBrowser.create(7),
     browserViewId: 12,
@@ -1717,13 +1721,13 @@ test('applySuggestions does not capture a page for an empty new tab', async () =
     hasSuggestionsOverlay: true,
     overlayIds: ['search-suggestions'],
     selectedSuggestionIndex: -1,
-    snapshot: '',
+    snapshot: 'blob:https://example.com/new-tab',
     suggestions: [
       { favicon: '', type: 'search', value: 'what is' },
       { favicon: '', type: 'search', value: 'what is my ip' },
     ],
   })
-  expect(ElectronWebContentsViewFunctions.capturePage).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.capturePage).toHaveBeenCalledWith(12)
   expect(ElectronWebContentsViewFunctions.hide).not.toHaveBeenCalled()
 
   await ViewletSimpleBrowser.afterRender(state, newState)

--- a/packages/renderer-worker/test/WebViewMenuOverlay.test.ts
+++ b/packages/renderer-worker/test/WebViewMenuOverlay.test.ts
@@ -24,7 +24,9 @@ test('restores the browser after the menu worker closes the menu for an action',
 
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Menu.hide', false)
   expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('menu')
-  expect(RendererProcess.invoke.mock.invocationCallOrder[0]).toBeLessThan(SimpleBrowserOverlay.hide.mock.invocationCallOrder[0])
+  expect(jest.mocked(RendererProcess.invoke).mock.invocationCallOrder[0]).toBeLessThan(
+    jest.mocked(SimpleBrowserOverlay.hide).mock.invocationCallOrder[0],
+  )
 })
 
 test('keeps the snapshot when only a submenu closes', async () => {

--- a/packages/renderer-worker/test/WebViewMenuOverlay.test.ts
+++ b/packages/renderer-worker/test/WebViewMenuOverlay.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/IsGitpod/IsGitpod.ts', () => ({
+  isGitpod: false,
+}))
+
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({
+  invoke: jest.fn(),
+}))
+jest.unstable_mockModule('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js', () => ({
+  hide: jest.fn(),
+}))
+
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.js')
+const SimpleBrowserOverlay = await import('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js')
+const WebView = await import('../src/parts/WebView/WebView.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('restores the browser after the menu worker closes the menu for an action', async () => {
+  await WebView.compat.rendererProcessInvoke('Menu.hide', false)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Menu.hide', false)
+  expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('menu')
+  expect(RendererProcess.invoke.mock.invocationCallOrder[0]).toBeLessThan(SimpleBrowserOverlay.hide.mock.invocationCallOrder[0])
+})
+
+test('keeps the snapshot when only a submenu closes', async () => {
+  await WebView.compat.rendererProcessInvoke('Menu.hideSubMenu', 1)
+
+  expect(RendererProcess.invoke).toHaveBeenCalledWith('Menu.hideSubMenu', 1)
+  expect(SimpleBrowserOverlay.hide).not.toHaveBeenCalled()
+})

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -98,6 +98,25 @@ try {
     }, url)
   await expect.poll(articleToken).toBeTruthy()
   const token = await articleToken()
+  const articleVisible = () =>
+    app.evaluate(({ BrowserWindow }, url) => {
+      return BrowserWindow.getAllWindows().some((window) =>
+        window.contentView.children.some((view) => view.webContents?.getURL() === url && view.getVisible()),
+      )
+    }, url)
+  const snapshot = page.locator('.SimpleBrowserSnapshot')
+  const menu = page.locator('#Menu-0')
+  await expect.poll(articleVisible).toBe(true)
+  await page.locator('.SimpleBrowserTabSelected').click({ button: 'right' })
+  await expect(menu).toBeVisible()
+  await expect(snapshot).toBeVisible()
+  await expect.poll(() => snapshot.evaluate((image) => image.complete && image.naturalWidth > 0)).toBe(true)
+  await expect.poll(articleVisible).toBe(false)
+  await page.keyboard.press('Escape')
+  await expect(menu).toHaveCount(0)
+  await expect(snapshot).toHaveCount(0)
+  await expect.poll(articleVisible).toBe(true)
+  assert.equal(await articleToken(), token, 'Dismissing the tab menu must restore the same page')
   await page.getByRole('button', { name: 'New Tab', exact: true }).click()
   await expect(address).toHaveValue('')
   const newTabStyles = () =>
@@ -113,6 +132,16 @@ try {
     })
   const lightStyle = { background: 'rgb(255, 255, 255)', foreground: 'rgb(36, 41, 47)', scheme: 'light', input: 'rgb(241, 243, 245)' }
   await expect.poll(newTabStyles).toEqual([lightStyle])
+  // A background tab's menu must cover the currently visible new-tab page too.
+  await page.getByRole('tab', { name: 'Local article', exact: true }).click({ button: 'right' })
+  await expect(menu).toBeVisible()
+  await expect(snapshot).toBeVisible()
+  await expect.poll(() => snapshot.evaluate((image) => image.complete && image.naturalWidth > 0)).toBe(true)
+  await page.getByRole('menuitem', { name: 'Mute Tab', exact: true }).click()
+  await expect(menu).toHaveCount(0)
+  await expect(snapshot).toHaveCount(0)
+  await expect(address).toHaveValue('')
+  assert.equal(await articleToken(), token, 'Tab menu actions must preserve the background page')
 
   // This matches the middle of a history URL, so there is no inline completion.
   // The resulting single Add patch must append the dropdown, never replace the browser.

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -82,6 +82,7 @@ try {
   await page.keyboard.press('Control+Alt+4')
   await expect(page.locator('.BrowserFullWidth')).toBeVisible()
   const address = page.locator('[name="simple-browser-address"]')
+  await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Example Domain')
   await address.fill(url)
   await address.press('Enter')
   await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Local article')

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -23,6 +23,7 @@ await writeFile(
     { source: 'User', key: parseKeyBindingString('Ctrl+Alt+1'), command: 'Preferences.update', args: [{ 'simpleBrowser.chromeTheme': 'inherit' }] },
     { source: 'User', key: parseKeyBindingString('Ctrl+Alt+2'), command: 'Preferences.update', args: [{ 'simpleBrowser.chromeTheme': 'light' }] },
     { source: 'User', key: parseKeyBindingString('Ctrl+Alt+3'), command: 'Layout.handleSettingsChanged' },
+    { source: 'User', key: parseKeyBindingString('Ctrl+Alt+4'), command: 'Layout.toggleSimpleBrowserFullWidth' },
   ]),
 )
 const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js')
@@ -73,19 +74,12 @@ try {
     if (message.type() === 'error') console.error('APP ERROR', message.text())
   })
   await expect(page.locator('#Workbench')).toBeVisible()
-  const runCommand = async (label) => {
-    await page.keyboard.press('Control+Shift+P')
-    const input = page.locator('[name="QuickPickInput"]')
-    await expect(input).toBeVisible()
-    await input.fill(`>${label}`)
-    await expect(page.getByRole('option', { name: label, exact: true })).toBeVisible()
-    await input.press('Enter')
-  }
+  await expect(page.getByRole('tree', { name: 'Files Explorer' })).toBeVisible()
   await page.evaluate(() => {
     localStorage.setItem('simple-browser-search-history', JSON.stringify(['known first', 'known second', 'offline local']))
     localStorage.setItem('simple-browser-history', JSON.stringify([{ date: Date.now(), url: 'https://known.example/article' }]))
   })
-  await runCommand('Simple Browser: Toggle Full Width')
+  await page.keyboard.press('Control+Alt+4')
   await expect(page.locator('.BrowserFullWidth')).toBeVisible()
   const address = page.locator('[name="simple-browser-address"]')
   await address.fill(url)


### PR DESCRIPTION
Replace visible Simple Browser pages with snapshots while tab context menus are open, including full-width browsers and the built-in New Tab page. Restore the live page when the menu is dismissed or an action is selected, without reloading it.