### PR TITLE
fix: resolve bundled extension view styles from their directory

### DIFF
--- a/packages/renderer-worker/src/parts/GetExtensionAbsolutePath/GetExtensionAbsolutePath.js
+++ b/packages/renderer-worker/src/parts/GetExtensionAbsolutePath/GetExtensionAbsolutePath.js
@@ -23,7 +23,8 @@ export const getExtensionAbsolutePath = (id, isWeb, isBuiltin, path, relativePat
     return path + '/' + relativePath
   }
   if (isBuiltin) {
-    return `${AssetDir.assetDir}/extensions/${id}/${relativePath}`
+    const folderName = path.split(/[/\\]/).filter(Boolean).at(-1) || id
+    return `${AssetDir.assetDir}/extensions/${folderName}/${relativePath}`
   }
   return new URL('/remote' + path + '/' + relativePath, origin).toString()
 }

--- a/packages/renderer-worker/src/parts/GetExtensionAbsolutePath/GetExtensionAbsolutePath.js
+++ b/packages/renderer-worker/src/parts/GetExtensionAbsolutePath/GetExtensionAbsolutePath.js
@@ -23,7 +23,7 @@ export const getExtensionAbsolutePath = (id, isWeb, isBuiltin, path, relativePat
     return path + '/' + relativePath
   }
   if (isBuiltin) {
-    const folderName = path.split(/[/\\]/).filter(Boolean).at(-1) || id
+    const folderName = path.split(/[/\\]/).findLast(Boolean) || id
     return `${AssetDir.assetDir}/extensions/${folderName}/${relativePath}`
   }
   return new URL('/remote' + path + '/' + relativePath, origin).toString()

--- a/packages/renderer-worker/test/GetExtensionAbsolutePath.test.ts
+++ b/packages/renderer-worker/test/GetExtensionAbsolutePath.test.ts
@@ -15,3 +15,26 @@ test('getExtensionAbsolutePath handles file urls for local extensions', () => {
 
   expect(absolutePath).toBe('http://localhost:3000/remote/D:/a/git/git/packages/extension/src/gitMain.js')
 })
+
+test.each([
+  '/usr/lib/lvce/resources/app/static/2d0c8e6/extensions/builtin.pull-request-github',
+  '/usr/lib/lvce/resources/app/static/2d0c8e6/extensions/builtin.pull-request-github/',
+  'C:\\Program Files\\LVCE\\resources\\app\\static\\2d0c8e6\\extensions\\builtin.pull-request-github',
+])('resolves bundled GitHub view CSS from its directory: %s', (path) => {
+  const absolutePath = GetExtensionAbsolutePath.getExtensionAbsolutePath(
+    'github.pull-requests',
+    false,
+    true,
+    path,
+    'media/pullRequests.css',
+    'lvce://-',
+    PlatformType.Electron,
+  )
+  expect(absolutePath).toBe('/extensions/builtin.pull-request-github/media/pullRequests.css')
+})
+
+test('falls back to the builtin id when the directory is omitted', () => {
+  expect(
+    GetExtensionAbsolutePath.getExtensionAbsolutePath('builtin.sample', false, true, '', 'media/view.css', 'lvce://-', PlatformType.Electron),
+  ).toBe('/extensions/builtin.sample/media/view.css')
+})


### PR DESCRIPTION
The GitHub Pull Requests extension has a different ID from its bundled directory, causing its view stylesheet to use a nonexistent production URL. Resolve built-in view resources from the manifest directory so the packaged stylesheet loads correctly.