### PR TITLE
feature: inspect component worker heap snapshots in Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:gpu-diagnostics": "node --test scripts/test/diagnose-gpu-process.test.mjs",
     "e2e:ci": "node packages/extension-host-worker-tests/src/_all.js --ci",
     "test:simple-browser-new-tab": "node scripts/test-simple-browser-new-tab.mjs",
+    "test:component-heap-snapshot": "node scripts/test-component-heap-snapshot.mjs",
     "test:simple-browser-workspace": "node scripts/test-simple-browser-workspace.mjs",
     "test:simple-browser-address": "node scripts/test-simple-browser-address.mjs",
     "test:simple-browser-workflows": "node scripts/test-simple-browser-workflows.mjs"

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -52,6 +52,7 @@ export const commandMap = {
   'ClipBoard.getSelectionText': lazy('ClipBoard.getSelectionText'),
   'ComponentState.getComponents': lazy('ComponentState.getComponents'),
   'ComponentState.getState': lazy('ComponentState.getState'),
+  'ComponentState.getWorkerName': lazy('ComponentState.getWorkerName'),
   'ComponentState.setState': lazy('ComponentState.setState'),
   'ColorTheme.getColorThemeNames': lazy('ColorTheme.getColorThemeNames'),
   'ColorTheme.hydrate': lazy('ColorTheme.hydrate'),

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.ipc.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.ipc.js
@@ -6,6 +6,7 @@ export const Commands = {
   getComponents: ComponentState.getComponents,
   getDom: ComponentState.getDom,
   getState: ComponentState.getState,
+  getWorkerName: ComponentState.getWorkerName,
   setDom: ComponentState.setDom,
   setState: ComponentState.setState,
 }

--- a/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
+++ b/packages/renderer-worker/src/parts/ComponentState/ComponentState.js
@@ -1,3 +1,9 @@
+import * as AssetDir from '../AssetDir/AssetDir.js'
+import * as ExtensionManagementWorker from '../ExtensionManagementWorker/ExtensionManagementWorker.js'
+import * as GetExtensionViews from '../GetExtensionViews/GetExtensionViews.ts'
+import * as ComponentWorkerNames from '../ComponentWorkerNames/ComponentWorkerNames.js'
+import * as Platform from '../Platform/Platform.js'
+import * as PlatformType from '../PlatformType/PlatformType.js'
 import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as EditorWorker from '../EditorWorker/EditorWorker.ts'
 import * as FilterFocusCommands from '../FilterFocusCommands/FilterFocusCommands.js'
@@ -240,6 +246,7 @@ export const getComponents = (viewUid = undefined) => {
       displayName,
       domAvailable: typeof instance.factory.getComponentDom === 'function',
       editable: isEditable(instance),
+      heapSnapshotAvailable: Platform.getPlatform() === PlatformType.Electron,
       moduleId,
       uid,
     })
@@ -339,4 +346,29 @@ export const setDom = async (uid, dom) => {
   }
   await RendererProcess.invoke('Viewlet.setComponentDom', uid, dom)
   await refreshOpenEditors(uid)
+}
+
+export const getWorkerName = async (uid) => {
+  if (Platform.getPlatform() !== PlatformType.Electron) {
+    throw new Error('Component heap snapshots require Electron')
+  }
+  const instance = getInstance(uid)
+  if (instance.moduleId === 'ExtensionView') {
+    const applicationId = ApplicationRegistry.getOwner(uid)
+    const view = await GetExtensionViews.getExtensionView(instance.state.viewId, applicationId)
+    const args = ['Extensions.getRunningExtensions', AssetDir.assetDir, PlatformType.Electron]
+    const extensions = await (applicationId === undefined
+      ? ExtensionManagementWorker.invoke(...args)
+      : ExtensionManagementWorker.invoke('Extensions.invokeForApplication', applicationId, ...args))
+    const extension = extensions.find((item) => item.id === view?.extensionId)
+    if (!extension?.isolated) {
+      throw new Error('Component extension does not have an isolated worker')
+    }
+    return extension.workerName || `Extension API (Electron): ${extension.id}`
+  }
+  const workerName = ComponentWorkerNames.getName(instance.factory, instance.moduleId)
+  if (workerName) {
+    return workerName
+  }
+  return globalThis.name
 }

--- a/packages/renderer-worker/src/parts/ComponentWorkerNames/ComponentWorkerNames.js
+++ b/packages/renderer-worker/src/parts/ComponentWorkerNames/ComponentWorkerNames.js
@@ -1,8 +1,16 @@
-import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
 import workers from '../Workers/Workers.json' with { type: 'json' }
 
 const owners = new WeakMap()
 const names = new Map()
+const urls = new Map()
+
+export const registerUrl = (preferenceKey, url) => {
+  for (const worker of workers) {
+    if (worker.settingName === preferenceKey) {
+      urls.set(worker.id, url)
+    }
+  }
+}
 
 export const registerViewlet = (create, workerId) => {
   owners.set(create, workerId)
@@ -13,7 +21,7 @@ export const registerWorker = (url, name) => {
     return
   }
   for (const worker of workers) {
-    if (url.endsWith(worker.fileName) || url === GetConfiguredWorkerUrl.getConfiguredWorkerUrl(worker.settingName, '')) {
+    if (url.endsWith(worker.fileName) || url === urls.get(worker.id)) {
       names.set(worker.id, name)
     }
   }

--- a/packages/renderer-worker/src/parts/ComponentWorkerNames/ComponentWorkerNames.js
+++ b/packages/renderer-worker/src/parts/ComponentWorkerNames/ComponentWorkerNames.js
@@ -1,0 +1,32 @@
+import * as GetConfiguredWorkerUrl from '../GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts'
+import workers from '../Workers/Workers.json' with { type: 'json' }
+
+const owners = new WeakMap()
+const names = new Map()
+
+export const registerViewlet = (create, workerId) => {
+  owners.set(create, workerId)
+}
+
+export const registerWorker = (url, name) => {
+  if (typeof url !== 'string' || typeof name !== 'string') {
+    return
+  }
+  for (const worker of workers) {
+    if (url.endsWith(worker.fileName) || url === GetConfiguredWorkerUrl.getConfiguredWorkerUrl(worker.settingName, '')) {
+      names.set(worker.id, name)
+    }
+  }
+}
+
+export const getName = (factory, moduleId) => {
+  const workerId = owners.get(factory.create) || (moduleId === 'Editor' ? 'editor' : undefined)
+  if (!workerId) {
+    return undefined
+  }
+  const name = names.get(workerId)
+  if (!name) {
+    throw new Error(`Component worker not found: ${workerId}`)
+  }
+  return name
+}

--- a/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
+++ b/packages/renderer-worker/src/parts/CreateWorkerViewlet/CreateWorkerViewlet.js
@@ -1,3 +1,4 @@
+import * as ComponentWorkerNames from '../ComponentWorkerNames/ComponentWorkerNames.js'
 import * as AdjustCommands from '../AdjustCommands/AdjustCommands.js'
 import * as ApplicationRegistry from '../ApplicationRegistry/ApplicationRegistry.ts'
 import * as AssetDir from '../AssetDir/AssetDir.js'
@@ -519,5 +520,7 @@ export const createWorkerViewlet = ({ workerId, getPlatform = Platform.getPlatfo
   const context = createContext(getPlatform)
   const worker = WorkerInvokerMap.getWorkerInvoker(workerId)
   const adapter = WorkerViewletAdapterMap.getWorkerViewletAdapter(workerId)
-  return createWorkerViewletInternal({ adapter, config, context, worker })
+  const viewlet = createWorkerViewletInternal({ adapter, config, context, worker })
+  ComponentWorkerNames.registerViewlet(viewlet.create, workerId)
+  return viewlet
 }

--- a/packages/renderer-worker/src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts
+++ b/packages/renderer-worker/src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts
@@ -1,8 +1,9 @@
+import * as ComponentWorkerNames from '../ComponentWorkerNames/ComponentWorkerNames.js'
 import * as IsProduction from '../IsProduction/IsProduction.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as RuntimeWorkerPaths from '../RuntimeWorkerPaths/RuntimeWorkerPaths.ts'
 
-export const getConfiguredWorkerUrl = (preferenceKey: string, fallback: string) => {
+const resolveConfiguredWorkerUrl = (preferenceKey: string, fallback: string) => {
   const runtimeWorkerUrl = RuntimeWorkerPaths.get(preferenceKey)
   if (runtimeWorkerUrl) {
     return runtimeWorkerUrl
@@ -17,4 +18,10 @@ export const getConfiguredWorkerUrl = (preferenceKey: string, fallback: string) 
     configuredWorkerUrl = fallback
   }
   return configuredWorkerUrl
+}
+
+export const getConfiguredWorkerUrl = (preferenceKey: string, fallback: string): string => {
+  const url = resolveConfiguredWorkerUrl(preferenceKey, fallback)
+  ComponentWorkerNames.registerUrl(preferenceKey, url)
+  return url
 }

--- a/packages/renderer-worker/src/parts/IpcParent/IpcParent.js
+++ b/packages/renderer-worker/src/parts/IpcParent/IpcParent.js
@@ -1,9 +1,11 @@
+import * as ComponentWorkerNames from '../ComponentWorkerNames/ComponentWorkerNames.js'
 import * as IpcParentModule from '../IpcParentModule/IpcParentModule.js'
 
 export const create = async ({ method, ...options }) => {
   const module = await IpcParentModule.getModule(method)
   // @ts-ignore
   const rawIpc = await module.create(options)
+  ComponentWorkerNames.registerWorker(options.url, options.name)
   if (options.noReturn) {
     return undefined
   }

--- a/packages/renderer-worker/test/ComponentState.test.ts
+++ b/packages/renderer-worker/test/ComponentState.test.ts
@@ -60,9 +60,9 @@ test('lists native and supported worker-backed components once', () => {
   })
 
   expect(ComponentState.getComponents()).toEqual([
-    { displayName: 'Editor', domAvailable: false, editable: false, moduleId: 'Editor', uid: 3 },
-    { displayName: 'Explorer', domAvailable: false, editable: true, moduleId: 'Explorer', uid: 2 },
-    { displayName: 'Layout', domAvailable: false, editable: true, moduleId: 'Layout', uid: 1 },
+    { displayName: 'Editor', domAvailable: false, heapSnapshotAvailable: false, editable: false, moduleId: 'Editor', uid: 3 },
+    { displayName: 'Explorer', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'Explorer', uid: 2 },
+    { displayName: 'Layout', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'Layout', uid: 1 },
   ])
 })
 
@@ -83,7 +83,14 @@ test('uses a worker-backed component state availability check', () => {
   })
 
   expect(ComponentState.getComponents()).toEqual([
-    { displayName: 'ExtensionView (extension)', domAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 4 },
+    {
+      displayName: 'ExtensionView (extension)',
+      domAvailable: false,
+      heapSnapshotAvailable: false,
+      editable: true,
+      moduleId: 'ExtensionView',
+      uid: 4,
+    },
   ])
   expect(isComponentStateAvailable).toHaveBeenCalledWith(rendererState)
 })
@@ -100,16 +107,24 @@ test('labels extension views by title and sorts by display name then uid', () =>
   }
 
   expect(ComponentState.getComponents()).toEqual([
-    { displayName: 'Hetzner (extension)', domAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 2 },
-    { displayName: 'Hetzner (extension)', domAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 3 },
-    { displayName: 'Notes (extension)', domAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 1 },
-    { displayName: 'sample.untitled (extension)', domAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 4 },
+    { displayName: 'Hetzner (extension)', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 2 },
+    { displayName: 'Hetzner (extension)', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 3 },
+    { displayName: 'Notes (extension)', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'ExtensionView', uid: 1 },
+    {
+      displayName: 'sample.untitled (extension)',
+      domAvailable: false,
+      heapSnapshotAvailable: false,
+      editable: true,
+      moduleId: 'ExtensionView',
+      uid: 4,
+    },
   ])
 
   ViewletStates.setRenderedState(1, { ...states[0], title: 'Bookmarks' })
   expect(ComponentState.getComponents()[0]).toEqual({
     displayName: 'Bookmarks (extension)',
     domAvailable: false,
+    heapSnapshotAvailable: false,
     editable: true,
     moduleId: 'ExtensionView',
     uid: 1,
@@ -326,7 +341,9 @@ test('gets virtual DOM through the component API without rendering or changing s
   expect(ViewletStates.getByUid(0.25).state).toBe(state)
   expect(ViewletManager.render).not.toHaveBeenCalled()
   expect(RendererProcess.invoke).toHaveBeenCalledWith('Viewlet.getComponentDom', 0.25)
-  expect(ComponentState.getComponents()).toEqual([{ displayName: 'TitleBar', domAvailable: true, editable: true, moduleId: 'TitleBar', uid: 0.25 }])
+  expect(ComponentState.getComponents()).toEqual([
+    { displayName: 'TitleBar', domAvailable: true, heapSnapshotAvailable: false, editable: true, moduleId: 'TitleBar', uid: 0.25 },
+  ])
 })
 
 test('rejects missing components and components without a DOM API', async () => {
@@ -342,7 +359,7 @@ test('exposes Simple Browser state and renders edits through its component state
   ViewletStates.set(10, { factory, moduleId: 'SimpleBrowser', renderedState: state, state })
 
   expect(ComponentState.getComponents()).toEqual([
-    { displayName: 'SimpleBrowser', domAvailable: false, editable: true, moduleId: 'SimpleBrowser', uid: 10 },
+    { displayName: 'SimpleBrowser', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'SimpleBrowser', uid: 10 },
   ])
   await expect(ComponentState.getState(10)).resolves.toBe(state)
 
@@ -364,7 +381,9 @@ test('exposes Layout state and renders edits through its component state hooks',
   const state = { ...factory.create(1), initial: false, statusBarId: 6, statusBarVisible: true }
   ViewletStates.set(1, { factory, moduleId: 'Layout', renderedState: state, state })
 
-  expect(ComponentState.getComponents()).toEqual([{ displayName: 'Layout', domAvailable: false, editable: true, moduleId: 'Layout', uid: 1 }])
+  expect(ComponentState.getComponents()).toEqual([
+    { displayName: 'Layout', domAvailable: false, heapSnapshotAvailable: false, editable: true, moduleId: 'Layout', uid: 1 },
+  ])
   await expect(ComponentState.getState(1)).resolves.toBe(state)
 
   const editedState = { ...state, sideBarWidth: 320, statusBarVisible: false }

--- a/packages/renderer-worker/test/ComponentStateHeapSnapshot.test.ts
+++ b/packages/renderer-worker/test/ComponentStateHeapSnapshot.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as ViewletStates from '../src/parts/ViewletStates/ViewletStates.js'
+
+jest.unstable_mockModule('../src/parts/Platform/Platform.js', () => ({ getPlatform: jest.fn(() => 2), platform: 2 }))
+jest.unstable_mockModule('../src/parts/EditorWorker/EditorWorker.ts', () => ({ invoke: jest.fn() }))
+jest.unstable_mockModule('../src/parts/RendererProcess/RendererProcess.js', () => ({ invoke: jest.fn() }))
+jest.unstable_mockModule('../src/parts/ViewletManager/ViewletManager.js', () => ({ render: jest.fn() }))
+jest.unstable_mockModule('../src/parts/Viewlet/Viewlet.js', () => ({ executeViewletCommand: jest.fn() }))
+jest.unstable_mockModule('../src/parts/GetExtensionViews/GetExtensionViews.ts', () => ({ getExtensionView: jest.fn() }))
+jest.unstable_mockModule('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js', () => ({ invoke: jest.fn() }))
+
+const Platform = await import('../src/parts/Platform/Platform.js')
+const ComponentState = await import('../src/parts/ComponentState/ComponentState.js')
+const WorkerNames = await import('../src/parts/ComponentWorkerNames/ComponentWorkerNames.js')
+const GetExtensionViews = await import('../src/parts/GetExtensionViews/GetExtensionViews.ts')
+const ExtensionManagementWorker = await import('../src/parts/ExtensionManagementWorker/ExtensionManagementWorker.js')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  jest.mocked(Platform.getPlatform).mockReturnValue(2)
+  ViewletStates.reset()
+})
+
+test('resolves worker ownership even when the displayed module name differs', async () => {
+  const factory = { create: () => {}, hasFunctionalRender: true }
+  WorkerNames.registerViewlet(factory.create, 'explorer')
+  WorkerNames.registerWorker('/explorerViewWorkerMain.js', 'Explorer Worker')
+  ViewletStates.set(9, { factory, renderedState: { uid: 9 }, moduleId: 'Renamed Explorer', state: { uid: 9 } })
+  await expect(ComponentState.getWorkerName(9)).resolves.toBe('Explorer Worker')
+  expect(ComponentState.getComponents()[0].heapSnapshotAvailable).toBe(true)
+})
+
+test('uses the current renderer worker for renderer-owned component state', async () => {
+  Object.defineProperty(globalThis, 'name', { configurable: true, value: 'Renderer Worker (Electron)' })
+  ViewletStates.set(9, { factory: {}, renderedState: { uid: 9 }, moduleId: 'Layout', state: { uid: 9 } })
+  await expect(ComponentState.getWorkerName(9)).resolves.toBe('Renderer Worker (Electron)')
+  Reflect.deleteProperty(globalThis, 'name')
+})
+
+test('rejects capture outside Electron and after component disposal', async () => {
+  await expect(ComponentState.getWorkerName(9)).rejects.toThrow('Component not found: 9')
+  jest.mocked(Platform.getPlatform).mockReturnValue(1)
+  ViewletStates.set(9, { factory: {}, renderedState: { uid: 9 }, moduleId: 'Layout', state: { uid: 9 } })
+  expect(ComponentState.getComponents()[0].heapSnapshotAvailable).toBe(false)
+  await expect(ComponentState.getWorkerName(9)).rejects.toThrow('require Electron')
+})
+
+test('resolves an extension component to its isolated extension worker', async () => {
+  ViewletStates.set(9, { factory: {}, renderedState: { uid: 9 }, moduleId: 'ExtensionView', state: { uid: 9, viewId: 'sample.view' } })
+  jest.mocked(GetExtensionViews.getExtensionView).mockResolvedValue({ extensionId: 'sample.extension' } as any)
+  jest.mocked(ExtensionManagementWorker.invoke).mockResolvedValue([{ id: 'sample.extension', isolated: true, workerName: 'Custom Extension' }])
+  await expect(ComponentState.getWorkerName(9)).resolves.toBe('Custom Extension')
+  jest.mocked(ExtensionManagementWorker.invoke).mockResolvedValue([{ id: 'sample.extension', isolated: true }])
+  await expect(ComponentState.getWorkerName(9)).resolves.toBe('Extension API (Electron): sample.extension')
+  jest.mocked(ExtensionManagementWorker.invoke).mockResolvedValue([{ id: 'sample.extension', isolated: false }])
+  await expect(ComponentState.getWorkerName(9)).rejects.toThrow('does not have an isolated worker')
+})

--- a/packages/renderer-worker/test/ComponentWorkerNames.test.ts
+++ b/packages/renderer-worker/test/ComponentWorkerNames.test.ts
@@ -1,15 +1,12 @@
-import { expect, jest, test } from '@jest/globals'
+import { expect, test } from '@jest/globals'
 
-jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => ({
-  getConfiguredWorkerUrl: (key: string) => (key === 'develop.explorerWorkerPath' ? '/custom/explorer.js' : ''),
-}))
-
-const { getName, registerViewlet, registerWorker } = await import('../src/parts/ComponentWorkerNames/ComponentWorkerNames.js')
+const { getName, registerUrl, registerViewlet, registerWorker } = await import('../src/parts/ComponentWorkerNames/ComponentWorkerNames.js')
 
 test('resolves the actual launch name through factory identity, including configured paths', () => {
   const factory = { create: () => {} }
   registerViewlet(factory.create, 'explorer')
   expect(() => getName(factory, 'Explorer')).toThrow('Component worker not found: explorer')
+  registerUrl('develop.explorerWorkerPath', '/custom/explorer.js')
   registerWorker('/custom/explorer.js', 'Custom Explorer')
   expect(getName(factory, 'Explorer')).toBe('Custom Explorer')
   registerWorker('/packages/explorerViewWorkerMain.js', 'Explorer Worker')

--- a/packages/renderer-worker/test/ComponentWorkerNames.test.ts
+++ b/packages/renderer-worker/test/ComponentWorkerNames.test.ts
@@ -1,0 +1,28 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/GetConfiguredWorkerUrl/GetConfiguredWorkerUrl.ts', () => ({
+  getConfiguredWorkerUrl: (key: string) => (key === 'develop.explorerWorkerPath' ? '/custom/explorer.js' : ''),
+}))
+
+const { getName, registerViewlet, registerWorker } = await import('../src/parts/ComponentWorkerNames/ComponentWorkerNames.js')
+
+test('resolves the actual launch name through factory identity, including configured paths', () => {
+  const factory = { create: () => {} }
+  registerViewlet(factory.create, 'explorer')
+  expect(() => getName(factory, 'Explorer')).toThrow('Component worker not found: explorer')
+  registerWorker('/custom/explorer.js', 'Custom Explorer')
+  expect(getName(factory, 'Explorer')).toBe('Custom Explorer')
+  registerWorker('/packages/explorerViewWorkerMain.js', 'Explorer Worker')
+  expect(getName(factory, 'Explorer')).toBe('Explorer Worker')
+})
+
+test('ignores transports without worker names and leaves renderer components unassigned', () => {
+  registerWorker(undefined, undefined)
+  registerWorker('/unknown.js', 'Other Worker')
+  expect(getName({}, 'Layout')).toBeUndefined()
+})
+
+test('tracks the editor worker separately from renderer-owned components', () => {
+  registerWorker('/editorWorkerMain.js', 'Editor Worker')
+  expect(getName({}, 'Editor')).toBe('Editor Worker')
+})

--- a/scripts/test-component-heap-snapshot.mjs
+++ b/scripts/test-component-heap-snapshot.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { mkdtemp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireTests = createRequire(join(root, 'packages/extension-host-worker-tests/package.json'))
+const requireBuild = createRequire(join(root, 'packages/build/package.json'))
+const { _electron } = requireTests('playwright')
+const { expect } = requireTests('@playwright/test')
+const { build } = requireBuild('esbuild')
+const profile = await mkdtemp(join(tmpdir(), 'lvce-component-heap-'))
+const downloads = join(profile, 'downloads')
+await mkdir(downloads)
+await writeFile(join(profile, 'example.txt'), 'component heap snapshot acceptance\n')
+const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js')
+const rendererSource = await readFile(rendererPath, 'utf8')
+const bundleUrl = '/packages/renderer-worker/dist/componentHeapSnapshotTestMain.js'
+await build({
+  entryPoints: [join(root, 'packages/renderer-worker/src/rendererWorkerMain.ts')],
+  outfile: join(root, bundleUrl),
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  external: ['node:*', '/static/*', 'electron'],
+  logLevel: 'error',
+})
+let app
+try {
+  await writeFile(rendererPath, rendererSource.replace('/packages/renderer-worker/src/rendererWorkerMain.ts', bundleUrl))
+  const env = { ...process.env, DEV: '1', LVCE_ROOT: root, LVCE_SHARED_PROCESS_PATH: join(root, 'packages/shared-process/src/sharedProcessMain.ts') }
+  delete env.ELECTRON_RUN_AS_NODE
+  for (const key of ['CONFIG', 'DATA', 'STATE', 'CACHE']) env[`XDG_${key}_HOME`] = join(profile, key.toLowerCase())
+  app = await _electron.launch({
+    executablePath: join(root, 'packages/main-process/node_modules/electron/dist/electron'),
+    args: ['--no-sandbox', '--disable-http-cache', '.', profile],
+    cwd: join(root, 'packages/main-process'),
+    env,
+    timeout: 60000,
+  })
+  await app.evaluate(({ app }, path) => app.setPath('downloads', path), downloads)
+  const page = await app.firstWindow()
+  page.setDefaultTimeout(15000)
+  page.on('console', (message) => {
+    if (message.type() === 'error') console.error('APP ERROR', message.text())
+  })
+  await expect(page.locator('#Workbench')).toBeVisible()
+  await expect(page.getByRole('treeitem', { name: 'example.txt', exact: true })).toBeVisible()
+  await page.keyboard.press('Control+Shift+P')
+  const input = page.locator('[name="QuickPickInput"]')
+  await input.fill('>Developer: Open Component State')
+  await expect(page.getByRole('option', { name: 'Developer: Open Component State', exact: true })).toBeVisible()
+  await input.press('Enter')
+  const card = page.locator('.ComponentStateCard').filter({ has: page.locator('.ComponentStateCardTitle', { hasText: /^Explorer$/ }) })
+  await expect(card).toBeVisible()
+  await card.click({ button: 'right' })
+  const action = page.getByRole('menuitem', { name: 'Show Heap Snapshot', exact: true })
+  await expect(action).toBeEnabled()
+  await action.click()
+  await expect(page.locator('.HeapSnapshotView')).toBeVisible({ timeout: 60000 })
+  await expect(page.locator('.HeapSnapshotViewError')).toHaveCount(0)
+  await expect(page.locator('.HeapSnapshotTable')).toBeVisible()
+  const files = (await readdir(downloads)).filter((name) => name.endsWith('.heapsnapshot'))
+  assert.equal(files.length, 1)
+  assert.match(files[0], /^Explorer-Worker-/)
+  const snapshot = JSON.parse(await readFile(join(downloads, files[0]), 'utf8'))
+  assert.ok(snapshot.snapshot.node_count > 0)
+  assert.ok(snapshot.nodes.length > 0)
+  console.log(`Component heap snapshot passed: ${join(downloads, files[0])}`)
+} finally {
+  await app?.close()
+  await writeFile(rendererPath, rendererSource)
+}


### PR DESCRIPTION
Resolve each component to its owning worker, including renderer-owned state and isolated extension views. Add an Electron acceptance test that opens a snapshot from the component context menu and validates the saved heap.