### PR TITLE
fix: align release targets with Electron 44 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
             { os: macos-26, arch: arm64 },
             { os: ubuntu-24.04, arch: x64 },
             { os: ubuntu-24.04, arch: arm64 },
-            { os: ubuntu-24.04, arch: armhf },
           ]
     runs-on: ${{ matrix.versions.os }}
     timeout-minutes: 80
@@ -108,9 +107,6 @@ jobs:
       - name: Build Electron App (deb, arm64)
         if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'arm64'
         run: npm run build:electron:deb:arm64
-      - name: Build Electron App (deb, armhf)
-        if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'armhf'
-        run: npm run build:electron:deb:armhf
       - name: Configure optional macOS signing
         id: macos-signing
         if: matrix.versions.os == 'macos-26' && matrix.versions.arch == 'arm64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,6 @@ jobs:
             { os: macos-26, arch: arm64 },
             { os: ubuntu-24.04, arch: x64 },
             { os: ubuntu-24.04, arch: arm64 },
-            { os: ubuntu-24.04, arch: armhf },
           ]
     runs-on: ${{ matrix.versions.os }}
     timeout-minutes: 80
@@ -169,28 +168,6 @@ jobs:
       - name: Publish Electron App (deb, arm64) to Cloudsmith
         if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'arm64'
         run: cloudsmith push deb lvce-editor/lvce-editor-2/any-distro/any-version "${{ env.ASSET_DEB_ARM64 }}"
-      - name: Build Electron App (deb, armhf)
-        if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'armhf'
-        run: npm run build:electron:deb:armhf -- --product=lvce
-        env:
-          HIGHEST_COMPRESSION: 1
-      - name: Rename Electron App (deb, armhf)
-        if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'armhf'
-        shell: bash
-        run: |
-          staging="lvce-${{ needs.create-release.outputs.rg_version }}_armhf.deb"
-          mv "packages/build/.tmp/releases/lvce-armhf.deb" "$staging"
-          echo "ASSET_DEB_ARMHF=$staging" >> $GITHUB_ENV
-      - name: Release Electron App (deb, armhf)
-        uses: actions/upload-release-asset@v1.0.1
-        if: matrix.versions.os == 'ubuntu-24.04' && matrix.versions.arch == 'armhf'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET_DEB_ARMHF }}
-          asset_name: ${{ env.ASSET_DEB_ARMHF }}
-          asset_content_type: application/octet-stream
       # - name: Build Electron App (Macos dmg, x64)
       #   if: matrix.versions.os == 'macos-26'
       #   run: npm run build:electron:mac:x64 -- --product=lvce


### PR DESCRIPTION
Electron 44 removed Linux armv7l and Windows ia32 builds. LVCE still schedules an armhf Debian build in main CI and releases, which requests an Electron archive that no longer exists.

Remove the armhf matrix entries and their packaging/upload steps. Keep Linux x64/arm64, Windows x64/arm64, and macOS arm64 releases.

[Electron 44 release notes](https://github.com/electron/electron/releases/tag/v44.0.0)
