### PR TITLE
feature: add anonymous replay uploads and worker-owned settings

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/session-replay-worker": "^1.2.0",
         "@lvce-editor/verror": "^1.7.0",
         "bytes": "^3.1.2",
         "esbuild": "^0.28.2",
@@ -1834,6 +1835,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
       "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/session-replay-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/session-replay-worker/-/session-replay-worker-1.2.0.tgz",
+      "integrity": "sha512-J9djtJiLWPUBOtBmDzXftpVcJvbSTQPGiVwAV6Y/QI8NK3zQZCa9y+XMIJNxKqYqk8B0CSObz9P8xfSDyYypXg==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/verror": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@lvce-editor/assert": "^1.9.0",
+    "@lvce-editor/session-replay-worker": "^1.2.0",
     "@lvce-editor/verror": "^1.7.0",
     "bytes": "^3.1.2",
     "esbuild": "^0.28.2",

--- a/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
+++ b/packages/build/src/parts/BundleBuiltinSettings/BundleBuiltinSettings.ts
@@ -1,3 +1,4 @@
+import sessionReplaySettings from '@lvce-editor/session-replay-worker/settings' with { type: 'json' }
 import { existsSync } from 'node:fs'
 import * as JsonFile from '../JsonFile/JsonFile.ts'
 import * as Path from '../Path/Path.ts'
@@ -116,6 +117,10 @@ export const bundleBuiltinSettings = async ({ workers, toRoot }): Promise<void> 
     {
       fileName: 'renderer-worker.json',
       settings: await JsonFile.readJson(Path.absolute(rendererSettingsPath)),
+    },
+    {
+      fileName: 'session-replay-worker.json',
+      settings: sessionReplaySettings,
     },
   ]
   for (const candidate of getSettingsContributionCandidates(workers)) {

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -143,7 +143,7 @@ test('rejects conflicting settings contributions', () => {
 
 test('session replay settings default to disabled', async () => {
   const settings = JSON.parse(await readFile(new URL('../../renderer-worker/settings.json', import.meta.url), 'utf8'))
-  for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled']) {
+  for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled', 'sessionReplay.allowAnonymousUploads']) {
     expect(settings.find((setting) => setting.id === id)).toMatchObject({ type: 'boolean', value: false })
   }
 })

--- a/packages/build/test/BundleBuiltinSettings.test.ts
+++ b/packages/build/test/BundleBuiltinSettings.test.ts
@@ -67,8 +67,8 @@ test('bundles schema-complete renderer settings contributions', async () => {
     const index = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'index.json'), 'utf8'))
     const settings = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'renderer-worker.json'), 'utf8'))
     const fileNames = await readdir(join(toRoot, 'builtin-settings'))
-    expect(index).toEqual(['renderer-worker.json'])
-    expect(fileNames).toEqual(['index.json', 'renderer-worker.json'])
+    expect(index).toEqual(['renderer-worker.json', 'session-replay-worker.json'])
+    expect(fileNames).toEqual(['index.json', 'renderer-worker.json', 'session-replay-worker.json'])
     expect(settings).toEqual(
       expect.arrayContaining([
         {
@@ -141,9 +141,32 @@ test('rejects conflicting settings contributions', () => {
   ).toThrow('Conflicting builtin setting chat.enabled')
 })
 
-test('session replay settings default to disabled', async () => {
-  const settings = JSON.parse(await readFile(new URL('../../renderer-worker/settings.json', import.meta.url), 'utf8'))
-  for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled', 'sessionReplay.allowAnonymousUploads']) {
-    expect(settings.find((setting) => setting.id === id)).toMatchObject({ type: 'boolean', value: false })
+test('bundles session replay declarations from their owning worker with disabled defaults', async () => {
+  const toRoot = await mkdtemp(join(tmpdir(), 'lvce-session-replay-settings-'))
+  try {
+    const workersUrl = new URL('../../renderer-worker/src/parts/Workers/Workers.json', import.meta.url)
+    const workers = JSON.parse(await readFile(workersUrl, 'utf8'))
+    await bundleBuiltinSettings({ toRoot, workers })
+    const index = JSON.parse(await readFile(join(toRoot, 'builtin-settings', 'index.json'), 'utf8'))
+    expect(index).toContain('session-replay-worker.json')
+    const contributions = await Promise.all(
+      index.map(async (fileName) => ({
+        fileName,
+        settings: JSON.parse(await readFile(join(toRoot, 'builtin-settings', fileName), 'utf8')),
+      })),
+    )
+    for (const id of ['sessionReplay.enabled', 'sessionReplay.uploadEnabled', 'sessionReplay.allowAnonymousUploads']) {
+      const owners = contributions.filter(({ settings }) => settings.some((setting) => setting.id === id))
+      expect(owners.map(({ fileName }) => fileName)).toEqual(['session-replay-worker.json'])
+      expect(owners[0].settings.find((setting) => setting.id === id)).toMatchObject({
+        category: 'workbench',
+        description: expect.any(String),
+        heading: expect.any(String),
+        type: 'boolean',
+        value: false,
+      })
+    }
+  } finally {
+    await rm(toRoot, { force: true, recursive: true })
   }
 })

--- a/packages/extension-host-worker-tests/src/session-replay.settings.ts
+++ b/packages/extension-host-worker-tests/src/session-replay.settings.ts
@@ -14,13 +14,16 @@ export const test: Test = async ({ Command, Settings }) => {
   }
 
   await assertDisabled()
-  if ((await Command.execute('Preferences.get', 'sessionReplay.allowAnonymousUploads')) !== false) {
+  if (await Command.execute('Preferences.get', 'sessionReplay.allowAnonymousUploads')) {
     throw new Error('Anonymous session replay uploads must default to disabled')
   }
   await Settings.update({ 'sessionReplay.allowAnonymousUploads': true })
-  await assertDisabled()
-  await Settings.update({ 'sessionReplay.enabled': true })
   try {
+    if ((await Command.execute('Preferences.get', 'sessionReplay.allowAnonymousUploads')) !== true) {
+      throw new Error('Anonymous session replay upload permission must be configurable')
+    }
+    await assertDisabled()
+    await Settings.update({ 'sessionReplay.enabled': true })
     if (await Command.execute('Preferences.get', 'sessionReplay.uploadEnabled')) {
       throw new Error('Enabling local replay must not enable uploads')
     }

--- a/packages/extension-host-worker-tests/src/session-replay.settings.ts
+++ b/packages/extension-host-worker-tests/src/session-replay.settings.ts
@@ -14,6 +14,11 @@ export const test: Test = async ({ Command, Settings }) => {
   }
 
   await assertDisabled()
+  if ((await Command.execute('Preferences.get', 'sessionReplay.allowAnonymousUploads')) !== false) {
+    throw new Error('Anonymous session replay uploads must default to disabled')
+  }
+  await Settings.update({ 'sessionReplay.allowAnonymousUploads': true })
+  await assertDisabled()
   await Settings.update({ 'sessionReplay.enabled': true })
   try {
     if (await Command.execute('Preferences.get', 'sessionReplay.uploadEnabled')) {
@@ -24,7 +29,7 @@ export const test: Test = async ({ Command, Settings }) => {
       throw new Error('Local session replay must capture a versioned recording with a visual frame')
     }
   } finally {
-    await Settings.update({ 'sessionReplay.enabled': false })
+    await Settings.update({ 'sessionReplay.enabled': false, 'sessionReplay.allowAnonymousUploads': false })
   }
   await assertDisabled()
 }

--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -121,6 +121,14 @@
     "value": false
   },
   {
+    "category": "workbench",
+    "description": "Allows session replay uploads without signing in when sessionReplay.uploadEnabled is enabled. Existing authentication is still used when available. The allowAnonymous=true URL parameter also permits anonymous uploads. Changing this setting starts a new recording segment.",
+    "heading": "Allow Anonymous Session Replay Uploads",
+    "id": "sessionReplay.allowAnonymousUploads",
+    "type": "boolean",
+    "value": false
+  },
+  {
     "category": "features",
     "description": "Selects the terminal backend",
     "heading": "Terminal Backend",

--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -105,30 +105,6 @@
     "value": true
   },
   {
-    "category": "workbench",
-    "description": "Records visual content and messages locally for replay. Includes visible source text. Changing this setting starts a new recording segment.",
-    "heading": "Local Session Replay",
-    "id": "sessionReplay.enabled",
-    "type": "boolean",
-    "value": false
-  },
-  {
-    "category": "workbench",
-    "description": "Sends recorded visual content and messages to the backend. Independent of local recording. Changing this setting starts a new recording segment.",
-    "heading": "Upload Session Replay",
-    "id": "sessionReplay.uploadEnabled",
-    "type": "boolean",
-    "value": false
-  },
-  {
-    "category": "workbench",
-    "description": "Allows session replay uploads without signing in when sessionReplay.uploadEnabled is enabled. Existing authentication is still used when available. The allowAnonymous=true URL parameter also permits anonymous uploads. Changing this setting starts a new recording segment.",
-    "heading": "Allow Anonymous Session Replay Uploads",
-    "id": "sessionReplay.allowAnonymousUploads",
-    "type": "boolean",
-    "value": false
-  },
-  {
     "category": "features",
     "description": "Selects the terminal backend",
     "heading": "Terminal Backend",

--- a/packages/renderer-worker/src/parts/SessionReplay/SessionReplay.js
+++ b/packages/renderer-worker/src/parts/SessionReplay/SessionReplay.js
@@ -15,7 +15,9 @@ export const startRecording = async (authState) => {
   const backendUrl = Preferences.get('layout.backendUrl') || Product.getBackendUrl()
   const endpoint = new URL('/session-replay', backendUrl || 'https://lvce-editor.dev')
   const href = await Location.getHref()
-  if (new URL(href).searchParams.get('allowAnonymous') === 'true') endpoint.searchParams.set('allowAnonymous', 'true')
+  if (Preferences.get('sessionReplay.allowAnonymousUploads') === true || new URL(href).searchParams.get('allowAnonymous') === 'true') {
+    endpoint.searchParams.set('allowAnonymous', 'true')
+  }
   const options = { local, upload, endpoint: endpoint.href, token: authState?.token || authState?.accessToken || '' }
   const configuration = JSON.stringify(options)
   if (configuration === state.configuration) return

--- a/packages/renderer-worker/test/SessionReplaySettings.test.ts
+++ b/packages/renderer-worker/test/SessionReplaySettings.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
   jest.resetModules()
   jest.clearAllMocks()
   get.mockReturnValue(undefined)
+  getHref.mockResolvedValue('https://lvce-editor.dev/')
 })
 
 test.each([undefined, false, 'true', 1])('recording requires explicit opt-in, not %p', async (value) => {
@@ -43,6 +44,68 @@ test('preference changes start local recording without uploads and stop recordin
     local: false,
     upload: false,
     endpoint: 'https://lvce-editor.dev/session-replay',
+    token: '',
+  })
+})
+
+test('allowing anonymous uploads alone does not start recording or uploads', async () => {
+  get.mockImplementation((key) => key === 'sessionReplay.allowAnonymousUploads')
+  const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
+  await SessionReplay.initialize(undefined)
+  expect(invoke).not.toHaveBeenCalled()
+})
+
+test.each([undefined, false, 'true', 1, true])('anonymous upload permission requires a boolean true setting: %p', async (value) => {
+  get.mockImplementation((key) => {
+    if (key === 'sessionReplay.uploadEnabled') return true
+    if (key === 'sessionReplay.allowAnonymousUploads') return value
+    if (key === 'layout.backendUrl') return 'https://backend.example/editor'
+    return undefined
+  })
+  const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
+  await SessionReplay.initialize({ token: 'test-token' })
+  expect(invoke).toHaveBeenCalledWith('SessionReplay.configure', {
+    local: false,
+    upload: true,
+    endpoint: `https://backend.example/session-replay${value === true ? '?allowAnonymous=true' : ''}`,
+    token: 'test-token',
+  })
+})
+
+test('anonymous upload permission can be toggled without reloading', async () => {
+  let allowAnonymousUploads = false
+  get.mockImplementation((key) => {
+    if (key === 'sessionReplay.uploadEnabled') return true
+    if (key === 'sessionReplay.allowAnonymousUploads') return allowAnonymousUploads
+    return undefined
+  })
+  const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
+  const GlobalEventBus = await import('../src/parts/GlobalEventBus/GlobalEventBus.js')
+  await SessionReplay.initialize(undefined)
+  for (const enabled of [true, false]) {
+    allowAnonymousUploads = enabled
+    await GlobalEventBus.emitEvent('preferences.changed')
+    expect(invoke).toHaveBeenLastCalledWith('SessionReplay.configure', {
+      local: false,
+      upload: true,
+      endpoint: `https://lvce-editor.dev/session-replay${enabled ? '?allowAnonymous=true' : ''}`,
+      token: '',
+    })
+  }
+  expect(invoke).toHaveBeenCalledTimes(3)
+  await GlobalEventBus.emitEvent('preferences.changed')
+  expect(invoke).toHaveBeenCalledTimes(3)
+})
+
+test.each(['true', 'false', '1'])('the anonymous upload URL opt-in remains supported: %s', async (value) => {
+  get.mockImplementation((key) => key === 'sessionReplay.uploadEnabled')
+  getHref.mockResolvedValue(`https://lvce-editor.dev/?allowAnonymous=${value}`)
+  const SessionReplay = await import('../src/parts/SessionReplay/SessionReplay.js')
+  await SessionReplay.initialize(undefined)
+  expect(invoke).toHaveBeenCalledWith('SessionReplay.configure', {
+    local: false,
+    upload: true,
+    endpoint: `https://lvce-editor.dev/session-replay${value === 'true' ? '?allowAnonymous=true' : ''}`,
     token: '',
   })
 })


### PR DESCRIPTION
Adds the opt-in sessionReplay.allowAnonymousUploads setting for uploads without signing in, while preserving independent recording and upload switches. Collects all three declarations from @lvce-editor/session-replay-worker into builtin-settings/session-replay-worker.json, including their types, defaults, and descriptions, and removes the renderer-worker copies.