### PR TITLE
fix: support application filesystem batch hashes

### DIFF
--- a/packages/renderer-worker/src/parts/ApplicationFileSystem/ApplicationFileSystem.ts
+++ b/packages/renderer-worker/src/parts/ApplicationFileSystem/ApplicationFileSystem.ts
@@ -15,10 +15,42 @@ const providerMethods: Readonly<Record<string, string>> = {
   writeFile: 'WriteFile',
 }
 
+const getFileHashes = async (id: string, uris: readonly string[]): Promise<readonly (string | null)[]> => {
+  if (!Array.isArray(uris)) {
+    throw new TypeError('uris must be an array')
+  }
+  for (const uri of uris) {
+    if (typeof uri !== 'string') {
+      throw new TypeError('Application filesystem requires a URI')
+    }
+  }
+  const hashes: Array<string | null> = Array.from({ length: uris.length }, () => null)
+  let nextIndex = 0
+  const hashNext = async (): Promise<void> => {
+    while (nextIndex < uris.length) {
+      const index = nextIndex++
+      try {
+        const content = await execute(id, 'readFile', uris[index])
+        const bytes = new TextEncoder().encode(content)
+        const digest = await crypto.subtle.digest('SHA-256', bytes)
+        hashes[index] = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+      } catch {
+        // An unreadable file is a cache miss, without failing the other hashes.
+        hashes[index] = null
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(32, uris.length) }, hashNext))
+  return hashes
+}
+
 // Memory storage and extension providers are owned by the application. Only
 // immutable HTTP assets use the shared filesystem; never fall back to another
 // application's provider when a scheme is unknown.
 export const execute = async (id: string, method: string, ...args: readonly any[]): Promise<any> => {
+  if (method === 'getFileHashes') {
+    return getFileHashes(id, args[0])
+  }
   const [uri] = args
   if (typeof uri !== 'string') {
     throw new TypeError('Application filesystem requires a URI')

--- a/packages/renderer-worker/test/ApplicationFileSystem.test.ts
+++ b/packages/renderer-worker/test/ApplicationFileSystem.test.ts
@@ -1,4 +1,5 @@
 import { expect, jest, test } from '@jest/globals'
+// @ts-ignore Node APIs are available in Jest but excluded from the web worker types.
 import { createHash } from 'node:crypto'
 
 jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({

--- a/packages/renderer-worker/test/ApplicationFileSystem.test.ts
+++ b/packages/renderer-worker/test/ApplicationFileSystem.test.ts
@@ -1,9 +1,15 @@
 import { expect, jest, test } from '@jest/globals'
+import { createHash } from 'node:crypto'
+
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  readFile: jest.fn(async () => 'http content'),
+}))
 
 jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({
   invoke: jest.fn(async () => ({ found: true, result: 'provider content' })),
 }))
 const FileSystem = await import('../src/parts/ApplicationFileSystem/ApplicationFileSystem.ts')
+const SharedFileSystem = await import('../src/parts/FileSystem/FileSystem.js')
 const Extensions = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 
 test('identical memory URIs belong to separate applications and disposal preserves siblings', async () => {
@@ -28,4 +34,79 @@ test('custom schemes use only the owning application runtime', async () => {
   )
   jest.mocked(Extensions.invoke).mockResolvedValueOnce({ found: false })
   await expect(FileSystem.execute('source', 'readFile', 'sample:///README.md')).rejects.toThrow('No sample filesystem provider in application source')
+})
+
+const hash = (content: string): string => createHash('sha256').update(content).digest('hex')
+
+test('batch hashes preserve URI order, content changes, missing files, and application isolation', async () => {
+  const uris = ['memfs:///main.ts', 'memfs:///missing.ts', 'memfs:///empty.ts', 'memfs:///folder']
+  try {
+    await FileSystem.execute('source', 'writeFile', uris[0], 'héllo 🌍')
+    await FileSystem.execute('preview', 'writeFile', uris[0], 'preview')
+    await FileSystem.execute('source', 'writeFile', uris[2], '')
+    await FileSystem.execute('source', 'mkdir', uris[3])
+    expect(await FileSystem.execute('source', 'getFileHashes', uris)).toEqual([hash('héllo 🌍'), null, hash(''), null])
+    expect(await FileSystem.execute('preview', 'getFileHashes', uris)).toEqual([hash('preview'), null, null, null])
+    await FileSystem.execute('source', 'writeFile', uris[0], 'changed')
+    expect(await FileSystem.execute('source', 'getFileHashes', [uris[0], uris[0]])).toEqual([hash('changed'), hash('changed')])
+    await FileSystem.execute('source', 'remove', uris[0])
+    expect(await FileSystem.execute('source', 'getFileHashes', [uris[0]])).toEqual([null])
+    expect(await FileSystem.execute('source', 'getFileHashes', [])).toEqual([])
+  } finally {
+    FileSystem.dispose('source')
+    FileSystem.dispose('preview')
+  }
+})
+
+test('batch hashes read extension providers in the owning application', async () => {
+  jest.mocked(Extensions.invoke).mockResolvedValueOnce({ found: false })
+  expect(await FileSystem.execute('preview', 'getFileHashes', ['missing:///file.ts', 'sample:///main.ts'])).toEqual([null, hash('provider content')])
+  expect(Extensions.invoke).toHaveBeenLastCalledWith(
+    'Extensions.invokeForApplication',
+    'preview',
+    'Extensions.executeFileSystemProviderReadFile',
+    'sample',
+    'sample:///main.ts',
+  )
+})
+
+test('batch hashes reject invalid arguments before reading files', async () => {
+  await expect(FileSystem.execute('source', 'getFileHashes', 'memfs:///main.ts')).rejects.toThrow('uris must be an array')
+  await expect(FileSystem.execute('source', 'getFileHashes', ['memfs:///main.ts', 1])).rejects.toThrow('Application filesystem requires a URI')
+})
+
+test('batch hashes support HTTP assets alongside application memory files', async () => {
+  await FileSystem.execute('source', 'writeFile', 'memfs:///main.ts', 'memory content')
+  try {
+    expect(await FileSystem.execute('source', 'getFileHashes', ['https://example.com/eslint.js', 'memfs:///main.ts'])).toEqual([
+      hash('http content'),
+      hash('memory content'),
+    ])
+    expect(SharedFileSystem.readFile).toHaveBeenLastCalledWith('https://example.com/eslint.js')
+  } finally {
+    FileSystem.dispose('source')
+  }
+})
+
+test('large batches bound concurrent reads and retain the order when reads finish out of order', async () => {
+  const uris = Array.from({ length: 65 }, (_, index) => `https://example.com/${index}.js`)
+  const pending = uris.map(() => Promise.withResolvers<string>())
+  const started = Promise.withResolvers<void>()
+  let calls = 0
+  jest.mocked(SharedFileSystem.readFile).mockImplementation(async (uri: string) => {
+    calls++
+    if (calls === 32) started.resolve()
+    return pending[uris.indexOf(uri)].promise
+  })
+  try {
+    const result = FileSystem.execute('source', 'getFileHashes', uris)
+    await started.promise
+    expect(calls).toBe(32)
+    for (let index = pending.length - 1; index >= 0; index--) pending[index].resolve(String(index))
+    expect(await result).toEqual(uris.map((_, index) => hash(String(index))))
+    expect(calls).toBe(65)
+  } finally {
+    for (const deferred of pending) deferred.resolve('')
+    jest.mocked(SharedFileSystem.readFile).mockImplementation(async () => 'http content')
+  }
 })


### PR DESCRIPTION
Implement FileSystem.getFileHashes for application filesystems so web ESLint can hash memory files, HTTP assets, and extension-provider files. Hashes use SHA-256 with bounded concurrency, preserve URI order and application isolation, and return null for unreadable files.