### PR TITLE
fix: resolve traced test URLs from pathname

### DIFF
--- a/packages/renderer-worker/src/parts/GetUrlBaseName/GetUrlBaseName.js
+++ b/packages/renderer-worker/src/parts/GetUrlBaseName/GetUrlBaseName.js
@@ -1,7 +1,8 @@
 const RE_HTML = /\.html$/
 
 export const getUrlBaseName = (href) => {
-  const fileName = href.slice(href.lastIndexOf('/') + 1)
+  const { pathname } = new URL(href)
+  const fileName = pathname.slice(pathname.lastIndexOf('/') + 1)
   const baseName = fileName.replace(RE_HTML, '')
   return baseName
 }

--- a/packages/renderer-worker/test/GetTestFilePath.test.ts
+++ b/packages/renderer-worker/test/GetTestFilePath.test.ts
@@ -1,0 +1,28 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('../src/parts/PlatformPaths/PlatformPaths.js', () => ({
+  getTestPath: jest.fn(async () => '/remote/test'),
+}))
+jest.unstable_mockModule('../src/parts/FileSystem/FileSystem.js', () => ({
+  exists: jest.fn(async () => false),
+}))
+
+const GetTestFilePath = await import('../src/parts/GetTestFilePath/GetTestFilePath.js')
+const FileSystem = await import('../src/parts/FileSystem/FileSystem.js')
+const PlatformType = await import('../src/parts/PlatformType/PlatformType.js')
+
+test.each([
+  'http://localhost:3000/tests/sample.html',
+  'http://localhost:3000/tests/sample.html?traceRendererWorker=true',
+  'http://localhost:3000/tests/sample.html?traceFocus=true&traceRendererWorker=true#details',
+  'http://localhost:3000/tests/sample.html?filter=folder/other.html',
+])('resolves the test module from the URL pathname: %s', async (href) => {
+  expect(await GetTestFilePath.getTestFilePath(PlatformType.Web, href)).toBe('/remote/test/src/sample.js')
+})
+
+test('checks the TypeScript source without passing trace parameters to the filesystem', async () => {
+  jest.mocked(FileSystem.exists).mockResolvedValueOnce(true)
+  const href = 'http://localhost:3000/tests/sample.html?traceRendererWorker=true'
+  expect(await GetTestFilePath.getTestFilePath(PlatformType.Remote, href)).toBe('/remote/test/src/sample.ts')
+  expect(FileSystem.exists).toHaveBeenCalledWith('file:///test/src/sample.ts')
+})


### PR DESCRIPTION
Resolve test module names from the URL pathname so trace query parameters and fragments do not become part of the imported JavaScript or TypeScript filename. Add regressions covering browser imports and native TypeScript lookup.