### PR TITLE
fix: close title bar menu on application blur

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,13 @@ jobs:
           npm run e2e:headless --prefix packages/extension-host-worker-tests -- --test-name-prefix=workspace.remote-local-services
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test title bar application blur
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          node --experimental-vm-modules node_modules/jest/bin/jest.js --config packages/renderer-worker/package.json --runInBand --coverage=false --testPathPatterns=ViewletLayoutBlur.test
+          npm run e2e:headless --prefix packages/extension-host-worker-tests -- --test-name-prefix=viewlet.title-bar-menu-close-on-application-blur
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test Codespaces workspace ports
         working-directory: ./packages/extension-host-worker-tests
         run: npm run e2e:headless -- --test-name-prefix=viewlet.ports-codespaces

--- a/packages/extension-host-worker-tests/src/viewlet.title-bar-menu-close-on-application-blur.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.title-bar-menu-close-on-application-blur.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.title-bar-menu-close-on-application-blur'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  const helpMenuItem = Locator('.TitleBarTopLevelEntry', { hasText: 'Help' })
+  const menu = Locator('.Menu')
+  const menuBar = Locator('.TitleBarMenuBar')
+
+  for (let iteration = 0; iteration < 3; iteration++) {
+    await helpMenuItem.click()
+    await expect(menu).toBeVisible()
+    await expect(helpMenuItem).toHaveAttribute('aria-expanded', 'true')
+
+    await Command.execute('Layout.handleBlur')
+    await expect(menu).toBeHidden()
+    await expect(helpMenuItem).toHaveAttribute('aria-expanded', 'false')
+    await expect(helpMenuItem).toHaveAttribute('id', null)
+    await expect(menuBar).toHaveAttribute('aria-activedescendant', null)
+
+    await Command.execute('Layout.handleFocus')
+    await expect(menu).toBeHidden()
+  }
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -2399,7 +2399,11 @@ export const showE2eTests = async (state: LayoutState) => {
   return state
 }
 
-export const handleBlur = (state: LayoutState) => {
+export const handleBlur = async (state: LayoutState) => {
+  const titleBar = ViewletStates.getInstance(LayoutModules.TitleBar.moduleId, state.applicationId)
+  if (titleBar) {
+    await Viewlet.executeViewletCommand(titleBar.state.uid, 'closeMenu', false)
+  }
   return handleFocusChange(state, false)
 }
 

--- a/packages/renderer-worker/test/ViewletLayoutBlur.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutBlur.test.ts
@@ -11,7 +11,9 @@ const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js'
 
 beforeEach(() => {
   ViewletStates.reset()
-  ApplicationRegistry.reset()
+  for (const id of ['first', 'second', 'other', 'current']) {
+    ApplicationRegistry.remove(id)
+  }
   jest.clearAllMocks()
 })
 

--- a/packages/renderer-worker/test/ViewletLayoutBlur.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutBlur.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const executeViewletCommand = jest.fn<(...args: unknown[]) => Promise<void>>()
-const handleFocusChange = jest.fn(() => [])
+const handleFocusChange = jest.fn<(id: string, isFocused: boolean) => unknown[]>(() => [])
 
 jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({ executeViewletCommand, handleFocusChange }))
 

--- a/packages/renderer-worker/test/ViewletLayoutBlur.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutBlur.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const executeViewletCommand = jest.fn<(...args: unknown[]) => Promise<void>>()
+const handleFocusChange = jest.fn(() => [])
+
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({ executeViewletCommand, handleFocusChange }))
+
+const ViewletLayout = await import('../src/parts/ViewletLayout/ViewletLayout.ts')
+const ApplicationRegistry = await import('../src/parts/ApplicationRegistry/ApplicationRegistry.ts')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
+
+beforeEach(() => {
+  ViewletStates.reset()
+  ApplicationRegistry.reset()
+  jest.clearAllMocks()
+})
+
+const addTitleBar = (uid: number, applicationId: string) => {
+  ApplicationRegistry.create({ id: applicationId, layoutUid: uid + 100, workspacePath: '', workspaceUri: '', href: '' })
+  const state = { uid, applicationId }
+  ViewletStates.set(uid, { factory: {}, moduleId: 'TitleBar', renderedState: state, state })
+}
+
+test('application blur closes its title bar menu without retaining focus', async () => {
+  addTitleBar(77, 'first')
+  addTitleBar(88, 'second')
+  const state = { ...ViewletLayout.create(1), applicationId: 'second', focused: true }
+
+  const result = await ViewletLayout.handleBlur(state)
+
+  expect(executeViewletCommand).toHaveBeenCalledTimes(1)
+  expect(executeViewletCommand).toHaveBeenCalledWith(88, 'closeMenu', false)
+  expect(result.newState.focused).toBe(false)
+  expect(handleFocusChange).toHaveBeenCalledWith('TitleBar', false)
+})
+
+test('application blur works without a loaded title bar', async () => {
+  addTitleBar(77, 'other')
+  const state = { ...ViewletLayout.create(1), applicationId: 'current', focused: true }
+
+  const result = await ViewletLayout.handleBlur(state)
+
+  expect(executeViewletCommand).not.toHaveBeenCalled()
+  expect(result.newState.focused).toBe(false)
+})
+
+test('application focus does not close the title bar menu', () => {
+  addTitleBar(77, 'current')
+  const state = { ...ViewletLayout.create(1), applicationId: 'current', focused: false }
+
+  const result = ViewletLayout.handleFocus(state)
+
+  expect(executeViewletCommand).not.toHaveBeenCalled()
+  expect(result.newState.focused).toBe(true)
+})


### PR DESCRIPTION
Close the title bar menu when the application loses focus, clearing the menu highlight without restoring focus. Target the application's loaded title bar and preserve normal menu behavior when focus returns.
