### PR TITLE
fix: create a new terminal with ctrl shift backtick

### DIFF
--- a/packages/extension-host-worker-tests/src/viewlet.terminal-new-shortcut.ts
+++ b/packages/extension-host-worker-tests/src/viewlet.terminal-new-shortcut.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.terminal-new-shortcut'
+
+export const test: Test = async ({ Command, KeyBoard, Locator, Settings, expect }) => {
+  await Settings.update({ 'terminal.backend': 'mock' })
+  await Command.execute('Layout.hidePanel')
+  const terminal = Locator('.XtermTerminal')
+  const tabs = Locator('.TerminalTab')
+  const input = terminal.locator('.xterm-helper-textarea')
+
+  await KeyBoard.press('Control+Shift+Backquote')
+  await expect(terminal).toBeVisible()
+  await expect(input).toBeFocused()
+  await expect(tabs).toHaveCount(0)
+
+  await KeyBoard.press('Control+Shift+Backquote')
+  await expect(tabs).toHaveCount(2)
+  await expect(input).toBeFocused()
+
+  await Command.execute('Layout.hidePanel')
+  await expect(terminal).toHaveCount(0)
+  await KeyBoard.press('Control+Shift+Backquote')
+  await expect(tabs).toHaveCount(3)
+  await expect(input).toBeFocused()
+
+  await Command.execute('Layout.showPanel', 'Problems')
+  await KeyBoard.press('Control+Shift+Backquote')
+  await expect(tabs).toHaveCount(4)
+  await expect(input).toBeFocused()
+}

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayout.ts
@@ -1016,8 +1016,13 @@ export const showPanel = async (state: LayoutState, moduleId = state.panelView, 
 }
 
 export const openIntegratedTerminal = async (state: LayoutState, cwd: string): Promise<LayoutStateResult> => {
-  const terminalsActive = state.panelVisible && Boolean(ViewletStates.getInstance(ViewletModuleId.Terminals))
-  if (terminalsActive) {
+  const terminalsExist = Boolean(ViewletStates.getInstance(ViewletModuleId.Terminals))
+  if (terminalsExist) {
+    if (!state.panelVisible || state.panelView !== ViewletModuleId.Terminals) {
+      await Viewlet.executeViewletCommand(state.uid, 'showPanel', ViewletModuleId.Terminals)
+      await Command.execute('Terminals.addTerminal', cwd)
+      return { newState: state, commands: [] }
+    }
     await Command.execute('Terminals.addTerminal', cwd)
     return {
       newState: {

--- a/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
+++ b/packages/renderer-worker/src/parts/ViewletLayout/ViewletLayoutKeyBindings.js
@@ -39,6 +39,11 @@ export const getKeyBindings = () => {
       args: ['Terminals'],
     },
     {
+      key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.Backquote,
+      command: 'Layout.openIntegratedTerminal',
+      args: [''],
+    },
+    {
       key: KeyModifier.CtrlCmd | KeyModifier.Shift | KeyCode.KeyM,
       command: 'ViewService.toggleView',
       args: ['Output'],

--- a/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
+++ b/packages/renderer-worker/test/ViewletLayoutOpenIntegratedTerminal.test.ts
@@ -63,7 +63,7 @@ test('opens a new terminal panel view with the requested cwd', async () => {
   expect(commandExecute).not.toHaveBeenCalled()
 })
 
-test('adds a focused terminal without reselecting the active terminal panel view', async () => {
+test.each([true, false])('adds a focused terminal after revealing existing terminals (panel visible: %s)', async (panelVisible) => {
   ViewletStates.set('Terminals', {
     factory: {},
     moduleId: 'Terminals',
@@ -76,11 +76,26 @@ test('adds a focused terminal without reselecting the active terminal panel view
     panelVisible: true,
   }
 
+  state.panelVisible = panelVisible
   const result = await ViewletLayout.openIntegratedTerminal(state, 'file:///workspace/folder')
 
-  expect(result.newState.panelView).toBe('Terminals')
+  expect(executeViewletCommand).toHaveBeenCalledWith(state.uid, 'showPanel', 'Terminals')
+  expect(result.newState).toBe(state)
   expect(panelWorkerInvocations).toEqual([])
   expect(commandExecute).toHaveBeenCalledWith('Terminals.addTerminal', 'file:///workspace/folder')
+})
+
+test('adds a terminal directly when the terminal panel is active', async () => {
+  ViewletStates.set('Terminals', {
+    factory: {},
+    moduleId: 'Terminals',
+    renderedState: { uid: 88 },
+    state: { uid: 88 },
+  })
+  const state = { ...ViewletLayout.create(1), panelView: 'Terminals', panelVisible: true }
+  await ViewletLayout.openIntegratedTerminal(state, '')
+  expect(executeViewletCommand).not.toHaveBeenCalled()
+  expect(commandExecute).toHaveBeenCalledWith('Terminals.addTerminal', '')
 })
 
 test.each([


### PR DESCRIPTION
Bind Ctrl+Shift+Backtick to New Terminal. Reveal the terminal panel and create a fresh terminal even when existing terminals are hidden or another panel tab is selected.