### PR TITLE
fix: keep simple browser new tab button visible

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,6 +103,10 @@ jobs:
           npm run e2e:headless -- --test-name-prefix=session-replay.settings '--initial-settings={"sessionReplay.enabled":true}' '--expect-console=Session replay command recording verified'
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Simple Browser tab overflow
+        run: node scripts/test-simple-browser-tabs.mjs
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test Simple Browser suggestions and new-tab theme
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -56,11 +56,16 @@ export const getSimpleBrowserVirtualDom = (
       className: 'SimpleBrowserTabs',
       role: AriaRoles.TabList,
       ariaLabel: 'Browser tabs',
-      childCount: tabs.length + 1,
+      childCount: 2,
       onDragOver: DomEventListenerFunctions.HandleDragOverSimpleBrowserTabs,
       onDragLeave: DomEventListenerFunctions.HandleDragLeaveSimpleBrowserTab,
       onDrop: DomEventListenerFunctions.HandleDropSimpleBrowserTab,
       onPointerUp: DomEventListenerFunctions.HandlePointerUpSimpleBrowserTab,
+    })
+    dom.push({
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserTabItems',
+      childCount: tabs.length,
     })
     for (let index = 0; index < tabs.length; index++) {
       const tab = tabs[index]

--- a/scripts/test-simple-browser-tabs.mjs
+++ b/scripts/test-simple-browser-tabs.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { getSimpleBrowserVirtualDom } from '../packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js'
+import * as Elements from '../packages/renderer-worker/src/parts/VirtualDomElements/VirtualDomElements.js'
+
+const requireTests = createRequire(new URL('../packages/extension-host-worker-tests/package.json', import.meta.url))
+const { chromium } = requireTests('playwright')
+const css = await readFile(new URL('../static/css/parts/ViewletSimpleBrowser.css', import.meta.url), 'utf8')
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage()
+  for (const count of [1, 6, 12, 40]) {
+    const tabs = Array.from({ length: count }, (_, index) => ({ title: `Long browser tab title ${index}`, favicon: '', isAudioPlaying: true }))
+    const dom = getSimpleBrowserVirtualDom(false, false, false, '', '', [], -1, tabs)
+    await page.setContent('<div id="host" style="display:flex;height:35px"></div>')
+    await page.addStyleTag({ content: css })
+    await page.evaluate(
+      ({ dom, Elements }) => {
+        let index = dom.findIndex((node) => node.className === 'SimpleBrowserTabs')
+        const render = () => {
+          const node = dom[index++]
+          if (node.type === Elements.Text) return document.createTextNode(node.text)
+          const tag = Object.keys(Elements).find((key) => Elements[key] === node.type)
+          const element = document.createElement(tag.toLowerCase())
+          if (node.className) element.className = node.className
+          if (node.ariaLabel) element.setAttribute('aria-label', node.ariaLabel)
+          for (let child = 0; child < node.childCount; child++) element.append(render())
+          return element
+        }
+        const strip = render()
+        strip.style.flex = '1'
+        document.querySelector('#host').append(strip)
+      },
+      { dom, Elements },
+    )
+    for (const width of [1000, 480, 240, 120]) {
+      await page.locator('#host').evaluate((element, width) => {
+        element.style.width = `${width}px`
+      }, width)
+      for (const scroll of [0, 10000]) {
+        await page.locator('.SimpleBrowserTabItems').evaluate((element, scroll) => {
+          element.scrollLeft = scroll
+        }, scroll)
+        const geometry = await page.evaluate(() => {
+          const button = document.querySelector('.SimpleBrowserNewTab')
+          const rect = button.getBoundingClientRect()
+          const strip = document.querySelector('.SimpleBrowserTabs').getBoundingClientRect()
+          const items = document.querySelector('.SimpleBrowserTabItems').getBoundingClientRect()
+          const target = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2)
+          return {
+            width: rect.width,
+            inside: rect.x >= strip.x && rect.right <= strip.right,
+            separate: items.right <= rect.x,
+            hit: button.contains(target),
+          }
+        })
+        assert.equal(geometry.width, 24)
+        assert(geometry.inside && geometry.separate && geometry.hit, JSON.stringify({ count, width, scroll, geometry }))
+        await page.getByRole('button', { name: 'New Tab', exact: true }).click({ timeout: 1000 })
+      }
+    }
+  }
+  console.log('Simple Browser tab layout: 32 crowded/narrow/scrolled cases passed')
+} finally {
+  await browser.close()
+}

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -81,7 +81,7 @@
   display: flex;
   flex: 0 1 180px;
   gap: 6px;
-  min-width: 64px;
+  min-width: 90px;
   padding: 0 5px 0 9px;
 }
 

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -59,8 +59,16 @@
   display: flex;
   flex: 0 0 35px;
   height: 35px;
+  overflow: hidden;
+}
+
+.SimpleBrowserTabItems {
+  display: flex;
+  flex: 0 1 auto;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
+  scrollbar-width: none;
 }
 
 .SimpleBrowserTab {
@@ -73,7 +81,7 @@
   display: flex;
   flex: 0 1 180px;
   gap: 6px;
-  min-width: 90px;
+  min-width: 64px;
   padding: 0 5px 0 9px;
 }
 


### PR DESCRIPTION
Reserve space for the New Tab button outside the scrollable browser tabs. Tabs shrink as the pane fills, then scroll without covering or pushing the button out of view.