### PR TITLE
fix: require matching dependency caches for release builds

### DIFF
--- a/.github/workflows/macos-signing-smoke.yml
+++ b/.github/workflows/macos-signing-smoke.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
-          restore-keys: ${{ runner.os }}-cacheNodeModules-
       - uses: actions/cache@v6
         id: electron-builder-cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-cacheNodeModules-${{ steps.nodeModulesCacheKey.outputs.value }}
-          restore-keys: ${{ runner.os }}-cacheNodeModules-
       - uses: actions/cache@v6
         id: electron-builder-cache
         with:


### PR DESCRIPTION
The Electron 44 release restored an older node_modules cache. Lerna kept the removed Electron 43 installation because the remaining direct dependencies were already satisfied, causing the release’s Electron version check to fail.

Require the complete dependency cache key in release and macOS signing builds, matching PR CI. A changed lockfile now triggers a clean installation instead of restoring stale package trees.
