### PR TITLE
fix: hide panel when the last terminal is trashed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Test integrated terminal rendering
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests
-        run: npm run e2e:headless -- --test-name-prefix=viewlet.terminal-xterm
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.terminal-
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test error dialog and notification rendering

--- a/packages/extension-host-worker-tests/src/viewlet.terminal-panel-actions.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-panel-actions.ts
@@ -23,10 +23,9 @@ export const test: Test = async (api) => {
   await runCommand('echo first-terminal')
   await api.expect(terminals).toContainText('first-terminal')
 
-  await api.Locator('.TitleBarTopLevelEntry[aria-label="More ..."]').click()
-  await api.Locator('#Menu-0 .MenuItem', { hasText: 'Terminal' }).hover()
-  await api.expect(api.Locator('#Menu-1')).toBeVisible()
-  await api.Locator('#Menu-1 .MenuItem', { hasText: 'New Terminal' }).click()
+  await api.Locator('.TitleBarTopLevelEntry', { hasText: 'Terminal' }).click()
+  await api.expect(api.Locator('#Menu-0')).toBeVisible()
+  await api.Locator('#Menu-0 .MenuItem', { hasText: 'New Terminal' }).click()
   await api.expect(api.Locator('.TerminalTab')).toHaveCount(2)
   await api.expect(api.Locator('.TerminalTabLabel').nth(0)).toHaveText('bash')
   await api.expect(api.Locator('.TerminalTabLabel').nth(1)).toHaveText('bash')
@@ -34,7 +33,7 @@ export const test: Test = async (api) => {
   await api.expect(terminals).toHaveCount(1)
   await api.expect(terminals.locator('.xterm-helper-textarea')).toBeFocused()
 
-  await api.Locator('#Panel .IconButton[title="New Terminal"]').click()
+  await api.Locator('.Panel .IconButton[title="New Terminal"]').click()
   await api.expect(api.Locator('.TerminalTab')).toHaveCount(3)
   await api.expect(terminals).toHaveCount(1)
   await runCommand('echo left-terminal')
@@ -49,7 +48,9 @@ export const test: Test = async (api) => {
   await api.expect(terminals.locator('.xterm-helper-textarea')).toBeFocused()
 
   const thirdTerminalTab = api.Locator('.TerminalTab').nth(2)
-  await thirdTerminalTab.hover()
+  // Synthetic hover events do not activate CSS :hover; focus the keyboard-accessible action instead.
+  const { uid: terminalsUid } = await api.ComponentState.getComponent('Terminals')
+  await api.Command.execute('Viewlet.focusSelector', terminalsUid, '.TerminalTab:nth-child(3) .TerminalTabKill')
   const killThirdTerminal = thirdTerminalTab.locator('.TerminalTabKill')
   await api.expect(killThirdTerminal).toHaveCSS('opacity', '1')
   await killThirdTerminal.click()
@@ -63,22 +64,22 @@ export const test: Test = async (api) => {
   await api.Locator('.TerminalTab').nth(1).click()
   await api.expect(terminals).toContainText('previous-terminal')
 
-  await api.Locator('#Panel .IconButton[title="Split Terminal"]').click()
+  await api.Locator('.Panel .IconButton[title="Split Terminal"]').click()
   await api.expect(terminals).toHaveCount(2)
   await runCommand('echo right-terminal')
   await api.expect(terminals.nth(1)).toContainText('right-terminal')
 
   await terminals.nth(0).click()
   await api.expect(terminals.nth(0).locator('.xterm-helper-textarea')).toBeFocused()
-  await api.Locator('#Panel .IconButton[title="Kill Terminal"]').click()
+  await api.Locator('.Panel .IconButton[title="Kill Terminal"]').click()
   await api.expect(terminals).toHaveCount(1)
   await api.expect(terminals).toContainText('right-terminal')
 
-  await api.Locator('#Panel .IconButton[title="Kill Terminal"]').click()
+  await api.Locator('.Panel .IconButton[title="Kill Terminal"]').click()
   await api.expect(terminals).toHaveCount(1)
   await api.expect(terminals).toContainText('first-terminal')
-  await api.Locator('#Panel .IconButton[title="Kill Terminal"]').click()
-  await api.expect(api.Locator('#Panel')).toHaveCount(0)
+  await api.Locator('.Panel .IconButton[title="Kill Terminal"]').click()
+  await api.expect(api.Locator('.Panel')).toHaveCount(0)
   await api.expect(terminals).toHaveCount(0)
 
   await api.Command.execute('Layout.showPanel', 'Terminals')

--- a/packages/extension-host-worker-tests/src/viewlet.terminal-panel-actions.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-panel-actions.ts
@@ -73,4 +73,17 @@ export const test: Test = async (api) => {
   await api.Locator('#Panel .IconButton[title="Kill Terminal"]').click()
   await api.expect(terminals).toHaveCount(1)
   await api.expect(terminals).toContainText('right-terminal')
+
+  await api.Locator('#Panel .IconButton[title="Kill Terminal"]').click()
+  await api.expect(terminals).toHaveCount(1)
+  await api.expect(terminals).toContainText('first-terminal')
+  await api.Locator('#Panel .IconButton[title="Kill Terminal"]').click()
+  await api.expect(api.Locator('#Panel')).toHaveCount(0)
+  await api.expect(terminals).toHaveCount(0)
+
+  await api.Command.execute('Layout.showPanel', 'Terminals')
+  await api.expect(terminals).toHaveCount(1)
+  await api.expect(terminals.locator('.xterm-helper-textarea')).toBeFocused()
+  await runCommand('echo reopened-terminal')
+  await api.expect(terminals).toContainText('reopened-terminal')
 }

--- a/packages/extension-host-worker-tests/src/viewlet.terminal-panel-persistence.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-panel-persistence.ts
@@ -10,11 +10,14 @@ export const test: Test = async ({ Command, KeyBoard, Locator, Settings, expect 
   await Command.execute('Layout.showPanel', 'Terminals')
   const terminal = Locator('.XtermTerminal')
   await expect(terminal).toBeVisible()
+  await terminal.click()
+  await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
 
   for (const character of 'touch persistent-terminal.txt') {
     await KeyBoard.press(character === ' ' ? 'Space' : character)
   }
   await KeyBoard.press('Enter')
+  await expect(terminal.locator('.xterm-rows')).toContainText('persistent-terminal.txt$')
   await KeyBoard.press('l')
   await KeyBoard.press('s')
   await KeyBoard.press('Enter')
@@ -26,6 +29,8 @@ export const test: Test = async ({ Command, KeyBoard, Locator, Settings, expect 
   await Command.execute('Layout.showPanel', 'Terminals')
   const reopenedTerminal = Locator('.XtermTerminal')
   await expect(reopenedTerminal).toBeVisible()
+  await reopenedTerminal.click()
+  await expect(reopenedTerminal.locator('.xterm-helper-textarea')).toBeFocused()
   await expect(reopenedTerminal).toContainText('ls')
   await expect(reopenedTerminal).toContainText('persistent-terminal.txt')
 

--- a/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js
@@ -18,7 +18,7 @@ export const executeWorkflow = async (id) => {
     for (const task of tasks) {
       if (task.type === 'open-simple-browser-tab') {
         await Command.execute('Layout.showPreview', 'simple-browser://')
-        await Command.execute('SimpleBrowser.createNewTab')
+        await Command.execute('SimpleBrowser.createNewTab', false)
         instance = ViewletStates.getInstance('SimpleBrowser')
         browserViewId = instance?.state.browserViewId
         if (!browserViewId) {

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -459,13 +459,16 @@ const switchToTab = async (state, initialTabs, selectedTabIndex) => {
   return activateTab(state, tabs, selectedTabIndex)
 }
 
-export const createNewTab = async (state) => {
+export const createNewTab = async (state, focusAddress = true) => {
   if (!state.tabsEnabled) {
     return state
   }
   const currentState = state.hasSuggestionsOverlay ? await closeSuggestions(state) : state
   const tab = await createEmptyTab(currentState)
   const newState = await switchToTab(currentState, [...currentState.tabs, tab], currentState.tabs.length)
+  if (!focusAddress) {
+    return newState
+  }
   await ElectronWindow.focus()
   return { ...newState, focusAddressVersion: newState.focusAddressVersion + 1 }
 }

--- a/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
+++ b/packages/renderer-worker/src/parts/ViewletTerminals/ViewletTerminals.js
@@ -302,8 +302,21 @@ export const handleTerminalExit = (state, terminalUid) => {
   return removeTerminal(state, terminalUid)
 }
 
-export const killTerminal = (state) => {
-  return removeTerminal(state, state.childUid)
+export const killTerminal = async (state) => {
+  const newState = await removeTerminal(state, state.childUid)
+  if (newState === state) {
+    return state
+  }
+  return {
+    ...newState,
+    hidePanel: newState.tabs.length === 0,
+  }
+}
+
+export const afterRender = async (oldState, newState) => {
+  if (newState.hidePanel && oldState.tabs.length > 0 && newState.tabs.length === 0) {
+    await Command.execute('Layout.hidePanel')
+  }
 }
 
 export const handleClickTab = (state, index) => {
@@ -328,6 +341,7 @@ export const killTerminalTab = async (state, index) => {
     activeTerminalUids,
     childUid,
     childUids,
+    hidePanel: tabs.length === 0,
     focusVersion: childUid === -1 ? focusVersion : focusVersion + 1,
     selectedIndex,
     tabs,

--- a/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
@@ -78,6 +78,11 @@ test('waits for navigation before sending sequential keys', async () => {
   ])
 })
 
+test('opens workflow tabs without requesting address focus', async () => {
+  await executeWorkflow('music')
+  expect(Command.execute).toHaveBeenCalledWith('SimpleBrowser.createNewTab', false)
+})
+
 test('stops after navigation failure and allows another invocation', async () => {
   jest.mocked(EmbedsWorker.invoke).mockRejectedValueOnce(new Error('load failed'))
   await expect(executeWorkflow('music')).rejects.toThrow('load failed')

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -531,6 +531,20 @@ test('creates and selects an empty tab while keeping the original view alive', a
   expect(ElectronWindow.focus).toHaveBeenCalledTimes(1)
 })
 
+test('workflow tab creation preserves page focus without scheduling address focus', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(13)
+  // @ts-ignore
+  ElectronWebContentsViewFunctions.getStats.mockResolvedValue({ title: 'New Tab' })
+  const state = { ...createTwoTabState(), focusAddressVersion: 3 }
+
+  const newState = await ViewletSimpleBrowser.createNewTab(state, false)
+
+  expect(newState.focusAddressVersion).toBe(3)
+  expect(ElectronWindow.focus).not.toHaveBeenCalled()
+  expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(13)
+})
+
 test('updates open new tab pages when the color theme changes', async () => {
   ColorTheme.state.colorThemeCss = ':root { --EditorBackground: #193549; --InputBoxBackground: #15232d; }'
   // @ts-ignore

--- a/packages/renderer-worker/test/ViewletTerminals.test.ts
+++ b/packages/renderer-worker/test/ViewletTerminals.test.ts
@@ -642,3 +642,27 @@ test('focus does nothing when there are no terminal instances', () => {
   expect(ViewletTerminals.focus(state)).toBe(state)
   expect(focusSetFocus).not.toHaveBeenCalled()
 })
+
+test.each(['killTerminal', 'killTerminalTab'])('%s hides the panel after rendering the final terminal removal', async (command) => {
+  const state = createLoadedState()
+  const newState = await ViewletTerminals[command](state, 0)
+  expect(newState.tabs).toEqual([])
+  expect(commandExecute).not.toHaveBeenCalled()
+  await ViewletTerminals.afterRender(state, newState)
+  expect(commandExecute).toHaveBeenCalledWith('Layout.hidePanel')
+})
+
+test('afterRender keeps the panel open while terminals remain', async () => {
+  const state = createLoadedState()
+  const splitState = { ...state, childUids: [41, 42], tabs: [{ ...state.tabs[0], terminalUids: [41, 42] }] }
+  const newState = await ViewletTerminals.killTerminal(splitState)
+  await ViewletTerminals.afterRender(splitState, newState)
+  expect(commandExecute).not.toHaveBeenCalled()
+})
+
+test('afterRender does not hide the panel for a terminal exit', async () => {
+  const state = createLoadedState()
+  const newState = await ViewletTerminals.handleTerminalExit(state, 41)
+  await ViewletTerminals.afterRender(state, newState)
+  expect(commandExecute).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Hide the panel after the last terminal is removed using a trash action. Keep it open while other terminals remain, and create a fresh terminal when the panel is reopened.