### PR TITLE
fix: scope live component state to its application

### DIFF
--- a/packages/renderer-worker/src/parts/ApplicationComponentStateFileSystem/ApplicationComponentStateFileSystem.ts
+++ b/packages/renderer-worker/src/parts/ApplicationComponentStateFileSystem/ApplicationComponentStateFileSystem.ts
@@ -1,0 +1,27 @@
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
+import * as ComponentState from '../ComponentState/ComponentState.js'
+import * as DirentType from '../DirentType/DirentType.js'
+import * as FileSystemComponentState from '../FileSystem/FileSystemComponentState.js'
+
+const pattern = /^live-component-state:\/\/\/(?:dom\/|schemas\/)?(\d+(?:\.\d+)?)\.json$/
+
+export const execute = async (applicationId: string, method: string, uri: string, ...args: readonly any[]): Promise<any> => {
+  const application = ApplicationRegistry.assertOpen(applicationId)
+  if (method === 'readDirWithFileTypes' && uri === 'live-component-state:///') {
+    return ComponentState.getComponents(application.layoutUid)
+      .filter((component) => component.editable)
+      .map((component) => ({ name: `${component.uid}.json`, type: DirentType.File }))
+  }
+  const match = pattern.exec(uri)
+  if (!match || ApplicationRegistry.getOwner(Number(match[1])) !== applicationId) {
+    if (method === 'exists') {
+      return false
+    }
+    throw new Error(`Component state does not belong to application ${applicationId}: ${uri}`)
+  }
+  const fn = FileSystemComponentState[method]
+  if (typeof fn !== 'function') {
+    throw new Error(`Unsupported component state filesystem operation: ${method}`)
+  }
+  return fn(uri, ...args)
+}

--- a/packages/renderer-worker/src/parts/ApplicationFileSystem/ApplicationFileSystem.ts
+++ b/packages/renderer-worker/src/parts/ApplicationFileSystem/ApplicationFileSystem.ts
@@ -26,6 +26,10 @@ export const execute = async (id: string, method: string, ...args: readonly any[
   if (method === 'readJson') {
     return JSON.parse(await execute(id, 'readFile', ...args))
   }
+  if (uri.startsWith('live-component-state:')) {
+    const ComponentStateFileSystem = await import('../ApplicationComponentStateFileSystem/ApplicationComponentStateFileSystem.ts')
+    return ComponentStateFileSystem.execute(id, method, uri, ...args.slice(1))
+  }
   if (uri.startsWith('untitled:') && method === 'readFile') {
     return ''
   }

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -221,6 +221,9 @@ const getInstance = (uid) => {
   return instance
 }
 
+/**
+ * @param {number=} viewUid
+ */
 export const getComponents = (viewUid = undefined) => {
   const applicationId = viewUid === undefined ? undefined : ApplicationRegistry.getOwner(viewUid)
   const seen = new Set()

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -1,3 +1,4 @@
+import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as FilterFocusCommands from '../FilterFocusCommands/FilterFocusCommands.js'
 import * as RendererProcess from '../RendererProcess/RendererProcess.js'
@@ -70,8 +71,8 @@ const unsubscribeComponent = (componentUid) => {
   }
 }
 
-const getEditorTabStates = async () => {
-  const mainInstance = ViewletStates.getInstance('Main')
+const getEditorTabStates = async (componentUid) => {
+  const mainInstance = ViewletStates.getInstance('Main', ApplicationRegistry.getOwner(componentUid))
   if (!mainInstance || typeof mainInstance.factory.getComponentState !== 'function') {
     return new Map()
   }
@@ -111,7 +112,7 @@ const runRefreshes = async (componentUid, refresh) => {
     while (refresh.pending) {
       refresh.pending = false
       const editorUids = [...(editorUidsByComponentUid.get(componentUid) || [])]
-      const editorTabStates = await getEditorTabStates()
+      const editorTabStates = await getEditorTabStates(componentUid)
       const isMainComponent = ViewletStates.getByUid(componentUid)?.moduleId === 'Main'
       const editorUidsToRefresh = editorUids.filter((editorUid) => {
         if (mainEditorUidsAwaitingInitialRefresh.has(editorUid)) {
@@ -220,12 +221,13 @@ const getInstance = (uid) => {
   return instance
 }
 
-export const getComponents = () => {
+export const getComponents = (viewUid = undefined) => {
+  const applicationId = viewUid === undefined ? undefined : ApplicationRegistry.getOwner(viewUid)
   const seen = new Set()
   const components = []
   for (const instance of ViewletStates.getValues()) {
     const uid = getUid(instance)
-    if (typeof uid !== 'number' || seen.has(uid)) {
+    if (typeof uid !== 'number' || seen.has(uid) || (viewUid !== undefined && ApplicationRegistry.getOwner(uid) !== applicationId)) {
       continue
     }
     seen.add(uid)

--- a/packages/renderer-worker/test/ApplicationComponentStateFileSystem.test.ts
+++ b/packages/renderer-worker/test/ApplicationComponentStateFileSystem.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 })
 
 const setup = () => {
-  Registry.create({ href: '', id: 'preview', layoutUid: 200, rootId: 'preview', workspacePath: '', workspaceUri: '' })
+  Registry.create({ href: '', id: 'preview', layoutUid: 200, workspacePath: '', workspaceUri: '' })
   Registry.own('preview', 201)
 }
 

--- a/packages/renderer-worker/test/ApplicationComponentStateFileSystem.test.ts
+++ b/packages/renderer-worker/test/ApplicationComponentStateFileSystem.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import * as Registry from '../src/parts/ApplicationRegistry/ApplicationRegistry.ts'
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystemComponentState.js', () => ({
+  exists: jest.fn(async () => true),
+  isReadonly: jest.fn(async () => false),
+  readFile: jest.fn(async () => '{"uid":201}'),
+  writeFile: jest.fn(async () => {}),
+}))
+jest.unstable_mockModule('../src/parts/ComponentState/ComponentState.js', () => ({
+  getComponents: jest.fn(() => [{ editable: true, uid: 201 }]),
+}))
+const FileSystem = await import('../src/parts/ApplicationComponentStateFileSystem/ApplicationComponentStateFileSystem.ts')
+const Provider = await import('../src/parts/FileSystem/FileSystemComponentState.js')
+const ComponentState = await import('../src/parts/ComponentState/ComponentState.js')
+
+afterEach(() => {
+  Registry.remove('preview')
+  jest.clearAllMocks()
+})
+
+const setup = () => {
+  Registry.create({ href: '', id: 'preview', layoutUid: 200, rootId: 'preview', workspacePath: '', workspaceUri: '' })
+  Registry.own('preview', 201)
+}
+
+test('reads and writes owned state, DOM and schema files through the built-in provider', async () => {
+  setup()
+  for (const path of ['201.json', 'dom/201.json', 'schemas/201.json']) {
+    const uri = `live-component-state:///${path}`
+    expect(await FileSystem.execute('preview', 'readFile', uri)).toBe('{"uid":201}')
+    expect(Provider.readFile).toHaveBeenLastCalledWith(uri)
+  }
+  await FileSystem.execute('preview', 'writeFile', 'live-component-state:///201.json', '{"uid":201}')
+  expect(Provider.writeFile).toHaveBeenCalledWith('live-component-state:///201.json', '{"uid":201}')
+})
+
+test('refuses another application component and malformed state URIs', async () => {
+  setup()
+  for (const uri of ['live-component-state:///101.json', 'live-component-state:///missing.json', 'live-component-state://host/201.json']) {
+    await expect(FileSystem.execute('preview', 'readFile', uri)).rejects.toThrow()
+    await expect(FileSystem.execute('preview', 'writeFile', uri, '{}')).rejects.toThrow()
+    expect(await FileSystem.execute('preview', 'exists', uri)).toBe(false)
+  }
+  expect(Provider.readFile).not.toHaveBeenCalled()
+  expect(Provider.writeFile).not.toHaveBeenCalled()
+})
+
+test('lists only the application components and rejects unsupported operations', async () => {
+  setup()
+  expect(await FileSystem.execute('preview', 'readDirWithFileTypes', 'live-component-state:///')).toEqual([{ name: '201.json', type: 7 }])
+  expect(ComponentState.getComponents).toHaveBeenCalledWith(200)
+  await expect(FileSystem.execute('preview', 'getBlob', 'live-component-state:///201.json')).rejects.toThrow('Unsupported')
+})

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -506,3 +506,55 @@ test('refreshes other DOM editors after a direct DOM edit', async () => {
   expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(10, 'loadContent', undefined, { preserveFocus: true })
   expect(ViewletStates.getState(2)).toBe(state)
 })
+
+test('lists only components belonging to the requesting inspector application', async () => {
+  const Registry = await import('../src/parts/ApplicationRegistry/ApplicationRegistry.ts')
+  for (const [id, uid] of [
+    ['source', 100],
+    ['preview', 200],
+  ] as const) {
+    Registry.create({ href: '', id, layoutUid: uid, rootId: id, workspacePath: '', workspaceUri: '' })
+    for (const componentUid of [uid, uid + 1]) {
+      const state = { applicationId: id, uid: componentUid }
+      ViewletStates.set(componentUid, { factory: {}, moduleId: 'Layout', renderedState: state, state })
+    }
+  }
+  try {
+    expect(ComponentState.getComponents(100).map(({ uid }) => uid)).toEqual([100, 101])
+    expect(ComponentState.getComponents(200).map(({ uid }) => uid)).toEqual([200, 201])
+    expect(ComponentState.getComponents().map(({ uid }) => uid)).toEqual([100, 101, 200, 201])
+  } finally {
+    ViewletStates.reset()
+    Registry.remove('source')
+    Registry.remove('preview')
+  }
+})
+
+test('uses the preview tab state to preserve unsaved live component edits', async () => {
+  const Registry = await import('../src/parts/ApplicationRegistry/ApplicationRegistry.ts')
+  const sourceMain = jest.fn(async () => ({ layout: { groups: [] } }))
+  const previewMain = jest.fn(async () => ({ layout: { groups: [{ tabs: [{ editorUid: 203, isDirty: true }] }] } }))
+  for (const [id, uid, getComponentState] of [
+    ['source', 100, sourceMain],
+    ['preview', 200, previewMain],
+  ] as const) {
+    Registry.create({ href: '', id, layoutUid: uid, rootId: id, workspacePath: '', workspaceUri: '' })
+    const state = { applicationId: id, uid: uid + 1 }
+    ViewletStates.set(uid + 1, { factory: { getComponentState }, moduleId: 'Main', renderedState: state, state })
+  }
+  try {
+    const componentState = { applicationId: 'preview', uid: 202, value: 0 }
+    const editorState = { applicationId: 'preview', uid: 203, uri: 'live-component-state:///202.json' }
+    ViewletStates.set(202, { factory: {}, moduleId: 'Explorer', renderedState: componentState, state: componentState })
+    ViewletStates.set(203, { factory: {}, moduleId: 'EditorText', renderedState: editorState, state: editorState })
+    ViewletStates.setRenderedState(202, { ...componentState, value: 1 })
+    await ComponentState.waitForRefreshes()
+    expect(previewMain).toHaveBeenCalledTimes(1)
+    expect(sourceMain).not.toHaveBeenCalled()
+    expect(Viewlet.executeViewletCommand).not.toHaveBeenCalled()
+  } finally {
+    ViewletStates.reset()
+    Registry.remove('source')
+    Registry.remove('preview')
+  }
+})

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -513,7 +513,7 @@ test('lists only components belonging to the requesting inspector application', 
     ['source', 100],
     ['preview', 200],
   ] as const) {
-    Registry.create({ href: '', id, layoutUid: uid, rootId: id, workspacePath: '', workspaceUri: '' })
+    Registry.create({ href: '', id, layoutUid: uid, workspacePath: '', workspaceUri: '' })
     for (const componentUid of [uid, uid + 1]) {
       const state = { applicationId: id, uid: componentUid }
       ViewletStates.set(componentUid, { factory: {}, moduleId: 'Layout', renderedState: state, state })
@@ -538,7 +538,7 @@ test('uses the preview tab state to preserve unsaved live component edits', asyn
     ['source', 100, sourceMain],
     ['preview', 200, previewMain],
   ] as const) {
-    Registry.create({ href: '', id, layoutUid: uid, rootId: id, workspacePath: '', workspaceUri: '' })
+    Registry.create({ href: '', id, layoutUid: uid, workspacePath: '', workspaceUri: '' })
     const state = { applicationId: id, uid: uid + 1 }
     ViewletStates.set(uid + 1, { factory: { getComponentState }, moduleId: 'Main', renderedState: state, state })
   }


### PR DESCRIPTION
Keep the component-state list and live JSON filesystem scoped to the inspector’s application. Preview components can be opened and edited in the preview IDE, and live refresh checks the owning IDE’s tabs so unsaved edits are preserved.
