### PR TITLE
feature: open workspace Git remote in Simple Browser

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,6 +117,9 @@ jobs:
         run: |
           node packages/main-process/node_modules/electron/install.js
           xvfb-run -a npm run test:simple-browser-address
+      - name: Test Git remote shortcut
+        if: matrix.os == 'ubuntu-24.04'
+        run: xvfb-run -a node scripts/test-open-remote.mjs
       - name: Test Simple Browser new tab suggestions
         if: matrix.os == 'ubuntu-24.04'
         run: npm run test:simple-browser-new-tab

--- a/packages/renderer-worker/settings.json
+++ b/packages/renderer-worker/settings.json
@@ -223,5 +223,15 @@
     "id": "keyBindings.fallTroughBrowserView",
     "type": "array",
     "value": ["ctrl+p", "ctrl+shift+p", "ctrl+b", "ctrl+m", "ctrl+Tab"]
+  },
+  {
+    "category": "git",
+    "description": "Maps Git remote hosts to repository website base URLs. Used by Git: Open Remote in Simple Browser (period in the Explorer). For example, map github.com to http://localhost:3001 for a local mirror.",
+    "heading": "Remote Hosts",
+    "id": "git.remoteHosts",
+    "type": "object",
+    "value": {
+      "github.com": "https://github.com"
+    }
   }
 ]

--- a/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
+++ b/packages/renderer-worker/src/parts/CommandMap/CommandMap.js
@@ -550,6 +550,7 @@ export const commandMap = {
   'Window.zoomOut': lazy('Window.zoomOut'),
   'Window.zoomReset': lazy('Window.zoomReset'),
   'WindowTitle.set': lazy('WindowTitle.set'),
+  'Workspace.openRemote': lazy('Workspace.openRemote'),
   'Workspace.close': lazy('Workspace.close'),
   'Workspace.getPath': lazy('Workspace.getPath'),
   'Workspace.getUri': lazy('Workspace.getUri'),

--- a/packages/renderer-worker/src/parts/GetRemoteHomepage/GetRemoteHomepage.js
+++ b/packages/renderer-worker/src/parts/GetRemoteHomepage/GetRemoteHomepage.js
@@ -1,0 +1,34 @@
+export const getRemoteHomepage = (remote, hosts = { 'github.com': 'https://github.com' }) => {
+  const value = remote.trim()
+  const scp = value.match(/^(?:[^@/]+@)?([^/:]+):([^/].*)$/) || value.match(/^[^@/]+@([^/:]+)\/(.+)$/)
+  let host
+  let path
+  if (!value.includes('://') && scp) {
+    host = scp[1].toLowerCase()
+    path = scp[2]
+  } else {
+    try {
+      const url = new URL(value)
+      if (!['https:', 'http:', 'ssh:', 'git:'].includes(url.protocol)) return ''
+      host = url.hostname
+      path = url.pathname.slice(1)
+    } catch {
+      return ''
+    }
+  }
+  if (!hosts || typeof hosts !== 'object' || !Object.hasOwn(hosts, host)) return ''
+  const base = hosts[host]
+  if (typeof base !== 'string') return ''
+  try {
+    const url = new URL(base)
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) return ''
+    const repository = path.replace(/\/$/, '').replace(/\.git$/, '')
+    if (!repository || repository.split('/').some((part) => !part || part === '.' || part === '..')) return ''
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/${repository}`
+    url.search = ''
+    url.hash = ''
+    return url.href
+  } catch {
+    return ''
+  }
+}

--- a/packages/renderer-worker/src/parts/GetRemoteHomepage/GetRemoteHomepage.js
+++ b/packages/renderer-worker/src/parts/GetRemoteHomepage/GetRemoteHomepage.js
@@ -1,3 +1,7 @@
+/**
+ * @param {string} remote
+ * @param {unknown} hosts
+ */
 export const getRemoteHomepage = (remote, hosts = { 'github.com': 'https://github.com' }) => {
   const value = remote.trim()
   const scp = value.match(/^(?:[^@/]+@)?([^/:]+):([^/].*)$/) || value.match(/^[^@/]+@([^/:]+)\/(.+)$/)

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -5,6 +5,11 @@ import * as WhenExpression from '../WhenExpression/WhenExpression.js'
 export const getKeyBindings = () => {
   return [
     {
+      key: KeyCode.Period,
+      command: 'Workspace.openRemote',
+      when: WhenExpression.FocusExplorer,
+    },
+    {
       key: KeyCode.Escape,
       command: 'Viewlet.closeWidget',
       when: WhenExpression.FocusFindWidget,

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutMenuEntries.js
@@ -463,6 +463,7 @@ export const getQuickPickMenuEntries = () => {
       id: 'Window.zoomReset',
       label: 'Window: Reset Zoom',
     },
+    { id: 'Workspace.openRemote', label: 'Git: Open Remote in Simple Browser' },
     { id: 'Layout.toggleSimpleBrowserFullWidth', label: 'Simple Browser: Toggle Full Width' },
     {
       id: 'Main.openUri',

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -550,7 +550,8 @@ export const reloadTab = async (state, index) => {
 export const openOrRevealTab = async (state, url) => {
   const index = state.tabs.findIndex((tab) => tab.iframeSrc === url)
   if (index !== -1) {
-    return selectTab(state, index)
+    const selected = await selectTab(state, index)
+    return updateTab({ ...selected, addressValueVersion: selected.addressValueVersion + 1 }, selected.browserViewId, { inputValue: url })
   }
   if (!state.iframeSrc) {
     return setUrl(state, url)

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -547,6 +547,17 @@ export const reloadTab = async (state, index) => {
   return updateTab(state, tab.browserViewId, { isLoading: true })
 }
 
+export const openOrRevealTab = async (state, url) => {
+  const index = state.tabs.findIndex((tab) => tab.iframeSrc === url)
+  if (index !== -1) {
+    return selectTab(state, index)
+  }
+  if (!state.iframeSrc) {
+    return setUrl(state, url)
+  }
+  return openTab(state, url, 'foreground-tab')
+}
+
 export const openTab = async (state, url, disposition) => {
   const { hasSuggestionsOverlay } = state
   const currentState = hasSuggestionsOverlay ? await closeSuggestions(state) : state

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowserCommands.js
@@ -64,6 +64,7 @@ export const Commands = {
   handleWillNavigate: SimpleBrowser.handleWillNavigate,
   hideTabHover: SimpleBrowser.hideTabHover,
   hideOverlay: SimpleBrowser.hideOverlay,
+  openOrRevealTab: SimpleBrowser.openOrRevealTab,
   openTab: SimpleBrowser.openTab,
   muteTab: SimpleBrowser.muteTab,
   reloadTab: SimpleBrowser.reloadTab,

--- a/packages/renderer-worker/src/parts/Workspace/Workspace.ipc.js
+++ b/packages/renderer-worker/src/parts/Workspace/Workspace.ipc.js
@@ -1,8 +1,10 @@
 import * as Workspace from './Workspace.js'
+import { openRemote } from '../WorkspaceOpenRemote/WorkspaceOpenRemote.js'
 
 export const name = 'Workspace'
 
 export const Commands = {
+  openRemote,
   close: Workspace.close,
   getPath: Workspace.getPath,
   getUri: Workspace.getUri,

--- a/packages/renderer-worker/src/parts/WorkspaceOpenRemote/WorkspaceOpenRemote.js
+++ b/packages/renderer-worker/src/parts/WorkspaceOpenRemote/WorkspaceOpenRemote.js
@@ -1,0 +1,34 @@
+import * as Command from '../Command/Command.js'
+import * as GetRemoteHomepage from '../GetRemoteHomepage/GetRemoteHomepage.js'
+import * as Notification from '../Notification/Notification.js'
+import * as Preferences from '../Preferences/Preferences.js'
+import * as SharedProcess from '../SharedProcess/SharedProcess.js'
+import * as Viewlet from '../Viewlet/Viewlet.js'
+import * as ViewletStates from '../ViewletStates/ViewletStates.js'
+import * as Workspace from '../Workspace/Workspace.js'
+import * as WorkspaceConnection from '../WorkspaceConnection/WorkspaceConnection.js'
+
+export const openRemote = async () => {
+  const cwd = Workspace.getPath()
+  if (!cwd) {
+    await Notification.create('info', 'Open a workspace folder to view its Git remote.')
+    return
+  }
+  if (WorkspaceConnection.isActive()) {
+    throw new Error('Opening Git remotes is not yet supported for remote workspaces.')
+  }
+  const remote = await SharedProcess.invoke('Workspace.getGitRemote', cwd)
+  if (Workspace.getPath() !== cwd) return
+  const url = GetRemoteHomepage.getRemoteHomepage(remote, Preferences.get('git.remoteHosts'))
+  if (!url) {
+    await Notification.create('info', 'No supported Git remote found. Configure git.remoteHosts to map its host to a website.')
+    return
+  }
+  const layout = ViewletStates.getInstance('Layout')?.state
+  if (layout?.secondaryPreviewVisible && layout.secondaryPreviewViewletId === 'SimpleBrowser') {
+    await Viewlet.executeViewletCommand(layout.secondaryPreviewId, 'openOrRevealTab', url)
+    return
+  }
+  await Command.execute('Layout.showPreview', 'simple-browser://')
+  await Command.execute('SimpleBrowser.openOrRevealTab', url)
+}

--- a/packages/renderer-worker/test/GetRemoteHomepage.test.ts
+++ b/packages/renderer-worker/test/GetRemoteHomepage.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@jest/globals'
+import { getRemoteHomepage } from '../src/parts/GetRemoteHomepage/GetRemoteHomepage.js'
+
+test.each([
+  'git@github.com:owner/repository.git',
+  'subdomain@github.com/owner/repository.git',
+  'ssh://git@github.com/owner/repository.git',
+  'https://github.com/owner/repository.git',
+  'https://github.com/owner/repository/',
+  'git://github.com/owner/repository',
+])('maps %s to the GitHub repository homepage', (remote) => {
+  expect(getRemoteHomepage(remote)).toBe('https://github.com/owner/repository')
+})
+
+test('maps a host to a configured local server and base path', () => {
+  expect(getRemoteHomepage('subdomain@github.com:owner/repo.git', { 'github.com': 'http://localhost:3001/mirror/' })).toBe(
+    'http://localhost:3001/mirror/owner/repo',
+  )
+})
+
+test.each(['', '/tmp/repo.git', 'file:///tmp/repo.git', 'git@unknown.com:owner/repo', 'https://github.com/', 'git@github.com:../repo'])(
+  'ignores unsupported remote %s',
+  (remote) => {
+    expect(getRemoteHomepage(remote)).toBe('')
+  },
+)
+
+test.each([null, {}, { 'github.com': 1 }, { 'github.com': 'javascript:alert(1)' }, { 'github.com': 'http://user:pass@localhost' }])(
+  'ignores invalid mappings %j',
+  (hosts) => {
+    expect(getRemoteHomepage('git@github.com:owner/repo', hosts)).toBe('')
+  },
+)

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -638,7 +638,9 @@ test.each([true, false])('keeps a target blank background tab hidden and preserv
   if (browserFocused) {
     expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(12)
     // @ts-ignore
-    expect(ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]).toBeLessThan(ElectronWebContentsViewFunctions.focus.mock.invocationCallOrder[0])
+    expect(ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]).toBeLessThan(
+      ElectronWebContentsViewFunctions.focus.mock.invocationCallOrder[0],
+    )
   } else {
     expect(ElectronWebContentsViewFunctions.focus).not.toHaveBeenCalled()
   }
@@ -2285,7 +2287,6 @@ test('reopens the last closed tab alongside the replacement new tab', async () =
   expect(reopened.tabs).toHaveLength(2)
   expect(reopened).toMatchObject({ browserViewId: 41, iframeSrc: 'https://one.example', selectedTabIndex: 0, closedTabs: [] })
 })
-
 
 test('openOrRevealTab selects an existing background tab without navigation', async () => {
   const state = createTwoTabState()

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -2285,3 +2285,24 @@ test('reopens the last closed tab alongside the replacement new tab', async () =
   expect(reopened.tabs).toHaveLength(2)
   expect(reopened).toMatchObject({ browserViewId: 41, iframeSrc: 'https://one.example', selectedTabIndex: 0, closedTabs: [] })
 })
+
+
+test('openOrRevealTab selects an existing background tab without navigation', async () => {
+  const state = createTwoTabState()
+  const url = state.tabs[1].iframeSrc
+  const result = await ViewletSimpleBrowser.openOrRevealTab(state, url)
+  expect(result.selectedTabIndex).toBe(1)
+  expect(result.tabs).toHaveLength(2)
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).not.toHaveBeenCalled()
+})
+
+test('openOrRevealTab preserves existing tabs when opening a new remote', async () => {
+  // @ts-ignore
+  ElectronWebContentsView.createWebContentsView.mockResolvedValue(14)
+  const state = createTwoTabState()
+  const url = 'https://github.com/owner/repo'
+  const result = await ViewletSimpleBrowser.openOrRevealTab(state, url)
+  expect(result.tabs).toHaveLength(3)
+  expect(result.tabs.slice(0, 2)).toEqual(state.tabs)
+  expect(result.iframeSrc).toBe(url)
+})

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -639,7 +639,7 @@ test.each([true, false])('keeps a target blank background tab hidden and preserv
     expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(12)
     // @ts-ignore
     expect(ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]).toBeLessThan(
-      ElectronWebContentsViewFunctions.focus.mock.invocationCallOrder[0],
+      jest.mocked(ElectronWebContentsViewFunctions.focus).mock.invocationCallOrder[0],
     )
   } else {
     expect(ElectronWebContentsViewFunctions.focus).not.toHaveBeenCalled()

--- a/packages/shared-process/src/parts/GetGitRemote/GetGitRemote.ts
+++ b/packages/shared-process/src/parts/GetGitRemote/GetGitRemote.ts
@@ -8,7 +8,7 @@ export const getGitRemote = async (cwd: string): Promise<string> => {
     const { stdout } = await execPromise('git', ['config', '--get', 'remote.origin.url'], { cwd, maxBuffer: 1024 * 1024, timeout: 10000 })
     return stdout.trim()
   } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 1) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 1) {
       return ''
     }
     throw error

--- a/packages/shared-process/src/parts/GetGitRemote/GetGitRemote.ts
+++ b/packages/shared-process/src/parts/GetGitRemote/GetGitRemote.ts
@@ -1,0 +1,16 @@
+import { execPromise } from '../ExecPromise/ExecPromise.ts'
+
+export const getGitRemote = async (cwd: string): Promise<string> => {
+  if (typeof cwd !== 'string' || !cwd) {
+    throw new TypeError('Expected a workspace path')
+  }
+  try {
+    const { stdout } = await execPromise('git', ['config', '--get', 'remote.origin.url'], { cwd, maxBuffer: 1024 * 1024, timeout: 10000 })
+    return stdout.trim()
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 1) {
+      return ''
+    }
+    throw error
+  }
+}

--- a/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
+++ b/packages/shared-process/src/parts/ModuleMap/ModuleMap.ts
@@ -314,6 +314,7 @@ export const getModuleId = (commandId: any): any => {
     case 'WebViewServer.setInfo2':
     case 'WebViewServer.start':
       return ModuleId.WebViewServer
+    case 'Workspace.getGitRemote':
     case 'Workspace.getHomeDir':
     case 'Workspace.resolveRoot':
       return ModuleId.Workspace

--- a/packages/shared-process/src/parts/Workspace/Workspace.ipc.ts
+++ b/packages/shared-process/src/parts/Workspace/Workspace.ipc.ts
@@ -1,8 +1,10 @@
+import { getGitRemote } from '../GetGitRemote/GetGitRemote.ts'
 import * as Workspace from './Workspace.ts'
 
 export const name = 'Workspace'
 
 export const Commands = {
+  getGitRemote,
   getHomeDir: Workspace.getHomeDir,
   resolveRoot: Workspace.resolveRoot,
 }

--- a/packages/shared-process/test/GetGitRemote.test.ts
+++ b/packages/shared-process/test/GetGitRemote.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execPromise } from '../src/parts/ExecPromise/ExecPromise.ts'
+import { getGitRemote } from '../src/parts/GetGitRemote/GetGitRemote.ts'
+
+test('reads origin from the selected workspace, including a path with spaces', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'lvce remote '))
+  try {
+    await execPromise('git', ['init'], { cwd })
+    expect(await getGitRemote(cwd)).toBe('')
+    await execPromise('git', ['remote', 'add', 'origin', 'git@github.com:owner/repository.git'], { cwd })
+    expect(await getGitRemote(cwd)).toBe('git@github.com:owner/repository.git')
+  } finally {
+    await rm(cwd, { force: true, recursive: true })
+  }
+})
+
+test('rejects an empty workspace instead of reading the process working directory', async () => {
+  await expect(getGitRemote('')).rejects.toThrow('Expected a workspace path')
+})

--- a/scripts/test-open-remote.mjs
+++ b/scripts/test-open-remote.mjs
@@ -21,7 +21,10 @@ const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-edi
 const rendererSource = await readFile(rendererPath, 'utf8')
 const bundleUrl = '/packages/renderer-worker/dist/openRemoteTestMain.js'
 await build({
-  entryPoints: [join(root, 'packages/renderer-worker/src/rendererWorkerMain.ts')],
+  stdin: {
+    contents: `import './packages/renderer-worker/src/rendererWorkerMain.ts'; import { state } from './packages/renderer-worker/src/parts/KeyBindingsState/KeyBindingsState.js'; globalThis.remoteShortcutReady = () => state.matchingKeyBindings.some(binding => binding.command === 'Workspace.openRemote');`,
+    resolveDir: root,
+  },
   outfile: join(root, bundleUrl),
   bundle: true,
   format: 'esm',
@@ -69,6 +72,12 @@ try {
   const explorer = page.getByRole('tree', { name: 'Files Explorer' })
   await expect(explorer).toBeVisible()
   await page.getByRole('treeitem', { name: 'cache', exact: true }).click()
+  await expect
+    .poll(async () => {
+      const worker = page.workers().find((worker) => worker.url().includes('openRemoteTestMain'))
+      return worker?.evaluate(() => globalThis.remoteShortcutReady())
+    })
+    .toBe(true)
   await page.keyboard.press('.')
   const address = page.locator('[name="simple-browser-address"]')
   await expect(address).toHaveValue(url)
@@ -101,6 +110,12 @@ try {
   await command('Layout: Hide Preview')
   await expect(page.locator('.SimpleBrowser')).not.toBeVisible()
   await page.getByRole('treeitem', { name: 'cache', exact: true }).click()
+  await expect
+    .poll(async () => {
+      const worker = page.workers().find((worker) => worker.url().includes('openRemoteTestMain'))
+      return worker?.evaluate(() => globalThis.remoteShortcutReady())
+    })
+    .toBe(true)
   await page.keyboard.press('.')
   await expect(address).toHaveValue(url)
   await expect.poll(token).toBeTruthy()

--- a/scripts/test-open-remote.mjs
+++ b/scripts/test-open-remote.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { createRequire } from 'node:module'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireTests = createRequire(join(root, 'packages/extension-host-worker-tests/package.json'))
+const requireBuild = createRequire(join(root, 'packages/build/package.json'))
+const { _electron } = requireTests('playwright')
+const { expect } = requireTests('@playwright/test')
+const { build } = requireBuild('esbuild')
+const profile = await mkdtemp(join(tmpdir(), 'lvce-open-remote-'))
+await writeFile(join(profile, 'example.txt'), 'Editor fixture')
+const { execFileSync } = await import('node:child_process')
+execFileSync('git', ['init', profile])
+execFileSync('git', ['-C', profile, 'remote', 'add', 'origin', 'git@github.com:owner/repo.git'])
+const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js')
+const rendererSource = await readFile(rendererPath, 'utf8')
+const bundleUrl = '/packages/renderer-worker/dist/openRemoteTestMain.js'
+await build({
+  entryPoints: [join(root, 'packages/renderer-worker/src/rendererWorkerMain.ts')],
+  outfile: join(root, bundleUrl),
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  external: ['node:*', '/static/*', 'electron'],
+  logLevel: 'error',
+})
+const server = createServer((_request, response) => {
+  response.setHeader('Content-Type', 'text/html')
+  response.end('<!doctype html><title>Local article</title><h1>Local article</h1><script>window.documentToken=crypto.randomUUID()</script>')
+})
+await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen))
+const url = `http://127.0.0.1:${server.address().port}/owner/repo`
+await mkdir(join(profile, 'config/lvce-oss'), { recursive: true })
+await writeFile(
+  join(profile, 'config/lvce-oss/settings.json'),
+  JSON.stringify({
+    'git.remoteHosts': { 'github.com': `http://127.0.0.1:${server.address().port}` },
+  }),
+)
+let app
+try {
+  await writeFile(rendererPath, rendererSource.replace('/packages/renderer-worker/src/rendererWorkerMain.ts', bundleUrl))
+  const env = { ...process.env, DEV: '1', LVCE_ROOT: root, LVCE_SHARED_PROCESS_PATH: join(root, 'packages/shared-process/src/sharedProcessMain.ts') }
+  delete env.ELECTRON_RUN_AS_NODE
+  for (const key of ['CONFIG', 'DATA', 'STATE', 'CACHE']) env[`XDG_${key}_HOME`] = join(profile, key.toLowerCase())
+  app = await _electron.launch({
+    executablePath: join(root, 'packages/main-process/node_modules/electron/dist/electron'),
+    args: ['--no-sandbox', `--user-data-dir=${join(profile, 'chromium')}`, '.', profile],
+    cwd: join(root, 'packages/main-process'),
+    env,
+    timeout: 60000,
+  })
+  const childEnv = await app.evaluate(() =>
+    Object.fromEntries(['CONFIG', 'DATA', 'STATE', 'CACHE'].map((key) => [key, process.env[`XDG_${key}_HOME`]])),
+  )
+  for (const key of ['CONFIG', 'DATA', 'STATE', 'CACHE']) assert.equal(childEnv[key], join(profile, key.toLowerCase()))
+  const page = await app.firstWindow()
+  page.setDefaultTimeout(15000)
+  page.on('pageerror', (error) => console.error(error))
+  page.on('console', (message) => {
+    if (message.type() === 'error') console.error(message.text())
+  })
+  await expect(page.locator('#Workbench')).toBeVisible()
+  const explorer = page.getByRole('tree', { name: 'Files Explorer' })
+  await expect(explorer).toBeVisible()
+  await page.getByRole('treeitem', { name: 'cache', exact: true }).click()
+  await page.keyboard.press('.')
+  const address = page.locator('[name="simple-browser-address"]')
+  await expect(address).toHaveValue(url)
+  const token = () =>
+    app.evaluate(async ({ webContents }, url) => {
+      const target = webContents.getAllWebContents().find((item) => item.getURL() === url)
+      return target?.executeJavaScript('document.querySelector("h1")?.textContent === "Local article" && window.documentToken')
+    }, url)
+  await expect.poll(token).toBeTruthy()
+  const originalToken = await token()
+  const count = await page.locator('.SimpleBrowser').getByRole('tab').count()
+  const command = async (label) => {
+    await page.keyboard.press('Control+Shift+P')
+    const input = page.locator('.QuickPick input')
+    await input.fill('>' + label)
+    await page.getByRole('option', { name: label, exact: true }).click()
+    await expect(input).not.toBeVisible()
+  }
+  await command('Git: Open Remote in Simple Browser')
+  await expect(address).toHaveValue(url)
+  await expect(page.locator('.SimpleBrowser').getByRole('tab')).toHaveCount(count)
+  assert.equal(await token(), originalToken)
+  // Typing a period in the address field must not invoke the workspace shortcut.
+  await address.click()
+  await expect(address).toBeFocused()
+  await address.press('Control+A')
+  await address.press('.')
+  await expect(address).toHaveValue('.')
+  await address.press('Escape')
+  await command('Layout: Hide Preview')
+  await expect(page.locator('.SimpleBrowser')).not.toBeVisible()
+  await page.getByRole('treeitem', { name: 'cache', exact: true }).click()
+  await page.keyboard.press('.')
+  await expect(address).toHaveValue(url)
+  await expect.poll(token).toBeTruthy()
+  console.log('Git remote shortcut opens the mapped local page, reuses its tab, preserves text input, and restores hidden preview')
+} finally {
+  await app?.close()
+  await writeFile(rendererPath, rendererSource)
+  await new Promise((resolveClose) => server.close(resolveClose))
+  await rm(profile, { recursive: true, force: true })
+}

--- a/static/config/defaultSettings.json
+++ b/static/config/defaultSettings.json
@@ -1,4 +1,5 @@
 {
+  "git.remoteHosts": { "github.com": "https://github.com" },
   "application.updateMode": "none",
   "application.useOnLoadJson": false,
 


### PR DESCRIPTION
Add Git: Open Remote in Simple Browser and a period shortcut in the Explorer. Resolve the workspace origin through configurable git.remoteHosts mappings, opening or revealing its repository tab in the preview area.