### PR TITLE
feature: support direct menu worker connections

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -403,6 +403,7 @@ export const commandMap = {
   'SendMessagePortToExtensionHostWorker.sendMessagePortToMarkdownWorker': lazy(
     'SendMessagePortToExtensionHostWorker.sendMessagePortToMarkdownWorker',
   ),
+  'SendMessagePortToExtensionHostWorker.sendMessagePortToMenuWorker': lazy('SendMessagePortToExtensionHostWorker.sendMessagePortToMenuWorker'),
   'SendMessagePortToExtensionHostWorker.sendMessagePortToRendererProcess': lazy(
     'SendMessagePortToExtensionHostWorker.sendMessagePortToRendererProcess',
   ),

--- a/packages/renderer-worker/src/parts/MenuWorker/MenuWorker.js
+++ b/packages/renderer-worker/src/parts/MenuWorker/MenuWorker.js
@@ -1,6 +1,6 @@
 import * as GetOrCreateWorker from '../GetOrCreateWorker/GetOrCreateWorker.js'
 import * as LaunchMenuWorker from '../LaunchMenuWorker/LaunchMenuWorker.js'
 
-const { invoke } = GetOrCreateWorker.getOrCreateWorker(LaunchMenuWorker.launchMenuWorker)
+const { invoke, invokeAndTransfer } = GetOrCreateWorker.getOrCreateWorker(LaunchMenuWorker.launchMenuWorker)
 
-export { invoke }
+export { invoke, invokeAndTransfer }

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -292,5 +292,5 @@ export const sendMessagePortToDiffWorker = async (port, initialCommand, rpcId) =
 
 export const sendMessagePortToMenuWorker = async (port) => {
   Assert.object(port)
-  await MenuWorker.invokeAndTransfer('HandleMessagePort.handleMessagePort', port)
+  await MenuWorker.invokeAndTransfer('Menu.handleMessagePort', port)
 }

--- a/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
+++ b/packages/renderer-worker/src/parts/SendMessagePortToExtensionHostWorker/SendMessagePortToExtensionHostWorker.js
@@ -29,6 +29,7 @@ import * as KeyBindingsViewWorker from '../KeyBindingsViewWorker/KeyBindingsView
 import * as LanguageModelsViewWorker from '../LanguageModelsViewWorker/LanguageModelsViewWorker.js'
 import * as MainAreaWorker from '../MainAreaWorker/MainAreaWorker.js'
 import * as MarkdownWorker from '../MarkdownWorker/MarkdownWorker.js'
+import * as MenuWorker from '../MenuWorker/MenuWorker.js'
 import * as OpenerWorker from '../OpenerWorker/OpenerWorker.js'
 import * as OutputViewWorker from '../OutputViewWorker/OutputViewWorker.js'
 import * as PanelWorker from '../PanelWorker/PanelWorker.js'
@@ -288,3 +289,8 @@ export const sendMessagePortToDiffWorker = async (port, initialCommand, rpcId) =
 }
 
 // TODO add only one function sendMessagePortToRpc(rpcId) which sends it to the matching rpc module
+
+export const sendMessagePortToMenuWorker = async (port) => {
+  Assert.object(port)
+  await MenuWorker.invokeAndTransfer('HandleMessagePort.handleMessagePort', port)
+}

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -53,6 +53,11 @@ jest.unstable_mockModule('../src/parts/WorkspaceConnection/WorkspaceConnection.j
   }
 })
 
+jest.unstable_mockModule('../src/parts/MenuWorker/MenuWorker.js', () => ({
+  invokeAndTransfer: jest.fn(),
+}))
+
+const MenuWorker = await import('../src/parts/MenuWorker/MenuWorker.js')
 const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
 const ExplorerViewWorker = await import('../src/parts/ExplorerViewWorker/ExplorerViewWorker.js')
 const HandleDialogWorkerMessagePort = await import('../src/parts/HandleDialogWorkerMessagePort/HandleDialogWorkerMessagePort.ts')
@@ -154,4 +159,10 @@ test('sendMessagePortToViewWorker rejects unknown workers', async () => {
   await expect(SendMessagePortToExtensionHostWorker.sendMessagePortToViewWorker({}, 'Unknown')).rejects.toThrow(
     'direct view worker not found: Unknown',
   )
+})
+
+test('transfers a port to the menu worker', async () => {
+  const port = {}
+  await SendMessagePortToExtensionHostWorker.sendMessagePortToMenuWorker(port)
+  expect(MenuWorker.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', port)
 })

--- a/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
+++ b/packages/renderer-worker/test/SendMessagePortToExtensionHostWorker.test.ts
@@ -164,5 +164,5 @@ test('sendMessagePortToViewWorker rejects unknown workers', async () => {
 test('transfers a port to the menu worker', async () => {
   const port = {}
   await SendMessagePortToExtensionHostWorker.sendMessagePortToMenuWorker(port)
-  expect(MenuWorker.invokeAndTransfer).toHaveBeenCalledWith('HandleMessagePort.handleMessagePort', port)
+  expect(MenuWorker.invokeAndTransfer).toHaveBeenCalledWith('Menu.handleMessagePort', port)
 })


### PR DESCRIPTION
Allow view workers to connect directly to the menu worker through a transferred message port. This provides the connection needed for component-state context menus.