### PR TITLE
fix: bundle corrected TypeScript readonly union highlighting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,11 @@ jobs:
           npm run e2e:headless --prefix packages/extension-host-worker-tests -- --test-name-prefix=workspace.remote-local-services
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test TypeScript readonly union highlighting
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.editor-typescript-readonly-union-parameters
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test title bar application blur
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
+++ b/packages/build/src/parts/DownloadBuiltinExtensions/builtinExtensions.json
@@ -432,8 +432,8 @@
   {
     "name": "builtin.language-basics-typescript",
     "repository": "github.com/lvce-editor/language-basics-typescript",
-    "version": "3.12.11",
-    "sha256": "d417ff5051a2d65726c8fa39ef59d491efdc93ca7bd1d571277e679ee5eb2368",
+    "version": "3.16.0",
+    "sha256": "6809dc634c0728f1892c350618aaa82f25b76b93b23702135a0cfac5d911230b",
     "created": "2022-06-26"
   },
   {

--- a/packages/extension-host-worker-tests/src/viewlet.editor-typescript-readonly-union-parameters.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.editor-typescript-readonly-union-parameters.ts
@@ -1,0 +1,31 @@
+export const name = 'viewlet.editor-typescript-readonly-union-parameters'
+
+export const test = async ({ FileSystem, Workspace, Main, Locator, expect }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const filePath = `${tmpDir}/processes.ts`
+  await FileSystem.writeFile(
+    filePath,
+    `const getChildren = (
+  collapsedPids: readonly (number | string)[],
+  process: ProcessInfo,
+): readonly VisibleProcess[] => {
+  if (collapsedPids.length === 0) {
+    return []
+  }
+  if (collapsedPids.includes(process.pid)) {
+    return []
+  }
+  return process.children
+}
+const nextValue = 123
+`,
+  )
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(filePath)
+
+  await expect(Locator('.Token.TypePrimitive', { hasText: 'number' })).toHaveText('number')
+  await expect(Locator('.Token.Type', { hasText: 'ProcessInfo' })).toHaveText('ProcessInfo')
+  await expect(Locator('.Token.Type', { hasText: 'VisibleProcess' })).toHaveText('VisibleProcess')
+  await expect(Locator('.Token.KeywordReturn')).toHaveCount(3)
+  await expect(Locator('.Token.Numeric', { hasText: '123' })).toHaveText('123')
+}


### PR DESCRIPTION
Update the bundled TypeScript grammar to 3.16.0 so readonly parenthesized union parameters preserve highlighting for subsequent types and functions. Add an editor regression covering the process explorer failure.