### PR TITLE
fix: refresh split editor dividers when resizing main area

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,11 @@ jobs:
           npm run e2e:headless --prefix packages/extension-host-worker-tests -- --test-name-prefix=workspace.remote-local-services
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Test split editor divider after hiding Explorer
+        working-directory: ./packages/extension-host-worker-tests
+        run: npm run e2e:headless -- --test-name-prefix=viewlet.main-area-split-hide-explorer
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
       - name: Test TypeScript readonly union highlighting
         working-directory: ./packages/extension-host-worker-tests
         run: npm run e2e:headless -- --test-name-prefix=viewlet.editor-typescript-readonly-union-parameters

--- a/packages/extension-host-worker-tests/src/viewlet.main-area-split-hide-explorer.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.main-area-split-hide-explorer.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.main-area-split-hide-explorer'
+
+export const test: Test = async ({ Command, DragAndDrop, expect, FileSystem, Locator, Main, Workspace }) => {
+  await Command.execute('Layout.setExplicitBounds', 880, 1042)
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/eslint.config.js`
+  await FileSystem.writeFile(uri, 'export default []')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Layout.moveSideBarRight')
+  await Command.execute('Layout.showSideBar')
+  await Command.execute('Layout.handleSashSideBarPointerDown')
+  await Command.execute('Layout.handleSashPointerMove', 432, 300)
+  await Command.execute('Layout.handleSashPointerUp', '')
+  await Main.openUri(uri)
+  await Main.splitRight()
+  const dropId = await DragAndDrop.createDropSession([{ kind: 'string', type: 'text/uri-list', value: uri }])
+  await Command.execute('Main.handleDragOver', 324, 500)
+  await Command.execute('Main.handleDrop', dropId)
+  const sash = Locator('.Main .SashVertical')
+  await expect(sash).toHaveCSS('left', '250px')
+  await Command.execute('Layout.hideSideBar')
+  await expect(Locator('.EditorGroup')).toHaveCount(2)
+  await expect(sash).toHaveCSS('left', '416px')
+  await expect(Locator('.EditorGroup').first()).toHaveCSS('width', '416px')
+
+  await Command.execute('Layout.showSideBar')
+  await expect(sash).toHaveCSS('left', '250px')
+  await Command.execute('Layout.hideSideBar')
+  await expect(sash).toHaveCSS('left', '416px')
+
+  await Command.execute('Layout.setExplicitBounds', 1080, 1042)
+  await expect(sash).toHaveCSS('left', '516px')
+  await expect(Locator('.EditorGroup').first()).toHaveCSS('width', '516px')
+}

--- a/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
@@ -57,7 +57,7 @@ const invokeMainAreaCommand = async (key: string, uid: number, args: readonly an
 
 export const wrapMainAreaCommand = (key: string) => {
   const fn = async (state, ...args) => {
-    const commands = []
+    const commands: any[] = []
     if (key === 'resize') {
       const resizeCommands = await MainAreaWorker.invoke(`MainArea.${key}`, state.uid, ...args)
       Assert.array(resizeCommands)

--- a/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
+++ b/packages/renderer-worker/src/parts/WrapMainAreaCommand/WrapMainAreaCommand.ts
@@ -57,20 +57,19 @@ const invokeMainAreaCommand = async (key: string, uid: number, args: readonly an
 
 export const wrapMainAreaCommand = (key: string) => {
   const fn = async (state, ...args) => {
+    const commands = []
     if (key === 'resize') {
-      const commands = await MainAreaWorker.invoke(`MainArea.${key}`, state.uid, ...args)
-      Assert.array(commands)
-      return {
-        ...state,
-        commands,
-      }
+      const resizeCommands = await MainAreaWorker.invoke(`MainArea.${key}`, state.uid, ...args)
+      Assert.array(resizeCommands)
+      commands.push(...resizeCommands)
+    } else {
+      await invokeMainAreaCommand(key, state.uid, args)
     }
-    await invokeMainAreaCommand(key, state.uid, args)
     const diffResult = await MainAreaWorker.invoke('MainArea.diff2', state.uid)
-    if (diffResult.length === 0) {
-      return state
+    if (diffResult.length > 0) {
+      const renderCommands = await MainAreaWorker.invoke('MainArea.render2', state.uid, diffResult)
+      commands.push(...renderCommands)
     }
-    const commands = await MainAreaWorker.invoke('MainArea.render2', state.uid, diffResult)
     if (commands.length === 0) {
       return state
     }

--- a/packages/renderer-worker/test/WrapMainAreaCommand.test.ts
+++ b/packages/renderer-worker/test/WrapMainAreaCommand.test.ts
@@ -256,3 +256,37 @@ test('renders pending state for tab selection commands', async () => {
   select.resolve(undefined)
   await resultPromise
 })
+
+test('resize includes refreshed main area rendering after child resize commands', async () => {
+  const dimensions = { x: 0, y: 25, width: 832, height: 900 }
+  const childCommands = [['Viewlet.setBounds', 8, 0, 60, 416, 865]]
+  const renderCommands = [['Viewlet.setCss', 7, '.SashVertical { left: 50%; }']]
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => {
+    if (method === 'MainArea.resize') {
+      return childCommands
+    }
+    if (method === 'MainArea.diff2') {
+      return [2]
+    }
+    return renderCommands
+  })
+
+  const result = await wrapMainAreaCommand('resize')(state, dimensions)
+
+  expect(MainAreaWorker.invoke).toHaveBeenNthCalledWith(1, 'MainArea.resize', state.uid, dimensions)
+  expect(MainAreaWorker.invoke).toHaveBeenNthCalledWith(2, 'MainArea.diff2', state.uid)
+  expect(MainAreaWorker.invoke).toHaveBeenNthCalledWith(3, 'MainArea.render2', state.uid, [2])
+  expect(result).toEqual({ ...state, commands: [...childCommands, ...renderCommands] })
+})
+
+test('resize preserves child commands when the main area has no render diff', async () => {
+  const childCommands = [['Viewlet.setBounds', 8, 0, 60, 416, 865]]
+  // @ts-ignore
+  MainAreaWorker.invoke.mockImplementation((method) => (method === 'MainArea.resize' ? childCommands : []))
+
+  const result = await wrapMainAreaCommand('resize')(state, { width: 832 })
+
+  expect(result).toEqual({ ...state, commands: childCommands })
+  expect(MainAreaWorker.invoke).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
Refresh the main area render after resize while preserving child-editor resize commands. Hiding Explorer now moves the split divider to the resized group boundary instead of leaving a vertical line inside the left editor. Add regression coverage for dragging the same file into a split, toggling Explorer, and resizing the layout.