### PR TITLE
fix: focus source control input from keyboard shortcut

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,6 +135,12 @@ jobs:
         run: npm run e2e:headless -- --test-name-prefix=viewlet.output-open-channel
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Source Control shortcut focus
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.source-control-shortcut-focus
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test integrated terminal rendering
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/packages/extension-host-worker-tests/src/viewlet.source-control-shortcut-focus.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.source-control-shortcut-focus.ts
@@ -1,0 +1,50 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.source-control-shortcut-focus'
+
+const waitFor = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      if (attempt === 99) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+}
+
+export const test: Test = async ({ ActivityBar, Command, expect, Extension, FileSystem, KeyBoard, Locator, Main, SideBar, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const fileUri = `${tmpDir}/file.txt`
+  await FileSystem.writeFile(fileUri, '')
+  await Workspace.setPath(tmpDir)
+  const extensionUri = new URL('../fixtures/sample.source-control-save-badge', import.meta.url).toString().replace(/\/$/, '')
+  await Extension.addWebExtension(extensionUri)
+  await Extension.enableWorkspace('sample.source-control-save-badge')
+  await ActivityBar.handleExtensionsChanged()
+  const activationResult = await Command.execute('ExtensionManagement.activateByEvent', 'onSourceControl:memfs', '', 0)
+  if (activationResult.error) {
+    throw activationResult.error
+  }
+  await Command.execute('Layout.handleExtensionsChanged')
+  await SideBar.open('Explorer')
+  await Main.openUri(fileUri)
+
+  const editorInput = Locator('[name="editor"]')
+  const sourceControlInput = Locator('.SideBar textarea[name="SourceControlInput"]')
+  await expect(editorInput).toBeFocused()
+  await KeyBoard.press('Control+Shift+G')
+  await waitFor(() => expect(sourceControlInput).toBeVisible())
+  await waitFor(() => expect(sourceControlInput).toBeFocused())
+  await sourceControlInput.type('commit message')
+  await expect(sourceControlInput).toHaveValue('commit message')
+
+  await Command.execute('Main.focus')
+  await expect(editorInput).toBeFocused()
+  await KeyBoard.press('Control+Shift+G')
+  await waitFor(() => expect(sourceControlInput).toBeFocused())
+  await expect(sourceControlInput).toHaveValue('commit message')
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2879,8 +2879,11 @@ export const openSideBarView = async (state: LayoutState, moduleId, focus = fals
     return result
   }
   await ViewletManager.waitForLoadContentLater(moduleId)
-  await Viewlet.focus(moduleId)
-  return result
+  const focusCommands = await Viewlet.getFocusCommands(moduleId)
+  return {
+    newState: result.newState,
+    commands: [...result.commands, ...focusCommands],
+  }
 }
 
 export const openTextSearch = async (state: LayoutState): Promise<LayoutStateResult> => {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -64,7 +64,7 @@ export const getKeyBindings = () => {
     {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyG,
       command: 'Layout.openSideBarViewlet',
-      args: ['Source Control'],
+      args: ['Source Control', true],
     },
     {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyE,

--- a/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutSideBar.test.ts
@@ -695,8 +695,10 @@ test('toggleSideBarView appends focus commands after showing the requested view'
   expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusElementByName', 12, 'SearchValue']])
 })
 
-test('openSideBarView waits for deferred content and focuses the mounted view when requested', async () => {
+test('openSideBarView waits for deferred content and appends focus after showing the view', async () => {
   mockActivityBarRender()
+  // @ts-ignore
+  Viewlet.getFocusCommands.mockResolvedValue([['Viewlet.focusSelector', 12, '[name="SourceControlInput"]']])
   const state = {
     ...ViewletLayout.create(1),
     activityBarId: 7,
@@ -704,11 +706,12 @@ test('openSideBarView waits for deferred content and focuses the mounted view wh
     sideBarVisible: true,
   }
 
-  const result = await ViewletLayout.openSideBarView(state, 'Extensions', true, undefined)
+  const result = await ViewletLayout.openSideBarView(state, 'Source Control', true, undefined)
 
-  expect(ViewletManager.waitForLoadContentLater).toHaveBeenCalledWith('Extensions')
-  expect(Viewlet.focus).toHaveBeenCalledWith('Extensions')
-  expect(result.commands).toEqual([['activity-bar.render2']])
+  expect(ViewletManager.waitForLoadContentLater).toHaveBeenCalledWith('Source Control')
+  expect(Viewlet.getFocusCommands).toHaveBeenCalledWith('Source Control')
+  expect(Viewlet.focus).not.toHaveBeenCalled()
+  expect(result.commands).toEqual([['activity-bar.render2'], ['Viewlet.focusSelector', 12, '[name="SourceControlInput"]']])
 })
 
 test('openSideBarView does not request focus by default', async () => {
@@ -723,6 +726,7 @@ test('openSideBarView does not request focus by default', async () => {
   await ViewletLayout.openSideBarView(state, 'Extensions', false, undefined)
 
   expect(ViewletManager.waitForLoadContentLater).not.toHaveBeenCalled()
+  expect(Viewlet.getFocusCommands).not.toHaveBeenCalled()
   expect(Viewlet.focus).not.toHaveBeenCalled()
 })
 


### PR DESCRIPTION
Ctrl+Shift+G now opens Source Control and focuses its commit input. Request focus from the shortcut and append the focus commands after the view's display commands.

Add an e2e regression for opening from the editor and refocusing an already-open input without losing its text, and run it in PR CI.
