### PR TITLE
fix: load restored browser pages when native ids are reused

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -117,6 +117,9 @@ jobs:
         run: |
           node packages/main-process/node_modules/electron/install.js
           xvfb-run -a npm run test:simple-browser-address
+      - name: Test Simple Browser restoration after app restart
+        if: matrix.os == 'ubuntu-24.04'
+        run: xvfb-run -a npm run test:simple-browser-restore
       - name: Test Simple Browser new tab suggestions
         if: matrix.os == 'ubuntu-24.04'
         run: npm run test:simple-browser-new-tab

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test-static-export": "node packages/build/src/parts/TestStaticExport/TestStaticExport.ts",
     "test:gpu-diagnostics": "node --test scripts/test/diagnose-gpu-process.test.mjs",
     "e2e:ci": "node packages/extension-host-worker-tests/src/_all.js --ci",
+    "test:simple-browser-restore": "node scripts/test-simple-browser-restore.mjs",
     "test:simple-browser-new-tab": "node scripts/test-simple-browser-new-tab.mjs",
     "test:simple-browser-workspace": "node scripts/test-simple-browser-workspace.mjs",
     "test:simple-browser-address": "node scripts/test-simple-browser-address.mjs",

--- a/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/SimpleBrowserWorkflow.js
@@ -3,6 +3,7 @@ import * as EmbedsWorker from '../EmbedsWorker/EmbedsWorker.js'
 import * as Preferences from '../Preferences/Preferences.js'
 import * as ViewletStates from '../ViewletStates/ViewletStates.js'
 import { validateWorkflow } from './ValidateWorkflow.js'
+import { waitForBrowserFrame } from './WaitForBrowserFrame.js'
 
 let running = false
 
@@ -25,6 +26,7 @@ export const executeWorkflow = async (id) => {
           throw new Error('Simple Browser requires an Electron browser tab')
         }
         await EmbedsWorker.invoke('ElectronWebContentsView.navigate', browserViewId, task.url)
+        await waitForBrowserFrame(browserViewId)
       } else {
         if (ViewletStates.getByUid(instance.state.uid) !== instance || instance.state.browserViewId !== browserViewId) {
           throw new Error('The workflow browser tab was closed or changed')

--- a/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/WaitForBrowserFrame.js
+++ b/packages/renderer-worker/src/parts/SimpleBrowserWorkflow/WaitForBrowserFrame.js
@@ -1,0 +1,23 @@
+import * as EmbedsWorker from '../EmbedsWorker/EmbedsWorker.js'
+
+// Navigation can finish while Chromium still holds the previous page's paint and drops input.
+// A second frame lets the first rendering update complete before the workflow sends a key.
+const waitForFrame = `new Promise((resolve, reject) => {
+  let firstFrame;
+  let secondFrame;
+  const timeout = setTimeout(() => {
+    cancelAnimationFrame(firstFrame);
+    cancelAnimationFrame(secondFrame);
+    reject(new Error('The workflow browser tab did not become ready for input'));
+  }, 5000);
+  firstFrame = requestAnimationFrame(() => {
+    secondFrame = requestAnimationFrame(() => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+})`
+
+export const waitForBrowserFrame = async (browserViewId) => {
+  await EmbedsWorker.invoke('ElectronWebContentsView.insertJavaScript', browserViewId, waitForFrame)
+}

--- a/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
+++ b/packages/renderer-worker/src/parts/ViewletSimpleBrowser/ViewletSimpleBrowser.js
@@ -327,7 +327,9 @@ export const loadContent = async (state, savedState) => {
   await ElectronWebContentsViewFunctions.setFallthroughKeyBindings(browserViewId, fallThroughKeyBindings)
   await ElectronWebContentsViewFunctions.resizeWebContentsView(browserViewId, browserViewX, browserViewY, browserViewWidth, browserViewHeight)
   Assert.number(browserViewId)
-  if (!iframeSrc || !id || id !== browserViewId) {
+  // Native IDs are reused after an app restart; a matching ID can still belong to a new, empty view.
+  const existingUrl = id && id === browserViewId ? (await ElectronWebContentsViewFunctions.getStats(browserViewId)).url : ''
+  if (!iframeSrc || !existingUrl) {
     await ElectronWebContentsViewFunctions.setIframeSrc(
       browserViewId,
       iframeSrc || SimpleBrowserNewTabPage.getUrl(undefined, suggestionsEnabled, state.chromeTheme),

--- a/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
+++ b/packages/renderer-worker/test/SimpleBrowserWorkflow.test.ts
@@ -73,6 +73,7 @@ test('waits for navigation before sending sequential keys', async () => {
   expect(ViewletStates.getByUid).toHaveBeenCalledWith(7)
   expect(jest.mocked(EmbedsWorker.invoke).mock.calls).toEqual([
     ['ElectronWebContentsView.navigate', 42, 'https://example.com/'],
+    ['ElectronWebContentsView.insertJavaScript', 42, expect.any(String)],
     ['ElectronWebContentsView.pressKey', 42, 'Space', []],
     ['ElectronWebContentsView.pressKey', 42, 'L', ['shift']],
   ])
@@ -93,5 +94,35 @@ test('stops after navigation failure and allows another invocation', async () =>
 test('does not send keys after the browser tab is closed', async () => {
   jest.mocked(ViewletStates.getByUid).mockReturnValue(undefined)
   await expect(executeWorkflow('music')).rejects.toThrow('closed or changed')
-  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(1)
+  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(2)
+})
+
+test('does not send a key until rendering is ready, and rechecks the selected tab afterwards', async () => {
+  const frame = Promise.withResolvers<void>()
+  const waiting = Promise.withResolvers<void>()
+  jest.mocked(EmbedsWorker.invoke).mockImplementation(async (method) => {
+    if (method === 'ElectronWebContentsView.insertJavaScript') {
+      waiting.resolve()
+      await frame.promise
+    }
+  })
+  const run = executeWorkflow('music')
+  await waiting.promise
+  expect(EmbedsWorker.invoke).not.toHaveBeenCalledWith('ElectronWebContentsView.pressKey', expect.anything(), expect.anything(), expect.anything())
+  jest.mocked(ViewletStates.getByUid).mockReturnValue(undefined)
+  frame.resolve()
+  await expect(run).rejects.toThrow('closed or changed')
+  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(2)
+})
+
+test('stops when rendering does not become ready and allows another invocation', async () => {
+  jest.mocked(EmbedsWorker.invoke).mockImplementation(async (method) => {
+    if (method === 'ElectronWebContentsView.insertJavaScript') {
+      throw new Error('The workflow browser tab did not become ready for input')
+    }
+  })
+  await expect(executeWorkflow('music')).rejects.toThrow('did not become ready for input')
+  expect(EmbedsWorker.invoke).toHaveBeenCalledTimes(2)
+  jest.mocked(EmbedsWorker.invoke).mockReset()
+  await expect(executeWorkflow('music')).resolves.toBeUndefined()
 })

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -415,6 +415,12 @@ test('loadContent enables inactive tab unloading through simpleBrowser.unloadTab
 })
 
 test('loadContent - restore id - same browser view', async () => {
+  jest.mocked(ElectronWebContentsViewFunctions.getStats).mockResolvedValue({
+    title: 'Example',
+    url: 'https://example.com/',
+    canGoBack: true,
+    canGoForward: false,
+  } as never)
   // @ts-ignore
   ElectronWebContentsView.createWebContentsView.mockImplementation(() => {
     return 1
@@ -430,6 +436,35 @@ test('loadContent - restore id - same browser view', async () => {
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledTimes(1)
   expect(ElectronWebContentsViewFunctions.setFallthroughKeyBindings).toHaveBeenCalledWith(1, browserTabKeyBindings)
   expect(ElectronWebContentsViewFunctions.setIframeSrc).not.toHaveBeenCalled()
+})
+
+test('loadContent navigates a restored tab when a new native view reuses its saved id', async () => {
+  jest.mocked(ElectronWebContentsView.createWebContentsView).mockResolvedValue(2 as never)
+  jest.mocked(ElectronWebContentsViewFunctions.setIframeSrc).mockResolvedValue(undefined as never)
+  jest.mocked(ElectronWebContentsViewFunctions.getStats).mockResolvedValue({
+    canGoBack: false,
+    canGoForward: false,
+    title: '',
+    url: '',
+  } as never)
+  const state = ViewletSimpleBrowser.create(7, 'simple-browser://2', 0, 0, 600, 400)
+  const savedState = {
+    iframeSrc: 'https://selected.example/',
+    selectedTabIndex: 1,
+    tabs: [
+      { iframeSrc: 'https://background.example/', title: 'Background' },
+      { iframeSrc: 'https://selected.example/', title: 'Selected' },
+    ],
+  }
+
+  const restored = await ViewletSimpleBrowser.loadContent(state, savedState)
+
+  expect(ElectronWebContentsViewFunctions.setIframeSrc).toHaveBeenCalledWith(2, 'https://selected.example/')
+  expect(restored.tabs).toMatchObject([
+    { browserViewId: 0, title: 'Background' },
+    { browserViewId: 2, title: 'Selected' },
+  ])
+  expect(restored.selectedTabIndex).toBe(1)
 })
 
 test('loadContent - restore id - browser view does not exist yet', async () => {
@@ -638,7 +673,9 @@ test.each([true, false])('keeps a target blank background tab hidden and preserv
   if (browserFocused) {
     expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(12)
     // @ts-ignore
-    expect(ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]).toBeLessThan(ElectronWebContentsViewFunctions.focus.mock.invocationCallOrder[0])
+    expect(ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]).toBeLessThan(
+      ElectronWebContentsViewFunctions.focus.mock.invocationCallOrder[0],
+    )
   } else {
     expect(ElectronWebContentsViewFunctions.focus).not.toHaveBeenCalled()
   }

--- a/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
+++ b/packages/renderer-worker/test/ViewletSimpleBrowser.test.ts
@@ -672,9 +672,8 @@ test.each([true, false])('keeps a target blank background tab hidden and preserv
   expect(ElectronWebContentsViewFunctions.show).not.toHaveBeenCalled()
   if (browserFocused) {
     expect(ElectronWebContentsViewFunctions.focus).toHaveBeenCalledWith(12)
-    // @ts-ignore
-    expect(ElectronWebContentsViewFunctions.hide.mock.invocationCallOrder[0]).toBeLessThan(
-      ElectronWebContentsViewFunctions.focus.mock.invocationCallOrder[0],
+    expect(jest.mocked(ElectronWebContentsViewFunctions.hide).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(ElectronWebContentsViewFunctions.focus).mock.invocationCallOrder[0],
     )
   } else {
     expect(ElectronWebContentsViewFunctions.focus).not.toHaveBeenCalled()

--- a/scripts/test-simple-browser-restore.mjs
+++ b/scripts/test-simple-browser-restore.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import { parseKeyBindingString } from '../packages/renderer-worker/src/parts/ParseKeyBindingString/ParseKeyBindingString.js'
+import { createServer } from 'node:http'
+import { createRequire } from 'node:module'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const requireTests = createRequire(join(root, 'packages/extension-host-worker-tests/package.json'))
+const requireBuild = createRequire(join(root, 'packages/build/package.json'))
+const { _electron } = requireTests('playwright')
+const { expect } = requireTests('@playwright/test')
+const { build } = requireBuild('esbuild')
+const profile = await mkdtemp(join(tmpdir(), 'lvce-browser-restore-'))
+await writeFile(join(profile, 'example.txt'), 'Editor fixture')
+await mkdir(join(profile, 'config/lvce-oss'), { recursive: true })
+await writeFile(
+  join(profile, 'config/lvce-oss/keybindings.json'),
+  JSON.stringify([
+    { source: 'User', key: parseKeyBindingString('Ctrl+Alt+1'), command: 'Main.openUri', args: ['simple-browser://'] },
+    { source: 'User', key: parseKeyBindingString('Ctrl+Alt+2'), command: 'SaveState.handleVisibilityChange', args: ['hidden'] },
+  ]),
+)
+const rendererPath = join(root, 'packages/renderer-worker/node_modules/@lvce-editor/renderer-process/dist/rendererProcessMain.js')
+const rendererSource = await readFile(rendererPath, 'utf8')
+const bundleUrl = '/packages/renderer-worker/dist/browserRestoreTestMain.js'
+await build({
+  entryPoints: [join(root, 'packages/renderer-worker/src/rendererWorkerMain.ts')],
+  outfile: join(root, bundleUrl),
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  external: ['node:*', '/static/*', 'electron'],
+  logLevel: 'error',
+})
+const server = createServer((_request, response) => {
+  response.setHeader('Content-Type', 'text/html')
+  response.end('<!doctype html><title>Restored article</title><h1>Restored article</h1>')
+})
+await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen))
+const url = `http://127.0.0.1:${server.address().port}/article`
+let app
+try {
+  await writeFile(rendererPath, rendererSource.replace('/packages/renderer-worker/src/rendererWorkerMain.ts', bundleUrl))
+  const env = { ...process.env, DEV: '1', LVCE_ROOT: root, LVCE_SHARED_PROCESS_PATH: join(root, 'packages/shared-process/src/sharedProcessMain.ts') }
+  delete env.ELECTRON_RUN_AS_NODE
+  for (const key of ['CONFIG', 'DATA', 'STATE', 'CACHE']) env[`XDG_${key}_HOME`] = join(profile, key.toLowerCase())
+  const launchOptions = {
+    executablePath: join(root, 'packages/main-process/node_modules/electron/dist/electron'),
+    args: ['--no-sandbox', '--user-data-dir=' + join(profile, 'chromium'), '.', profile],
+    cwd: join(root, 'packages/main-process'),
+    env,
+    timeout: 60000,
+  }
+  app = await _electron.launch(launchOptions)
+  await app.evaluate(({ session }) => {
+    session.fromPartition('persist:browserView').protocol.handle('https', () => new Response('<title>Example</title>'))
+  })
+  let page = await app.firstWindow()
+  await expect(page.getByRole('tree', { name: 'Files Explorer' })).toBeVisible()
+  await page.keyboard.press('Control+Alt+1')
+  let address = page.locator('[name="simple-browser-address"]')
+  await expect(address).toBeVisible()
+  await address.fill(url)
+  await address.evaluate((input) => input.form.requestSubmit())
+  await expect(page.locator('.SimpleBrowserTabSelected')).toHaveAttribute('aria-label', 'Restored article')
+  const getNativePage = () =>
+    app.evaluate(({ BrowserWindow }) => {
+      const child = BrowserWindow.getAllWindows()[0].contentView.children.find((view) => view.webContents)
+      return child && { id: child.webContents.id, url: child.webContents.getURL() }
+    })
+  const before = await getNativePage()
+  assert.equal(before.url, url)
+  await page.keyboard.press('Control+Alt+2')
+  await expect.poll(() => page.evaluate(() => Object.values(localStorage).some((value) => value.includes('selectedTabIndex')))).toBe(true)
+  await app.close()
+
+  app = await _electron.launch(launchOptions)
+  page = await app.firstWindow()
+  address = page.locator('[name="simple-browser-address"]')
+  await expect(address).toHaveValue(url)
+  // Restarting Electron reuses the ID. Restored metadata must not substitute for loading the native page.
+  await expect.poll(async () => (await getNativePage())?.id).toBe(before.id)
+  await expect.poll(async () => (await getNativePage())?.url).toBe(url)
+  const heading = await app.evaluate(
+    async ({ webContents }, id) => webContents.fromId(id).executeJavaScript('document.querySelector("h1").textContent'),
+    before.id,
+  )
+  assert.equal(heading, 'Restored article')
+  console.log('PASS: app restart navigates the new native view even when its ID is reused')
+} finally {
+  await app?.close()
+  await writeFile(rendererPath, rendererSource)
+  await new Promise((resolveClose) => server.close(resolveClose))
+  await rm(profile, { recursive: true, force: true })
+}


### PR DESCRIPTION
Restoring Simple Browser after restarting Electron could leave a blank page with the saved address and title because a new, empty native view reused the saved ID. Check that the native view actually has a URL before skipping navigation, while retaining already-loaded pages. Add a regression that closes and relaunches Electron with the same isolated profile.

Browser workflows also wait for the new page to render before sending their first key; navigation can finish while Chromium still holds the previous page’s paint and discards input.
