### PR TITLE
fix: keep remote SSH transport on the client

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js
+++ b/packages/renderer-worker/src/parts/ExtensionNodeRpc/ExtensionNodeRpc.js
@@ -1,9 +1,15 @@
+import * as GetWebSocketUrl from '../GetWebSocketUrl/GetWebSocketUrl.js'
+import * as Location from '../Location/Location.js'
 import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 import * as WebSocketCapability from '../WebSocketCapability/WebSocketCapability.js'
 import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
 
 export const createConnection = async (extensionId, rpcId) => {
-  const connection = await WebSocketCapability.create('extension-node-process')
+  // The SSH transport owns the local tunnel and must remain on the client.
+  const connection =
+    extensionId === 'builtin.remote-ssh'
+      ? { protocols: [], url: GetWebSocketUrl.getWebSocketUrl('extension-node-process', Location.getHost()) }
+      : await WebSocketCapability.create('extension-node-process')
   const url = new URL(connection.url)
   url.searchParams.set('extensionId', extensionId)
   url.searchParams.set('rpcId', rpcId)
@@ -16,7 +22,10 @@ export const createConnection = async (extensionId, rpcId) => {
 export const supportsDirectConnection = () => true
 
 export const createMessagePort = async (port, extensionId, rpcId) => {
-  if (await WorkspaceConnection.connectMessagePort('extension-node-process', port, { extensionId, rpcId })) {
+  if (
+    extensionId !== 'builtin.remote-ssh' &&
+    (await WorkspaceConnection.connectMessagePort('extension-node-process', port, { extensionId, rpcId }))
+  ) {
     return
   }
   await SharedProcess.invokeAndTransfer('HandleMessagePortForExtensionNodeProcess.handleMessagePortForExtensionNodeProcess', port, extensionId, rpcId)

--- a/packages/renderer-worker/test/ExtensionNodeRpc.test.ts
+++ b/packages/renderer-worker/test/ExtensionNodeRpc.test.ts
@@ -4,6 +4,14 @@ beforeEach(() => {
   jest.resetAllMocks()
 })
 
+jest.unstable_mockModule('../src/parts/GetWebSocketUrl/GetWebSocketUrl.js', () => ({
+  getWebSocketUrl: () => 'ws://localhost:3000/websocket/extension-node-process',
+}))
+
+jest.unstable_mockModule('../src/parts/Location/Location.js', () => ({
+  getHost: () => 'localhost:3000',
+}))
+
 jest.unstable_mockModule('../src/parts/SharedProcess/SharedProcess.js', () => ({
   invokeAndTransfer: jest.fn(),
 }))
@@ -80,4 +88,35 @@ test('bridges an extension-bound message port to an active remote workspace', as
   expect(SharedProcess.invokeAndTransfer).not.toHaveBeenCalled()
   port1.close()
   port2.close()
+})
+
+test('keeps the SSH transport node process local when a remote workspace is active', async () => {
+  jest.mocked(WebSocketCapability.create).mockResolvedValue({
+    protocols: [],
+    url: 'ws://127.0.0.1:46099/websocket/extension-node-process?token=remote-token',
+  })
+
+  await expect(ExtensionNodeRpc.createConnection('builtin.remote-ssh', 'builtin.remote-ssh.node')).resolves.toEqual({
+    protocols: [],
+    url: 'ws://localhost:3000/websocket/extension-node-process?extensionId=builtin.remote-ssh&rpcId=builtin.remote-ssh.node',
+  })
+  expect(WebSocketCapability.create).not.toHaveBeenCalled()
+})
+
+test('keeps the SSH transport message port in the local shared process', async () => {
+  const { port1, port2 } = new MessageChannel()
+  jest.mocked(WorkspaceConnection.connectMessagePort).mockResolvedValueOnce(true)
+  try {
+    await ExtensionNodeRpc.createMessagePort(port1, 'builtin.remote-ssh', 'builtin.remote-ssh.node')
+    expect(WorkspaceConnection.connectMessagePort).not.toHaveBeenCalled()
+    expect(SharedProcess.invokeAndTransfer).toHaveBeenCalledWith(
+      'HandleMessagePortForExtensionNodeProcess.handleMessagePortForExtensionNodeProcess',
+      port1,
+      'builtin.remote-ssh',
+      'builtin.remote-ssh.node',
+    )
+  } finally {
+    port1.close()
+    port2.close()
+  }
 })


### PR DESCRIPTION
Keep the Remote SSH transport node process on the client when a remote workspace is active. Routing it to the remote host requested an extension that is not installed there, disconnected the shared process, and caused cascading WebSocket errors.

Cover both direct WebSocket and message-port connections with regressions while preserving remote routing for workspace extensions.
