### PR TITLE
feature: use numeric extension manifest status

### DIFF
--- a/packages/renderer-worker/src/parts/ExtensionManifestStatus/ExtensionManifestStatus.js
+++ b/packages/renderer-worker/src/parts/ExtensionManifestStatus/ExtensionManifestStatus.js
@@ -1,3 +1,3 @@
-export const Resolved = 'resolved'
+export const Resolved = 1
 
-export const Rejected = 'rejected'
+export const Rejected = 2

--- a/packages/renderer-worker/test/ExtensionMeta.test.ts
+++ b/packages/renderer-worker/test/ExtensionMeta.test.ts
@@ -138,7 +138,7 @@ test('organizeExtensions', () => {
         ],
         name: 'Language Basics CSS',
         path: '/test/builtin.language-basics-css',
-        status: 'resolved',
+        status: ExtensionManifestStatus.Resolved,
       },
     ],
   })

--- a/packages/shared-process/src/parts/ExtensionManifestStatus/ExtensionManifestStatus.ts
+++ b/packages/shared-process/src/parts/ExtensionManifestStatus/ExtensionManifestStatus.ts
@@ -1,3 +1,3 @@
-export const Resolved = 'resolved'
+export const Resolved = 1
 
-export const Rejected = 'rejected'
+export const Rejected = 2


### PR DESCRIPTION
Use numeric Resolved and Rejected constants for extension manifests in the shared process and renderer worker, so extension detail state stores a numeric status. Update the extension classification test to use the same enum.