### PR TITLE
feature: run configurable Simple Browser workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,6 +117,9 @@ jobs:
         run: npm run test:simple-browser-new-tab
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test Simple Browser workflows
+        if: matrix.os == 'ubuntu-24.04'
+        run: xvfb-run -a npm run test:simple-browser-workflows
       - name: Test Simple Browser workspace switching
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/documentation/simple-browser-workflows.md
+++ b/documentation/simple-browser-workflows.md
@@ -1,0 +1,36 @@
+# Simple Browser workflows
+
+Define ordered tasks in `settings.json`:
+
+```json
+{
+  "simpleBrowser.workflows": [
+    {
+      "id": "play-soundcloud-music",
+      "tasks": [
+        { "type": "open-simple-browser-tab", "url": "https://soundcloud.com" },
+        { "type": "press-key", "key": "space" },
+        { "type": "press-key", "key": "shift+L" }
+      ]
+    }
+  ]
+}
+```
+
+Invoke a workflow using a `keybindings.json` entry:
+
+```json
+[
+  {
+    "key": "ctrl+shift+s",
+    "command": "SimpleBrowser.executeWorkflow",
+    "args": ["play-soundcloud-music"]
+  }
+]
+```
+
+Workflows run in Electron. Each workflow starts by opening an HTTP(S) page in Simple Browser and waits for its page-load completion before sending native keys. URLs without a scheme use HTTPS. Additional open tasks change the workflow's target to the newly opened page.
+
+Supported keys include letters, digits, Space, Enter, Tab, Escape, Backspace, Delete, arrows, Home, End, PageUp, PageDown, and F1–F24. Combine keys with ctrl, shift, alt, or meta (cmd). Only one workflow runs at a time. Invalid tasks are rejected before opening a page; navigation errors and closing or switching the target tab stop execution.
+
+Page-load completion does not guarantee that a site's asynchronously loaded controls are ready. Login, consent dialogs, and website-specific shortcuts still apply.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "e2e:ci": "node packages/extension-host-worker-tests/src/_all.js --ci",
     "test:simple-browser-new-tab": "node scripts/test-simple-browser-new-tab.mjs",
     "test:simple-browser-workspace": "node scripts/test-simple-browser-workspace.mjs",
-    "test:simple-browser-address": "node scripts/test-simple-browser-address.mjs"
+    "test:simple-browser-address": "node scripts/test-simple-browser-address.mjs",
+    "test:simple-browser-workflows": "node scripts/test-simple-browser-workflows.mjs"
   },
   "keywords": [],
   "author": "",

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -438,6 +438,7 @@ export const commandMap = {
   'SideBar.open': lazy('SideBar.open'),
   'SideBar.openViewlet': lazy('SideBar.openViewlet'),
   'SideBar.show': lazy('SideBar.show'),
+  'SimpleBrowser.executeWorkflow': lazy('SimpleBrowser.executeWorkflow'),
   'SimpleBrowser.acceptSuggestion': lazy('SimpleBrowser.acceptSuggestion'),
   'SimpleBrowser.closeSuggestions': lazy('SimpleBrowser.closeSuggestions'),
   'SimpleBrowser.getDomTree': lazy('SimpleBrowser.getDomTree'),

--- a/packages/renderer-worker/src/parts/Module/Module.js
+++ b/packages/renderer-worker/src/parts/Module/Module.js
@@ -6,6 +6,8 @@ export const load = (moduleId) => {
       return import('../About/About.ipc.js')
     case ModuleId.Ajax:
       return import('../Ajax/Ajax.ipc.js')
+    case ModuleId.SimpleBrowserWorkflow:
+      return import('../SimpleBrowserWorkflow/SimpleBrowserWorkflow.ipc.js')
     case ModuleId.Audio:
       return import('../Audio/Audio.ipc.js')
     case ModuleId.AutoUpdater:

--- a/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
+++ b/packages/renderer-worker/src/parts/ModuleId/ModuleId.js
@@ -119,3 +119,5 @@ export const ExtensionHotReload = 154
 export const RevealInExplorer = 155
 export const ComponentState = 156
 export const Application = 157
+
+export const SimpleBrowserWorkflow = 158

--- a/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
+++ b/packages/renderer-worker/src/parts/ModuleMap/ModuleMap.js
@@ -14,6 +14,9 @@ const getPrefix = (commandId) => {
 }
 
 export const getModuleId = (commandId) => {
+  if (commandId === 'SimpleBrowser.executeWorkflow') {
+    return ModuleId.SimpleBrowserWorkflow
+  }
   const prefix = getPrefix(commandId)
   if (!prefix) {
     throw new CommandNotFoundError(commandId)

--- a/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.ipc.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.ipc.js
@@ -1,0 +1,5 @@
+export const name = 'SimpleBrowser'
+
+import { executeWorkflow } from './SimpleBrowserWorkflow.js'
+
+export const Commands = { executeWorkflow }

--- a/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js
@@ -1,0 +1,40 @@
+import * as Command from '../Command/Command.js'
+import * as EmbedsWorker from '../EmbedsWorker/EmbedsWorker.js'
+import * as Preferences from '../Preferences/Preferences.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import { validateWorkflow } from './ValidateWorkflow.js'
+
+let running = false
+
+export const executeWorkflow = async (id) => {
+  const tasks = validateWorkflow(Preferences.get('simpleBrowser.workflows'), id)
+  if (running) {
+    throw new Error('A Simple Browser workflow is already running')
+  }
+  running = true
+  try {
+    let instance
+    let browserViewId
+    for (const task of tasks) {
+      if (task.type === 'open-simple-browser-tab') {
+        await Command.execute('Layout.showPreview', 'simple-browser://')
+        await Command.execute('SimpleBrowser.createNewTab')
+        instance = ViewletStates.getInstance('SimpleBrowser')
+        browserViewId = instance?.state.browserViewId
+        if (!browserViewId) {
+          throw new Error('Simple Browser requires an Electron browser tab')
+        }
+        await EmbedsWorker.invoke('ElectronWebContentsView.navigate', browserViewId, task.url)
+      } else {
+        if (ViewletStates.getByUid(instance.state.uid) !== instance || instance.state.browserViewId !== browserViewId) {
+          throw new Error('The workflow browser tab was closed or changed')
+        }
+        await EmbedsWorker.invoke('ElectronWebContentsView.pressKey', browserViewId, task.keyCode, task.modifiers)
+      }
+    }
+  } finally {
+    running = false
+  }
+}
+
+executeWorkflow.requiresInstance = false

--- a/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/ValidateWorkflow.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/ValidateWorkflow.js
@@ -1,0 +1,62 @@
+const characterKey = /^[a-z0-9]$/
+const functionKey = /^f([1-9]|1[0-9]|2[0-4])$/
+const modifierNames = { alt: 'alt', cmd: 'meta', command: 'meta', control: 'control', ctrl: 'control', meta: 'meta', shift: 'shift' }
+const keyNames = {
+  space: 'Space',
+  enter: 'Enter',
+  tab: 'Tab',
+  escape: 'Escape',
+  esc: 'Escape',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  up: 'Up',
+  down: 'Down',
+  left: 'Left',
+  right: 'Right',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+}
+
+export const validateWorkflow = (workflows, id) => {
+  if (typeof id !== 'string' || !id || !Array.isArray(workflows)) {
+    throw new Error('Define simpleBrowser.workflows and supply a workflow id')
+  }
+  const matches = workflows.filter((workflow) => workflow?.id === id)
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one Simple Browser workflow with id ${id}`)
+  }
+  const { tasks } = matches[0]
+  if (!Array.isArray(tasks) || tasks.length === 0 || tasks[0]?.type !== 'open-simple-browser-tab') {
+    throw new Error('A workflow must start with an open-simple-browser-tab task')
+  }
+  return tasks.map((task) => {
+    if (task?.type === 'open-simple-browser-tab') {
+      if (typeof task.url !== 'string' || !task.url.trim()) {
+        throw new Error('An open-simple-browser-tab task requires a URL')
+      }
+      const url = new URL(task.url.includes('://') ? task.url : `https://${task.url}`)
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error('Workflow URLs must use HTTP or HTTPS')
+      }
+      return { type: task.type, url: url.href }
+    }
+    if (task?.type !== 'press-key' || typeof task.key !== 'string') {
+      throw new Error('Unknown or invalid Simple Browser workflow task')
+    }
+    const parts = task.key.toLowerCase().split('+')
+    const key = parts.pop()
+    const modifiers = parts.map((modifier) => {
+      if (!Object.hasOwn(modifierNames, modifier)) {
+        throw new Error(`Unknown key modifier: ${modifier}`)
+      }
+      return modifierNames[modifier]
+    })
+    const keyCode = Object.hasOwn(keyNames, key) ? keyNames[key] : characterKey.test(key) || functionKey.test(key) ? key.toUpperCase() : undefined
+    if (!keyCode) {
+      throw new Error(`Unsupported workflow key: ${task.key}`)
+    }
+    return { type: task.type, keyCode, modifiers }
+  })
+}

--- a/packages/renderer-worker/src/parts/UserKeyBindings/UserKeyBindings.js
+++ b/packages/renderer-worker/src/parts/UserKeyBindings/UserKeyBindings.js
@@ -1,3 +1,4 @@
+import { parseKeyBindingString } from '../ParseKeyBindingString/ParseKeyBindingString.js'
 import * as FileSystem from '../FileSystem/FileSystem.js'
 
 const isValidUserKeyBinding = (keyBinding) => {
@@ -20,7 +21,14 @@ export const getKeyBindings = async () => {
     if (!Array.isArray(parsed)) {
       return []
     }
-    return parsed.filter(isValidUserKeyBinding)
+    return parsed
+      .map((entry) => {
+        if (typeof entry?.key !== 'string') return entry
+        const key = parseKeyBindingString(entry.key)
+        if (!key) return undefined
+        return { ...entry, key, source: entry.source ?? 'User' }
+      })
+      .filter(isValidUserKeyBinding)
   } catch {
     return []
   }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -1,3 +1,4 @@
+import { executeWorkflow } from '../SimpleBrowserWorkflow/SimpleBrowserWorkflow.js'
 import * as ContextMenuAction from './ViewletSimpleBrowserContextMenuAction.js'
 import * as SimpleBrowser from './ViewletSimpleBrowser.js'
 import * as ViewletSimpleBrowserGetDomTree from './ViewletSimpleBrowserGetDomTree.js'
@@ -8,6 +9,7 @@ import * as ViewletSimpleBrowserInsertJavaScript from './ViewletSimpleBrowserIns
 import * as TabDrag from './ViewletSimpleBrowserTabDrag.js'
 
 export const Commands = {
+  executeWorkflow,
   handleBrowserViewDestroyed: SimpleBrowser.handleBrowserViewDestroyed,
   handleWindowOpen: SimpleBrowser.handleWindowOpen,
   handleContextMenuAction: ContextMenuAction.handleContextMenuAction,

--- a/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/Command/Command.js', () => ({ execute: jest.fn() }))
+jest.unstable_mockModule('../src/parts/EmbedsWorker/EmbedsWorker.js', () => ({ invoke: jest.fn() }))
+jest.unstable_mockModule('../src/parts/Preferences/Preferences.js', () => ({ get: jest.fn() }))
+jest.unstable_mockModule('../src/parts/ViewletStates/ViewletStates.js', () => ({ getInstance: jest.fn(), getByUid: jest.fn() }))
+
+const Command = await import('../src/parts/Command/Command.js')
+const EmbedsWorker = await import('../src/parts/EmbedsWorker/EmbedsWorker.js')
+const Preferences = await import('../src/parts/Preferences/Preferences.js')
+const ViewletStates = await import('../src/parts/ViewletStates/ViewletStates.js')
+const { executeWorkflow } = await import('../src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js')
+const { validateWorkflow } = await import('../src/parts/SimpleBrowserWorkflow/ValidateWorkflow.js')
+
+const workflows = [
+  {
+    id: 'music',
+    tasks: [
+      { type: 'open-simple-browser-tab', url: 'example.com' },
+      { type: 'press-key', key: 'space' },
+      { type: 'press-key', key: 'shift+L' },
+    ],
+  },
+]
+const instance = { renderedState: { uid: 7 }, state: { uid: 7, browserViewId: 42 } }
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(Preferences.get).mockReturnValue(workflows)
+  jest.mocked(ViewletStates.getInstance).mockReturnValue(instance)
+  jest.mocked(ViewletStates.getByUid).mockReturnValue(instance)
+})
+
+test('normalizes URLs and keys without changing settings', () => {
+  expect(validateWorkflow(workflows, 'music')).toEqual([
+    { type: 'open-simple-browser-tab', url: 'https://example.com/' },
+    { type: 'press-key', keyCode: 'Space', modifiers: [] },
+    { type: 'press-key', keyCode: 'L', modifiers: ['shift'] },
+  ])
+  expect(workflows[0].tasks[0].url).toBe('example.com')
+})
+
+test.each([
+  undefined,
+  [],
+  [...workflows, ...workflows],
+  [{ id: 'music', tasks: [] }],
+  [{ id: 'music', tasks: [{ type: 'press-key', key: 'space' }] }],
+  [{ id: 'music', tasks: [{ type: 'open-simple-browser-tab', url: 'file:///tmp/file' }] }],
+  [{ id: 'music', tasks: [...workflows[0].tasks, { type: 'press-key', key: 'invalid+L' }] }],
+  [{ id: 'music', tasks: [...workflows[0].tasks, { type: 'press-key', key: 'unknown' }] }],
+  [{ id: 'music', tasks: [...workflows[0].tasks, { type: 'unknown' }] }],
+])('rejects invalid workflows before opening a browser: %j', async (value) => {
+  jest.mocked(Preferences.get).mockReturnValue(value)
+  await expect(executeWorkflow('music')).rejects.toThrow()
+  expect(Command.execute).not.toHaveBeenCalled()
+})
+
+test('waits for navigation before sending sequential keys', async () => {
+  let finishLoad: () => void = () => {}
+  jest.mocked(EmbedsWorker.invoke).mockImplementationOnce(
+    () =>
+      new Promise<void>((resolve) => {
+        finishLoad = resolve
+      }),
+  )
+  const run = executeWorkflow('music')
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(EmbedsWorker.invoke).toHaveBeenCalledWith('ElectronWebContentsView.navigate', 42, 'https://example.com/')
+  await expect(executeWorkflow('music')).rejects.toThrow('already running')
+  finishLoad()
+  await run
+  expect(ViewletStates.getByUid).toHaveBeenCalledWith(7)
+  expect(jest.mocked(EmbedsWorker.invoke).mock.calls).toEqual([
+    ['ElectronWebContentsView.navigate', 42, 'https://example.com/'],
+    ['ElectronWebContentsView.pressKey', 42, 'Space', []],
+    ['ElectronWebContentsView.pressKey', 42, 'L', ['shift']],
+  ])
+})
+
+test('stops after navigation failure and allows another invocation', async () => {
+  jest.mocked(EmbedsWorker.invoke).mockRejectedValueOnce(new Error('load failed'))
+  await expect(executeWorkflow('music')).rejects.toThrow('load failed')
+  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(1)
+  await expect(executeWorkflow('music')).resolves.toBeUndefined()
+})
+
+test('does not send keys after the browser tab is closed', async () => {
+  jest.mocked(ViewletStates.getByUid).mockReturnValue(undefined)
+  await expect(executeWorkflow('music')).rejects.toThrow('closed or changed')
+  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(1)
+})

--- a/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
@@ -57,19 +57,18 @@ test.each([
 })
 
 test('waits for navigation before sending sequential keys', async () => {
-  let finishLoad: () => void = () => {}
-  jest.mocked(EmbedsWorker.invoke).mockImplementationOnce(
-    () =>
-      new Promise<void>((resolve) => {
-        finishLoad = resolve
-      }),
-  )
+  const loaded = Promise.withResolvers<void>()
+  const started = Promise.withResolvers<void>()
+  jest.mocked(EmbedsWorker.invoke).mockImplementationOnce(() => {
+    started.resolve()
+    return loaded.promise
+  })
   const run = executeWorkflow('music')
-  for (let i = 0; i < 5; i++) await Promise.resolve()
+  await started.promise
   expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(1)
   expect(EmbedsWorker.invoke).toHaveBeenCalledWith('ElectronWebContentsView.navigate', 42, 'https://example.com/')
   await expect(executeWorkflow('music')).rejects.toThrow('already running')
-  finishLoad()
+  loaded.resolve()
   await run
   expect(ViewletStates.getByUid).toHaveBeenCalledWith(7)
   expect(jest.mocked(EmbedsWorker.invoke).mock.calls).toEqual([

--- a/packages/renderer-worker/test/UserKeyBindings.test.ts
+++ b/packages/renderer-worker/test/UserKeyBindings.test.ts
@@ -13,13 +13,15 @@ beforeEach(() => {
 
 test('getKeyBindings loads valid user entries from persisted keybindings', async () => {
   const userKeyBinding = { command: 'Explorer.focusNext', key: 29, when: 13, source: 'User' }
-  jest.mocked(FileSystem.readFile).mockResolvedValue(
-    JSON.stringify([
-      { command: 'Explorer.focusNext', key: 16, when: 13, source: 'System' },
-      userKeyBinding,
-      { command: '', key: 30, source: 'User' },
-    ]),
-  )
+  jest
+    .mocked(FileSystem.readFile)
+    .mockResolvedValue(
+      JSON.stringify([
+        { command: 'Explorer.focusNext', key: 16, when: 13, source: 'System' },
+        userKeyBinding,
+        { command: '', key: 30, source: 'User' },
+      ]),
+    )
 
   await expect(UserKeyBindings.getKeyBindings()).resolves.toEqual([userKeyBinding])
   expect(FileSystem.readFile).toHaveBeenCalledWith('app://keybindings.json')
@@ -35,4 +37,16 @@ test('getKeyBindings ignores read errors', async () => {
   jest.mocked(FileSystem.readFile).mockRejectedValue(new Error('EACCES'))
 
   await expect(UserKeyBindings.getKeyBindings()).resolves.toEqual([])
+})
+
+test('accepts readable workflow shortcuts and preserves command arguments', async () => {
+  jest.mocked(FileSystem.readFile).mockResolvedValue(
+    JSON.stringify([
+      { key: 'ctrl+shift+s', command: 'SimpleBrowser.executeWorkflow', args: ['music'] },
+      { key: 'unknown', command: 'SimpleBrowser.executeWorkflow' },
+    ]),
+  )
+  await expect(UserKeyBindings.getKeyBindings()).resolves.toEqual([
+    { key: 3119, source: 'User', command: 'SimpleBrowser.executeWorkflow', args: ['music'] },
+  ])
 })

--- a/scripts/test-simple-browser-workflows.mjs
+++ b/scripts/test-simple-browser-workflows.mjs
@@ -1,4 +1,3 @@
-import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import { createRequire } from 'node:module'
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'

--- a/scripts/test-simple-browser-workflows.mjs
+++ b/scripts/test-simple-browser-workflows.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { createRequire } from 'node:module'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireTests = createRequire(join(root, 'packages/extension-host-worker-tests/package.json'))
+const requireBuild = createRequire(join(root, 'packages/build/package.json'))
+const { _electron } = requireTests('playwright')
+const { expect } = requireTests('@playwright/test')
+const { build } = requireBuild('esbuild')
+const profile = await mkdtemp(join(tmpdir(), 'lvce-browser-workflows-'))
+const server = createServer((_request, response) => {
+  response.setHeader('Content-Type', 'text/html')
+  response.end(
+    '<!doctype html><title>Workflow fixture</title><link rel="icon" href="data:,"><h1>Workflow fixture</h1><script>window.keys=[];addEventListener("keydown",e=>keys.push({key:e.key,shift:e.shiftKey,trusted:e.isTrusted}))</script>',
+  )
+})
+await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen))
+const url = `http://127.0.0.1:${server.address().port}/workflow`
+await mkdir(join(profile, 'config/lvce-oss'), { recursive: true })
+await writeFile(
+  join(profile, 'config/lvce-oss/settings.json'),
+  JSON.stringify({
+    'simpleBrowser.workflows': [
+      {
+        id: 'fixture',
+        tasks: [
+          { type: 'open-simple-browser-tab', url },
+          { type: 'press-key', key: 'space' },
+          { type: 'press-key', key: 'shift+L' },
+          { type: 'open-simple-browser-tab', url: `${url}/second` },
+          { type: 'press-key', key: 'enter' },
+        ],
+      },
+    ],
+  }),
+)
+await writeFile(
+  join(profile, 'config/lvce-oss/keybindings.json'),
+  JSON.stringify([{ key: 'ctrl+shift+s', command: 'SimpleBrowser.executeWorkflow', args: ['fixture'] }]),
+)
+const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js')
+const rendererSource = await readFile(rendererPath, 'utf8')
+const bundleUrl = '/packages/renderer-worker/dist/browserWorkflowTestMain.js'
+await build({
+  entryPoints: [join(root, 'packages/renderer-worker/src/rendererWorkerMain.ts')],
+  outfile: join(root, bundleUrl),
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  external: ['node:*', '/static/*', 'electron'],
+  logLevel: 'error',
+})
+let app
+try {
+  await writeFile(rendererPath, rendererSource.replace('/packages/renderer-worker/src/rendererWorkerMain.ts', bundleUrl))
+  const env = { ...process.env, DEV: '1', LVCE_ROOT: root, LVCE_SHARED_PROCESS_PATH: join(root, 'packages/shared-process/src/sharedProcessMain.ts') }
+  delete env.ELECTRON_RUN_AS_NODE
+  for (const key of ['CONFIG', 'DATA', 'STATE', 'CACHE']) env[`XDG_${key}_HOME`] = join(profile, key.toLowerCase())
+  app = await _electron.launch({
+    executablePath: join(root, 'packages/main-process/node_modules/electron/dist/electron'),
+    args: ['--no-sandbox', '--disable-http-cache', '.', profile],
+    cwd: join(root, 'packages/main-process'),
+    env,
+    timeout: 60000,
+  })
+  await app.evaluate(({ session, net }) => {
+    session.defaultSession.protocol.handle('https', (request) => {
+      if (request.url === 'https://example.com/') {
+        return new Response('<title>Example Domain</title>', { headers: { 'Content-Type': 'text/html' } })
+      }
+      return net.fetch(request.url, { bypassCustomProtocolHandlers: true })
+    })
+  })
+  const page = await app.firstWindow()
+  page.on('console', (message) => {
+    if (message.type() === 'error') console.error(message.text())
+  })
+  await expect(page.locator('#Workbench')).toBeVisible({ timeout: 30000 })
+  await page.keyboard.press('Control+Shift+s')
+  const getKeys = (targetUrl = url) =>
+    app.evaluate(async ({ webContents }, url) => {
+      const guest = webContents.getAllWebContents().find((item) => item.getURL() === url)
+      return guest ? guest.executeJavaScript('window.keys') : undefined
+    }, targetUrl)
+  await expect.poll(getKeys, { timeout: 30000 }).toEqual([
+    { key: ' ', shift: false, trusted: true },
+    { key: 'L', shift: true, trusted: true },
+  ])
+  await expect.poll(() => getKeys(`${url}/second`), { timeout: 30000 }).toEqual([{ key: 'Enter', shift: false, trusted: true }])
+  await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Workflow fixture')
+  console.log('Workflow shortcut opened a browser and delivered sequential trusted Space and Shift+L events')
+} finally {
+  await app?.close()
+  await writeFile(rendererPath, rendererSource)
+  await new Promise((resolveClose) => server.close(resolveClose))
+  await rm(profile, { recursive: true, force: true })
+}


### PR DESCRIPTION
Add `simpleBrowser.workflows` settings and `SimpleBrowser.executeWorkflow` so a keyboard shortcut can open a page, wait for loading, and send native keys in order. Validate tasks before running and stop on navigation failures or a closed or changed target tab.

Support readable user shortcuts such as `ctrl+shift+s` and document a SoundCloud workflow example.
