### PR TITLE
fix: resize extension detail responsive sidebar

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -211,6 +211,12 @@ jobs:
         run: npm run e2e:headless -- --test-name-prefix=viewlet.extension-detail-canonical-uri
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test extension detail sidebar resizing
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.extension-detail-sidebar-resize
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test saving extension filesystem files
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/extension-host-worker-tests

--- a/packages/extension-host-worker-tests/src/viewlet.extension-detail-sidebar-resize.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.extension-detail-sidebar-resize.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.extension-detail-sidebar-resize'
+
+export const test: Test = async ({ Command, expect, ExtensionDetail, Locator }) => {
+  await Command.execute('Layout.handleResize', 1200, 720)
+  await ExtensionDetail.open('builtin.theme-atom-one-dark')
+  const aside = Locator('.ExtensionDetail .Aside')
+  await expect(aside).toBeVisible()
+
+  await Command.execute('Layout.handleResize', 600, 720)
+  await expect(aside).toHaveCount(0)
+
+  await Command.execute('Layout.handleResize', 1200, 720)
+  await expect(aside).toBeVisible()
+}

--- a/packages/renderer-worker/src/parts/Workers/Workers.json
+++ b/packages/renderer-worker/src/parts/Workers/Workers.json
@@ -744,6 +744,10 @@
           "name": "ExtensionDetail.render2",
           "parameters": [{ "source": "state", "name": "uid" }, { "source": "result", "name": "diff" }]
         },
+        "resize": {
+          "name": "ExtensionDetail.resize",
+          "parameters": [{ "source": "state", "name": "uid" }, { "source": "argument", "name": "dimensions" }]
+        },
         "saveState": { "name": "ExtensionDetail.saveState", "parameters": [{ "source": "state", "name": "uid" }] },
         "terminate": { "name": "ExtensionDetail.terminate", "parameters": [] },
         "getCommandIds": { "name": "ExtensionDetail.getCommandIds", "parameters": [] },

--- a/packages/renderer-worker/test/ViewletExtensionDetail.test.ts
+++ b/packages/renderer-worker/test/ViewletExtensionDetail.test.ts
@@ -124,3 +124,25 @@ test.skip('loadContent - error - readme not found', async () => {
   expect(FileSystem.readFile).toHaveBeenCalledTimes(1)
   expect(FileSystem.readFile).toHaveBeenCalledWith('/test/test-extension/README.md')
 })
+
+test('resize forwards dimensions to the worker and renders the updated layout', async () => {
+  const state = { uid: 42, width: 1000, height: 600, x: 0, y: 0 }
+  const dimensions = { width: 400, height: 600, x: 0, y: 0 }
+  const commands = [['Viewlet.setCss', 42, ':root {}']]
+  // @ts-ignore
+  ExtensionDetailViewWorker.invoke.mockImplementation(async (method) => {
+    if (method === 'ExtensionDetail.diff2') {
+      return [7, 5]
+    }
+    if (method === 'ExtensionDetail.render2') {
+      return commands
+    }
+  })
+
+  const result = await ViewletExtensionDetail.resize(state, dimensions)
+
+  expect(ExtensionDetailViewWorker.invoke).toHaveBeenNthCalledWith(1, 'ExtensionDetail.resize', 42, dimensions)
+  expect(ExtensionDetailViewWorker.invoke).toHaveBeenNthCalledWith(2, 'ExtensionDetail.diff2', 42)
+  expect(ExtensionDetailViewWorker.invoke).toHaveBeenNthCalledWith(3, 'ExtensionDetail.render2', 42, [7, 5])
+  expect(result).toMatchObject({ ...dimensions, commands })
+})


### PR DESCRIPTION
Forward extension detail view size changes to its worker so the details sidebar hides in narrow editor groups and reappears when widened.