### PR TITLE
fix: preserve focus during background viewlet reloads

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.component-state-quick-pick-focus.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.component-state-quick-pick-focus.ts
@@ -20,6 +20,13 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Main, Q
   await Command.execute('QuickPick.showCommands')
   const input = Locator('#QuickPick .InputBox')
   await expect(input).toBeFocused()
+  const editorComponents = await Command.execute('ComponentState.getComponents')
+  const editor = editorComponents.find((component) => component.moduleId === 'Editor' || component.moduleId === 'EditorText')
+  if (!editor) {
+    throw new Error('Expected an editor component')
+  }
+  await Command.execute('Viewlet.reload', editor.uid)
+  await expect(input).toBeFocused()
 
   for (const focusedIndex of [1, 0, 1]) {
     const state = await Command.execute('ComponentState.getState', explorer.uid)

--- a/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
+++ b/packages/renderer-worker/src/parts/Viewlet/Viewlet.js
@@ -2,6 +2,7 @@ import * as Assert from '../Assert/Assert.ts'
 import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.js'
 import * as ElectronBrowserView from '../ElectronBrowserView/ElectronBrowserView.js'
+import * as FilterFocusCommands from '../FilterFocusCommands/FilterFocusCommands.js'
 import * as GlobalEventBus from '../GlobalEventBus/GlobalEventBus.js'
 import * as Id from '../Id/Id.js'
 import * as KeyBindingsState from '../KeyBindingsState/KeyBindingsState.js'
@@ -162,9 +163,9 @@ export const reload = async (id) => {
       commands.push(...contentLoadedCommands)
     }
     ViewletStates.setRenderedState(id, newState)
-    UpdateDynamicFocusContext.updateDynamicFocusContext(commands)
-    if (commands.length > 0) {
-      await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+    const backgroundCommands = FilterFocusCommands.filterFocusCommands(commands)
+    if (backgroundCommands.length > 0) {
+      await RendererProcess.invoke('Viewlet.sendMultiple', backgroundCommands)
     }
     instance.loadContentLaterStarted = false
     instance.loadContentLaterPromise = undefined

--- a/packages/renderer-worker/test/Viewlet.test.ts
+++ b/packages/renderer-worker/test/Viewlet.test.ts
@@ -315,7 +315,7 @@ test('reload restores a viewlet from its current saved state and rerenders it', 
   const saveState = jest.fn(async (_state: typeof oldState) => savedState)
   const dispose = jest.fn(async (_state: typeof oldState) => {})
   const loadContent = jest.fn(async (_state: typeof oldState, _savedState: typeof savedState) => newState)
-  const contentLoaded = jest.fn(async (_state: typeof newState) => [['Viewlet.afterLoad', 2]])
+  const contentLoaded = jest.fn(async (_state: typeof newState) => [['Viewlet.afterLoad', 2], ['Viewlet.focus', 2]])
   const contentLoadedEffects = jest.fn(async (_state: typeof newState) => {})
   ViewletStates.set(2, {
     factory: { contentLoaded, contentLoadedEffects, dispose, loadContent, saveState },
@@ -323,7 +323,11 @@ test('reload restores a viewlet from its current saved state and rerenders it', 
     renderedState: oldState,
     state: oldState,
   })
-  jest.mocked(ViewletManager.render).mockReturnValue([['Viewlet.setDom2', 2, []]])
+  jest.mocked(ViewletManager.render).mockReturnValue([
+    ['Viewlet.setDom2', 2, []],
+    ['Viewlet.send', 2, 'focusSelector', 'textarea'],
+    ['Viewlet.setFocusContext', 2, 1],
+  ])
   jest.mocked(RendererProcess.invoke).mockResolvedValue(undefined)
 
   await Viewlet.reload(2)


### PR DESCRIPTION
A background workspace refresh could reload an editor and move focus away from an open command picker. Filter focus commands from the reload render and its content-loaded commands so background updates preserve the current focus.

The component-state e2e test now forces this reload while the picker is open, reproducing the focus loss before the fix and passing afterward.
