### PR TITLE
feature: approve dependency install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,12 @@
       "**/.tmp/**"
     ],
     "exec": "node packages/server/bin/server.js"
+  },
+  "allowScripts": {
+    "nx@20.8.4": true,
+    "nx@21.6.11": true,
+    "@parcel/watcher@2.6.0": true,
+    "unrs-resolver@1.12.2": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -106,5 +106,11 @@
         }
       ]
     }
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.6.0": true,
+    "electron-winstaller@5.4.0": true,
+    "esbuild@0.28.2": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/packages/extension-host-worker-tests/package.json
+++ b/packages/extension-host-worker-tests/package.json
@@ -69,5 +69,8 @@
   },
   "dependencies": {
     "cors": "^2.8.6"
+  },
+  "allowScripts": {
+    "fsevents@2.3.2": true
   }
 }

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -33,5 +33,8 @@
     "@jest/globals": "^30.5.1",
     "electron": "43.1.0",
     "ws": "^8.21.3"
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.6.0": true
   }
 }

--- a/packages/renderer-worker/package.json
+++ b/packages/renderer-worker/package.json
@@ -119,5 +119,8 @@
     "@lvce-editor/chat-message-parsing-worker": "^1.8.0",
     "@types/node": "^26.1.1",
     "@vscode/codicons": "^0.0.45"
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.6.0": true
   }
 }

--- a/packages/shared-process/package.json
+++ b/packages/shared-process/package.json
@@ -122,5 +122,10 @@
         }
       ]
     }
+  },
+  "allowScripts": {
+    "node-pty@1.1.0-beta34": true,
+    "@parcel/watcher@2.6.0": true,
+    "@vscode/windows-process-tree@0.8.0": true
   }
 }

--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -45,5 +45,8 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.5.1"
+  },
+  "allowScripts": {
+    "@parcel/watcher@2.6.0": true
   }
 }


### PR DESCRIPTION
Record version-specific npm allowScripts approvals for all current dependency install scripts in the root and package projects, including macOS-only fsevents dependencies. This prepares installs for npm versions that require explicit script approval.