### PR TITLE
fix: refresh git gutters without an active editor

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletEditorText/ViewletEditorTextCommands.js
@@ -153,6 +153,8 @@ const handleColorPickerSliderKeyDown = (editor, ...args) => {
   return executeWidgetCommand(editor, ...args)
 }
 
+const refreshGutterDecorationsAll = Object.assign(() => EditorWorker.invoke('Editor.refreshGutterDecorationsAll'), { requiresInstance: false })
+
 export const getCommands = async () => {
   const commandIds = await EditorWorker.invoke('Editor.getCommandIds')
   Object.assign(Commands, WrapEditorCommands.wrapEditorCommands(commandIds), WrapEditorCommands.wrapEditorCommands(subWidgetCommandIds), {
@@ -162,6 +164,7 @@ export const getCommands = async () => {
     loadContent,
     loadContentLater,
     renderPending,
+    refreshGutterDecorationsAll,
     showOverlayMessage,
     updateDiagnostics,
     hotReload,

--- a/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
+++ b/packages/renderer-worker/src/parts/ViewletManager/ViewletManager.js
@@ -182,6 +182,9 @@ const runFnWithSideEffect = async (instance, id, key, fn, ...args) => {
 const wrapViewletCommand = (id, key, fn) => {
   Assert.string(id)
   Assert.fn(fn)
+  if (fn.requiresInstance === false) {
+    return fn
+  }
   if (fn.targetUid) {
     return async (uid, ...args) => {
       const instance = ViewletStates.getByUid(uid)

--- a/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
+++ b/packages/renderer-worker/test/ViewletEditorTextCommands.test.ts
@@ -424,3 +424,13 @@ test('diagnostic renders after a background reload preserve focus while navigati
   expect((await commands.updateDiagnostics(editor)).commands).toEqual(contentCommands)
   expect((await commands.loadContent(editor)).commands).toEqual([...contentCommands, ...focusCommands])
 })
+
+test('refreshing all gutter decorations does not require or forward an active editor', async () => {
+  editorWorkerInvoke.mockImplementation(async (method) => (method === 'Editor.getCommandIds' ? ['refreshGutterDecorationsAll'] : undefined))
+  const commands = await ViewletEditorTextCommands.getCommands()
+  editorWorkerInvoke.mockClear()
+  expect(commands.refreshGutterDecorationsAll.requiresInstance).toBe(false)
+  await commands.refreshGutterDecorationsAll()
+  expect(editorWorkerInvoke).toHaveBeenCalledTimes(1)
+  expect(editorWorkerInvoke).toHaveBeenCalledWith('Editor.refreshGutterDecorationsAll')
+})

--- a/packages/renderer-worker/test/ViewletManager.test.ts
+++ b/packages/renderer-worker/test/ViewletManager.test.ts
@@ -1436,3 +1436,24 @@ test('functional commands retain concurrent layout flags and compare hooks again
   expect(ViewletStates.getState(94)).toEqual({ ...latest, inputValue: 'typed' })
   expect(afterRender).toHaveBeenCalledWith(latest, { ...latest, inputValue: 'typed' })
 })
+
+test('commands without an instance still run after the last viewlet is disposed', async () => {
+  const refreshAll = Object.assign(
+    jest.fn(async () => {}),
+    { requiresInstance: false },
+  )
+  const factory = {
+    Commands: { refreshAll },
+    create: () => ({ uid: 93 }),
+    loadContent: (state) => state,
+    render: [],
+  }
+  await ViewletManager.load({ getModule: async () => factory, id: 'RefreshAll', uid: 93, type: 0 })
+  await Command.execute('RefreshAll.refreshAll')
+  expect(refreshAll).toHaveBeenLastCalledWith()
+  ViewletStates.remove(93)
+  refreshAll.mockClear()
+  await Command.execute('RefreshAll.refreshAll')
+  expect(refreshAll).toHaveBeenCalledTimes(1)
+  expect(refreshAll).toHaveBeenLastCalledWith()
+})


### PR DESCRIPTION
Git refreshes after closing the last editor logged a missing active Editor instance. Forward the refresh-all command directly to the editor worker, which owns the editor collection and safely handles an empty collection.