### PR TITLE
fix: serialize simple browser overlay transitions

### DIFF
--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -36,6 +36,9 @@ import * as WhenExpression from '../WhenExpression/WhenExpression.js'
 import * as BrowserFind from './ViewletSimpleBrowserFind.js'
 import * as TabDrag from './ViewletSimpleBrowserTabDrag.js'
 
+// Overlay snapshots and native visibility must commit together before the next command.
+export const serializeCommands = true
+
 const navigationHeaderHeight = 30
 const tabsHeaderHeight = 35
 const closeTabKeyBinding = KeyModifier.CtrlCmd | KeyCode.KeyW
@@ -838,7 +841,8 @@ export const afterRender = async (oldState, newState) => {
     }
   }
   if (oldState.suggestionSessionId !== newState.suggestionSessionId && newState.suggestionSessionId) {
-    await Viewlet.executeViewletCommand(
+    // Queue the follow-up without waiting on the command that is currently rendering.
+    void Viewlet.executeViewletCommand(
       newState.uid,
       'applySuggestions',
       newState.uid,
@@ -846,7 +850,9 @@ export const afterRender = async (oldState, newState) => {
       [],
       getLocalSuggestions(newState, newState.inputValue),
       newState.suggestionSessionId,
-    )
+    ).catch((error) => {
+      console.error('[renderer-worker] Failed to apply browser suggestions', error)
+    })
   }
 }
 
@@ -1199,7 +1205,10 @@ export const handleKeyBinding = async (state, browserViewId, keyBinding) => {
     await Command.execute('Main.openUri', 'simple-browser-history://')
     return state
   }
-  await KeyBindings.handleKeyBinding(keyBinding)
+  // A fallback binding may dispatch another command to this viewlet.
+  void KeyBindings.handleKeyBinding(keyBinding).catch((error) => {
+    console.error('[renderer-worker] Failed to handle browser key binding', error)
+  })
   return state
 }
 

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserHandleContextMenu.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserHandleContextMenu.js
@@ -22,6 +22,9 @@ export const handleContextMenu = async (state, params) => {
           }
         : entry,
   )
-  await ElectronContextMenu.openBrowserContextMenu(x, y, entries, browserViewId)
+  // Opening a menu can enqueue overlay changes or actions on this same viewlet.
+  void ElectronContextMenu.openBrowserContextMenu(x, y, entries, browserViewId).catch((error) => {
+    console.error('[renderer-worker] Failed to open browser menu', error)
+  })
   return state
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserHandleTabContextMenu.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserHandleTabContextMenu.js
@@ -10,6 +10,9 @@ export const handleTabContextMenu = async (state, index, x, y) => {
   if (tabIndex < 0 || tabIndex >= tabs.length) {
     return state
   }
-  await ContextMenu.show2(uid, MenuEntryId.SimpleBrowserTab, x, y, tabIndex)
+  // Opening a menu can enqueue overlay changes or actions on this same viewlet.
+  void ContextMenu.show2(uid, MenuEntryId.SimpleBrowserTab, x, y, tabIndex).catch((error) => {
+    console.error('[renderer-worker] Failed to open browser menu', error)
+  })
   return state
 }

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserShowMenu.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserShowMenu.js
@@ -3,6 +3,9 @@ import * as MenuEntryId from '../MenuEntryId/MenuEntryId.js'
 
 export const showMenu = async (state, x, toolbarTop, buttonTop, buttonHeight) => {
   const y = state.y + toolbarTop + buttonTop + buttonHeight
-  await ContextMenu.show2Below(state.uid, MenuEntryId.SimpleBrowserToolbar, x, y, state.browserViewId)
+  // Opening a menu can enqueue overlay changes or actions on this same viewlet.
+  void ContextMenu.show2Below(state.uid, MenuEntryId.SimpleBrowserToolbar, x, y, state.browserViewId).catch((error) => {
+    console.error('[renderer-worker] Failed to open browser menu', error)
+  })
   return state
 }

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -9,6 +9,7 @@ afterEach(() => {
 
 beforeEach(() => {
   jest.resetAllMocks()
+  jest.mocked(Viewlet.executeViewletCommand).mockResolvedValue(undefined as never)
   FocusState.set(0)
 })
 
@@ -2146,6 +2147,19 @@ test('a delayed local popup cannot overwrite a provider popup', async () => {
   capture.resolve(new Uint8Array())
   expect(await local).toBe(typed)
   expect(provider.suggestions.some((item) => item.value === 'known result')).toBe(true)
+})
+
+test('rendering does not wait for suggestions queued behind its own command', async () => {
+  const state = { ...ViewletSimpleBrowser.create(7), suggestionsEnabled: true }
+  const typed = ViewletSimpleBrowser.handleInput(state, 'known')
+  const pending = Promise.withResolvers<void>()
+  jest.mocked(Viewlet.executeViewletCommand).mockReturnValue(pending.promise as never)
+  try {
+    await ViewletSimpleBrowser.afterRender(state, typed)
+    expect(Viewlet.executeViewletCommand).toHaveBeenCalled()
+  } finally {
+    pending.resolve()
+  }
 })
 
 test('rendering committed input starts local suggestions without waiting for the provider', async () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowserHandleContextMenu.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserHandleContextMenu.test.ts
@@ -6,6 +6,7 @@ const ElectronContextMenu = await import('../src/parts/ElectronContextMenu/Elect
 const { handleContextMenu } = await import('../src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserHandleContextMenu.js')
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.mocked(ElectronContextMenu.openBrowserContextMenu).mockResolvedValue(undefined as never)
 })
 const state = { uid: 42, x: 100, y: 50, headerHeight: 65, tabs: [{ browserViewId: 17, canGoBack: false, canGoForward: true }] }
 

--- a/packages/renderer-worker/test/ViewletSimpleBrowserHandleTabContextMenu.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserHandleTabContextMenu.test.ts
@@ -3,6 +3,7 @@ import * as MenuEntryId from '../src/parts/MenuEntryId/MenuEntryId.js'
 
 beforeEach(() => {
   jest.resetAllMocks()
+  jest.mocked(ContextMenu.show2).mockResolvedValue(undefined as never)
 })
 
 jest.unstable_mockModule('../src/parts/ContextMenu/ContextMenu.js', () => ({

--- a/packages/renderer-worker/test/ViewletSimpleBrowserShowMenu.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowserShowMenu.test.ts
@@ -10,6 +10,7 @@ const ViewletSimpleBrowserShowMenu = await import('../src/parts/ViewletSimpleBro
 
 beforeEach(() => {
   jest.resetAllMocks()
+  jest.mocked(ContextMenu.show2Below).mockResolvedValue(undefined as never)
 })
 
 test('opens the toolbar menu below the menu button in its nested toolbar', async () => {

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -164,6 +164,22 @@ try {
   await address.press('Escape')
   await page.locator('.SimpleBrowserFullWidthButton').click()
   await expect(page.locator('.BrowserFullWidth')).toHaveCount(0)
+  // Blur suggestions while opening an Explorer menu, then dismiss it immediately.
+  // The native page must stay attached, and the snapshot must remain owned by the menu.
+  for (let iteration = 0; iteration < 20; iteration++) {
+    await address.click()
+    await address.fill('known')
+    if (iteration % 2 === 0) await expect(page.locator('.SimpleBrowserSuggestions')).toBeVisible()
+    await page.getByRole('treeitem', { name: 'other-workspace', exact: true }).click({ button: 'right' })
+    await expect(page.getByRole('menuitem', { name: 'New File...', exact: true })).toBeVisible()
+    await expect(snapshot).toBeVisible()
+    await expect.poll(articleVisible).toBe(false)
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('menuitem', { name: 'New File...', exact: true })).toHaveCount(0)
+    await expect(snapshot).toHaveCount(0)
+    await expect.poll(articleVisible).toBe(true)
+    assert.equal(await articleToken(), token)
+  }
   for (const folder of [otherFolder, profile]) {
     await page.getByRole('menuitem', { name: 'File', exact: true }).click()
     await page.getByRole('menuitem', { name: 'Open Recent', exact: true }).hover()

--- a/scripts/test-simple-browser-address.mjs
+++ b/scripts/test-simple-browser-address.mjs
@@ -164,6 +164,7 @@ try {
   await address.press('Escape')
   await page.locator('.SimpleBrowserFullWidthButton').click()
   await expect(page.locator('.BrowserFullWidth')).toHaveCount(0)
+  await expect(page.locator('[name="editor"]')).toBeFocused()
   // Blur suggestions while opening an Explorer menu, then dismiss it immediately.
   // The native page must stay attached, and the snapshot must remain owned by the menu.
   for (let iteration = 0; iteration < 20; iteration++) {

--- a/scripts/test-simple-browser-workspace.mjs
+++ b/scripts/test-simple-browser-workspace.mjs
@@ -102,6 +102,9 @@ try {
   await expect(page.locator('.BrowserFullWidth')).toBeVisible()
   const address = page.locator('[name="simple-browser-address"]')
   await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Example Domain')
+  await expect(address).toHaveValue('https://example.com/')
+  await address.click()
+  await expect(address).toBeFocused()
   await address.fill(url)
   await address.press('Enter')
   const guestSnapshot = () =>


### PR DESCRIPTION
Closing address suggestions while opening an Explorer context menu could overwrite the menu's overlay state, revoke its snapshot, and leave Simple Browser blank after Escape. Serialize browser state and native visibility transitions, and let menu and suggestion callbacks queue without waiting on their own command.

Adds repeated Explorer right-click/Escape regression coverage that checks snapshot ownership, native page attachment, and preservation of the loaded document.
