### PR TITLE
fix: scope embedded extension views to their application

### DIFF
--- a/packages/renderer-worker/src/parts/Application/Application.ts
+++ b/packages/renderer-worker/src/parts/Application/Application.ts
@@ -173,7 +173,7 @@ export const execute = (applicationId: string, command: string, ...args: readonl
         await ExtensionManagementWorker.invoke('Extensions.reloadApplicationExtension', applicationId, ...args)
         for (const uid of ApplicationRegistry.getUids(applicationId)) {
           const instance = ViewletStates.getByUid(uid)
-          if (instance?.moduleId === ViewletModuleId.EditorText) {
+          if (instance?.moduleId === ViewletModuleId.EditorText || instance?.moduleId === ViewletModuleId.ExtensionView) {
             await Viewlet.executeViewletCommand(uid, 'loadContent', undefined, { preserveFocus: true })
           }
         }

--- a/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
+++ b/packages/renderer-worker/src/parts/GetExtensionViews/GetExtensionViews.ts
@@ -95,10 +95,14 @@ const mergeCss = (views: readonly ExtensionView[], extensions: readonly Extensio
   })
 }
 
-export const getExtensionViews = async (): Promise<readonly ExtensionView[]> => {
+export const getExtensionViews = async (applicationId?: string): Promise<readonly ExtensionView[]> => {
+  const invoke = (command: string, ...args: readonly unknown[]): Promise<any> =>
+    applicationId === undefined
+      ? ExtensionManagementWorker.invoke(command, ...args)
+      : ExtensionManagementWorker.invoke('Extensions.invokeForApplication', applicationId, command, ...args)
   const [views, extensions] = await Promise.all([
-    ExtensionManagementWorker.invoke('Extensions.getViews', assetDir, getPlatform()) as Promise<readonly ExtensionView[]>,
-    ExtensionManagementWorker.invoke('Extensions.getAllExtensions', assetDir, getPlatform()) as Promise<readonly ExtensionManifest[]>,
+    invoke('Extensions.getViews', assetDir, getPlatform()) as Promise<readonly ExtensionView[]>,
+    invoke('Extensions.getAllExtensions', assetDir, getPlatform()) as Promise<readonly ExtensionManifest[]>,
   ])
   return mergeCss(views, extensions)
 }
@@ -112,7 +116,7 @@ export const findExtensionView = (views: readonly ExtensionView[], idOrUri: stri
   return views.find((view) => view.type === 'preview' && view.selector?.some((selector) => normalizedUri.endsWith(selector.toLowerCase())))
 }
 
-export const getExtensionView = async (idOrUri: string): Promise<ExtensionView | undefined> => {
-  const views = await getExtensionViews()
+export const getExtensionView = async (idOrUri: string, applicationId?: string): Promise<ExtensionView | undefined> => {
+  const views = await getExtensionViews(applicationId)
   return findExtensionView(views, idOrUri)
 }

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionView.ts
@@ -185,7 +185,7 @@ export const create = (
 }
 
 export const loadContent = async (state: ViewletExtensionViewState, savedState: unknown): Promise<ViewletExtensionViewState> => {
-  const view = await GetExtensionViews.getExtensionView(state.uri)
+  const view = await GetExtensionViews.getExtensionView(state.uri, state.applicationId)
   if (!view) {
     throw new Error(`view ${state.uri} not found`)
   }
@@ -205,6 +205,7 @@ export const loadContent = async (state: ViewletExtensionViewState, savedState: 
       createContext(stateWithViewId, savedState),
       assetDir,
       getPlatform(),
+      state.applicationId,
     )
     const createResult = result as CreateViewInstanceResult
     if (createResult.ok === false) {
@@ -382,6 +383,7 @@ export const Commands = {
   handleSubmit,
   handleViewCommand,
   handleViewEvent,
+  loadContent,
   rerender,
 }
 

--- a/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
+++ b/packages/renderer-worker/src/parts/ViewletExtensionView/ViewletExtensionViewState.ts
@@ -1,4 +1,5 @@
 export interface ViewletExtensionViewState {
+  readonly applicationId?: string
   readonly commands: readonly (readonly unknown[])[]
   readonly actionsDom: readonly unknown[]
   readonly css: string

--- a/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
+++ b/packages/renderer-worker/src/parts/ViewletSideBar/ViewletSideBar.js
@@ -97,8 +97,8 @@ const getChildModuleId = (moduleId) => {
   return ViewletModuleId.ExtensionView
 }
 
-const getExtensionViewMetadata = async (moduleId) => {
-  const view = await GetExtensionViews.getExtensionView(moduleId)
+const getExtensionViewMetadata = async (moduleId, applicationId) => {
+  const view = await GetExtensionViews.getExtensionView(moduleId, applicationId)
   return {
     extensionId: view?.extensionId || '',
     titleAreaHeight: view?.showSideBarHeader === false ? 0 : defaultTitleAreaHeight,
@@ -141,7 +141,7 @@ export const handleSideBarViewletChange = async (state, moduleId, restore = true
   const childModuleId = getChildModuleId(moduleId)
   const extensionViewMetadata =
     childModuleId === ViewletModuleId.ExtensionView
-      ? await getExtensionViewMetadata(moduleId)
+      ? await getExtensionViewMetadata(moduleId, state.applicationId)
       : {
           extensionId: '',
           titleAreaHeight: defaultTitleAreaHeight,

--- a/packages/renderer-worker/test/Application.test.ts
+++ b/packages/renderer-worker/test/Application.test.ts
@@ -184,9 +184,12 @@ test('extension reload refreshes existing application views without disposing th
   const uri = 'sample-memfs:///README.md'
   ApplicationRegistry.own('preview', 100)
   ViewletStates.set(100, { moduleId: 'Editor', factory: {}, state: { uid: 100, uri, applicationId: 'preview' }, renderedState: { uid: 100 } })
+  ApplicationRegistry.own('preview', 101)
+  ViewletStates.set(101, { moduleId: 'ExtensionView', factory: {}, state: { uid: 101, applicationId: 'preview' }, renderedState: { uid: 101 } })
   await Application.execute('preview', 'Extensions.reload', 'sample', replacement)
   expect(ExtensionManagementWorker.invoke).toHaveBeenCalledWith('Extensions.reloadApplicationExtension', 'preview', 'sample', replacement)
   expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(100, 'loadContent', undefined, { preserveFocus: true })
+  expect(Viewlet.executeViewletCommand).toHaveBeenCalledWith(101, 'loadContent', undefined, { preserveFocus: true })
   expect(ViewletManager.executeForApplication).toHaveBeenCalledWith('preview', 'Layout.handleWorkspaceRefresh')
   expect(Viewlet.dispose).not.toHaveBeenCalled()
   expect(ApplicationRegistry.getOwner(source)).toBe('source')

--- a/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionViewCss.test.ts
@@ -188,6 +188,7 @@ test('loadContent opens a document view with its contributed id and resource uri
     },
     '',
     4,
+    undefined,
   )
   expect(newState.uri).toBe('file:///workspace/image.png')
   expect(newState.viewId).toBe('sample.views.testing')


### PR DESCRIPTION
Resolve embedded sidebar contributions in their owning application and reload virtual DOM views when their extension changes. This lets the sidebar counter render and reflect saved edits without replacing either editor.
