### PR TITLE
fix: connect workspace port providers to the Ports panel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,11 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Codespaces workspace ports
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.ports-codespaces
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test session replay settings
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/packages/extension-host-worker-tests/fixtures/sample.codespaces-ports/extension.json
+++ b/packages/extension-host-worker-tests/fixtures/sample.codespaces-ports/extension.json
@@ -1,0 +1,9 @@
+{
+  "id": "sample.codespaces-ports",
+  "name": "Codespaces Ports",
+  "version": "0.0.0",
+  "browser": "main.js",
+  "isolated": true,
+  "activation": ["onPorts:codespaces", "onFileSystem:codespaces"],
+  "fileSystemProviders": [{ "id": "codespaces" }]
+}

--- a/packages/extension-host-worker-tests/fixtures/sample.codespaces-ports/main.js
+++ b/packages/extension-host-worker-tests/fixtures/sample.codespaces-ports/main.js
@@ -1,0 +1,33 @@
+const currentUrl = new URL(import.meta.url)
+const assetDir = currentUrl.pathname.startsWith('/remote/') ? '' : currentUrl.pathname.slice(0, currentUrl.pathname.indexOf('/packages/'))
+const { WebWorkerRpcClient } = await import(`${assetDir}/js/lvce-editor-rpc.js`)
+
+await WebWorkerRpcClient.create({
+  commandMap: {
+    'ExtensionApi.providePorts'(uri) {
+      if (uri !== 'codespaces://test-space/workspaces/app') throw new Error(`Unexpected workspace URI: ${uri}`)
+      return [{ port: 3000, forwardedAddress: 'https://test-space-3000.app.github.dev/', origin: 'devcontainer.json' }]
+    },
+    'ExtensionApi.executeFileSystemProviderIsReadonly'() {
+      return true
+    },
+    'ExtensionApi.executeFileSystemProviderReadDirWithFileTypes'() {
+      return []
+    },
+    'ExtensionApi.getFileSystemProviderRegistrySnapshot'() {
+      return { providers: [{ id: 'codespaces' }] }
+    },
+    'ExtensionApi.getStatusBarItems'() {
+      return []
+    },
+    'ExtensionApi.getViewRegistrySnapshot'() {
+      return { views: [] }
+    },
+    'ExtensionApi.getViewActions'() {
+      return []
+    },
+    'ExtensionApi.getViewMenuEntries'() {
+      return []
+    },
+  },
+})

--- a/packages/extension-host-worker-tests/src/viewlet.ports-codespaces.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.ports-codespaces.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.ports-codespaces'
+
+export const test: Test = async ({ Command, expect, Extension, Locator, Workspace }) => {
+  await Workspace.openTmpDir()
+  const extensionUri = new URL('../fixtures/sample.codespaces-ports', import.meta.url).href
+  await Extension.addWebExtension(extensionUri)
+  await Extension.enableWorkspace('sample.codespaces-ports')
+  await Command.execute('Workspace.setUri', 'codespaces://test-space/workspaces/app')
+  await Command.execute('Layout.showPanel', 'Ports')
+  const address = Locator('.Ports a')
+  await expect(address).toHaveText('https://test-space-3000.app.github.dev/')
+  await expect(Locator('.Ports')).toContainText('3000')
+  await expect(Locator('.Ports')).toContainText('devcontainer.json')
+  await Command.execute('Workspace.setUri', 'memfs:///')
+  await expect(address).toHaveCount(0)
+  await expect(Locator('.Ports')).toContainText('No forwarded ports')
+}

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -54,6 +54,7 @@
         "@lvce-editor/opener-worker": "^1.17.0",
         "@lvce-editor/output-view": "^2.23.1",
         "@lvce-editor/panel-worker": "^2.12.0",
+        "@lvce-editor/ports-view": "github:lvce-editor/ports-view#d6e7f0da9de311a078133652b92e16d46b713a73",
         "@lvce-editor/preview-sandbox-worker": "^4.15.0",
         "@lvce-editor/preview-worker": "^6.18.0",
         "@lvce-editor/problems-view": "^1.37.0",
@@ -84,7 +85,6 @@
         "@jest/globals": "^30.5.1",
         "@lvce-editor/blob-worker": "^1.11.0",
         "@lvce-editor/chat-message-parsing-worker": "^1.8.0",
-        "@lvce-editor/ports-view": "github:lvce-editor/ports-view#d6e7f0da9de3",
         "@types/node": "^26.1.1",
         "@vscode/codicons": "^0.0.45"
       }
@@ -1203,7 +1203,7 @@
     "node_modules/@lvce-editor/ports-view": {
       "version": "0.0.0-dev",
       "resolved": "git+ssh://git@github.com/lvce-editor/ports-view.git#d6e7f0da9de311a078133652b92e16d46b713a73",
-      "dev": true,
+      "integrity": "sha512-pWQYOdhUOZQ1gt9pMnDWR4IYSYdRnMPA9YeQluRV6xgcVs/Qmh9qV+x+R2d8Lk2T+9TxpAFwpuM6B7tuBqFIzA==",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/packages/renderer-worker/package-lock.json
+++ b/packages/renderer-worker/package-lock.json
@@ -54,7 +54,6 @@
         "@lvce-editor/opener-worker": "^1.17.0",
         "@lvce-editor/output-view": "^2.23.1",
         "@lvce-editor/panel-worker": "^2.12.0",
-        "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#4da1d4aa920ad60fcef379cc88852ea9dd5d5918",
         "@lvce-editor/preview-sandbox-worker": "^4.15.0",
         "@lvce-editor/preview-worker": "^6.18.0",
         "@lvce-editor/problems-view": "^1.37.0",
@@ -85,6 +84,7 @@
         "@jest/globals": "^30.5.1",
         "@lvce-editor/blob-worker": "^1.11.0",
         "@lvce-editor/chat-message-parsing-worker": "^1.8.0",
+        "@lvce-editor/ports-view": "github:lvce-editor/ports-view#d6e7f0da9de3",
         "@types/node": "^26.1.1",
         "@vscode/codicons": "^0.0.45"
       }
@@ -1202,8 +1202,8 @@
     },
     "node_modules/@lvce-editor/ports-view": {
       "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/lvce-editor/ports-view.git#4da1d4aa920ad60fcef379cc88852ea9dd5d5918",
-      "integrity": "sha512-Hb9XQcj1Zivy76n2mtFkM83BS00F0bD9iBuGksTtPPEUotL9zNXfneVXKNz5edcYg6WkOGLZOGnPrkR15ZnrIg==",
+      "resolved": "git+ssh://git@github.com/lvce-editor/ports-view.git#d6e7f0da9de311a078133652b92e16d46b713a73",
+      "dev": true,
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -86,7 +86,6 @@
     "@lvce-editor/opener-worker": "^1.17.0",
     "@lvce-editor/output-view": "^2.23.1",
     "@lvce-editor/panel-worker": "^2.12.0",
-    "@lvce-editor/ports-view": "git+https://github.com/lvce-editor/ports-view.git#4da1d4aa920ad60fcef379cc88852ea9dd5d5918",
     "@lvce-editor/preview-sandbox-worker": "^4.15.0",
     "@lvce-editor/preview-worker": "^6.18.0",
     "@lvce-editor/problems-view": "^1.37.0",
@@ -117,6 +116,7 @@
     "@jest/globals": "^30.5.1",
     "@lvce-editor/blob-worker": "^1.11.0",
     "@lvce-editor/chat-message-parsing-worker": "^1.8.0",
+    "@lvce-editor/ports-view": "github:lvce-editor/ports-view#d6e7f0da9de3",
     "@types/node": "^26.1.1",
     "@vscode/codicons": "^0.0.45"
   }

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -86,6 +86,7 @@
     "@lvce-editor/opener-worker": "^1.17.0",
     "@lvce-editor/output-view": "^2.23.1",
     "@lvce-editor/panel-worker": "^2.12.0",
+    "@lvce-editor/ports-view": "github:lvce-editor/ports-view#d6e7f0da9de311a078133652b92e16d46b713a73",
     "@lvce-editor/preview-sandbox-worker": "^4.15.0",
     "@lvce-editor/preview-worker": "^6.18.0",
     "@lvce-editor/problems-view": "^1.37.0",
@@ -116,7 +117,6 @@
     "@jest/globals": "^30.5.1",
     "@lvce-editor/blob-worker": "^1.11.0",
     "@lvce-editor/chat-message-parsing-worker": "^1.8.0",
-    "@lvce-editor/ports-view": "github:lvce-editor/ports-view#d6e7f0da9de3",
     "@types/node": "^26.1.1",
     "@vscode/codicons": "^0.0.45"
   }

--- a/packages/renderer-worker/src/parts/Application/Application.ts
+++ b/packages/renderer-worker/src/parts/Application/Application.ts
@@ -177,6 +177,10 @@ export const execute = (applicationId: string, command: string, ...args: readonl
 export const executeForView = (uid: number, command: string, ...args: readonly any[]): Promise<any> => {
   const applicationId = ApplicationRegistry.getOwner(uid)
   if (applicationId === undefined) {
+    // Ports requests its initial content before the view is added to ViewletStates.
+    if (command === 'PortProvider.getPorts') {
+      return import('../PortProvider/PortProvider.ts').then(({ getPorts }) => getPorts(args[0]))
+    }
     if (!ViewletStates.getByUid(uid)) {
       return Promise.reject(new Error(`Component not found: ${uid}`))
     }

--- a/packages/renderer-worker/src/parts/Application/Application.ts
+++ b/packages/renderer-worker/src/parts/Application/Application.ts
@@ -148,6 +148,11 @@ export const execute = (applicationId: string, command: string, ...args: readonl
     })
   }
   switch (command) {
+    case 'PortProvider.getPorts':
+      return ApplicationRegistry.track(applicationId, async () => {
+        const { getPorts } = await import('../PortProvider/PortProvider.ts')
+        return getPorts(application.workspaceUri, applicationId)
+      })
     case 'ExtensionHostSourceControl.getEnabledProviderIds':
     case 'ExtensionHostSourceControl.getFileDecorations':
       return ApplicationRegistry.track(applicationId, () =>

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -8,6 +8,7 @@ const lazy =
   }
 
 export const commandMap = {
+  'PortProvider.getPorts': async (...args) => (await import('../PortProvider/PortProvider.ts')).getPorts(...args),
   'Application.create': lazy('Application.create'),
   'Application.dispose': lazy('Application.dispose'),
   'Application.execute': lazy('Application.execute'),

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -8,7 +8,7 @@ const lazy =
   }
 
 export const commandMap = {
-  'PortProvider.getPorts': async (...args) => (await import('../PortProvider/PortProvider.ts')).getPorts(...args),
+  'PortProvider.getPorts': async (workspaceUri) => (await import('../PortProvider/PortProvider.ts')).getPorts(workspaceUri),
   'Application.create': lazy('Application.create'),
   'Application.dispose': lazy('Application.dispose'),
   'Application.execute': lazy('Application.execute'),

--- a/packages/renderer-worker/src/parts/PortProvider/PortProvider.ts
+++ b/packages/renderer-worker/src/parts/PortProvider/PortProvider.ts
@@ -1,0 +1,16 @@
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+
+const schemePattern = /^([a-z][a-z0-9+.-]*):/i
+
+export const getPorts = async (workspaceUri: string, applicationId?: string): Promise<readonly unknown[]> => {
+  const scheme = schemePattern.exec(workspaceUri)?.[1].toLowerCase()
+  if (!scheme) {
+    return []
+  }
+  const args = [`onPorts:${scheme}`, 'ExtensionApi.providePorts', workspaceUri]
+  const results =
+    applicationId === undefined
+      ? await ExtensionManagementWorker.invoke('Extensions.executeProvidersByEvent', ...args)
+      : await ExtensionManagementWorker.invoke('Extensions.invokeForApplication', applicationId, 'Extensions.executeProvidersByEvent', ...args)
+  return results.flat()
+}

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -1343,6 +1343,7 @@
     "hotReloadCommand": "",
     "viewlet": {
       "name": "Ports",
+      "extraCommands": [{ "name": "handleWorkspaceChange", "method": "loadContent" }, { "name": "refresh", "method": "loadContent" }],
       "css": ["/css/parts/ViewletPorts.css"],
       "state": {
         "idKey": "uid",
@@ -1360,7 +1361,7 @@
             { "source": "state", "name": "parentUid" }
           ]
         },
-        "loadContent": { "name": "Ports.loadContent", "parameters": [{ "source": "state", "name": "uid" }] },
+        "loadContent": { "name": "Ports.loadContent", "parameters": [{ "source": "state", "name": "uid" }, { "source": "context", "name": "workspaceUri" }] },
         "diff": { "name": "Ports.diff2", "parameters": [{ "source": "state", "name": "uid" }] },
         "render": { "name": "Ports.render2", "parameters": [{ "source": "state", "name": "uid" }, { "source": "result", "name": "diff" }] },
         "dispose": { "name": "Ports.dispose", "parameters": [{ "source": "state", "name": "uid" }] },

--- a/packages/renderer-worker/test/Application.test.ts
+++ b/packages/renderer-worker/test/Application.test.ts
@@ -153,3 +153,15 @@ test('text editor associations are scoped to the source application', async () =
     focus: true,
   })
 })
+
+test('loads workspace ports before the initial panel is registered', async () => {
+  const ports = [{ port: 3000, forwardedAddress: 'https://test-3000.app.github.dev/' }]
+  jest.mocked(ExtensionManagementWorker.invoke).mockResolvedValueOnce([ports])
+  expect(await Application.executeForView(12345, 'PortProvider.getPorts', 'codespaces://test/app')).toEqual(ports)
+  expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith(
+    'Extensions.executeProvidersByEvent',
+    'onPorts:codespaces',
+    'ExtensionApi.providePorts',
+    'codespaces://test/app',
+  )
+})

--- a/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
+++ b/packages/renderer-worker/test/CreateWorkerViewletContext.test.ts
@@ -48,3 +48,10 @@ test('creates text search with the workspace URI instead of the filesystem path'
 
   expect(invoke).toHaveBeenCalledWith('TextSearch.create', 8, 1, 2, 300, 200, 'file:///workspace', 'test://assets', 22, '', '', 2, false)
 })
+
+test('passes the workspace URI to Ports on load', async () => {
+  const viewlet = createWorkerViewlet({ workerId: 'portsView' })
+  const state = viewlet.create(9, 'ports://', 1, 2, 300, 200)
+  await viewlet.loadContent(state, undefined)
+  expect(invoke).toHaveBeenCalledWith('Ports.loadContent', 9, 'file:///workspace')
+})

--- a/packages/renderer-worker/test/PortProvider.test.ts
+++ b/packages/renderer-worker/test/PortProvider.test.ts
@@ -1,0 +1,38 @@
+import { expect, jest, test } from '@jest/globals'
+
+const invoke = jest.fn<any>()
+// The renderer worker uses its local worker launcher rather than rpc-registry.
+// eslint-disable-next-line jest/no-restricted-jest-methods
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({ invoke }))
+const { getPorts } = await import('../src/parts/PortProvider/PortProvider.ts')
+
+test('queries scheme providers and combines their ports', async () => {
+  const port = { forwardedAddress: 'https://test-3000.app.github.dev/', port: 3000 }
+  invoke.mockResolvedValueOnce([[port], []])
+  expect(await getPorts('codespaces://test/app')).toEqual([port])
+  expect(invoke).toHaveBeenLastCalledWith(
+    'Extensions.executeProvidersByEvent',
+    'onPorts:codespaces',
+    'ExtensionApi.providePorts',
+    'codespaces://test/app',
+  )
+})
+
+test('queries providers in the owning application', async () => {
+  invoke.mockResolvedValueOnce([])
+  expect(await getPorts('codespaces://test/app', 'preview')).toEqual([])
+  expect(invoke).toHaveBeenLastCalledWith(
+    'Extensions.invokeForApplication',
+    'preview',
+    'Extensions.executeProvidersByEvent',
+    'onPorts:codespaces',
+    'ExtensionApi.providePorts',
+    'codespaces://test/app',
+  )
+})
+
+test('ignores workspaces without a URI scheme', async () => {
+  invoke.mockClear()
+  expect(await getPorts('')).toEqual([])
+  expect(invoke).not.toHaveBeenCalled()
+})

--- a/packages/renderer-worker/test/PortProvider.test.ts
+++ b/packages/renderer-worker/test/PortProvider.test.ts
@@ -1,6 +1,6 @@
 import { expect, jest, test } from '@jest/globals'
 
-const invoke = jest.fn<any>()
+const invoke = jest.fn<(...args: readonly unknown[]) => Promise<readonly unknown[]>>()
 // The renderer worker uses its local worker launcher rather than rpc-registry.
 // eslint-disable-next-line jest/no-restricted-jest-methods
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({ invoke }))

--- a/packages/renderer-worker/test/ViewletPorts.test.ts
+++ b/packages/renderer-worker/test/ViewletPorts.test.ts
@@ -34,7 +34,7 @@ test('loads the ports view with platform, assets, and parent uid', async () => {
   await ViewletPorts.loadContent(state)
 
   expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(1, 'Ports.create', 1, 'ports://', 10, 20, 800, 600, 2, '/test-assets', 99)
-  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(2, 'Ports.loadContent', 1)
+  expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(2, 'Ports.loadContent', 1, '')
   expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(3, 'Ports.diff2', 1)
   expect(PortsViewWorker.invoke).toHaveBeenNthCalledWith(4, 'Ports.render2', 1, [])
 })


### PR DESCRIPTION
Query extension port providers for the active workspace URI and show their forwarded addresses in Ports. Refresh when the workspace changes, preserve application isolation, and consume the updated Ports worker through the existing pinned Git dependency.