### PR TITLE
fix: make on-load JSON commands opt-in

### DIFF
--- a/packages/build/src/parts/TestStaticExport/TestStaticExport.ts
+++ b/packages/build/src/parts/TestStaticExport/TestStaticExport.ts
@@ -54,6 +54,8 @@ const main = async () => {
   }
   await ReadFile.readFile(join(tmpDir, 'dist', commitHash, 'tests', 'sample.test.html'))
   await ReadFile.readFile(join(tmpDir, 'dist', 'tests', 'sample.test.html'))
+  // Static e2e pages must start without an optional on-load commands file.
+  await Remove.remove(join(tmpDir, 'dist', commitHash, 'config', 'onLoadCommands.json'))
   const testOverview = await ReadFile.readFile(join(tmpDir, 'dist', commitHash, 'tests', 'index.html'))
   if (!testOverview.includes('sample.test.html')) {
     throw new Error('static export test overview does not include sample.test.html')

--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -8,6 +8,14 @@
     "value": "none"
   },
   {
+    "category": "applications",
+    "description": "Loads and executes commands from config/onLoadCommands.json on web startup",
+    "heading": "Use On Load JSON",
+    "id": "application.useOnLoadJson",
+    "type": "boolean",
+    "value": false
+  },
+  {
     "category": "workbench",
     "description": "Stores the cached color theme",
     "heading": "Color Theme Cache",

--- a/packages/renderer-worker/src/parts/OnLoadCommands/OnLoadCommands.js
+++ b/packages/renderer-worker/src/parts/OnLoadCommands/OnLoadCommands.js
@@ -1,6 +1,7 @@
 import * as Ajax from '../Ajax/Ajax.js'
 import * as Command from '../Command/Command.js'
 import * as PlatformType from '../PlatformType/PlatformType.js'
+import * as Preferences from '../Preferences/Preferences.js'
 
 const defaultDependencies = {
   executeCommand: Command.execute,
@@ -29,7 +30,7 @@ export const executeOnLoadCommands = async (commands, executeCommand = Command.e
 }
 
 export const run = async (assetDir, platform, dependencies = defaultDependencies) => {
-  if (platform !== PlatformType.Web) {
+  if (platform !== PlatformType.Web || Preferences.get('application.useOnLoadJson') !== true) {
     return
   }
   const commands = await getOnLoadCommands(assetDir, dependencies.getJson)

--- a/packages/renderer-worker/test/OnLoadCommands.test.ts
+++ b/packages/renderer-worker/test/OnLoadCommands.test.ts
@@ -1,8 +1,27 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import * as OnLoadCommands from '../src/parts/OnLoadCommands/OnLoadCommands.js'
 import * as PlatformType from '../src/parts/PlatformType/PlatformType.js'
+import * as PreferencesState from '../src/parts/PreferencesState/PreferencesState.js'
+
+beforeEach(() => {
+  PreferencesState.setAll({})
+})
+
+test.each([undefined, false, 'true'])('run skips a missing on-load file when the setting is %p', async (value) => {
+  PreferencesState.set('application.useOnLoadJson', value)
+  const executeCommand = jest.fn<(...parameters: readonly unknown[]) => Promise<void>>(async () => {})
+  const getJson = jest.fn<(url: string) => Promise<readonly unknown[]>>(async () => {
+    throw new Error('Failed to request json: 404 Not Found')
+  })
+
+  await OnLoadCommands.run('/video-preview/55af9e7', PlatformType.Web, { executeCommand, getJson })
+
+  expect(getJson).not.toHaveBeenCalled()
+  expect(executeCommand).not.toHaveBeenCalled()
+})
 
 test('run executes configured extension commands in order', async () => {
+  PreferencesState.set('application.useOnLoadJson', true)
   const executeCommand = jest.fn<(...parameters: readonly unknown[]) => Promise<void>>(async () => {})
   const getJson = jest.fn<(url: string) => Promise<readonly unknown[]>>(async () => {
     return [
@@ -26,6 +45,7 @@ test('run executes configured extension commands in order', async () => {
 })
 
 test('run does nothing outside the web platform', async () => {
+  PreferencesState.set('application.useOnLoadJson', true)
   const executeCommand = jest.fn<(...parameters: readonly unknown[]) => Promise<void>>(async () => {})
   const getJson = jest.fn<(url: string) => Promise<readonly unknown[]>>(async () => [])
 

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -1,5 +1,6 @@
 {
   "application.updateMode": "none",
+  "application.useOnLoadJson": false,
 
   "breadcrumbs.enabled": false,
 


### PR DESCRIPTION
Web startup currently fails before running e2e tests when a static site lacks config/onLoadCommands.json. Add application.useOnLoadJson with a default of false so the file is fetched and its commands executed only when explicitly enabled.