### PR TITLE
fix: use absolute application settings URI

### DIFF
--- a/packages/extension-host-worker-tests/src/workspace.remote-local-services.ts
+++ b/packages/extension-host-worker-tests/src/workspace.remote-local-services.ts
@@ -2,11 +2,13 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'workspace.remote-local-services'
 
-export const test: Test = async ({ Command, Extension, FileSystem, Locator, Workspace, expect }) => {
+export const test: Test = async ({ Command, Editor, Extension, FileSystem, Locator, Workspace, expect }) => {
   await Workspace.openTmpDir()
   const localUri = await Command.execute('Workspace.getUri')
   await FileSystem.writeFile(`${localUri}/local.txt`, 'local file content')
-  await Command.execute('FileSystem.writeFile', 'app://settings.json', JSON.stringify({ 'editor.fontSize': 17 }))
+  await Command.execute('FileSystem.writeFile', 'app:///settings.json', JSON.stringify({ 'editor.fontSize': 17 }))
+  await Command.execute('Preferences.openSettingsJson')
+  if (JSON.parse(await Editor.getText())['editor.fontSize'] !== 17) throw new Error('Settings editor must open the application settings URI')
   await Command.execute('RecentlyOpened.clearRecentlyOpened')
   await Command.execute('RecentlyOpened.addToRecentlyOpened', `${localUri}/local.txt`)
   const extensionUri = new URL('../fixtures/sample.remote-local-services', import.meta.url).href
@@ -18,7 +20,7 @@ export const test: Test = async ({ Command, Extension, FileSystem, Locator, Work
   })
   const localContent = await Command.execute('FileSystem.readFile', `${localUri}/local.txt`)
   if (localContent !== 'local file content') throw new Error('Local files must remain local in a remote workspace')
-  const settings = JSON.parse(await Command.execute('FileSystem.readFile', 'app://settings.json'))
+  const settings = JSON.parse(await Command.execute('FileSystem.readFile', 'app:///settings.json'))
   if (settings['editor.fontSize'] !== 17) throw new Error('User settings must remain local in a remote workspace')
   const remoteContent = await Command.execute('FileSystem.readFile', 'remote-test://host/work/remote.txt')
   if (remoteContent !== 'remote provider content') throw new Error('Remote files must use the extension provider')

--- a/packages/renderer-worker/src/parts/FileSystem/FileSystemApp.js
+++ b/packages/renderer-worker/src/parts/FileSystem/FileSystemApp.js
@@ -4,6 +4,9 @@ const appPrefix = 'app://'
 const readonlyPaths = new Set(['memory-usage', 'session.json', 'startup-performance'])
 
 const getPath = (uri) => {
+  if (uri.startsWith(`${appPrefix}/`)) {
+    return uri.slice(appPrefix.length + 1)
+  }
   if (uri.startsWith(appPrefix)) {
     return uri.slice(appPrefix.length)
   }

--- a/packages/renderer-worker/src/parts/Preferences/Preferences.js
+++ b/packages/renderer-worker/src/parts/Preferences/Preferences.js
@@ -13,7 +13,7 @@ import * as SharedProcess from '../SharedProcess/SharedProcess.js'
 import * as SharedProcessCommandType from '../SharedProcessCommandType/SharedProcessCommandType.js'
 
 export const openSettingsJson = async () => {
-  await OpenUri.openUri('app://settings.json')
+  await OpenUri.openUri('app:///settings.json')
 }
 
 export const openSettingsUi = async () => {
@@ -91,7 +91,7 @@ export const set = async (key, value) => {
     return
   }
   const content = Json.stringify(PreferencesState.getAll())
-  await FileSystem.writeFile('app://settings.json', content)
+  await FileSystem.writeFile('app:///settings.json', content)
 }
 
 export const update = async (settings) => {
@@ -99,7 +99,7 @@ export const update = async (settings) => {
   const content = Json.stringify(newSettings)
   PreferencesState.setAll(newSettings)
   if (!isTest()) {
-    await FileSystem.writeFile('app://settings.json', content)
+    await FileSystem.writeFile('app:///settings.json', content)
   }
   await GlobalEventBus.emitEvent('preferences.changed')
 }

--- a/packages/renderer-worker/test/FileSystemApp.test.ts
+++ b/packages/renderer-worker/test/FileSystemApp.test.ts
@@ -73,7 +73,7 @@ const KeyBindings = await import('../src/parts/KeyBindings/KeyBindings.js')
 const PlatformPaths = await import('../src/parts/PlatformPaths/PlatformPaths.js')
 const FileSystem = await import('../src/parts/FileSystem/FileSystem.js')
 
-test('readFile - settings', async () => {
+test.each(['settings.json', 'app://settings.json', 'app:///settings.json'])('readFile - settings %s', async (uri) => {
   // @ts-ignore
   PlatformPaths.getUserSettingsPath.mockImplementation(() => {
     return '~/.config/app/settings.json'
@@ -82,7 +82,7 @@ test('readFile - settings', async () => {
   FileSystem.readFile.mockImplementation(() => {
     return '{}'
   })
-  expect(await FileSystemApp.readFile('settings.json')).toBe('{}')
+  expect(await FileSystemApp.readFile(uri)).toBe('{}')
 })
 
 test('writeFile - keybindings reloads runtime keybindings after persisting', async () => {
@@ -217,4 +217,13 @@ test('writeFile - settings - creates windows parent folder', async () => {
 
   expect(FileSystem.mkdir).toHaveBeenCalledWith(String.raw`C:\Users\test\.config\lvce-oss`)
   expect(FileSystem.writeFile).toHaveBeenLastCalledWith(settingsPath, '{}')
+})
+
+test.each(['app://settings.json', 'app:///settings.json'])('writeFile - settings %s', async (uri) => {
+  jest.mocked(PlatformPaths.getUserSettingsPath).mockResolvedValue('~/.config/app/settings.json')
+  jest.mocked(FileSystem.writeFile).mockResolvedValue()
+
+  await FileSystemApp.writeFile(uri, '{"editor.fontSize":17}')
+
+  expect(FileSystem.writeFile).toHaveBeenCalledWith('~/.config/app/settings.json', '{"editor.fontSize":17}')
 })

--- a/packages/renderer-worker/test/Languages.test.ts
+++ b/packages/renderer-worker/test/Languages.test.ts
@@ -75,7 +75,7 @@ test('getLanguageConfiguration - uses file name language over extension language
     throw new Error('unexpected message')
   })
   const editor = {
-    uri: 'app://settings.json',
+    uri: 'app:///settings.json',
     languageId: 'json',
   }
   expect(await Languages.getLanguageConfiguration(editor)).toEqual({
@@ -190,7 +190,7 @@ test('getLanguageId - by file name in uri', async () => {
       fileNames: ['settings.json'],
     },
   ])
-  expect(Languages.getLanguageId('app://settings.json')).toBe('jsonc')
+  expect(Languages.getLanguageId('app:///settings.json')).toBe('jsonc')
 })
 
 test("addLanguage - don't override tokenize path", async () => {

--- a/packages/renderer-worker/test/Preferences.test.ts
+++ b/packages/renderer-worker/test/Preferences.test.ts
@@ -61,7 +61,7 @@ test.skip('openSettingsJson', async () => {
   // @ts-ignore
   expect(Main.openUri).toHaveBeenCalledTimes(1)
   // @ts-ignore
-  expect(Main.openUri).toHaveBeenCalledWith('app://settings.json')
+  expect(Main.openUri).toHaveBeenCalledWith('app:///settings.json')
 })
 
 test.skip('openKeyBindingsJson', async () => {


### PR DESCRIPTION
Open and persist application settings using app:///settings.json. Accept the absolute URI in the application file system provider while preserving support for legacy saved URIs.