### PR TITLE
fix: size problems content within the panel

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-edit-problems.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-edit-problems.ts
@@ -10,6 +10,7 @@ export const name = 'viewlet.component-state-edit-problems'
 
 export const test: Test = async ({ Command, Editor, expect, Locator, Main }) => {
   await Command.execute('Layout.showPanel', 'Problems')
+  await expect(Locator('.Problems .Message')).toBeVisible()
   const filter = Locator('.Panel .InputBox')
   await expect(filter).toBeVisible()
   await Command.execute('Developer.openComponentState')

--- a/static/css/parts/ViewletProblems.css
+++ b/static/css/parts/ViewletProblems.css
@@ -1,6 +1,15 @@
 .Problems {
   color: var(--WorkbenchForeground, white);
   flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.ProblemsContent {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  position: relative;
 }
 
 .ProblemList {


### PR DESCRIPTION
Restore the Problems panel flex layout and size its content so strict containment does not collapse messages to zero height. Keep the narrow filter above the content and position the scrollbar relative to the content area.