### PR TITLE
feature: group simple browser header buttons

### DIFF
--- a/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
+++ b/packages/renderer-worker/src/parts/GetSimpleBrowserVirtualDom/GetSimpleBrowserVirtualDom.js
@@ -191,7 +191,12 @@ export const getSimpleBrowserVirtualDom = (
     {
       type: VirtualDomElements.Div,
       className: ClassNames.SimpleBrowserHeader,
-      childCount: 7,
+      childCount: 3,
+    },
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserButtonsLeft',
+      childCount: 3,
     },
     {
       type: VirtualDomElements.Button,
@@ -273,6 +278,11 @@ export const getSimpleBrowserVirtualDom = (
     )
   }
   dom.push(
+    {
+      type: VirtualDomElements.Div,
+      className: 'SimpleBrowserButtonsRight',
+      childCount: 3,
+    },
     {
       type: VirtualDomElements.Button,
       className: ClassNames.IconButton,

--- a/packages/renderer-worker/src/parts/SimpleBrowserPreferences/SimpleBrowserPreferences.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserPreferences/SimpleBrowserPreferences.js
@@ -1,7 +1,7 @@
 import * as Preferences from '../Preferences/Preferences.js'
 
 export const getDefaultUrl = () => {
-  return 'https://example.com'
+  return 'https://example.com/'
 }
 
 export const getShortCuts = () => {

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -313,7 +313,8 @@ test('loadContent', async () => {
   expect(await ViewletSimpleBrowser.loadContent(state)).toMatchObject({
     audioIndicatorEnabled: true,
     headerHeight: 65,
-    iframeSrc: 'https://example.com',
+    iframeSrc: 'https://example.com/',
+    inputValue: 'https://example.com/',
     searchHistory: ['cheeseburger'],
     tabHoverEnabled: false,
     tabsEnabled: true,
@@ -422,7 +423,7 @@ test('loadContent - restore id - same browser view', async () => {
   ElectronWebContentsViewFunctions.setIframeSrc.mockImplementation(() => {})
   const state = ViewletSimpleBrowser.create(0, 'simple-browser://1', 0, 0, 0, 0)
   expect(await ViewletSimpleBrowser.loadContent(state)).toMatchObject({
-    iframeSrc: 'https://example.com',
+    iframeSrc: 'https://example.com/',
   })
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledWith(1, 0)
@@ -440,14 +441,14 @@ test('loadContent - restore id - browser view does not exist yet', async () => {
   ElectronWebContentsViewFunctions.setIframeSrc.mockImplementation(() => {})
   const state = ViewletSimpleBrowser.create(0, 'simple-browser://1', 0, 0, 0, 0)
   expect(await ViewletSimpleBrowser.loadContent(state)).toMatchObject({
-    iframeSrc: 'https://example.com',
+    iframeSrc: 'https://example.com/',
   })
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsView.createWebContentsView).toHaveBeenCalledWith(1, 0)
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith(2, browserTabKeyBindings)
   expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledTimes(1)
-  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(2, 'https://example.com')
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(2, 'https://example.com/')
 })
 
 test('loadContent restores every tab but creates a web contents view only for the selected tab', async () => {

--- a/scripts/test-simple-browser-workflows.mjs
+++ b/scripts/test-simple-browser-workflows.mjs
@@ -92,6 +92,14 @@ try {
   ])
   await expect.poll(() => getKeys(`${url}/second`), { timeout: 30000 }).toEqual([{ key: 'Enter', shift: false, trusted: true }])
   await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Workflow fixture')
+  const header = page.locator('.SimpleBrowserHeader')
+  await expect(header.locator(':scope > button')).toHaveCount(0)
+  await expect(header.locator(':scope > div.SimpleBrowserButtonsLeft > button')).toHaveCount(3)
+  await expect(header.locator(':scope > div.SimpleBrowserButtonsRight > button')).toHaveCount(3)
+  for (const title of ['Back', 'Forward', 'Reload']) {
+    await expect(header.locator('.SimpleBrowserButtonsLeft').getByRole('button', { name: title, exact: true })).toBeVisible()
+  }
+  await expect(header.locator('.SimpleBrowserButtonsRight .SimpleBrowserMenuButton')).toBeVisible()
   console.log('Workflow shortcut opened a browser and delivered sequential trusted Space and Shift+L events')
 } finally {
   await app?.close()

--- a/static/css/parts/ViewletSimpleBrowser.css
+++ b/static/css/parts/ViewletSimpleBrowser.css
@@ -18,6 +18,13 @@
   display: flex;
 }
 
+.SimpleBrowserButtonsLeft,
+.SimpleBrowserButtonsRight {
+  display: flex;
+  flex-shrink: 0;
+  gap: inherit;
+}
+
 .SimpleBrowserAddressBar {
   background: var(--InputBoxBackground, var(--MainBackground, var(--EditorBackground)));
   flex: 1;


### PR DESCRIPTION
Wrap the left navigation buttons and right toolbar buttons in separate divs around the address bar, preserving horizontal spacing. Use a canonical default browser URL so its initial address stays consistent before and after navigation events.