### PR TITLE
feature: prepare direct context menu worker connections

### DIFF
--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -278,6 +278,7 @@ export const commandMap = {
   'Markdown.renderMarkdown': lazy('Markdown.renderMarkdown'),
   'MeasureTextHeight.measureTextBlockHeight': lazy('MeasureTextHeight.measureTextBlockHeight'),
   'MeasureTextHeight.measureTextHeight': lazy('MeasureTextHeight.measureTextHeight'),
+  'Menu.prepareContextMenu': lazy('Menu.prepareContextMenu'),
   'Menu.focusFirst': lazy('Menu.focusFirst'),
   'Menu.focusIndex': lazy('Menu.focusIndex'),
   'Menu.focusLast': lazy('Menu.focusLast'),

--- a/packages/renderer-worker/src/parts/Menu/Menu.ipc.js
+++ b/packages/renderer-worker/src/parts/Menu/Menu.ipc.js
@@ -4,6 +4,7 @@ import * as Menu from './Menu.js'
 export const name = 'Menu'
 
 export const Commands = {
+  prepareContextMenu: Menu.prepareContextMenu,
   focusFirst: Menu.focusFirst,
   focusIndex: Menu.focusIndex,
   focusLast: Menu.focusLast,

--- a/packages/renderer-worker/src/parts/Menu/Menu.js
+++ b/packages/renderer-worker/src/parts/Menu/Menu.js
@@ -100,3 +100,13 @@ export const resetFocusedIndex = async (menu) => {
 // TODO pageup / pagedown keys
 
 // TODO more tests
+
+export const prepareContextMenu = async (port) => {
+  await SimpleBrowserOverlay.show('menu')
+  try {
+    await MenuWorker.invokeAndTransfer('Menu.handleMessagePort', port)
+  } catch (error) {
+    await SimpleBrowserOverlay.hide('menu')
+    throw error
+  }
+}

--- a/packages/renderer-worker/test/Menu.test.ts
+++ b/packages/renderer-worker/test/Menu.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('../src/parts/MenuWorker/MenuWorker.js', () => ({
   invoke: jest.fn(),
+  invokeAndTransfer: jest.fn(),
 }))
 jest.unstable_mockModule('../src/parts/SimpleBrowserOverlay/SimpleBrowserOverlay.js', () => ({
   hide: jest.fn(),
@@ -54,4 +55,19 @@ test('selectCurrent invokes the menu worker command', async () => {
 
 test('selectCurrent is exported through the menu IPC command map', () => {
   expect(MenuIpc.Commands.selectCurrent).toBe(Menu.selectCurrent)
+})
+
+test('prepareContextMenu connects the menu worker and hides the browser overlay', async () => {
+  const port = {} as MessagePort
+  await Menu.prepareContextMenu(port)
+  expect(SimpleBrowserOverlay.show).toHaveBeenCalledWith('menu')
+  expect(MenuWorker.invokeAndTransfer).toHaveBeenCalledWith('Menu.handleMessagePort', port)
+  expect(MenuIpc.Commands.prepareContextMenu).toBe(Menu.prepareContextMenu)
+})
+
+test('prepareContextMenu restores the browser when connection fails', async () => {
+  // @ts-ignore
+  MenuWorker.invokeAndTransfer.mockRejectedValue(new Error('connection failed'))
+  await expect(Menu.prepareContextMenu({} as MessagePort)).rejects.toThrow('connection failed')
+  expect(SimpleBrowserOverlay.hide).toHaveBeenCalledWith('menu')
 })


### PR DESCRIPTION
Prepare a direct connection to the menu worker for title-bar context menus while preserving Simple Browser overlay handling and restoring it if connection setup fails.